### PR TITLE
[nodes] `convertSfMFormat` users can now specify a view white list

### DIFF
--- a/meshroom/nodes/aliceVision/ConvertSfMFormat.py
+++ b/meshroom/nodes/aliceVision/ConvertSfMFormat.py
@@ -5,7 +5,8 @@ from meshroom.core import desc
 
 class ConvertSfMFormat(desc.CommandLineNode):
     commandLine = 'aliceVision_convertSfMFormat {allParams}'
-
+    size = desc.DynamicNodeSize('input')
+    
     inputs = [
         desc.File(
             name='input',
@@ -33,6 +34,18 @@ class ConvertSfMFormat(desc.CommandLineNode):
             exclusive=False,
             uid=[0],
             joinChar=',',
+        ),
+        desc.ListAttribute(
+            elementDesc=desc.File(
+                name="imageId",
+                label="Image id",
+                description="",
+                value="",
+                uid=[0],
+            ),
+            name="imageWhiteList",
+            label="Image White List",
+            description='image white list (uids or image paths).',
         ),
         desc.BoolParam(
             name='views',


### PR DESCRIPTION
- [x] Add `imageWhiteList` in node `convertSfMFormat`
#### use aliceVision branch `dev_convertSfMWhiteList`
See alicevision/AliceVision/pull/550