### PR TITLE
Save nodes position + undoable nodes moves

### DIFF
--- a/meshroom/core/graph.py
+++ b/meshroom/core/graph.py
@@ -426,13 +426,14 @@ class Graph(BaseObject):
 
         return inEdges, outEdges
 
-    def addNewNode(self, nodeType, name=None, **kwargs):
+    def addNewNode(self, nodeType, name=None, position=None, **kwargs):
         """
         Create and add a new node to the graph.
 
         Args:
             nodeType (str): the node type name.
             name (str): if specified, the desired name for this node. If not unique, will be prefixed (_N).
+            position (Position): (optional) the position of the node
             **kwargs: keyword arguments to initialize node's attributes
 
         Returns:
@@ -441,7 +442,7 @@ class Graph(BaseObject):
         if name and name in self._nodes.keys():
             name = self._createUniqueNodeName(name)
 
-        n = self.addNode(Node(nodeType, **kwargs), uniqueName=name)
+        n = self.addNode(Node(nodeType, position=position, **kwargs), uniqueName=name)
         n.updateInternals()
         return n
 

--- a/meshroom/core/graph.py
+++ b/meshroom/core/graph.py
@@ -482,7 +482,7 @@ class Graph(BaseObject):
                 except (KeyError, ValueError) as e:
                     logging.warning("Failed to restore edge {} -> {}: {}".format(src, dst, str(e)))
 
-        return inEdges, outEdges
+        return upgradedNode, inEdges, outEdges
 
     def upgradeAllNodes(self):
         """ Upgrade all upgradable CompatibilityNode instances in the graph. """

--- a/meshroom/core/graph.py
+++ b/meshroom/core/graph.py
@@ -5,7 +5,7 @@ import logging
 import os
 import re
 import weakref
-from collections import defaultdict
+from collections import defaultdict, OrderedDict
 from contextlib import contextmanager
 
 from enum import Enum
@@ -363,10 +363,11 @@ class Graph(BaseObject):
             fromNode (Node): the node to start the duplication from
 
         Returns:
-            Dict[Node, Node]: the source->duplicate map
+            OrderedDict[Node, Node]: the source->duplicate map
         """
         srcNodes, srcEdges = self.nodesFromNode(fromNode)
-        duplicates = {}
+        # use OrderedDict to keep duplicated nodes creation order
+        duplicates = OrderedDict()
 
         with GraphModification(self):
             duplicateEdges = {}

--- a/meshroom/core/graph.py
+++ b/meshroom/core/graph.py
@@ -162,7 +162,7 @@ class Graph(BaseObject):
 
     class IO(object):
         """ Centralize Graph file keys and IO version. """
-        __version__ = "1.0"
+        __version__ = "1.1"
 
         class Keys(object):
             """ File Keys. """
@@ -179,6 +179,7 @@ class Graph(BaseObject):
             Header = "header"
             NodesVersions = "nodesVersions"
             PrecomputedOutputs = "precomputedOutputs"
+            NodesPositions = "nodesPositions"
 
         @staticmethod
         def getFeaturesForVersion(fileVersion):
@@ -199,6 +200,8 @@ class Graph(BaseObject):
                              Graph.IO.Features.NodesVersions,
                              Graph.IO.Features.PrecomputedOutputs,
                              ]
+            if fileVersion >= Version("1.1"):
+                features += [Graph.IO.Features.NodesPositions]
             return features
 
     def __init__(self, name, parent=None):

--- a/meshroom/core/graph.py
+++ b/meshroom/core/graph.py
@@ -13,7 +13,7 @@ from enum import Enum
 import meshroom
 import meshroom.core
 from meshroom.common import BaseObject, DictModel, Slot, Signal, Property
-from meshroom.core import Version
+from meshroom.core import Version, pyCompatibility
 from meshroom.core.attribute import Attribute, ListAttribute
 from meshroom.core.exception import StopGraphVisit, StopBranchVisit
 from meshroom.core.node import nodeFactory, Status, Node, CompatibilityNode
@@ -191,7 +191,7 @@ class Graph(BaseObject):
             Returns:
                 tuple of Graph.IO.Features: the list of supported features
             """
-            if isinstance(fileVersion, str):
+            if isinstance(fileVersion, pyCompatibility.basestring):
                 fileVersion = Version(fileVersion)
 
             features = [Graph.IO.Features.Graph]

--- a/meshroom/core/graph.py
+++ b/meshroom/core/graph.py
@@ -189,7 +189,7 @@ class Graph(BaseObject):
                 fileVersion (str, Version): the file version
 
             Returns:
-                list of Graph.IO.Features: the list of supported features
+                tuple of Graph.IO.Features: the list of supported features
             """
             if isinstance(fileVersion, str):
                 fileVersion = Version(fileVersion)
