### PR TITLE
Travis CI: Add flake8 to the testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,13 @@ python:
 
 install:
   - "pip install -r requirements.txt -r dev_requirements.txt --timeout 45"
+  - pip install flake8
+
+before_script:
+  # stop the build if there are Python syntax errors or undefined names
+  - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+  # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
+  - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 
 script:
   - "pytest tests/"

--- a/meshroom/core/desc.py
+++ b/meshroom/core/desc.py
@@ -5,7 +5,6 @@ import collections
 import math
 import os
 import psutil
-import sys
 
 
 class Attribute(BaseObject):
@@ -121,9 +120,10 @@ class IntParam(Param):
 
     def validateValue(self, value):
         # handle unsigned int values that are translated to int by shiboken and may overflow
-        longInt = int if sys.version_info > (3,) else long
         try:
-            return longInt(value)
+            return long(value)  # Python 2
+        except NameError:
+            return int(value)   # Python 3
         except:
             raise ValueError('IntParam only supports int value (param:{}, value:{}, type:{})'.format(self.name, value, type(value)))
 


### PR DESCRIPTION
Add http://flake8.pycqa.org tests to look for Python syntax errors and undefined names

E901,E999,F821,F822,F823 are the "showstopper" flake8 issues that can halt the runtime with a SyntaxError, NameError, etc. Most [other flake8 issues](https://travis-ci.org/alicevision/meshroom/jobs/414794287#L479) are merely "style violations" -- useful for readability but they do not effect runtime safety.

    F821: undefined name name
    F822: undefined name name in __all__
    F823: local variable name referenced before assignment
    E901: SyntaxError or IndentationError
    E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree