### PR TITLE
Viewer3D: let QmlAlembic manage entities visibility

### DIFF
--- a/meshroom/ui/qml/Viewer3D/MediaLoader.qml
+++ b/meshroom/ui/qml/Viewer3D/MediaLoader.qml
@@ -93,12 +93,8 @@ import Utils 1.0
                     if(obj.status === SceneLoader.Ready) {
                         for(var i = 0; i < obj.pointClouds.length; ++i) {
                             vertexCount += Scene3DHelper.vertexCount(obj.pointClouds[i]);
-                            obj.pointClouds[i].enabled = Qt.binding(function() { return Viewer3DSettings.pointSize > 0; });
                         }
                         cameraCount = obj.spawnCameraSelectors();
-                        for(var i = 0; i < obj.cameras.length; ++i) {
-                            obj.cameras[i].enabled = Qt.binding(function() { return Viewer3DSettings.cameraScale > 0; });
-                        }
                     }
                     root.status = obj.status;
                 })


### PR DESCRIPTION
Bindings driving pointClouds/cameras 'enabled' property don't work properly here (at least for PySide2 < 5.11.2).
In https://github.com/alicevision/qmlAlembic/pull/11, QmlAlembic ensures entities are correctly hidden when their corresponding size/scale is set to 0; and therefore discard the need for those bindings.