### PR TITLE
[nodes][aliceVision] remove voctree path from uid 0 computation

### DIFF
--- a/meshroom/nodes/aliceVision/ImageMatching.py
+++ b/meshroom/nodes/aliceVision/ImageMatching.py
@@ -33,7 +33,7 @@ class ImageMatching(desc.CommandLineNode):
             label='Tree',
             description='Input name for the vocabulary tree file.',
             value=os.environ.get('ALICEVISION_VOCTREE', ''),
-            uid=[0],
+            uid=[],
         ),
         desc.File(
             name='weights',

--- a/meshroom/nodes/aliceVision/ImageMatchingMultiSfM.py
+++ b/meshroom/nodes/aliceVision/ImageMatchingMultiSfM.py
@@ -41,7 +41,7 @@ class ImageMatchingMultiSfM(desc.CommandLineNode):
             label='Tree',
             description='Input name for the vocabulary tree file.',
             value=os.environ.get('ALICEVISION_VOCTREE', ''),
-            uid=[0],
+            uid=[],
         ),
         desc.File(
             name='weights',


### PR DESCRIPTION
With prebuilt release in mind, avoid invalidating scenes because of an embedded resource.