### PR TITLE
Bump to PySide2 5.11.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # runtime
 psutil
 enum34;python_version<"3.4"
-PySide2==5.11.0
+PySide2==5.11.1
 markdown==2.6.11


### PR DESCRIPTION
Fix #215 
Update to the latest PySide2 version available.

- [X] make Meshroom compatible with Python 3.7 on Windows