### PR TITLE
meshroom_photogrammetry: add --pipeline parameter to use a pre-configured pipeline graph

### DIFF
--- a/bin/meshroom_photogrammetry
+++ b/bin/meshroom_photogrammetry
@@ -92,8 +92,10 @@ else:
     # default pipeline
     graph = multiview.photogrammetry(inputViewpoints=views, inputIntrinsics=intrinsics, output=args.output)
 
+# setup DepthMap downscaling
 if args.scale > 0:
-    graph.findNode('DepthMap_1').downscale.value = args.scale
+    for node in graph.nodesByType('DepthMap'):
+        node.downscale.value = args.scale
 
 cameraInit = graph.findNode('CameraInit')
 views, intrinsics = cameraInit.nodeDesc.buildIntrinsics(cameraInit, images)

--- a/bin/meshroom_photogrammetry
+++ b/bin/meshroom_photogrammetry
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 import argparse
+import os
 
 import meshroom
 meshroom.setupEnvironment()

--- a/bin/meshroom_photogrammetry
+++ b/bin/meshroom_photogrammetry
@@ -11,20 +11,29 @@ from meshroom import multiview
 parser = argparse.ArgumentParser(description='Launch the full photogrammetry pipeline.')
 parser.add_argument('--input', metavar='FOLDER_OR_SFM', type=str,
                     default='',
-                    help='Input folder with images or SfM file (.sfm, .json).')
+                    help='Input folder containing images or file (.sfm or .json) '
+                         'with images paths and optionally predefined camera intrinsics.')
 parser.add_argument('--inputImages', metavar='IMAGES', type=str, nargs='*',
                     default=[],
                     help='Input images.')
 
 parser.add_argument('--pipeline', metavar='MESHROOM_FILE', type=str, required=False,
                     help='Meshroom file containing a pre-configured photogrammetry pipeline to run on input images. '
-                         'Requirements: the graph must contain one CameraInit and one Publish node.')
+                         'If not set, the default photogrammetry pipeline will be used. ' 
+                         'Requirements: the graph must contain one CameraInit node, '
+                         'and one Publish node if --output is set.')
 
