### PR TITLE
FeatureExtraction: don't force CPU extraction by default

### DIFF
--- a/meshroom/nodes/aliceVision/FeatureExtraction.py
+++ b/meshroom/nodes/aliceVision/FeatureExtraction.py
@@ -1,4 +1,4 @@
-__version__ = "1.0"
+__version__ = "1.1"
 
 from meshroom.core import desc
 
@@ -40,7 +40,7 @@ class FeatureExtraction(desc.CommandLineNode):
             name='forceCpuExtraction',
             label='Force CPU Extraction',
             description='Use only CPU feature extraction.',
-            value=True,
+            value=False,
             uid=[],
         ),
         desc.ChoiceParam(


### PR DESCRIPTION
Use GPU feature extraction if available. Bump node version to 1.1 (no incompatibilities).