@@ -202,7 +202,7 @@ class Graph(BaseObject):
                              ]
             if fileVersion >= Version("1.1"):
                 features += [Graph.IO.Features.NodesPositions]
-            return features
+            return tuple(features)
 
     def __init__(self, name, parent=None):
         super(Graph, self).__init__(parent)

--- a/meshroom/core/graph.py
+++ b/meshroom/core/graph.py
@@ -163,11 +163,15 @@ class Graph(BaseObject):
         """ Centralize Graph file keys and IO version. """
         __version__ = "1.0"
 
-        Header = "header"
-        NodesVersions = "nodesVersions"
-        ReleaseVersion = "releaseVersion"
-        FileVersion = "fileVersion"
-        Graph = "graph"
+        class Keys(object):
+            """ File Keys. """
+            # Doesn't inherit enum to simplify usage (Graph.IO.Keys.XX, without .value)
+            Header = "header"
+            NodesVersions = "nodesVersions"
+            ReleaseVersion = "releaseVersion"
+            FileVersion = "fileVersion"
+            Graph = "graph"
+
 
     def __init__(self, name, parent=None):
         super(Graph, self).__init__(parent)
@@ -198,14 +202,13 @@ class Graph(BaseObject):
             fileData = json.load(jsonFile)
 
         # older versions of Meshroom files only contained the serialized nodes
-        graphData = fileData.get(Graph.IO.Graph, fileData)
+        graphData = fileData.get(Graph.IO.Keys.Graph, fileData)
 
         if not isinstance(graphData, dict):
             raise RuntimeError('loadGraph error: Graph is not a dict. File: {}'.format(filepath))
 
-        self.header = fileData.get(Graph.IO.Header, {})
-        nodesVersions = self.header.get(Graph.IO.NodesVersions, {})
-        fileVersion = self.header.get(Graph.IO.FileVersion, "0.0")
+        self.header = fileData.get(Graph.IO.Keys.Header, {})
+        nodesVersions = self.header.get(Graph.IO.Keys.NodesVersions, {})
 
         with GraphModification(self):
             # iterate over nodes sorted by suffix index in their names
@@ -858,20 +861,20 @@ class Graph(BaseObject):
         if not path:
             raise ValueError("filepath must be specified for unsaved files.")
 
-        self.header[Graph.IO.ReleaseVersion] = meshroom.__version__
-        self.header[Graph.IO.FileVersion] = Graph.IO.__version__
+        self.header[Graph.IO.Keys.ReleaseVersion] = meshroom.__version__
+        self.header[Graph.IO.Keys.FileVersion] = Graph.IO.__version__
 
         # store versions of node types present in the graph (excluding CompatibilityNode instances)
         usedNodeTypes = set([n.nodeDesc.__class__ for n in self._nodes if isinstance(n, Node)])
 
