### PR TITLE
Graph editor improvements

### DIFF
--- a/meshroom/core/graph.py
+++ b/meshroom/core/graph.py
@@ -1004,6 +1004,11 @@ class Graph(BaseObject):
         for node in self.nodes:
             node.clearSubmittedChunks()
 
+    @Slot(Node)
+    def clearDataFrom(self, startNode):
+        for node in self.nodesFromNode(startNode)[0]:
+            node.clearData()
+
     def iterChunksByStatus(self, status):
         """ Iterate over NodeChunks with the given status """
         for node in self.nodes:

--- a/meshroom/core/graph.py
+++ b/meshroom/core/graph.py
@@ -999,6 +999,7 @@ class Graph(BaseObject):
         for chunk in self.iterChunksByStatus(Status.RUNNING):
             chunk.stopProcess()
 
+    @Slot()
     def clearSubmittedNodes(self):
         """ Reset the status of already submitted nodes to Status.NONE """
         for node in self.nodes:

--- a/meshroom/ui/graph.py
+++ b/meshroom/ui/graph.py
@@ -390,6 +390,18 @@ class UIGraph(QObject):
     def removeNode(self, node):
         self.push(commands.RemoveNodeCommand(self._graph, node))
 
+    @Slot(Node)
+    def removeNodesFrom(self, startNode):
+        """
+        Remove all nodes starting from 'startNode' to graph leaves.
+        Args:
+            startNode (Node): the node to start from.
+        """
+        with self.groupedGraphModification("Remove Nodes from {}".format(startNode.name)):
+            # Perform nodes removal from leaves to start node so that edges
+            # can be re-created in correct order on redo.
+            [self.removeNode(node) for node in reversed(self._graph.nodesFromNode(startNode)[0])]
+
     @Slot(Attribute, Attribute)
     def addEdge(self, src, dst):
         if isinstance(dst, ListAttribute) and not isinstance(src, ListAttribute):

--- a/meshroom/ui/qml/Controls/SearchBar.qml
+++ b/meshroom/ui/qml/Controls/SearchBar.qml
@@ -1,0 +1,41 @@
+import QtQuick 2.9
+import QtQuick.Controls 2.3
+import QtQuick.Layouts 1.3
+import MaterialIcons 2.2
+
+
+/**
+ * Basic SearchBar component with an appropriate icon and a TextField.
+ */
+FocusScope {
+    property alias textField: field
+    property alias text: field.text
+
+    implicitHeight: childrenRect.height
+    Keys.forwardTo: [field]
+
+    function forceActiveFocus() {
+        field.forceActiveFocus()
+    }
+
+    function clear() {
+        field.clear()
+    }
+
+    RowLayout {
+        width: parent.width
+
+        MaterialLabel {
+            text: MaterialIcons.search
+        }
+
+        TextField {
+            id: field
+            focus: true
+            Layout.fillWidth: true
+            selectByMouse: true
+        }
+    }
+}
+
+

--- a/meshroom/ui/qml/Controls/qmldir
+++ b/meshroom/ui/qml/Controls/qmldir
@@ -4,3 +4,4 @@ FloatingPane 1.0 FloatingPane.qml
 Group 1.0 Group.qml
 MessageDialog 1.0 MessageDialog.qml
 Panel 1.0 Panel.qml
+SearchBar 1.0 SearchBar.qml

--- a/meshroom/ui/qml/GraphEditor/AttributeEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/AttributeEditor.qml
@@ -15,7 +15,7 @@ ListView {
     property int labelWidth: 180
 
     signal upgradeRequest()
-    signal attributeDoubleClicked(var attribute)
+    signal attributeDoubleClicked(var mouse, var attribute)
 
     implicitHeight: contentHeight
 
@@ -40,7 +40,7 @@ ListView {
                 readOnly: root.readOnly
                 labelWidth: root.labelWidth
                 attribute: object
-                onDoubleClicked: root.attributeDoubleClicked(attr)
+                onDoubleClicked: root.attributeDoubleClicked(mouse, attr)
             }
         }
     }

