### PR TITLE
GraphLayout: fix bouding box computation

### DIFF
--- a/meshroom/ui/graph.py
+++ b/meshroom/ui/graph.py
@@ -154,7 +154,7 @@ class GraphLayout(QObject):
         if nodes is None:
             nodes = self.graph.nodes.values()
         first = nodes[0]
-        bbox = [first.x, first.y, 1, 1]
+        bbox = [first.x, first.y, first.x + self._nodeWidth, first.y + self._nodeHeight]
         for n in nodes:
             bbox[0] = min(bbox[0], n.x)
             bbox[1] = min(bbox[1], n.y)

--- a/meshroom/ui/qml/GraphEditor/GraphEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/GraphEditor.qml
@@ -415,7 +415,7 @@ Item {
     function boundingBox()
     {
         var first = nodeRepeater.itemAt(0)
-        var bbox = Qt.rect(first.x, first.y, 1, 1)
+        var bbox = Qt.rect(first.x, first.y, first.x + first.width, first.y + first.height)
         for(var i=0; i<root.graph.nodes.count; ++i) {
             var item = nodeRepeater.itemAt(i)
             bbox.x = Math.min(bbox.x, item.x)


### PR DESCRIPTION
Fix incorrectly initialized width and height for graph bounding box.