### PR TITLE
Multi-platform monospace display in Log view

### DIFF
--- a/meshroom/ui/qml/GraphEditor/NodeLog.qml
+++ b/meshroom/ui/qml/GraphEditor/NodeLog.qml
@@ -178,7 +178,7 @@ FocusScope {
                         selectByMouse: true
                         selectByKeyboard: true
                         persistentSelection: true
-                        font.family: "Monospace"
+                        font.family: "Monospace, Consolas, Monaco"
                     }
                 }
             }

--- a/meshroom/ui/qml/GraphEditor/NodeLog.qml
+++ b/meshroom/ui/qml/GraphEditor/NodeLog.qml
@@ -87,8 +87,9 @@ FocusScope {
                 property string currentFile: chunksLV.currentChunk ? chunksLV.currentChunk[currentItem.fileProperty] : ""
                 property string lastLoadedFile
                 property date lastModTime
-                onCurrentFileChanged: if(visible) loadCurrentFile(false)
-                onVisibleChanged: loadCurrentFile()
+                onCurrentFileChanged: if(visible) loadCurrentFile()
+                onVisibleChanged: if(visible) loadCurrentFile()
+
 
                 TabButton {
                     property string fileProperty: "logFile"
@@ -197,6 +198,8 @@ FocusScope {
 
     function loadCurrentFile(keepCursorPosition)
     {
+        if(keepCursorPosition == undefined)
+            keepCursorPosition = false
         var xhr = new XMLHttpRequest;
         xhr.open("GET", Filepath.stringToUrl(fileSelector.currentFile));
         xhr.onreadystatechange = function() {


### PR DESCRIPTION
Fix #219 

Add monospaced system font families for all platforms.

- [x] fix monospace display on platforms other than Linux
- [x] avoid loading current file if Log view is not visible