### PR TITLE
[ui] Display metadata and lens status flag

### DIFF
--- a/meshroom/nodes/aliceVision/CameraInit.py
+++ b/meshroom/nodes/aliceVision/CameraInit.py
@@ -170,14 +170,10 @@ class CameraInit(desc.CommandLineNode):
                 intrinsic['principalPoint'] = [intrinsic['principalPoint']['x'], intrinsic['principalPoint']['y']]
             views = node.viewpoints.getPrimitiveValue(exportDefault=False)
 
-            # convert metadata string into a map
+            # convert the metadata string into a map
             for view in views:
-                # filter out unnecessary attributes
                 if 'metadata' in view:
-                    try:
-                        view['metadata'] = eval(view['metadata'])
-                    except:
-                        del view['metadata']
+                    view['metadata'] = json.loads(view['metadata'])
 
             sfmData = {
                 "version": [1, 0, 0],

--- a/meshroom/nodes/aliceVision/CameraInit.py
+++ b/meshroom/nodes/aliceVision/CameraInit.py
@@ -170,10 +170,14 @@ class CameraInit(desc.CommandLineNode):
                 intrinsic['principalPoint'] = [intrinsic['principalPoint']['x'], intrinsic['principalPoint']['y']]
             views = node.viewpoints.getPrimitiveValue(exportDefault=False)
 
+            # convert metadata string into a map
             for view in views:
                 # filter out unnecessary attributes
                 if 'metadata' in view:
-                    del view['metadata']
+                    try:
+                        view['metadata'] = eval(view['metadata'])
+                    except:
+                        del view['metadata']
 
             sfmData = {
                 "version": [1, 0, 0],

--- a/meshroom/ui/qml/ImageDelegate.qml
+++ b/meshroom/ui/qml/ImageDelegate.qml
@@ -19,6 +19,8 @@ Item {
     signal pressed(var mouse)
     signal removeRequest()
 
+    default property alias children: imageMA.children
+
     // retrieve viewpoints inner data
     QtObject {
         id: _viewpoint

--- a/meshroom/ui/qml/ImageGallery.qml
+++ b/meshroom/ui/qml/ImageGallery.qml
@@ -110,61 +110,44 @@ Panel {
                     Row {
                         anchors.top: parent.top
                         anchors.right: parent.right
-                        anchors.margins: 10
-                        // Lens recognized
-                        ToolButton {
-                            id: metadataIndicator
+                        anchors.margins: 4
+                        spacing: 2
 
-                            // object can be evaluated to null at some point during creation/deletion
-                            property bool valid: Qt.isQtObject(object)
-                            property bool hasMetadata: _reconstruction.hasMetadata(model.object)
+                        property bool valid: Qt.isQtObject(object) // object can be evaluated to null at some point during creation/deletion
+                        property bool noMetadata: valid && !_reconstruction.hasMetadata(model.object)
+                        property bool noIntrinsic: valid  && !_reconstruction.hasValidIntrinsic(model.object)
+                        property bool inViews: valid && _reconstruction.sfmReport && _reconstruction.isInViews(object)
 
-                            contentItem: Label {
-                                font.family: MaterialIcons.fontFamily
+                        // Missing metadata indicator
+                        Loader {
+                            active: parent.noMetadata
+                            visible: active
+                            sourceComponent: MaterialLabel {
                                 text: MaterialIcons.info_outline
-                                color: parent.hasMetadata ? "#4CAF50" : "#F44336"
-                                font.pointSize: 10
+                                color: "#FF9800"
+                                ToolTip.text: "No Metadata"
                             }
-                            ToolTip.text: hasMetadata ? "Has Metadata" : "Missing Metadata"
-                            ToolTip.visible: pressed
-                            visible: valid && !hasMetadata
                         }
-                        // Lens recognized
-                        ToolButton {
-                            id: lensIndicator
-
-                            // object can be evaluated to null at some point during creation/deletion
-                            property bool valid: Qt.isQtObject(object)
-                            property bool hasValidIntrinsic: _reconstruction.hasValidIntrinsic(model.object)
-
-                            contentItem: Label {
-                                font.family: MaterialIcons.fontFamily
-                                text: MaterialIcons.warning
-                                color: "#F44336"
-                                font.pointSize: 10
+                        // Unknown camera instrinsics indicator
+                        Loader {
+                            active: parent.noIntrinsic
+                            visible: active
+                            sourceComponent: MaterialLabel {
+                                text: MaterialIcons.camera
+                                color: "#FF9800"
+                                ToolTip.text: "No Camera Instrinsic Parameters (missing Metadata?)"
                             }
-                            visible: valid && !hasValidIntrinsic
-
-                            ToolTip.text: "Unable to find camera intrinsic parameters.\nCheck image metadata."
-                            ToolTip.visible: pressed
                         }
                         // Reconstruction status indicator
-                        ToolButton {
-                            id: statusIndicator
-
-                            // object can be evaluated to null at some point during creation/deletion
-                            property bool inViews: Qt.isQtObject(object) && _reconstruction.sfmReport && _reconstruction.isInViews(object)
-                            property bool reconstructed: inViews && _reconstruction.isReconstructed(model.object)
-
-                            contentItem: Label {
-                                font.family: MaterialIcons.fontFamily
-                                text: parent.reconstructed ? MaterialIcons.check_circle : MaterialIcons.remove_circle
-                                color: parent.reconstructed ? "#4CAF50" : "#F44336"
-                                font.pointSize: 10
+                        Loader {
+                            active: parent.inViews
+                            visible: active
+                            sourceComponent: MaterialLabel {
+                                property bool reconstructed: _reconstruction.isReconstructed(model.object)
+                                text: reconstructed ? MaterialIcons.check_circle : MaterialIcons.remove_circle
+                                color: reconstructed ? "#4CAF50" : "#F44336"
+                                ToolTip.text: reconstructed ? "Reconstructed" : "Not Reconstructed"
                             }
-                            ToolTip.text: reconstructed ? "Reconstructed" : "Not Reconstructed"
-                            ToolTip.visible: pressed
-                            visible: inViews
                         }
                     }
                 }

--- a/meshroom/ui/qml/ImageGallery.qml
+++ b/meshroom/ui/qml/ImageGallery.qml
@@ -107,22 +107,65 @@ Panel {
                     onRemoveRequest: sendRemoveRequest()
                     Keys.onDeletePressed: sendRemoveRequest()
 
-                    // Reconstruction status indicator
-                    Label {
-                        id: statusIndicator
-
-                        // object can be evaluated to null at some point during creation/deletion
-                        property bool inViews: Qt.isQtObject(object) && _reconstruction.sfmReport && _reconstruction.isInViews(object)
-                        property bool reconstructed: inViews && _reconstruction.isReconstructed(model.object)
-
-                        font.family: MaterialIcons.fontFamily
-                        text: reconstructed ? MaterialIcons.check_circle : MaterialIcons.remove_circle
-                        color: reconstructed ? "#4CAF50" : "#F44336"
+                    Row {
                         anchors.top: parent.top
                         anchors.right: parent.right
                         anchors.margins: 10
-                        font.pointSize: 10
-                        visible: inViews
+                        // Lens recognized
+                        ToolButton {
+                            id: metadataIndicator
+
+                            // object can be evaluated to null at some point during creation/deletion
+                            property bool valid: Qt.isQtObject(object)
+                            property bool hasMetadata: _reconstruction.hasMetadata(model.object)
+
+                            contentItem: Label {
+                                font.family: MaterialIcons.fontFamily
+                                text: MaterialIcons.info_outline
+                                color: parent.hasMetadata ? "#4CAF50" : "#F44336"
+                                font.pointSize: 10
+                            }
+                            ToolTip.text: hasMetadata ? "Has Metadata" : "Missing Metadata"
+                            ToolTip.visible: pressed
+                            visible: valid && !hasMetadata
+                        }
+                        // Lens recognized
+                        ToolButton {
+                            id: lensIndicator
+
+                            // object can be evaluated to null at some point during creation/deletion
+                            property bool valid: Qt.isQtObject(object)
+                            property bool hasValidIntrinsic: _reconstruction.hasValidIntrinsic(model.object)
+
+                            contentItem: Label {
+                                font.family: MaterialIcons.fontFamily
+                                text: MaterialIcons.warning
+                                color: "#F44336"
+                                font.pointSize: 10
+                            }
+                            visible: valid && !hasValidIntrinsic
+
+                            ToolTip.text: "Unable to find camera intrinsic parameters.\nCheck image metadata."
+                            ToolTip.visible: pressed
+                        }
+                        // Reconstruction status indicator
+                        ToolButton {
+                            id: statusIndicator
+
+                            // object can be evaluated to null at some point during creation/deletion
+                            property bool inViews: Qt.isQtObject(object) && _reconstruction.sfmReport && _reconstruction.isInViews(object)
+                            property bool reconstructed: inViews && _reconstruction.isReconstructed(model.object)
+
+                            contentItem: Label {
+                                font.family: MaterialIcons.fontFamily
+                                text: parent.reconstructed ? MaterialIcons.check_circle : MaterialIcons.remove_circle
+                                color: parent.reconstructed ? "#4CAF50" : "#F44336"
+                                font.pointSize: 10
+                            }
+                            ToolTip.text: reconstructed ? "Reconstructed" : "Not Reconstructed"
+                            ToolTip.visible: pressed
+                            visible: inViews
+                        }
                     }
                 }
             }

--- a/meshroom/ui/qml/MaterialIcons/MaterialLabel.qml
+++ b/meshroom/ui/qml/MaterialIcons/MaterialLabel.qml
@@ -1,0 +1,24 @@
+import QtQuick 2.9
+import QtQuick.Controls 2.4
+
+
+/**
+ * MaterialLabel is a standard Label using MaterialIcons font.
+ * If ToolTip.text is set, it also shows up a tooltip when hovered.
+ */
+Label {
+    font.family: MaterialIcons.fontFamily
+    font.pointSize: 10
+    ToolTip.visible: toolTipLoader.active && toolTipLoader.item.containsMouse
+    ToolTip.delay: 1000
+
+    Loader {
+        id: toolTipLoader
+        anchors.fill: parent
+        active: parent.ToolTip.text
+        sourceComponent: MouseArea {
+            hoverEnabled: true
+            acceptedButtons: Qt.NoButton
+        }
+    }
+}

--- a/meshroom/ui/qml/MaterialIcons/qmldir
+++ b/meshroom/ui/qml/MaterialIcons/qmldir
@@ -1,3 +1,4 @@
 module MaterialIcons
 singleton MaterialIcons 2.2 MaterialIcons.qml
 MaterialToolButton 2.2 MaterialToolButton.qml
+MaterialLabel 2.2 MaterialLabel.qml

--- a/meshroom/ui/reconstruction.py
+++ b/meshroom/ui/reconstruction.py
@@ -495,6 +495,17 @@ class Reconstruction(UIGraph):
         # keys are strings (faster lookup)
         return str(viewpoint.poseId.value) in self._poses
 
+    @Slot(QObject, result=bool)
+    def hasValidIntrinsic(self, viewpoint):
+        # keys are strings (faster lookup)
+        allIntrinsicIds = [i.intrinsicId.value for i in self._cameraInit.intrinsics.value]
+        return viewpoint.intrinsicId.value in allIntrinsicIds
+
+    @Slot(QObject, result=bool)
+    def hasMetadata(self, viewpoint):
+        # Should be greater than 2 to avoid the particular case of ""
+        return len(viewpoint.metadata.value) > 2
+
     def setSelectedViewId(self, viewId):
         if viewId == self._selectedViewId:
             return


### PR DESCRIPTION
- [x] display flag if there is no metadata
- [x] display flag if there is no associated intrinsic
- [x] bug fix: metadata should be exported by CameraInit in `viewpoints.sfm`, else we loose metadata on the previous images when we drag&drop new images.

![image](https://user-images.githubusercontent.com/153585/43101806-900b997e-8ec9-11e8-9b3b-23da21aed270.png)
