### PR TITLE
[ui] IntrinsicsIndicator: display distortion model

### DIFF
--- a/meshroom/ui/qml/ImageGallery/ImageGallery.qml
+++ b/meshroom/ui/qml/ImageGallery/ImageGallery.qml
@@ -154,12 +154,11 @@ Panel {
                         spacing: 2
 
                         property bool valid: Qt.isQtObject(object) // object can be evaluated to null at some point during creation/deletion
-                        property string intrinsicInitMode: valid ? _reconstruction.getIntrinsicInitMode(object) : ""
                         property bool inViews: valid && _reconstruction.sfmReport && _reconstruction.isInViews(object)
 
                         // Camera Initialization indicator
                         IntrinsicsIndicator {
-                            intrinsicInitMode: parent.intrinsicInitMode
+                            intrinsic: parent.valid ? _reconstruction.getIntrinsic(object) : null
                             metadata: imageDelegate.metadata
                         }
 

--- a/meshroom/ui/qml/ImageGallery/IntrinsicsIndicator.qml
+++ b/meshroom/ui/qml/ImageGallery/IntrinsicsIndicator.qml
@@ -11,7 +11,11 @@ import Utils 1.0
 ImageBadge {
     id: root
 
-    property string intrinsicInitMode
+    // Intrinsic GroupAttribute
+    property var intrinsic: null
+
+    readonly property string intrinsicInitMode: intrinsic ? childAttributeValue(intrinsic, "initializationMode", "none") : "unknown"
+    readonly property string distortionModel: intrinsic ? childAttributeValue(intrinsic, "type", "") : ""
     property var metadata: ({})
 
     // access useful metadata
@@ -29,6 +33,11 @@ ImageBadge {
     property string helperText: ""
 
     text: MaterialIcons.camera
+    
+    function childAttributeValue(attribute, childName, defaultValue) {
+        var attr = attribute.value.get(childName);
+        return attr ? attr.value : defaultValue;
+    }
 
     function metaStr(value) {
         return value || "<i>undefined</i>"
@@ -37,6 +46,7 @@ ImageBadge {
     ToolTip.text: "<b>Camera Intrinsics: " + statusText + "</b><br>"
                   + (detailsText ? detailsText + "<br>" : "")
                   + (helperText ? helperText + "<br>" : "")
+                  + (distortionModel ? 'Distortion Model: ' + distortionModel + "<br>" : "")
                   + "<br>"
                   + "[Metadata]<br>"
                   + " - Make: " + metaStr(make) + "<br>"
@@ -47,7 +57,7 @@ ImageBadge {
                   + ((bodySerialNumber || lensSerialNumber) ? "" : "<br><br>Warning: SerialNumber metadata is missing.<br> Images from different devices might incorrectly share the same camera internal settings.")
 
 
-    state: intrinsicInitMode ? intrinsicInitMode : "unknown"
+    state: intrinsicInitMode
 
     states: [
         State {

--- a/meshroom/ui/reconstruction.py
+++ b/meshroom/ui/reconstruction.py
@@ -540,27 +540,10 @@ class Reconstruction(UIGraph):
         Returns:
             Attribute: the Viewpoint's corresponding intrinsic or None if not found.
         """
+        if not viewpoint:
+            return None
         return next((i for i in self._cameraInit.intrinsics.value if i.intrinsicId.value == viewpoint.intrinsicId.value)
                     , None)
-
-    @Slot(QObject, result=str)
-    def getIntrinsicInitMode(self, viewpoint):
-        """
-        Get the initialization mode for the intrinsic associated to 'viewpoint'.
-
-        Args:
-            viewpoint (Attribute): the Viewpoint to consider.
-        Returns:
-            str: the initialization mode of the Viewpoint's intrinsic or an empty string if none.
-        """
-        intrinsic = self.getIntrinsic(viewpoint)
-        if not intrinsic:
-            return ""
-        try:
-            return intrinsic.initializationMode.value
-        except AttributeError:
-            # handle older versions that did not have this attribute
-            return ""
 
     @Slot(QObject, result=bool)
     def hasMetadata(self, viewpoint):


### PR DESCRIPTION
- [X] directly use intrinsic attribute in IntrinsicsIndicator to retrieve useful values, instead of dedicated methods in 'Reconstruction'.
- [X] display distortion model in IntrinsicsIndicator's ToolTip