### PR TITLE
[CLI] Add possibility to run pipeline from a .sfm file

### DIFF
--- a/bin/meshroom_photogrammetry
+++ b/bin/meshroom_photogrammetry
@@ -1,8 +1,5 @@
 #!/usr/bin/env python
 import argparse
-import json
-import os
-import io
 
 import meshroom
 meshroom.setupEnvironment()
@@ -49,8 +46,8 @@ if not args.input and not args.inputImages:
 
 if  args.input and os.path.isfile(args.input):
         views, intrinsics = readSfMData(args.input)
-        print(views)
-        print(intrinsics)
+        # print(views)
+        # print(intrinsics)
 
         graph = multiview.photogrammetry(inputViewpoints=views, inputIntrinsics=intrinsics, inputImages=args.inputImages, output=args.output)
 else:

--- a/bin/meshroom_photogrammetry
+++ b/bin/meshroom_photogrammetry
@@ -1,5 +1,8 @@
 #!/usr/bin/env python
 import argparse
+import json
+import os
+import io
 
 import meshroom
 meshroom.setupEnvironment()
@@ -43,8 +46,34 @@ if not args.input and not args.inputImages:
     print('Nothing to compute. You need to set --input or --inputImages.')
     exit(1)
 
-graph = multiview.photogrammetry(inputFolder=args.input, inputImages=args.inputImages, output=args.output)
-graph.findNode('DepthMap_1').downscale.value = args.scale
+if  args.input and os.path.isfile(args.input):
+    # with open(args.input) as jsonFile:
+    with io.open(args.input, 'r', encoding='utf-8', errors='ignore') as jsonFile:
+        fileData = json.load(jsonFile)
+        intrinsics = fileData.get("intrinsics", [])
+        print(intrinsics)
+        intrinsics = [{k: v for k, v in item.items()} for item in fileData.get("intrinsics", [])]
+        for intrinsic in intrinsics:
+            pp = intrinsic['principalPoint']
+            intrinsic['principalPoint'] = {}
+            intrinsic['principalPoint']['x'] = pp[0]
+            intrinsic['principalPoint']['y'] = pp[1]
+            # convert empty string distortionParams (i.e: Pinhole model) to empty list
+            if intrinsic['distortionParams'] == '':
+                intrinsic['distortionParams'] = list()
+        print(intrinsics)
+
+        # views = fileData.get("views", [])
+        views = [{k: v for k, v in item.items()} for item in fileData.get("views", [])]
+        for view in views:
+            view['metadata'] = json.dumps(view['metadata'])  # convert metadata to string
+        # print(views)
+
+        graph = multiview.photogrammetry(inputViewpoints=views, inputIntrinsics=intrinsics, inputImages=args.inputImages, output=args.output)
+        graph.findNode('DepthMap_1').downscale.value = args.scale
+else:
+    graph = multiview.photogrammetry(inputFolder=args.input, inputImages=args.inputImages, output=args.output)
+    graph.findNode('DepthMap_1').downscale.value = args.scale
 
 if args.save:
     graph.save(args.save)
@@ -62,4 +91,3 @@ if args.toNode:
     toNodes = graph.findNodes(args.toNode)
 
 meshroom.core.graph.executeGraph(graph, toNodes=toNodes, forceCompute=args.forceCompute, forceStatus=args.forceStatus)
-

--- a/bin/meshroom_photogrammetry
+++ b/bin/meshroom_photogrammetry
@@ -53,10 +53,10 @@ if  args.input and os.path.isfile(args.input):
         print(intrinsics)
 
         graph = multiview.photogrammetry(inputViewpoints=views, inputIntrinsics=intrinsics, inputImages=args.inputImages, output=args.output)
-        graph.findNode('DepthMap_1').downscale.value = args.scale
 else:
     graph = multiview.photogrammetry(inputFolder=args.input, inputImages=args.inputImages, output=args.output)
-    graph.findNode('DepthMap_1').downscale.value = args.scale
+
+graph.findNode('DepthMap_1').downscale.value = args.scale
 
 if args.save:
     graph.save(args.save)

--- a/bin/meshroom_photogrammetry
+++ b/bin/meshroom_photogrammetry
@@ -8,6 +8,7 @@ import meshroom
 meshroom.setupEnvironment()
 
 import meshroom.core.graph
+from meshroom.nodes.aliceVision.CameraInit import readSfMData
 from meshroom import multiview
 
 parser = argparse.ArgumentParser(description='Launch the full photogrammetry pipeline.')
