### PR TITLE
Viewer3D: use DepthMapEntity 2.0 + various fixes

### DIFF
--- a/meshroom/ui/qml/Viewer3D/DefaultCameraController.qml
+++ b/meshroom/ui/qml/Viewer3D/DefaultCameraController.qml
@@ -14,7 +14,9 @@ Entity {
     property real translateSpeed: 75.0
     property real tiltSpeed: 500.0
     property real panSpeed: 500.0
-    property bool moving: pressed || (actionAlt.active && keyboardHandler._pressed)
+    readonly property bool moving: actionLMB.active
+    readonly property bool panning: (keyboardHandler._pressed && actionLMB.active && actionShift.active) || actionMMB.active
+    readonly property bool zooming: keyboardHandler._pressed && actionRMB.active && actionAlt.active
     property alias focus: keyboardHandler.focus
     readonly property bool pickingActive: actionControl.active && keyboardHandler._pressed
     property alias rotationSpeed: trackball.rotationSpeed
@@ -159,19 +161,19 @@ Entity {
     components: [
         FrameAction {
             onTriggered: {
-                if(actionMMB.active || (actionLMB.active && actionShift.active)) { // translate
+                if(panning) { // translate
                     var d = (root.camera.viewCenter.minus(root.camera.position)).length() * 0.03;
                     var tx = axisMX.value * root.translateSpeed * d;
                     var ty = axisMY.value * root.translateSpeed * d;
                     root.camera.translate(Qt.vector3d(-tx, -ty, 0).times(dt))
                     return;
                 }
-                if(actionLMB.active){ // trackball rotation
+                if(moving){ // trackball rotation
                     trackball.rotate(mouseHandler.lastPosition, mouseHandler.currentPosition, dt);
                     mouseHandler.lastPosition = mouseHandler.currentPosition;
                     return;
                 }
-                if(actionAlt.active && actionRMB.active) { // zoom with alt + RMD
+                if(zooming) { // zoom with alt + RMD
                     var d = (root.camera.viewCenter.minus(root.camera.position)).length() * 0.1;
                     var tz = axisMX.value * root.translateSpeed * d;
                     root.camera.translate(Qt.vector3d(0, 0, tz).times(dt), Camera.DontTranslateViewCenter)

--- a/meshroom/ui/qml/Viewer3D/DefaultCameraController.qml
+++ b/meshroom/ui/qml/Viewer3D/DefaultCameraController.qml
@@ -44,7 +44,8 @@ Entity {
         sourceDevice: mouseSourceDevice
         onPressed: {
             _pressed = true;
-            currentPosition = lastPosition = Qt.point(mouse.x, mouse.y);
+            currentPosition.x = lastPosition.x = mouse.x;
+            currentPosition.y = lastPosition.y = mouse.y;
             mousePressed(mouse);
         }
         onReleased: {
@@ -52,7 +53,7 @@ Entity {
             mouseReleased(mouse);
         }
         onClicked: mouseClicked(mouse)
-        onPositionChanged: { currentPosition = Qt.point(mouse.x, mouse.y) }
+        onPositionChanged: { currentPosition.x = mouse.x; currentPosition.y = mouse.y }
         onDoubleClicked: mouseDoubleClicked(mouse)
         onWheel: {
             var d = (root.camera.viewCenter.minus(root.camera.position)).length() * 0.2;

--- a/meshroom/ui/qml/Viewer3D/DepthMapLoader.qml
+++ b/meshroom/ui/qml/Viewer3D/DepthMapLoader.qml
@@ -1,4 +1,4 @@
-import DepthMapEntity 1.0
+import DepthMapEntity 2.0
 
 /**
  * Support for Depth Map files (EXR) in Qt3d.
@@ -6,4 +6,9 @@ import DepthMapEntity 1.0
  */
 DepthMapEntity {
     id: root
+
+    pointSize: Viewer3DSettings.pointSize * (Viewer3DSettings.fixedPointSize ? 1.0 : 0.001)
+    // map render modes to custom visualization modes
+    displayMode: Viewer3DSettings.renderMode == 1 ? DepthMapEntity.Points : DepthMapEntity.Triangles
+    displayColor: Viewer3DSettings.renderMode == 2
 }

--- a/meshroom/ui/qml/Viewer3D/Inspector3D.qml
+++ b/meshroom/ui/qml/Viewer3D/Inspector3D.qml
@@ -40,12 +40,15 @@ FloatingPane {
                 columnSpacing: 6
                 rowSpacing: 3
 
-                Label { text: "Points"; padding: 2 }
+                MaterialLabel { font.family: MaterialIcons.fontFamily; text: MaterialIcons.grain; padding: 2 }
                 RowLayout {
                     Slider {
-                        Layout.fillWidth: true; from: 0; to: 10; stepSize: 0.1
+                        Layout.fillWidth: true; from: 0; to: 5; stepSize: 0.1
                         value: Viewer3DSettings.pointSize
                         onValueChanged: Viewer3DSettings.pointSize = value
+                        ToolTip.text: "Point Size: " + value.toFixed(2)
+                        ToolTip.visible: hovered || pressed
+                        ToolTip.delay: 150
                     }
                     MaterialToolButton {
                         text: MaterialIcons.center_focus_strong
@@ -57,7 +60,7 @@ FloatingPane {
                     }
 
                 }
-                Label { text: "Cameras"; padding: 2 }
+                MaterialLabel { font.family: MaterialIcons.fontFamily; text: MaterialIcons.videocam; padding: 2 }
                 Slider {
                     value: Viewer3DSettings.cameraScale
                     from: 0
@@ -66,6 +69,9 @@ FloatingPane {
                     Layout.fillWidth: true
                     padding: 0
                     onMoved: Viewer3DSettings.cameraScale = value
+                    ToolTip.text: "Camera Scale: " + value.toFixed(2)
+                    ToolTip.visible: hovered || pressed
+                    ToolTip.delay: 150
                 }
                 Flow {
                     Layout.columnSpan: 2

--- a/meshroom/ui/qml/Viewer3D/Locator3D.qml
+++ b/meshroom/ui/qml/Viewer3D/Locator3D.qml
@@ -20,7 +20,7 @@ Entity {
                     name: defaultPositionAttributeName
                     buffer: Buffer {
                         type: Buffer.VertexBuffer
-                        data: Float32Array([
+                        data: new Float32Array([
                             0.0, 0.001, 0.0,
                             1.0, 0.001, 0.0,
                             0.0, 0.001, 0.0,
@@ -38,7 +38,7 @@ Entity {
                     name: defaultColorAttributeName
                     buffer: Buffer {
                         type: Buffer.VertexBuffer
-                        data: Float32Array([
+                        data: new Float32Array([
                             Colors.red.r, Colors.red.g, Colors.red.b,
                             Colors.red.r, Colors.red.g, Colors.red.b,
                             Colors.green.r, Colors.green.g, Colors.green.b,

--- a/meshroom/ui/qml/Viewer3D/MediaLibrary.qml
+++ b/meshroom/ui/qml/Viewer3D/MediaLibrary.qml
@@ -30,7 +30,7 @@ Entity {
 
     QtObject {
         id: m
-        property ListModel mediaModel: ListModel {}
+        property ListModel mediaModel: ListModel { dynamicRoles: true }
         property var sourceToEntity: ({})
 
         readonly property var mediaElement: ({

--- a/meshroom/ui/qml/Viewer3D/Viewer3D.qml
+++ b/meshroom/ui/qml/Viewer3D/Viewer3D.qml
@@ -130,7 +130,10 @@ FocusScope {
 
             DefaultCameraController {
                 id: cameraController
-                windowSize: Qt.size(root.width, root.height)
+                windowSize {
+                    width: root.width
+                    height: root.height
+                }
                 rotationSpeed: 10
                 trackballSize: 0.4
 


### PR DESCRIPTION
3DViewer small fixes and updates:
- [x] use DepthMapEntity 2.0 + bind render modes to custom visualization modes
- [x] Locator3D: Fix crash using PySide2 5.12: "calling a TypedArray constructor without new is invalid"
- [x] CameraController: improved stability
- [x] Inpector3D sliders: use icons + tweak ranges + add tooltips
- [x] MediaLibrary: fix broken Attributes loading when first ever loaded media is an outside file