-        self.header[Graph.IO.NodesVersions] = {
+        self.header[Graph.IO.Keys.NodesVersions] = {
             "{}".format(p.__name__): meshroom.core.nodeVersion(p, "0.0")
             for p in usedNodeTypes
         }
 
         data = {
-            Graph.IO.Header: self.header,
-            Graph.IO.Graph: self.toDict()
+            Graph.IO.Keys.Header: self.header,
+            Graph.IO.Keys.Graph: self.toDict()
         }
 
         with open(path, 'w') as jsonFile:
@@ -1016,7 +1019,7 @@ class Graph(BaseObject):
     edges = Property(BaseObject, edges.fget, constant=True)
     filepathChanged = Signal()
     filepath = Property(str, lambda self: self._filepath, notify=filepathChanged)
-    fileReleaseVersion = Property(str, lambda self: self.header.get(Graph.IO.ReleaseVersion, "0.0"), notify=filepathChanged)
+    fileReleaseVersion = Property(str, lambda self: self.header.get(Graph.IO.Keys.ReleaseVersion, "0.0"), notify=filepathChanged)
     cacheDirChanged = Signal()
     cacheDir = Property(str, cacheDir.fget, cacheDir.fset, notify=cacheDirChanged)
     updated = Signal()

--- a/meshroom/core/node.py
+++ b/meshroom/core/node.py
@@ -669,6 +669,7 @@ class Node(BaseNode):
 
         return {
             'nodeType': self.nodeType,
+            'position': self._position,
             'parallelization': {
                 'blockSize': self.nodeDesc.parallelization.blockSize if self.isParallelized else 0,
                 'size': self.size,
@@ -883,6 +884,8 @@ class CompatibilityNode(BaseNode):
         """
         # update inputs to get up-to-date connections
         self.nodeDict.update({"inputs": self.inputs})
+        # update position
+        self.nodeDict.update({"position": self.position})
         return self.nodeDict
 
     @property
@@ -931,6 +934,7 @@ def nodeFactory(nodeDict, name=None):
     outputs = nodeDict.get("outputs", {})
     version = nodeDict.get("version", None)
     internalFolder = nodeDict.get("internalFolder", None)
+    position = Position(*nodeDict.get("position", []))
 
     compatibilityIssue = None
 
@@ -956,11 +960,11 @@ def nodeFactory(nodeDict, name=None):
 
     # no compatibility issues: instantiate a Node
     if compatibilityIssue is None:
-        n = Node(nodeType, **inputs)
+        n = Node(nodeType, position, **inputs)
     # otherwise, instantiate a CompatibilityNode
     else:
         logging.warning("Compatibility issue detected for node '{}': {}".format(name, compatibilityIssue.name))
-        n = CompatibilityNode(nodeType, nodeDict, compatibilityIssue)
+        n = CompatibilityNode(nodeType, nodeDict, position, compatibilityIssue)
         # retro-compatibility: no internal folder saved
         # can't spawn meaningful CompatibilityNode with precomputed outputs
         # => automatically try to perform node upgrade

--- a/meshroom/ui/commands.py
+++ b/meshroom/ui/commands.py
@@ -149,14 +149,14 @@ class DuplicateNodeCommand(GraphCommand):
         srcNode = self.graph.node(self.srcNodeName)
 
         if self.duplicateFollowingNodes:
-            duplicates = self.graph.duplicateNodesFromNode(srcNode)
-            self.duplicates = [n.name for n in duplicates.values()]
+            duplicates = list(self.graph.duplicateNodesFromNode(srcNode).values())
             self.setText("Duplicate {} nodes from {}".format(len(duplicates), self.srcNodeName))
         else:
-            self.duplicates = [self.graph.duplicateNode(srcNode).name]
+            duplicates = [self.graph.duplicateNode(srcNode)]
             self.setText("Duplicate {}".format(self.srcNodeName))
 
-        return self.duplicates
+        self.duplicates = [n.name for n in duplicates]
+        return duplicates
 
     def undoImpl(self):
         # delete all the duplicated nodes
@@ -289,8 +289,8 @@ class UpgradeNodeCommand(GraphCommand):
     def redoImpl(self):
         if not self.graph.node(self.nodeName).canUpgrade:
             return False
-        inEdges, self.outEdges = self.graph.upgradeNode(self.nodeName)
-        return True
+        upgradedNode, inEdges, self.outEdges = self.graph.upgradeNode(self.nodeName)
+        return upgradedNode
 
     def undoImpl(self):
         # delete upgraded node

--- a/meshroom/ui/commands.py
+++ b/meshroom/ui/commands.py
@@ -258,6 +258,23 @@ class ListAttributeRemoveCommand(GraphCommand):
         listAttribute.insert(self.index, self.value)
 
 
+class MoveNodeCommand(GraphCommand):
+    """ Move a node to a given position. """
+    def __init__(self, graph, node, position, parent=None):
+        super(MoveNodeCommand, self).__init__(graph, parent)
+        self.nodeName = node.name
+        self.oldPosition = node.position
+        self.newPosition = position
+        self.setText("Move {}".format(self.nodeName))
+
+    def redoImpl(self):
+        self.graph.node(self.nodeName).position = self.newPosition
+        return True
+
+    def undoImpl(self):
+        self.graph.node(self.nodeName).position = self.oldPosition
+
+
 class UpgradeNodeCommand(GraphCommand):
     """
     Perform node upgrade on a CompatibilityNode.

--- a/meshroom/ui/commands.py
+++ b/meshroom/ui/commands.py
@@ -87,10 +87,11 @@ class GraphCommand(UndoCommand):
 
 
 class AddNodeCommand(GraphCommand):
-    def __init__(self, graph, nodeType, parent=None, **kwargs):
+    def __init__(self, graph, nodeType, position, parent=None, **kwargs):
         super(AddNodeCommand, self).__init__(graph, parent)
         self.nodeType = nodeType
         self.nodeName = None
+        self.position = position
         self.kwargs = kwargs
         # Serialize Attributes as link expressions
         for key, value in self.kwargs.items():
@@ -102,7 +103,7 @@ class AddNodeCommand(GraphCommand):
                          value[idx] = v.asLinkExpr()
 
     def redoImpl(self):
-        node = self.graph.addNewNode(self.nodeType, **self.kwargs)
+        node = self.graph.addNewNode(self.nodeType, position=self.position, **self.kwargs)
         self.nodeName = node.name
         self.setText("Add Node {}".format(self.nodeName))
         return node

--- a/meshroom/ui/components/edge.py
+++ b/meshroom/ui/components/edge.py
@@ -12,10 +12,12 @@ class MouseEvent(QObject):
         self._x = evt.x()
         self._y = evt.y()
         self._button = evt.button()
+        self._modifiers = evt.modifiers()
 
     x = Property(float, lambda self: self._x, constant=True)
     y = Property(float, lambda self: self._y, constant=True)
     button = Property(Qt.MouseButton, lambda self: self._button, constant=True)
+    modifiers = Property(int, lambda self: self._modifiers, constant=True)
 
 
 class EdgeMouseArea(QQuickItem):

--- a/meshroom/ui/graph.py
+++ b/meshroom/ui/graph.py
@@ -252,6 +252,19 @@ class UIGraph(QObject):
         """
         return self.push(commands.AddNodeCommand(self._graph, nodeType, **kwargs))
 
+    @Slot(Node, QPoint)
+    def moveNode(self, node, position):
+        """
+        Move 'node' to the given 'position'.
+
+        Args:
+            node (Node): the node to move
+            position (QPoint): the target position
+        """
+        if isinstance(position, QPoint):
+            position = Position(position.x(), position.y())
+        self.push(commands.MoveNodeCommand(self._graph, node, position))
+
     @Slot(Node)
     def removeNode(self, node):
         self.push(commands.RemoveNodeCommand(self._graph, node))

--- a/meshroom/ui/graph.py
+++ b/meshroom/ui/graph.py
@@ -211,6 +211,10 @@ class UIGraph(QObject):
         self._graph = g
         self._graph.updated.connect(self.onGraphUpdated)
         self._graph.update()
+        # perform auto-layout if graph does not provide nodes positions
+        if Graph.IO.Features.NodesPositions not in self._graph.fileFeatures:
+            self._layout.reset()
+            self._undoStack.clear()  # clear undo-stack after layout
         self.graphChanged.emit()
 
     def onGraphUpdated(self):

--- a/meshroom/ui/graph.py
+++ b/meshroom/ui/graph.py
@@ -417,10 +417,10 @@ class UIGraph(QObject):
         """
         return self.push(commands.DuplicateNodeCommand(self._graph, srcNode, duplicateFollowingNodes))
 
-    @Slot(CompatibilityNode)
+    @Slot(CompatibilityNode, result=Node)
     def upgradeNode(self, node):
         """ Upgrade a CompatibilityNode. """
-        self.push(commands.UpgradeNodeCommand(self._graph, node))
+        return self.push(commands.UpgradeNodeCommand(self._graph, node))
 
     @Slot()
     def upgradeAllNodes(self):

--- a/meshroom/ui/qml/GraphEditor/AttributeItemDelegate.qml
+++ b/meshroom/ui/qml/GraphEditor/AttributeItemDelegate.qml
@@ -142,6 +142,10 @@ RowLayout {
                     setTextFieldAttribute(text)
                     root.forceActiveFocus()
                 }
+                Component.onDestruction: {
+                    if(activeFocus)
+                        setTextFieldAttribute(text)
+                }
                 DropArea {
                     enabled: root.editable
                     anchors.fill: parent
@@ -209,6 +213,10 @@ RowLayout {
                     validator: attribute.type == "FloatParam" ? doubleValidator : intValidator
                     onEditingFinished: setTextFieldAttribute(text)
                     onAccepted: setTextFieldAttribute(text)
+                    Component.onDestruction: {
+                        if(activeFocus)
+                            setTextFieldAttribute(text)
+                    }
                 }
 
                 Loader {

--- a/meshroom/ui/qml/GraphEditor/Edge.qml
+++ b/meshroom/ui/qml/GraphEditor/Edge.qml
@@ -60,7 +60,7 @@ Shape {
         anchors.fill: parent
         curveScale: cubic.curveScale
         acceptedButtons: Qt.LeftButton | Qt.RightButton
-        thickness: root.thickness + 2
+        thickness: root.thickness + 4
         onPressed: root.pressed(arguments[0])   // can't get named args, use arguments array
         onReleased: root.released(arguments[0])
     }

--- a/meshroom/ui/qml/GraphEditor/GraphEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/GraphEditor.qml
@@ -92,7 +92,10 @@ Item {
         }
 
         onPressed: {
-            if(mouse.button & Qt.MiddleButton || (mouse.button & Qt.LeftButton && mouse.modifiers & Qt.ControlModifier))
+            if(mouse.button == Qt.LeftButton)
+                selectNode(null)
+
+            if(mouse.button == Qt.MiddleButton || (mouse.button & Qt.LeftButton && mouse.modifiers & Qt.ControlModifier))
                 drag.target = draggable // start drag
         }
         onReleased: {
@@ -106,7 +109,7 @@ Item {
         }
 
         onClicked: {
-            if(mouse.button & Qt.RightButton)
+            if(mouse.button == Qt.RightButton)
             {
                 // store mouse click position in 'draggable' coordinates as new node spawn position
                 newNodeMenu.spawnPosition = mouseArea.mapToItem(draggable, mouse.x, mouse.y)
@@ -310,13 +313,11 @@ Item {
                     onAttributePinDeleted: unregisterAttributePin(attribute, pin)
 
                     onPressed: {
-                        if(mouse.modifiers & Qt.AltModifier)
+                        selectNode(node)
+
+                        if(mouse.button == Qt.LeftButton && mouse.modifiers & Qt.AltModifier)
                         {
                             duplicateNode(node, true)
-                        }
-                        else
-                        {
-                            selectNode(node)
                         }
                         if(mouse.button == Qt.RightButton)
                         {

--- a/meshroom/ui/qml/GraphEditor/GraphEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/GraphEditor.qml
@@ -296,11 +296,11 @@ Item {
 
                     Behavior on x {
                         enabled: animatePosition
-                        NumberAnimation {}
+                        NumberAnimation { duration: 100 }
                     }
                     Behavior on y {
                         enabled: animatePosition
-                        NumberAnimation {}
+                        NumberAnimation { duration: 100 }
                     }
                 }
             }

--- a/meshroom/ui/qml/GraphEditor/GraphEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/GraphEditor.qml
@@ -182,6 +182,15 @@ Item {
             width: 1000
             height: 1000
 
+            Menu {
+                id: edgeMenu
+                property var currentEdge: null
+                MenuItem {
+                    text: "Remove"
+                    enabled: !root.readOnly
+                    onTriggered: uigraph.removeEdge(edgeMenu.currentEdge)
+                }
+            }
 
             // Edges
             Repeater {
@@ -196,16 +205,27 @@ Item {
                     property var srcAnchor: src.nodeItem.mapFromItem(src, src.edgeAnchorPos.x, src.edgeAnchorPos.y)
                     property var dstAnchor: dst.nodeItem.mapFromItem(dst, dst.edgeAnchorPos.x, dst.edgeAnchorPos.y)
 
+                    property bool inFocus: containsMouse || (edgeMenu.opened && edgeMenu.currentEdge == edge)
+
                     edge: object
-                    color: containsMouse && !readOnly ? activePalette.highlight : activePalette.text
+                    color: inFocus ? activePalette.highlight : activePalette.text
+                    thickness: inFocus ? 2 : 1
                     opacity: 0.7
                     point1x: src.nodeItem.x + srcAnchor.x
                     point1y: src.nodeItem.y + srcAnchor.y
                     point2x: dst.nodeItem.x + dstAnchor.x
                     point2y: dst.nodeItem.y + dstAnchor.y
                     onPressed: {
-                        if(!root.readOnly && event.button == Qt.RightButton)
-                            uigraph.removeEdge(edge)
+                        if(event.button == Qt.RightButton)
+                        {
+                            if(!root.readOnly && event.modifiers & Qt.AltModifier) {
+                                uigraph.removeEdge(edge)
+                            }
+                            else {
+                                edgeMenu.currentEdge = edge
+                                edgeMenu.popup()
+                            }
+                        }
                     }
                 }
             }

--- a/meshroom/ui/qml/GraphEditor/GraphEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/GraphEditor.qml
@@ -267,7 +267,8 @@ Item {
                     node: object
                     width: uigraph.layout.nodeWidth
                     readOnly: root.readOnly
-                    baseColor: root.selectedNode == node ? Qt.lighter(defaultColor, 1.2) : defaultColor
+                    selected: root.selectedNode == node
+                    onSelectedChanged: if(selected) forceActiveFocus()
 
                     onAttributePinCreated: registerAttributePin(attribute, pin)
                     onAttributePinDeleted: unregisterAttributePin(attribute, pin)

--- a/meshroom/ui/qml/GraphEditor/GraphEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/GraphEditor.qml
@@ -1,6 +1,8 @@
 import QtQuick 2.7
 import QtQuick.Controls 2.3
 import QtQuick.Layouts 1.3
+import Controls 1.0
+import MaterialIcons 2.2
 
 /**
   A component displaying a Graph (nodes, attributes and edges).
@@ -345,25 +347,58 @@ Item {
         }
     }
 
-    Row {
+    // Toolbar
+    FloatingPane {
+        padding: 2
         anchors.bottom: parent.bottom
+        RowLayout {
+            spacing: 4
+            // Fit
+            MaterialToolButton {
+                text: MaterialIcons.fullscreen
+                ToolTip.text: "Fit"
+                onClicked: root.fit()
+            }
+            // Auto-Layout
+            MaterialToolButton {
+                text: MaterialIcons.linear_scale
+                ToolTip.text: "Auto-Layout"
+                onClicked: uigraph.layout.reset()
+            }
 
-        Button {
-            text: "Fit"
-            onClicked: root.fit()
-            z: 10
-        }
-
-        Button {
-            text: "Layout"
-            onClicked: uigraph.layout.reset()
-            z: 10
-        }
-        ComboBox {
-            model: ['Min Depth', 'Max Depth']
-            currentIndex: uigraph.layout.depthMode
-            onActivated: {
-                uigraph.layout.depthMode = currentIndex
+            // Separator
+            Rectangle {
+                Layout.fillHeight: true
+                Layout.margins: 2
+                implicitWidth: 1
+                color: activePalette.window
+            }
+            // Settings
+            MaterialToolButton {
+                text: MaterialIcons.settings
+                font.pointSize: 11
+                onClicked: menu.open()
+                Menu {
+                    id: menu
+                    y: -height
+                    padding: 4
+                    RowLayout {
+                        spacing: 2
+                        Label {
+                            padding: 2
+                            text: "Auto-Layout Depth:"
+                        }
+                        ComboBox {
+                            flat: true
+                            model: ['Minimum', 'Maximum']
+                            implicitWidth: 80
+                            currentIndex: uigraph.layout.depthMode
+                            onActivated: {
+                                uigraph.layout.depthMode = currentIndex
+                            }
+                        }
+                    }
+                }
             }
         }
     }

--- a/meshroom/ui/qml/GraphEditor/GraphEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/GraphEditor.qml
@@ -21,6 +21,16 @@ Item {
     signal workspaceClicked()
     signal nodeDoubleClicked(var node)
 
+    // trigger initial fit() after initialization
+    // (ensure GraphEditor has its final size)
+    Component.onCompleted: firstFitTimer.start()
+
+    Timer {
+        id: firstFitTimer
+        running: false
+        interval: 10
+        onTriggered: fit()
+    }
 
     clip: true
 
@@ -47,6 +57,12 @@ Item {
     function duplicateNode(node, duplicateFollowingNodes) {
         var nodes = uigraph.duplicateNode(node, duplicateFollowingNodes)
         selectNode(nodes[0])
+    }
+
+
+    Keys.onPressed: {
+        if(event.key === Qt.Key_F)
+            fit()
     }
 
     MouseArea {

--- a/meshroom/ui/qml/GraphEditor/Node.qml
+++ b/meshroom/ui/qml/GraphEditor/Node.qml
@@ -15,6 +15,7 @@ Item {
 
     signal pressed(var mouse)
     signal doubleClicked(var mouse)
+    signal moved(var position)
     signal attributePinCreated(var attribute, var pin)
     signal attributePinDeleted(var attribute, var pin)
 
@@ -23,14 +24,32 @@ Item {
 
     SystemPalette { id: activePalette }
 
+    // initialize position with node coordinates
+    x: root.node.x
+    y: root.node.y
+
+    Connections {
+        target: root.node
+        // update x,y when node position changes
+        onPositionChanged: {
+            root.x = root.node.x
+            root.y = root.node.y
+        }
+    }
+
     MouseArea {
         anchors.fill: parent
         drag.target: parent
-        drag.threshold: 0
+        // small drag threshold to avoid moving the node by mistake
+        drag.threshold: 2
         hoverEnabled: true
         acceptedButtons: Qt.LeftButton | Qt.RightButton
         onPressed: root.pressed(mouse)
         onDoubleClicked: root.doubleClicked(mouse)
+        drag.onActiveChanged: {
+            if(!drag.active)
+                root.moved(Qt.point(root.x, root.y))
+        }
     }
 
     Rectangle {

--- a/meshroom/ui/qml/GraphEditor/Node.qml
+++ b/meshroom/ui/qml/GraphEditor/Node.qml
@@ -106,6 +106,7 @@ Item {
             Column {
                 id: inputs
                 width: parent.width / 2
+                spacing: 1
                 Repeater {
                     model: node.attributes
                     delegate: Loader {
@@ -120,6 +121,7 @@ Item {
                             readOnly: root.readOnly
                             Component.onCompleted: attributePinCreated(attribute, inPin)
                             Component.onDestruction: attributePinDeleted(attribute, inPin)
+                            onPressed: root.pressed(mouse)
                             onChildPinCreated: attributePinCreated(childAttribute, inPin)
                             onChildPinDeleted: attributePinDeleted(childAttribute, inPin)
                         }
@@ -130,6 +132,7 @@ Item {
                 id: outputs
                 width: parent.width / 2
                 anchors.right: parent.right
+                spacing: 1
                 Repeater {
                     model: node.attributes
 
@@ -143,7 +146,9 @@ Item {
                             nodeItem: root
                             attribute: object
                             readOnly: root.readOnly
+                            onPressed: root.pressed(mouse)
                             Component.onCompleted: attributePinCreated(object, outPin)
+                            Component.onDestruction: attributePinDeleted(attribute, outPin)
                         }
                     }
                 }

--- a/meshroom/ui/qml/GraphEditor/Node.qml
+++ b/meshroom/ui/qml/GraphEditor/Node.qml
@@ -12,6 +12,7 @@ Item {
     property color shadowColor: "black"
     readonly property bool isCompatibilityNode: node.hasOwnProperty("compatibilityIssue")
     readonly property color defaultColor: isCompatibilityNode ? "#444" : "#607D8B"
+    property bool selected: false
 
     signal pressed(var mouse)
     signal doubleClicked(var mouse)
@@ -50,6 +51,17 @@ Item {
             if(!drag.active)
                 root.moved(Qt.point(root.x, root.y))
         }
+    }
+
+    // Selection border
+    Rectangle {
+        anchors.fill: parent
+        anchors.margins: -border.width
+        visible: root.selected
+        border.width: 2.5
+        border.color: activePalette.highlight
+        opacity: 0.9
+        color: "transparent"
     }
 
     Rectangle {

--- a/meshroom/ui/qml/LiveSfmView.qml
+++ b/meshroom/ui/qml/LiveSfmView.qml
@@ -13,8 +13,6 @@ Panel {
     property variant reconstruction
     readonly property variant liveSfmManager: reconstruction.liveSfmManager
 
-    signal requestGraphAutoLayout()
-
     title: "Live Reconstruction"
     icon: Label {
         text: MaterialIcons.linked_camera;

--- a/meshroom/ui/qml/MaterialIcons/MaterialToolButton.qml
+++ b/meshroom/ui/qml/MaterialIcons/MaterialToolButton.qml
@@ -1,0 +1,15 @@
+import QtQuick 2.9
+import QtQuick.Controls 2.3
+
+
+/**
+ * MaterialToolButton is a standard ToolButton using MaterialIcons font.
+ * It also shows up its tooltip when hovered.
+ */
+ToolButton {
+    font.family: MaterialIcons.fontFamily
+    padding: 4
+    font.pointSize: 13
+    ToolTip.visible: ToolTip.text && hovered
+    ToolTip.delay: 100
+}

--- a/meshroom/ui/qml/MaterialIcons/qmldir
+++ b/meshroom/ui/qml/MaterialIcons/qmldir
@@ -1,2 +1,3 @@
 module MaterialIcons
 singleton MaterialIcons 2.2 MaterialIcons.qml
+MaterialToolButton 2.2 MaterialToolButton.qml

--- a/meshroom/ui/qml/WorkspaceView.qml
+++ b/meshroom/ui/qml/WorkspaceView.qml
@@ -24,7 +24,6 @@ Item {
     implicitWidth: 300
     implicitHeight: 400
 
-    signal requestGraphAutoLayout()
 
     // Load a 3D media file in the 3D viewer
     function load3DMedia(filepath)
@@ -79,7 +78,6 @@ Item {
                 reconstruction: root.reconstruction
                 Layout.fillWidth: true
                 Layout.preferredHeight: childrenRect.height
-                onRequestGraphAutoLayout: graphEditor.doAutoLayout()
             }
         }
         Panel {

--- a/meshroom/ui/qml/main.qml
+++ b/meshroom/ui/qml/main.qml
@@ -322,6 +322,8 @@ ApplicationWindow {
             // open CompatibilityManager after file loading if any issue is detected
             if(compatibilityManager.issueCount)
                 compatibilityManager.open()
+            // trigger fit to visualize all nodes
+            graphEditor.fit()
         }
 
         onInfo: createDialog(dialogsFactory.info, arguments[0])

--- a/meshroom/ui/qml/main.qml
+++ b/meshroom/ui/qml/main.qml
@@ -130,7 +130,6 @@ ApplicationWindow {
         nameFilters: ["Meshroom Graphs (*.mg)"]
         onAccepted: {
             _reconstruction.loadUrl(file.toString())
-            graphEditor.doAutoLayout()
         }
     }
 
@@ -209,7 +208,6 @@ ApplicationWindow {
     CompatibilityManager {
         id: compatibilityManager
         uigraph: _reconstruction
-        onUpgradeDone: graphEditor.doAutoLayout()
     }
 
     Action {
@@ -242,7 +240,7 @@ ApplicationWindow {
             title: "File"
             Action {
                 text: "New"
-                onTriggered: ensureSaved(function() { _reconstruction.new(); graphEditor.doAutoLayout() })
+                onTriggered: ensureSaved(function() { _reconstruction.new() })
             }
             Action {
                 text: "Open"
@@ -309,12 +307,6 @@ ApplicationWindow {
 
     Connections {
         target: _reconstruction
-        // Request graph auto-layout when an augmentation step is added for readability
-        onSfmAugmented: graphEditor.doAutoLayout(_reconstruction.graph.nodes.indexOf(arguments[0]),
-                                                 _reconstruction.graph.nodes.indexOf(arguments[1]),
-                                                 0,
-                                                 graphEditor.boundingBox().height + graphEditor.gridSpacing
-                                                 )
 
         // Bind messages to DialogsFactory
         function createDialog(func, message)
@@ -429,7 +421,6 @@ ApplicationWindow {
                 Layout.minimumHeight: 50
                 reconstruction: _reconstruction
                 readOnly: _reconstruction.computing
-                onRequestGraphAutoLayout: graphEditor.doAutoLayout()
             }
         }
 
@@ -489,11 +480,8 @@ ApplicationWindow {
                                 readOnly: _reconstruction.computing
 
                                 onUpgradeRequest: {
-                                    var delegate = graphEditor.nodeDelegate(node.name)
-                                    var posX = delegate.x
-                                    var posY = delegate.y
-                                    _reconstruction.upgradeNode(node)
-                                    graphEditor.moveNode(node.name, posX, posY)
+                                    var n = _reconstruction.upgradeNode(node)
+                                    graphEditor.selectNode(n)
                                 }
                             }
                         }

--- a/meshroom/ui/qml/main.qml
+++ b/meshroom/ui/qml/main.qml
@@ -440,13 +440,16 @@ ApplicationWindow {
                 Item {
                     Layout.fillHeight: true
                     Layout.fillWidth: true
-                    Layout.margins: 10
+                    Layout.margins: 2
+
                     GraphEditor {
                         id: graphEditor
+
                         anchors.fill: parent
                         uigraph: _reconstruction
                         nodeTypesModel: _nodeTypes
                         readOnly: _reconstruction.computing
+
                         onNodeDoubleClicked: {
                             if(node.nodeType == "StructureFromMotion")
                             {

--- a/meshroom/ui/reconstruction.py
+++ b/meshroom/ui/reconstruction.py
@@ -200,13 +200,16 @@ class Reconstruction(UIGraph):
                     "Open it with the corresponding version of Meshroom to recover your data."
                 ))
         except Exception as e:
+            import traceback
+            trace = traceback.format_exc()
             self.error.emit(
                 Message(
                     "Error while loading {}".format(os.path.basename(filepath)),
                     "An unexpected error has occurred",
-                    str(e)
+                    trace
                 )
             )
+            logging.error(trace)
 
     def onGraphChanged(self):
         """ React to the change of the internal graph. """


### PR DESCRIPTION
This PR adds nodes move operations to the undo stack and save nodes positions in the project file. This allows to restore nodes positions when loading a project or whenever an operation recreates a deleted node on "undo".
It also improves GraphEditor UX regarding node selection, visual feedbacks and attributes connections.

- [x] [core] introduce position property on Nodes
- [x] [core][io] add "position" field to serialized node data
- [x] [core] expose available features given a Meshroom file version
- [x] [ui] add commands to include Nodes movements in the undo stack
- [x] [ui] GraphLayout: move graph layout management to Python
- [x] [ui] use GraphLayout from Python after nodes duplication/sfm augmentation
- [x] [ui] GraphEditor UI improvements