@@ -47,27 +48,9 @@ if not args.input and not args.inputImages:
     exit(1)
 
 if  args.input and os.path.isfile(args.input):
-    # with open(args.input) as jsonFile:
-    with io.open(args.input, 'r', encoding='utf-8', errors='ignore') as jsonFile:
-        fileData = json.load(jsonFile)
-        intrinsics = fileData.get("intrinsics", [])
+        views, intrinsics = readSfMData(args.input)
+        print(views)
         print(intrinsics)
-        intrinsics = [{k: v for k, v in item.items()} for item in fileData.get("intrinsics", [])]
-        for intrinsic in intrinsics:
-            pp = intrinsic['principalPoint']
-            intrinsic['principalPoint'] = {}
-            intrinsic['principalPoint']['x'] = pp[0]
-            intrinsic['principalPoint']['y'] = pp[1]
-            # convert empty string distortionParams (i.e: Pinhole model) to empty list
-            if intrinsic['distortionParams'] == '':
-                intrinsic['distortionParams'] = list()
-        print(intrinsics)
-
-        # views = fileData.get("views", [])
-        views = [{k: v for k, v in item.items()} for item in fileData.get("views", [])]
-        for view in views:
-            view['metadata'] = json.dumps(view['metadata'])  # convert metadata to string
-        # print(views)
 
         graph = multiview.photogrammetry(inputViewpoints=views, inputIntrinsics=intrinsics, inputImages=args.inputImages, output=args.output)
         graph.findNode('DepthMap_1').downscale.value = args.scale

--- a/meshroom/multiview.py
+++ b/meshroom/multiview.py
@@ -20,7 +20,7 @@ def findFiles(folder, patterns):
     return outFiles
 
 
