### PR TITLE
Add intrinsic locked option in CameraInit node

### DIFF
--- a/meshroom/core/desc.py
+++ b/meshroom/core/desc.py
@@ -106,7 +106,7 @@ class BoolParam(Param):
 
     def validateValue(self, value):
         try:
-            return bool(value)
+            return bool(int(value)) # int cast is useful to handle string values ('0', '1')
         except:
             raise ValueError('BoolParam only supports bool value (param:{}, value:{}, type:{})'.format(self.name, value, type(value)))
 

--- a/meshroom/nodes/aliceVision/CameraInit.py
+++ b/meshroom/nodes/aliceVision/CameraInit.py
@@ -1,4 +1,4 @@
-__version__ = "1.0"
+__version__ = "2.0"
 
 import os
 import json
@@ -40,6 +40,7 @@ Intrinsic = [
             label="Distortion Params",
             description="Distortion Parameters",
         ),
+    desc.BoolParam(name='locked', label='Locked', description='Whether Intrinsic is locked.', value=False, uid=[0]),
 ]
 
 

--- a/meshroom/nodes/aliceVision/CameraInit.py
+++ b/meshroom/nodes/aliceVision/CameraInit.py
@@ -40,7 +40,9 @@ Intrinsic = [
             label="Distortion Params",
             description="Distortion Parameters",
         ),
-    desc.BoolParam(name='locked', label='Locked', description='Whether Intrinsic is locked.', value=False, uid=[0]),
+    desc.BoolParam(name='locked', label='Locked',
+                   description='If the camera has been calibrated, the internal camera parameters (intrinsics) can be locked. It should improve robustness and speedup the reconstruction.',
+                   value=False, uid=[0]),
 ]
 
 


### PR DESCRIPTION
## Features list

- [x] `BoolParam` add int cast to handle string values ('0', '1')
- [x]  Add per intrinsic param `locked` in `CameraInit` node

#### use aliceVision branch `dev_lockedIntrinsic`
See alicevision/AliceVision/pull/540