### PR TITLE
Fix UIGraph unit tests crash

### DIFF
--- a/tests/test_ui_graph.py
+++ b/tests/test_ui_graph.py
@@ -32,3 +32,6 @@ def test_duplicate_nodes():
     assert nMap[n2].input.getLinkParam() == nMap[n1].output
     assert nMap[n3].input.getLinkParam() == nMap[n1].output
     assert nMap[n3].input2.getLinkParam() == nMap[n2].output
+
+    # ensure de-allocation order for un-parented UIGraph (QObject) with no QApplication instance
+    g.deleteLater()


### PR DESCRIPTION
Unparented QObject with no QApplication causes crash after test execution if not explicitly deleted.