### PR TITLE
Minor UI fixes

### DIFF
--- a/meshroom/ui/graph.py
+++ b/meshroom/ui/graph.py
@@ -257,7 +257,11 @@ class UIGraph(QObject):
 
     @Slot(QUrl)
     def saveAs(self, url):
-        self._graph.save(url.toLocalFile())
+        localFile = url.toLocalFile()
+        # ensure file is saved with ".mg" extension
+        if os.path.splitext(localFile)[-1] != ".mg":
+            localFile += ".mg"
+        self._graph.save(localFile)
         self._undoStack.setClean()
 
     @Slot()

--- a/meshroom/ui/qml/GraphEditor/AttributePin.qml
+++ b/meshroom/ui/qml/GraphEditor/AttributePin.qml
@@ -134,30 +134,38 @@ RowLayout {
             point1y: parent.width / 2
             point2x: dragTarget.x + dragTarget.width/2
             point2y: dragTarget.y + dragTarget.height/2
-            color: nameLabel.palette.text
+            color: nameLabel.color
         }
     }
 
     // Attribute name
-    Label {
-        id: nameLabel
-        text: attribute.name
-        elide: Text.ElideMiddle
+    Item {
+        id: nameContainer
         Layout.fillWidth: true
-        font.pointSize: 5
-        horizontalAlignment: attribute.isOutput ? Text.AlignRight : Text.AlignLeft
+        implicitHeight: childrenRect.height
 
-        Loader {
-            active: parent.truncated && (connectMA.containsMouse || connectMA.drag.active || dropArea.containsDrag)
-            anchors.right: root.layoutDirection == Qt.LeftToRight ? undefined : nameLabel.right
-            // Non-elided label
-            sourceComponent: Label {
-                leftPadding: root.layoutDirection == Qt.LeftToRight ? 0 : 1
-                rightPadding: root.layoutDirection == Qt.LeftToRight ? 1 : 0
-                text: attribute.name
-                background: Rectangle {
-                    color: parent.palette.window
-                }
+        TextMetrics {
+            id: metrics
+            property bool truncated: width > nameContainer.width
+            text: nameLabel.text
+            font: nameLabel.font
+        }
+
+        Label {
+            id: nameLabel
+
+            property bool hovered: (connectMA.containsMouse || connectMA.drag.active || dropArea.containsDrag)
+            text: attribute.name
+            elide: hovered ? Text.ElideNone : Text.ElideMiddle
+            width: hovered ? contentWidth : parent.width
+            font.pointSize: 5
+            horizontalAlignment: attribute.isOutput ? Text.AlignRight : Text.AlignLeft
+            anchors.right: attribute.isOutput ? parent.right : undefined
+
+            background: Rectangle {
+                visible: parent.hovered && metrics.truncated
+                anchors { fill: parent; leftMargin: -1; rightMargin: -1 }
+                color: parent.palette.window
             }
         }
     }

--- a/meshroom/ui/qml/ImageGallery/IntrinsicsIndicator.qml
+++ b/meshroom/ui/qml/ImageGallery/IntrinsicsIndicator.qml
@@ -15,14 +15,14 @@ ImageBadge {
     property var metadata: ({})
 
     // access useful metadata
-    readonly property string make: metadata["Make"]
-    readonly property string model: metadata["Model"]
-    readonly property string focalLength: metadata["Exif:FocalLength"]
-    readonly property string focalLength35: metadata["Exif:FocalLengthIn35mmFilm"]
-    readonly property string bodySerialNumber: metadata["Exif:BodySerialNumber"]
-    readonly property string lensSerialNumber: metadata["Exif:LensSerialNumber"]
-    readonly property string sensorWidth: metadata["AliceVision:SensorWidth"]
-    readonly property string sensorWidthEstimation: metadata["AliceVision:SensorWidthEstimation"]
+    readonly property var make: metadata["Make"]
+    readonly property var model: metadata["Model"]
+    readonly property var focalLength: metadata["Exif:FocalLength"]
+    readonly property var focalLength35: metadata["Exif:FocalLengthIn35mmFilm"]
+    readonly property var bodySerialNumber: metadata["Exif:BodySerialNumber"]
+    readonly property var lensSerialNumber: metadata["Exif:LensSerialNumber"]
+    readonly property var sensorWidth: metadata["AliceVision:SensorWidth"]
+    readonly property var sensorWidthEstimation: metadata["AliceVision:SensorWidthEstimation"]
 
     property string statusText: ""
     property string detailsText: ""


### PR DESCRIPTION
- [X] filter non silenced, inoffensive warnings from QML + log Qt messages via Python logging
- [X] make sure Meshroom files are saved with `.mg` extension
- [X] use TextMetrics to handle AttributePins expanding instead of having 2 Labels
- [X] IntrinsicsIndicator: avoid warnings when trying to store `undefined` in string properties