-parser.add_argument('--output', metavar='FOLDER', type=str, required=True,
-                    help='Output folder.')
+parser.add_argument('--output', metavar='FOLDER', type=str, required=False,
+                    help='Output folder where results should be copied to. '
+                         'If not set, results will have to be retrieved directly from the cache folder.')
+
+parser.add_argument('--cache', metavar='FOLDER', type=str,
+                    default=None,
+                    help='Custom cache folder to write computation results. '
+                         'If not set, the default cache folder will be used: ' + meshroom.core.defaultCacheFolder)
 
 parser.add_argument('--save', metavar='FILE', type=str, required=False,
-                    help='Save the resulting pipeline to a Meshroom file (instead of running it).')
+                    help='Save the configured Meshroom project to a file (instead of running it).')
 
 parser.add_argument('--scale', type=int, default=-1,
                     choices=[-1, 1, 2, 4, 8, 16],
@@ -34,9 +43,7 @@ parser.add_argument('--scale', type=int, default=-1,
 parser.add_argument('--toNode', metavar='NODE', type=str, nargs='*',
                     default=None,
                     help='Process the node(s) with its dependencies.')
-parser.add_argument('--cache', metavar='FOLDER', type=str,
-                    default=None,
-                    help='Choose a custom cache folder')
+
 parser.add_argument('--forceStatus', help='Force computation if status is RUNNING or SUBMITTED.',
                     action='store_true')
 parser.add_argument('--forceCompute', help='Compute in all cases even if already computed.',
@@ -44,16 +51,18 @@ parser.add_argument('--forceCompute', help='Compute in all cases even if already
 
 args = parser.parse_args()
 
-if not args.output and not args.save:
-    print('Nothing to do. You need to set --output or --save.')
-    exit(1)
+
+def getOnlyNodeOfType(g, nodeType):
+    """ Helper function to get a node of 'nodeType' in the graph 'g' and raise if no or multiple candidates. """
+    nodes = g.nodesByType(nodeType)
+    if len(nodes) != 1:
+        raise RuntimeError("meshroom_photogrammetry requires a pipeline graph with exactly one '{}' node, {} found."
+                           .format(nodeType, len(nodes)))
+    return nodes[0]
+
 
 if not args.input and not args.inputImages:
     print('Nothing to compute. You need to set --input or --inputImages.')
-    exit(1)
-
-if args.pipeline and not args.output:
-    print('--output must be set when using --pipeline.')
     exit(1)
 
 views, intrinsics = [], []
@@ -72,49 +81,44 @@ elif os.path.isfile(args.input) and os.path.splitext(args.input)[-1] in ('.json'
 if args.pipeline:
     # custom pipeline
     graph = meshroom.core.graph.loadGraph(args.pipeline)
-    try:
-        cameraInit = graph.findNode('CameraInit')
-        # reset graph inputs
-        cameraInit.viewpoints.resetValue()
-        cameraInit.intrinsics.resetValue()
-    except KeyError:
-        raise RuntimeError("meshroom_photogrammetry requires a pipeline graph with exactly one 'CameraInit' node.")
+    cameraInit = getOnlyNodeOfType(graph, 'CameraInit')
+    # reset graph inputs
+    cameraInit.viewpoints.resetValue()
+    cameraInit.intrinsics.resetValue()
 
     if not graph.canComputeLeaves:
         raise RuntimeError("Graph cannot be computed. Check for compatibility issues.")
 
-    try:
-        publish = graph.findNode('Publish')
+    if args.output:
+        publish = getOnlyNodeOfType(graph, 'Publish')
         publish.output.value = args.output
-    except KeyError:
-        raise RuntimeError("meshroom_photogrammetry requires a pipeline graph with exactly one 'Publish' node.")
 else:
     # default pipeline
     graph = multiview.photogrammetry(inputViewpoints=views, inputIntrinsics=intrinsics, output=args.output)
+    cameraInit = getOnlyNodeOfType(graph, 'CameraInit')
+
+views, intrinsics = cameraInit.nodeDesc.buildIntrinsics(cameraInit, images)
+cameraInit.viewpoints.value = views
+cameraInit.intrinsics.value = intrinsics
 
 # setup DepthMap downscaling
 if args.scale > 0:
     for node in graph.nodesByType('DepthMap'):
         node.downscale.value = args.scale
 
-cameraInit = graph.findNode('CameraInit')
-views, intrinsics = cameraInit.nodeDesc.buildIntrinsics(cameraInit, images)
-cameraInit.viewpoints.value = views
-cameraInit.intrinsics.value = intrinsics
-
 if args.save:
     graph.save(args.save)
     print('File successfully saved:', args.save)
     exit(0)
 
-if args.cache:
-    graph.cacheDir = args.cache
+# setup cache directory
+graph.cacheDir = args.cache if args.cache else meshroom.core.defaultCacheFolder
 
-if not graph.cacheDir:
-    graph.cacheDir = meshroom.core.defaultCacheFolder
+if not args.output:
+    print('No output set, results will be available in {}'.format(graph.cacheDir))
 
-toNodes = None
-if args.toNode:
-    toNodes = graph.findNodes(args.toNode)
+# find end nodes (None will compute all graph)
+toNodes = graph.findNodes(args.toNode) if args.toNode else None
 
+# start computation
 meshroom.core.graph.executeGraph(graph, toNodes=toNodes, forceCompute=args.forceCompute, forceStatus=args.forceStatus)

--- a/bin/meshroom_photogrammetry
+++ b/bin/meshroom_photogrammetry
@@ -6,14 +6,14 @@ import meshroom
 meshroom.setupEnvironment()
 
 import meshroom.core.graph
-from meshroom.nodes.aliceVision.CameraInit import readSfMData
 from meshroom import multiview
 
 parser = argparse.ArgumentParser(description='Launch the full photogrammetry pipeline.')
-parser.add_argument('--input', metavar='FOLDER', type=str,
+parser.add_argument('--input', metavar='FOLDER_OR_SFM', type=str,
                     default='',
-                    help='Input folder or json file.')
+                    help='Input folder with images or SfM file (.sfm, .json).')
 parser.add_argument('--inputImages', metavar='IMAGES', type=str, nargs='*',
+                    default=[],
                     help='Input images.')
 parser.add_argument('--output', metavar='FOLDER', type=str, required=True,
                     help='Output folder.')
@@ -45,16 +45,27 @@ if not args.input and not args.inputImages:
     print('Nothing to compute. You need to set --input or --inputImages.')
     exit(1)
 
-if  args.input and os.path.isfile(args.input):
-        views, intrinsics = readSfMData(args.input)
-        # print(views)
-        # print(intrinsics)
 
-        graph = multiview.photogrammetry(inputViewpoints=views, inputIntrinsics=intrinsics, inputImages=args.inputImages, output=args.output)
-else:
-    graph = multiview.photogrammetry(inputFolder=args.input, inputImages=args.inputImages, output=args.output)
+views, intrinsics = [], []
+# Build image files list from inputImages arguments
+images = [f for f in args.inputImages if multiview.isImageFile(f)]
+
+if os.path.isdir(args.input):
+    # args.input is a folder: extend images list with images in that folder
+    images += multiview.findImageFiles(args.input)
+elif os.path.isfile(args.input) and os.path.splitext(args.input)[-1] in ('.json', '.sfm'):
+    # args.input is a sfmData file: setup pre-calibrated views and intrinsics
+    from meshroom.nodes.aliceVision.CameraInit import readSfMData
+    views, intrinsics = readSfMData(args.input)
+
+graph = multiview.photogrammetry(inputViewpoints=views, inputIntrinsics=intrinsics, output=args.output)
 
 graph.findNode('DepthMap_1').downscale.value = args.scale
+
+cameraInit = graph.findNode('CameraInit')
+views, intrinsics = cameraInit.nodeDesc.buildIntrinsics(cameraInit, images)
+cameraInit.viewpoints.value = views
+cameraInit.intrinsics.value = intrinsics
 
 if args.save:
     graph.save(args.save)

--- a/bin/meshroom_photogrammetry
+++ b/bin/meshroom_photogrammetry
@@ -18,11 +18,13 @@ parser.add_argument('--inputImages', metavar='IMAGES', type=str, nargs='*',
 parser.add_argument('--output', metavar='FOLDER', type=str, required=True,
                     help='Output folder.')
 
-parser.add_argument('--save', metavar='FOLDER', type=str, required=False,
-                    help='Save the workflow to a meshroom files (instead of running it).')
+parser.add_argument('--save', metavar='FILE', type=str, required=False,
+                    help='Save the resulting pipeline to a Meshroom file (instead of running it).')
 
-parser.add_argument('--scale', type=int, default=2,
-                    help='Downscale factor for MVS steps. Possible values are: 1, 2, 4, 8, 16.')
+parser.add_argument('--scale', type=int, default=-1,
+                    choices=[-1, 1, 2, 4, 8, 16],
+                    help='Downscale factor override for DepthMap estimation. '
+                         'By default (-1): use pipeline default value.')
 
 parser.add_argument('--toNode', metavar='NODE', type=str, nargs='*',
                     default=None,
@@ -60,7 +62,8 @@ elif os.path.isfile(args.input) and os.path.splitext(args.input)[-1] in ('.json'
 
 graph = multiview.photogrammetry(inputViewpoints=views, inputIntrinsics=intrinsics, output=args.output)
 
-graph.findNode('DepthMap_1').downscale.value = args.scale
+if args.scale > 0:
+    graph.findNode('DepthMap_1').downscale.value = args.scale
 
 cameraInit = graph.findNode('CameraInit')
 views, intrinsics = cameraInit.nodeDesc.buildIntrinsics(cameraInit, images)

--- a/bin/meshroom_photogrammetry
+++ b/bin/meshroom_photogrammetry
@@ -15,6 +15,11 @@ parser.add_argument('--input', metavar='FOLDER_OR_SFM', type=str,
 parser.add_argument('--inputImages', metavar='IMAGES', type=str, nargs='*',
                     default=[],
                     help='Input images.')
+
+parser.add_argument('--pipeline', metavar='MESHROOM_FILE', type=str, required=False,
+                    help='Meshroom file containing a pre-configured photogrammetry pipeline to run on input images. '
+                         'Requirements: the graph must contain one CameraInit and one Publish node.')
+
 parser.add_argument('--output', metavar='FOLDER', type=str, required=True,
                     help='Output folder.')
 
@@ -47,6 +52,9 @@ if not args.input and not args.inputImages:
     print('Nothing to compute. You need to set --input or --inputImages.')
     exit(1)
 
+if args.pipeline and not args.output:
+    print('--output must be set when using --pipeline.')
+    exit(1)
 
 views, intrinsics = [], []
 # Build image files list from inputImages arguments
@@ -60,7 +68,29 @@ elif os.path.isfile(args.input) and os.path.splitext(args.input)[-1] in ('.json'
     from meshroom.nodes.aliceVision.CameraInit import readSfMData
     views, intrinsics = readSfMData(args.input)
 
-graph = multiview.photogrammetry(inputViewpoints=views, inputIntrinsics=intrinsics, output=args.output)
+# initialize photogrammetry pipeline
+if args.pipeline:
+    # custom pipeline
+    graph = meshroom.core.graph.loadGraph(args.pipeline)
+    try:
+        cameraInit = graph.findNode('CameraInit')
+        # reset graph inputs
+        cameraInit.viewpoints.resetValue()
+        cameraInit.intrinsics.resetValue()
+    except KeyError:
+        raise RuntimeError("meshroom_photogrammetry requires a pipeline graph with exactly one 'CameraInit' node.")
+
+    if not graph.canComputeLeaves:
+        raise RuntimeError("Graph cannot be computed. Check for compatibility issues.")
+
+    try:
+        publish = graph.findNode('Publish')
+        publish.output.value = args.output
+    except KeyError:
+        raise RuntimeError("meshroom_photogrammetry requires a pipeline graph with exactly one 'Publish' node.")
+else:
+    # default pipeline
+    graph = multiview.photogrammetry(inputViewpoints=views, inputIntrinsics=intrinsics, output=args.output)
 
 if args.scale > 0:
     graph.findNode('DepthMap_1').downscale.value = args.scale

--- a/meshroom/core/graph.py
+++ b/meshroom/core/graph.py
@@ -1078,6 +1078,7 @@ def loadGraph(filepath):
     """
     graph = Graph("")
     graph.load(filepath)
+    graph.update()
     return graph
 
 

--- a/meshroom/core/node.py
+++ b/meshroom/core/node.py
@@ -337,8 +337,8 @@ class BaseNode(BaseObject):
         self.packageName = self.packageVersion = ""
         self._internalFolder = ""
 
-        self._name = None  # type: str
-        self.graph = None  # type: Graph
+        self._name = None
+        self.graph = None
         self.dirty = True  # whether this node's outputs must be re-evaluated on next Graph update
         self._chunks = ListModel(parent=self)
         self._uids = dict()

--- a/meshroom/multiview.py
+++ b/meshroom/multiview.py
@@ -2,22 +2,29 @@
 __version__ = "1.0"
 
 import os
-import fnmatch
-import re
 
 from meshroom.core.graph import Graph, GraphModification
 
+# Supported image extensions
+imageExtensions = ('.jpg', '.jpeg', '.tif', '.tiff', '.png', '.exr', '.rw2', '.cr2', '.nef', '.arw')
 
-def findFiles(folder, patterns):
-    rules = [re.compile(fnmatch.translate(pattern), re.IGNORECASE) for pattern in patterns]
-    outFiles = []
-    for name in os.listdir(folder):
-        for rule in rules:
-            if rule.match(name):
-                filepath = os.path.join(folder, name)
-                outFiles.append(filepath)
-                break
-    return outFiles
+
+def isImageFile(filepath):
+    """ Return whether filepath is a path to an image file supported by Meshroom. """
+    return os.path.splitext(filepath)[1].lower() in imageExtensions
+
+
+def findImageFiles(folder):
+    """
+    Return all files that are images in 'folder' based on their extensions.
+
+    Args:
+        folder (str): the folder to look into
+
+    Returns:
+        list: the list of image files.
+    """
+    return [os.path.join(folder, filename) for filename in os.listdir(folder) if isImageFile(filename)]
 
 
 def photogrammetry(inputFolder='', inputImages=(), inputViewpoints=(), inputIntrinsics=(), output=''):
@@ -38,7 +45,7 @@ def photogrammetry(inputFolder='', inputImages=(), inputViewpoints=(), inputIntr
         sfmNodes, mvsNodes = photogrammetryPipeline(graph)
         cameraInit = sfmNodes[0]
         if inputFolder:
-            images = findFiles(inputFolder, ['*.jpg', '*.png'])
+            images = findImageFiles(inputFolder)
             cameraInit.viewpoints.extend([{'path': image} for image in images])
         if inputImages:
             cameraInit.viewpoints.extend([{'path': image} for image in inputImages])

--- a/meshroom/multiview.py
+++ b/meshroom/multiview.py
@@ -27,12 +27,11 @@ def findImageFiles(folder):
     return [os.path.join(folder, filename) for filename in os.listdir(folder) if isImageFile(filename)]
 
 
-def photogrammetry(inputFolder='', inputImages=(), inputViewpoints=(), inputIntrinsics=(), output=''):
+def photogrammetry(inputImages=list(), inputViewpoints=list(), inputIntrinsics=list(), output=''):
     """
     Create a new Graph with a complete photogrammetry pipeline.
 
     Args:
-        inputFolder (str, optional): folder containing image files
         inputImages (list of str, optional): list of image file paths
         inputViewpoints (list of Viewpoint, optional): list of Viewpoints
         output (str, optional): the path to export reconstructed model to
@@ -44,15 +43,9 @@ def photogrammetry(inputFolder='', inputImages=(), inputViewpoints=(), inputIntr
     with GraphModification(graph):
         sfmNodes, mvsNodes = photogrammetryPipeline(graph)
         cameraInit = sfmNodes[0]
-        if inputFolder:
-            images = findImageFiles(inputFolder)
-            cameraInit.viewpoints.extend([{'path': image} for image in images])
-        if inputImages:
-            cameraInit.viewpoints.extend([{'path': image} for image in inputImages])
-        if inputViewpoints:
-            cameraInit.viewpoints.extend(inputViewpoints)
-        if inputIntrinsics:
-            cameraInit.intrinsics.extend(inputIntrinsics)
+        cameraInit.viewpoints.extend([{'path': image} for image in inputImages])
+        cameraInit.viewpoints.extend(inputViewpoints)
+        cameraInit.intrinsics.extend(inputIntrinsics)
 
     if output:
         texturing = mvsNodes[-1]

--- a/meshroom/nodes/aliceVision/CameraInit.py
+++ b/meshroom/nodes/aliceVision/CameraInit.py
@@ -171,7 +171,10 @@ class CameraInit(desc.CommandLineNode):
             The updated views and intrinsics as two separate lists
         """
         assert isinstance(node.nodeDesc, CameraInit)
-        assert node.graph is None
+        if node.graph:
+            # make a copy of the node outside the graph
+            # to change its cache folder without modifying the original node
+            node = node.graph.copyNode(node)[0]
 
         tmpCache = tempfile.mkdtemp()
         node.updateInternals(tmpCache)

--- a/meshroom/ui/reconstruction.py
+++ b/meshroom/ui/reconstruction.py
@@ -99,8 +99,7 @@ class LiveSfmManager(QObject):
         to include those images to the reconstruction.
         """
         # Get all new images in the watched folder
-        filesInFolder = [os.path.join(self._folder, f) for f in os.listdir(self._folder)]
-        imagesInFolder = [f for f in filesInFolder if Reconstruction.isImageFile(f)]
+        imagesInFolder = multiview.findImageFiles(self._folder)
         newImages = set(imagesInFolder).difference(self.allImages)
         for imagePath in newImages:
             # print('[LiveSfmManager] New image file : {}'.format(imagePath))
@@ -159,8 +158,6 @@ class Reconstruction(UIGraph):
     """
     Specialization of a UIGraph designed to manage a 3D reconstruction.
     """
-
-    imageExtensions = ('.jpg', '.jpeg', '.tif', '.tiff', '.png', '.exr', '.rw2', '.cr2', '.nef', '.arw')
 
     def __init__(self, graphFilepath='', parent=None):
         super(Reconstruction, self).__init__(graphFilepath, parent)
@@ -333,11 +330,6 @@ class Reconstruction(UIGraph):
         self.importImages(self.getImageFilesFromDrop(drop), cameraInit)
 
     @staticmethod
-    def isImageFile(filepath):
-        """ Return whether filepath is a path to an image file supported by Meshroom. """
-        return os.path.splitext(filepath)[1].lower() in Reconstruction.imageExtensions
-
-    @staticmethod
     def getImageFilesFromDrop(drop):
         urls = drop.property("urls")
         # Build the list of images paths
@@ -345,10 +337,9 @@ class Reconstruction(UIGraph):
         for url in urls:
             localFile = url.toLocalFile()
             if os.path.isdir(localFile):  # get folder content
-                files = [os.path.join(localFile, f) for f in os.listdir(localFile)]
-            else:
-                files = [localFile]
-            images.extend([f for f in files if Reconstruction.isImageFile(f)])
+                images.extend(multiview.findImageFiles(localFile))
+            elif multiview.isImageFile(localFile):
+                images.append(localFile)
         return images
 
     def importImages(self, images, cameraInit):


### PR DESCRIPTION
Same goal as #354, taking #329 into account + deeper refactoring.
Add `--pipeline` parameter to use a Meshroom file as a pre-configured pipeline graph to run on input images. Simplify and generalize the way image files are detected and pipeline graphs are initialized.

- [X] factorize image files detection functions 
- [X] meshroom_photogrammetry: enable to input a pre-configured pipeline graph
- [X] meshroom_photogrammetry: use `buildIntrinsics` to initialize the `CameraInit` node the same way it's done interactively
- [X] fix missing import, clean up doc and parameters