--- a/meshroom/ui/qml/GraphEditor/AttributeItemDelegate.qml
+++ b/meshroom/ui/qml/GraphEditor/AttributeItemDelegate.qml
@@ -18,7 +18,7 @@ RowLayout {
 
     readonly property bool editable: !attribute.isOutput && !attribute.isLink && !readOnly
 
-    signal doubleClicked(var attr)
+    signal doubleClicked(var mouse, var attr)
 
     spacing: 2
 
@@ -62,7 +62,7 @@ RowLayout {
                     anchors.fill: parent
                     hoverEnabled: true
                     acceptedButtons: Qt.AllButtons
-                    onDoubleClicked: root.doubleClicked(root.attribute)
+                    onDoubleClicked: root.doubleClicked(mouse, root.attribute)
 
                     property Component menuComp: Menu {
                         id: paramMenu

--- a/meshroom/ui/qml/GraphEditor/GraphEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/GraphEditor.qml
@@ -21,7 +21,7 @@ Item {
     // signals
     signal workspaceMoved()
     signal workspaceClicked()
-    signal nodeDoubleClicked(var node)
+    signal nodeDoubleClicked(var mouse, var node)
 
     // trigger initial fit() after initialization
     // (ensure GraphEditor has its final size)
@@ -409,7 +409,7 @@ Item {
                         }
                     }
 
-                    onDoubleClicked: root.nodeDoubleClicked(node)
+                    onDoubleClicked: root.nodeDoubleClicked(mouse, node)
 
                     onMoved: uigraph.moveNode(node, position)
 

--- a/meshroom/ui/qml/GraphEditor/GraphEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/GraphEditor.qml
@@ -2,6 +2,7 @@ import QtQuick 2.7
 import QtQuick.Controls 2.3
 import QtQuick.Layouts 1.3
 import Controls 1.0
+import Utils 1.0
 import MaterialIcons 2.2
 
 /**
@@ -274,7 +275,7 @@ Item {
                 }
                 MenuSeparator {}
                 MenuItem {
-                    text: "Duplicate"
+                    text: "Duplicate Node"
                     onTriggered: duplicateNode(nodeMenu.currentNode, false)
                 }
                 MenuItem {
@@ -283,14 +284,21 @@ Item {
                 }
                 MenuSeparator {}
                 MenuItem {
-                    text: "Clear Data"
-                    enabled: !root.readOnly
-                    onTriggered: nodeMenu.currentNode.clearData()
-                }
-                MenuItem {
                     text: "Delete Node"
                     enabled: !root.readOnly
                     onTriggered: uigraph.removeNode(nodeMenu.currentNode)
+                }
+                MenuItem {
+                    text: "Delete From Here"
+                    enabled: !root.readOnly
+                    onTriggered: uigraph.removeNodesFrom(nodeMenu.currentNode)
+                }
+                MenuSeparator {}
+                MenuItem {
+                    text: "Clear Data"
+                    palette.text: Colors.red
+                    enabled: !root.readOnly
+                    onTriggered: nodeMenu.currentNode.clearData()
                 }
             }
 
@@ -337,7 +345,12 @@ Item {
                     onEntered: uigraph.hoveredNode = node
                     onExited: uigraph.hoveredNode = null
 
-                    Keys.onDeletePressed: uigraph.removeNode(node)
+                    Keys.onDeletePressed: {
+                        if(event.modifiers == Qt.AltModifier)
+                            uigraph.removeNodesFrom(node)
+                        else
+                            uigraph.removeNode(node)
+                    }
 
                     Behavior on x {
                         enabled: animatePosition

--- a/meshroom/ui/qml/GraphEditor/GraphEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/GraphEditor.qml
@@ -142,18 +142,14 @@ Item {
                 if(visible) {
                     // when menu is shown,
                     // clear and give focus to the TextField filter
-                    filterTextField.clear()
-                    filterTextField.forceActiveFocus()
+                    searchBar.clear()
+                    searchBar.forceActiveFocus()
                 }
             }
 
-            TextField {
-                id: filterTextField
-                selectByMouse: true
+            SearchBar {
+                id: searchBar
                 width: parent.width
-                // ensure down arrow give focus to the first MenuItem
-                // (without this, we have to pressed the down key twice to do so)
-                Keys.onDownPressed: nextItemInFocusChain().forceActiveFocus()
             }
 
             Repeater {
@@ -164,24 +160,28 @@ Item {
                     id: menuItemDelegate
                     font.pointSize: 8
                     padding: 3
+
                     // Hide items that does not match the filter text
-                    visible: modelData.toLowerCase().indexOf(filterTextField.text.toLocaleLowerCase()) > -1
+                    visible: modelData.toLowerCase().indexOf(searchBar.text.toLowerCase()) > -1
+                    // Reset menu currentIndex if highlighted items gets filtered out
+                    onVisibleChanged: if(highlighted) newNodeMenu.currentIndex = 0
                     text: modelData
+                    // Forward key events to the search bar to continue typing seamlessly
+                    // even if this delegate took the activeFocus due to mouse hovering
+                    Keys.forwardTo: [searchBar.textField]
                     Keys.onPressed: {
+                        event.accepted = false;
                         switch(event.key)
                         {
                         case Qt.Key_Return:
                         case Qt.Key_Enter:
                             // create node on validation (Enter/Return keys)
-                            newNodeMenu.createNode(modelData)
-                            newNodeMenu.dismiss()
-                            break;
-                        case Qt.Key_Home:
-                            // give focus back to filter
-                            filterTextField.forceActiveFocus()
+                            newNodeMenu.createNode(modelData);
+                            newNodeMenu.close();
+                            event.accepted = true;
                             break;
                         default:
-                            break;
+                            searchBar.textField.forceActiveFocus();
                         }
                     }
                     // Create node on mouse click

--- a/meshroom/ui/qml/GraphEditor/GraphEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/GraphEditor.qml
@@ -264,6 +264,8 @@ Item {
                 MenuItem {
                     text: "Submit"
                     enabled: !root.readOnly && nodeMenu.canComputeNode
+                    visible: uigraph.canSubmit
+                    height: visible ? implicitHeight : 0
                     onTriggered: uigraph.submit(nodeMenu.currentNode)
                 }
                 MenuItem {

--- a/meshroom/ui/qml/GraphEditor/GraphEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/GraphEditor.qml
@@ -305,10 +305,53 @@ Item {
                 }
                 MenuSeparator {}
                 MenuItem {
-                    text: "Clear Data"
-                    palette.text: Colors.red
+                    text: "Delete Data" + (deleteFollowingButton.hovered ? " From Here" : "" ) + "..."
                     enabled: !root.readOnly
-                    onTriggered: nodeMenu.currentNode.clearData()
+
+                    function showConfirmationDialog(deleteFollowing) {
+                        var obj = deleteDataDialog.createObject(root,
+                                           {
+                                               "node": nodeMenu.currentNode,
+                                               "deleteFollowing": deleteFollowing
+                                           });
+                        obj.open()
+                        nodeMenu.close();
+                    }
+
+                    onTriggered: showConfirmationDialog(false)
+
+                    MaterialToolButton {
+                        id: deleteFollowingButton
+                        anchors { right: parent.right; rightMargin: parent.padding }
+                        height: parent.height
+                        text: MaterialIcons.fast_forward
+                        onClicked: parent.showConfirmationDialog(true)
+                    }
+
+                    // Confirmation dialog for node cache deletion
+                    Component {
+                        id: deleteDataDialog
+                        MessageDialog  {
+                            property var node
+                            property bool deleteFollowing: false
+
+                            focus: true
+                            modal: false
+                            header.visible: false
+
+                            text: "Delete Data computed by '" + node.label + (deleteFollowing ?  "' and following Nodes?" : "'?")
+                            helperText: "Warning: This operation can not be undone."
+                            standardButtons: Dialog.Yes | Dialog.Cancel
+
+                            onAccepted: {
+                                if(deleteFollowing)
+                                    graph.clearDataFrom(node);
+                                else
+                                    node.clearData();
+                            }
+                            onClosed: destroy()
+                        }
+                    }
                 }
             }
 

--- a/meshroom/ui/qml/GraphEditor/GraphEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/GraphEditor.qml
@@ -275,23 +275,33 @@ Item {
                 }
                 MenuSeparator {}
                 MenuItem {
-                    text: "Duplicate Node"
+                    text: "Duplicate Node" + (duplicateFollowingButton.hovered ? "s From Here" : "")
                     onTriggered: duplicateNode(nodeMenu.currentNode, false)
+                    MaterialToolButton {
+                        id: duplicateFollowingButton
+                        height: parent.height
+                        anchors { right: parent.right; rightMargin: parent.padding }
+                        text: MaterialIcons.fast_forward
+                        onClicked: {
+                            duplicateNode(nodeMenu.currentNode, true);
+                            nodeMenu.close();
+                        }
+                    }
                 }
                 MenuItem {
-                    text: "Duplicate From Here"
-                    onTriggered: duplicateNode(nodeMenu.currentNode, true)
-                }
-                MenuSeparator {}
-                MenuItem {
-                    text: "Delete Node"
+                    text: "Remove Node" + (removeFollowingButton.hovered ? "s From Here" : "")
                     enabled: !root.readOnly
                     onTriggered: uigraph.removeNode(nodeMenu.currentNode)
-                }
-                MenuItem {
-                    text: "Delete From Here"
-                    enabled: !root.readOnly
-                    onTriggered: uigraph.removeNodesFrom(nodeMenu.currentNode)
+                    MaterialToolButton {
+                        id: removeFollowingButton
+                        height: parent.height
+                        anchors { right: parent.right; rightMargin: parent.padding }
+                        text: MaterialIcons.fast_forward
+                        onClicked: {
+                            uigraph.removeNodesFrom(nodeMenu.currentNode);
+                            nodeMenu.close();
+                        }
+                    }
                 }
                 MenuSeparator {}
                 MenuItem {

--- a/meshroom/ui/qml/GraphEditor/GraphEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/GraphEditor.qml
@@ -82,6 +82,8 @@ Item {
         hoverEnabled: true
         acceptedButtons: Qt.LeftButton | Qt.RightButton | Qt.MiddleButton
         drag.threshold: 0
+        cursorShape: drag.active ? Qt.ClosedHandCursor : Qt.ArrowCursor
+
         onWheel: {
             var zoomFactor = wheel.angleDelta.y > 0 ? factor : 1/factor
             var scale = draggable.scale * zoomFactor

--- a/meshroom/ui/qml/GraphEditor/GraphEditorSettings.qml
+++ b/meshroom/ui/qml/GraphEditor/GraphEditorSettings.qml
@@ -8,4 +8,5 @@ import Qt.labs.settings 1.0
 Settings {
     category: 'GraphEditor'
     property bool showAdvancedAttributes: false
+    property bool lockOnCompute: true
 }

--- a/meshroom/ui/qml/GraphEditor/NodeEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/NodeEditor.qml
@@ -16,7 +16,7 @@ Panel {
     property bool readOnly: false
     property bool isCompatibilityNode: node && node.compatibilityIssue !== undefined
 
-    signal attributeDoubleClicked(var attribute)
+    signal attributeDoubleClicked(var mouse, var attribute)
     signal upgradeRequest()
 
     title: "Node" + (node !== null ? " - <b>" + node.label + "</b>" : "")
@@ -116,7 +116,7 @@ Panel {
                             Layout.fillWidth: true
                             attributes: root.node.attributes
                             readOnly: root.readOnly || root.isCompatibilityNode
-                            onAttributeDoubleClicked: root.attributeDoubleClicked(attribute)
+                            onAttributeDoubleClicked: root.attributeDoubleClicked(mouse, attribute)
                             onUpgradeRequest: root.upgradeRequest()
                         }
 

--- a/meshroom/ui/qml/GraphEditor/NodeEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/NodeEditor.qml
@@ -54,7 +54,7 @@ Panel {
                 MenuSeparator {}
                 MenuItem {
                     enabled: root.node !== null
-                    text: "Clear Submitted Status"
+                    text: "Clear Pending Status"
                     onClicked: node.clearSubmittedChunks()
                 }
             }
@@ -115,7 +115,7 @@ Panel {
                         AttributeEditor {
                             Layout.fillWidth: true
                             attributes: root.node.attributes
-                            readOnly: root.isCompatibilityNode
+                            readOnly: root.readOnly || root.isCompatibilityNode
                             onAttributeDoubleClicked: root.attributeDoubleClicked(attribute)
                             onUpgradeRequest: root.upgradeRequest()
                         }

--- a/meshroom/ui/qml/Viewer/ImageMetadataView.qml
+++ b/meshroom/ui/qml/Viewer/ImageMetadataView.qml
@@ -121,17 +121,9 @@ FloatingPane {
     ColumnLayout {
         anchors.fill: parent
 
-        // Search toolbar
-        RowLayout {
-            Label {
-                text: MaterialIcons.search
-                font.family: MaterialIcons.fontFamily
-            }
-            TextField {
-                id: filter
-                Layout.fillWidth: true
-                z: 2
-            }
+        SearchBar {
+            id: searchBar
+            Layout.fillWidth: true
         }
 
         // Metadata ListView
@@ -148,7 +140,7 @@ FloatingPane {
                 model: metadataModel
                 sortRole: "raw"
                 filterRole: "raw"
-                filterValue: filter.text
+                filterValue: searchBar.text
                 delegate: RowLayout {
                     width: parent.width
                     Label {

--- a/meshroom/ui/qml/Viewer3D/Viewer3D.qml
+++ b/meshroom/ui/qml/Viewer3D/Viewer3D.qml
@@ -37,8 +37,21 @@ FocusScope {
         mediaLibrary.load(filepath);
     }
 
+    /// View 'attribute' in the 3D Viewer. Media will be loaded if needed.
+    /// Returns whether the attribute can be visualized (matching type and extension).
     function view(attribute) {
-        mediaLibrary.view(attribute)
+        if( attribute.desc.type === "File"
+           && Viewer3DSettings.supportedExtensions.indexOf(Filepath.extension(attribute.value)) > - 1 )
+        {
+            mediaLibrary.view(attribute);
+            return true;
+        }
+        return false;
+    }
+
+    /// Solo (i.e display only) the given attribute.
+    function solo(attribute) {
+        mediaLibrary.solo(mediaLibrary.find(attribute));
     }
 
     function clear() {

--- a/meshroom/ui/qml/Viewer3D/Viewer3DSettings.qml
+++ b/meshroom/ui/qml/Viewer3D/Viewer3DSettings.qml
@@ -11,6 +11,16 @@ Item {
     readonly property Component depthMapLoaderComp: Qt.createComponent("DepthMapLoader.qml")
     readonly property bool supportDepthMap: depthMapLoaderComp.status == Component.Ready
 
+    // supported 3D files extensions
+    readonly property var supportedExtensions: {
+        var exts = ['.obj'];
+        if(supportAlembic)
+            exts.push('.abc');
+        if(supportDepthMap)
+            exts.push('.exr');
+        return exts;
+    }
+
     // Available render modes
     readonly property var renderModes: [ // Can't use ListModel because of MaterialIcons expressions
                          {"name": "Solid", "icon": MaterialIcons.crop_din },

--- a/meshroom/ui/qml/WorkspaceView.qml
+++ b/meshroom/ui/qml/WorkspaceView.qml
@@ -21,6 +21,7 @@ Item {
     property variant reconstruction: _reconstruction
     readonly property variant cameraInits: _reconstruction.cameraInits
     property bool readOnly: false
+    readonly property Viewer3D viewer3D: viewer3D
 
 
     implicitWidth: 300
@@ -30,10 +31,6 @@ Item {
     // Load a 3D media file in the 3D viewer
     function load3DMedia(filepath) {
         viewer3D.load(filepath);
-    }
-
-    function viewAttribute(attr) {
-        viewer3D.view(attr);
     }
 
     Connections {
@@ -48,7 +45,7 @@ Item {
     function viewSfM() {
         if(!reconstruction.sfm)
             return;
-        viewAttribute(reconstruction.sfm.attribute('output'));
+        viewer3D.view(reconstruction.sfm.attribute('output'));
     }
 
     SystemPalette { id: activePalette }
@@ -144,7 +141,7 @@ Item {
                 anchors.bottomMargin: 10
                 anchors.horizontalCenter: parent.horizontalCenter
                 visible: outputReady && outputMediaIndex == -1
-                onClicked: viewAttribute(_reconstruction.endNode.attribute("outputMesh"))
+                onClicked: viewer3D.view(_reconstruction.endNode.attribute("outputMesh"))
             }
         }
     }

--- a/meshroom/ui/qml/main.qml
+++ b/meshroom/ui/qml/main.qml
@@ -518,7 +518,25 @@ ApplicationWindow {
                 Layout.fillWidth: true
                 padding: 4
                 title: "Graph Editor"
-                visible: settings_UILayout.showGraphEditor
+
+                headerBar: RowLayout {
+                    MaterialToolButton {
+                        text: MaterialIcons.more_vert
+                        font.pointSize: 11
+                        padding: 2
+                        onClicked: graphEditorMenu.open()
+                        Menu {
+                            id: graphEditorMenu
+                            y: parent.height
+                            x: -width + parent.width
+                            MenuItem {
+                                text: "Clear Pending Status"
+                                enabled: !_reconstruction.computingLocally
+                                onTriggered: _reconstruction.graph.clearSubmittedNodes()
+                            }
+                        }
+                    }
+                }
 
                 function displayAttribute(attr) {
                     if( attr.desc.type === "File"


### PR DESCRIPTION
This PR contains various improvements in the Graph Editor module.
- [x] consistent read-only mode when computing, that can be unlocked in advanced settings
- [x] Improved Node Menu: "duplicate"/"remove"/"delete data" with "From Here" accessible on the same entry via an additional button
- [x] confirmation popup before deleting node data
- [x] add "Clear Pending Status" action at Graph level
- [x] solo media in 3D viewer with Ctrl+ double click on node/attribute