-def photogrammetry(inputFolder='', inputImages=(), inputViewpoints=(), output=''):
+def photogrammetry(inputFolder='', inputImages=(), inputViewpoints=(), inputIntrinsics=(), output=''):
     """
     Create a new Graph with a complete photogrammetry pipeline.
 
@@ -44,6 +44,8 @@ def photogrammetry(inputFolder='', inputImages=(), inputViewpoints=(), output=''
             cameraInit.viewpoints.extend([{'path': image} for image in inputImages])
         if inputViewpoints:
             cameraInit.viewpoints.extend(inputViewpoints)
+        if inputIntrinsics:
+            cameraInit.intrinsics.extend(inputIntrinsics)
 
     if output:
         texturing = mvsNodes[-1]

--- a/meshroom/nodes/aliceVision/CameraInit.py
+++ b/meshroom/nodes/aliceVision/CameraInit.py
@@ -70,12 +70,12 @@ def readSfMData(sfmFile):
         # convert empty string distortionParams (i.e: Pinhole model) to empty list
         if intrinsic['distortionParams'] == '':
             intrinsic['distortionParams'] = list()
-    print('intrinsics:', intrinsics)
+
     viewsKeys = [v.name for v in Viewpoint]
     views = [{k: v for k, v in item.items() if k in viewsKeys} for item in data.get("views", [])]
     for view in views:
         view['metadata'] = json.dumps(view['metadata'])  # convert metadata to string
-    print('views:', views)
+
     return views, intrinsics
 
 class CameraInit(desc.CommandLineNode):

--- a/meshroom/nodes/aliceVision/CameraInit.py
+++ b/meshroom/nodes/aliceVision/CameraInit.py
@@ -45,6 +45,38 @@ Intrinsic = [
                    value=False, uid=[0]),
 ]
 
+def readSfMData(sfmFile):
+    """ Read views and intrinsics from a .sfm file
+
+    Args:
+        sfmFile: the .sfm file containing views and intrinsics
+
+    Returns:
+        The views and intrinsics of the .sfm as two separate lists
+    """
+    import io  # use io.open for Python2/3 compatibility (allow to specify encoding + errors handling)
+    # skip decoding errors to avoid potential exceptions due to non utf-8 characters in images metadata
+    with io.open(sfmFile, 'r', encoding='utf-8', errors='ignore') as f:
+        data = json.load(f)
+
+    intrinsicsKeys = [i.name for i in Intrinsic]
+
+    intrinsics = [{k: v for k, v in item.items() if k in intrinsicsKeys} for item in data.get("intrinsics", [])]
+    for intrinsic in intrinsics:
+        pp = intrinsic['principalPoint']
+        intrinsic['principalPoint'] = {}
+        intrinsic['principalPoint']['x'] = pp[0]
+        intrinsic['principalPoint']['y'] = pp[1]
+        # convert empty string distortionParams (i.e: Pinhole model) to empty list
+        if intrinsic['distortionParams'] == '':
+            intrinsic['distortionParams'] = list()
+    print('intrinsics:', intrinsics)
+    viewsKeys = [v.name for v in Viewpoint]
+    views = [{k: v for k, v in item.items() if k in viewsKeys} for item in data.get("views", [])]
+    for view in views:
+        view['metadata'] = json.dumps(view['metadata'])  # convert metadata to string
+    print('views:', views)
+    return views, intrinsics
 
 class CameraInit(desc.CommandLineNode):
     commandLine = 'aliceVision_cameraInit {allParams} --allowSingleView 1' # don't throw an error if there is only one image
@@ -134,28 +166,7 @@ class CameraInit(desc.CommandLineNode):
 
             # Reload result of aliceVision_cameraInit
             cameraInitSfM = node.output.value
-            import io  # use io.open for Python2/3 compatibility (allow to specify encoding + errors handling)
-            # skip decoding errors to avoid potential exceptions due to non utf-8 characters in images metadata
-            with io.open(cameraInitSfM, 'r', encoding='utf-8', errors='ignore') as f:
-                data = json.load(f)
-
-            intrinsicsKeys = [i.name for i in Intrinsic]
-            intrinsics = [{k: v for k, v in item.items() if k in intrinsicsKeys} for item in data.get("intrinsics", [])]
-            for intrinsic in intrinsics:
-                pp = intrinsic['principalPoint']
-                intrinsic['principalPoint'] = {}
-                intrinsic['principalPoint']['x'] = pp[0]
-                intrinsic['principalPoint']['y'] = pp[1]
-                # convert empty string distortionParams (i.e: Pinhole model) to empty list
-                if intrinsic['distortionParams'] == '':
-                    intrinsic['distortionParams'] = list()
-            # print('intrinsics:', intrinsics)
-            viewsKeys = [v.name for v in Viewpoint]
-            views = [{k: v for k, v in item.items() if k in viewsKeys} for item in data.get("views", [])]
-            for view in views:
-                view['metadata'] = json.dumps(view['metadata'])  # convert metadata to string
-            # print('views:', views)
-            return views, intrinsics
+            return readSfMData(cameraInitSfM)
 
         except Exception:
             raise
@@ -198,4 +209,3 @@ class CameraInit(desc.CommandLineNode):
     def processChunk(self, chunk):
         self.createViewpointsFile(chunk.node)
         desc.CommandLineNode.processChunk(self, chunk)
-

--- a/meshroom/nodes/aliceVision/StructureFromMotion.py
+++ b/meshroom/nodes/aliceVision/StructureFromMotion.py
@@ -169,13 +169,12 @@ class StructureFromMotion(desc.CommandLineNode):
             uid=[0],
         ),
         desc.BoolParam(
-            name='refineIntrinsics',
-            label='Refine intrinsic parameters.',
-            description='The intrinsics parameters of the cameras (focal length, \n'
-                        'principal point, distortion if any) are kept constant '
-                        'during the reconstruction.\n'
+            name='lockAllIntrinsics',
+            label='Force Lock of All Intrinsic Camera Parameters.',
+            description='Force to keep constant all the intrinsics parameters of the cameras (focal length, \n'
+                        'principal point, distortion if any) during the reconstruction.\n'
                         'This may be helpful if the input cameras are already fully calibrated.',
-            value=True,
+            value=False,
             uid=[0],
         ),
         desc.File(

--- a/meshroom/nodes/aliceVision/StructureFromMotion.py
+++ b/meshroom/nodes/aliceVision/StructureFromMotion.py
@@ -168,6 +168,16 @@ class StructureFromMotion(desc.CommandLineNode):
             value=True,
             uid=[0],
         ),
+        desc.BoolParam(
+            name='refineIntrinsics',
+            label='Refine intrinsic parameters.',
+            description='The intrinsics parameters of the cameras (focal length, \n'
+                        'principal point, distortion if any) are kept constant '
+                        'during the reconstruction.\n'
+                        'This may be helpful if the input cameras are already fully calibrated.',
+            value=True,
+            uid=[0],
+        ),
         desc.File(
             name='initialPairA',
             label='Initial Pair A',


### PR DESCRIPTION
* Allows to run the pipeline from a .sfm file, optionally containing the camera intrinsics
* exposes the refineIntrinsics parameter in sfm node to lock the camera intrinsics (eg the cameras have been already calibrated