### PR TITLE
[bin] use sys.exit + build meshroom_compute executable

### DIFF
--- a/bin/meshroom_compute
+++ b/bin/meshroom_compute
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 import argparse
+import sys
 
 import meshroom
 meshroom.setupEnvironment()
@@ -47,7 +48,7 @@ if args.node:
         for chunk in chunks:
             if chunk.status.status in submittedStatuses:
                 print('Error: Node is already submitted with status "{}". See file: "{}"'.format(chunk.status.status.name, chunk.statusFile))
-                # exit(-1)
+                # sys.exit(-1)
     if args.iteration != -1:
         chunk = node.chunks[args.iteration]
         chunk.process(args.forceCompute)
@@ -56,7 +57,7 @@ if args.node:
 else:
     if args.iteration != -1:
         print('Error: "--iteration" only make sense when used with "--node".')
-        exit(-1)
+        sys.exit(-1)
     toNodes = None
     if args.toNode:
         toNodes = graph.findNodes([args.toNode])

--- a/bin/meshroom_newNodeType
+++ b/bin/meshroom_newNodeType
@@ -86,7 +86,7 @@ elif sys.stdin.isatty():
 if not inputCmdLineDoc:
     print('No input documentation.')
     print('Usage: YOUR_COMMAND --help | {cmd}'.format(cmd=os.path.splitext(__file__)[0]))
-    exit(-1)
+    sys.exit(-1)
 
 
 fileStr = '''import sys
@@ -131,7 +131,7 @@ elif args.parser == 'basic':
     args_re = re.compile('()--(?P<argLongName>\w+)()()()()')
 else:
     print('Error: Unknown input parser "{}"'.format(args.parser))
-    exit(-1)
+    sys.exit(-1)
 
 choiceValues1_re = re.compile('\* (?P<value>\w+):')
 choiceValues2_re = re.compile('\((?P<value>.+?)\)')
@@ -299,7 +299,7 @@ outputFilepath = os.path.join(args.output, args.node + '.py')
 
 if not args.force and os.path.exists(outputFilepath):
     print('Plugin "{}" already exists "{}".'.format(args.node, outputFilepath))
-    exit(-1)
+    sys.exit(-1)
 
 with open(outputFilepath, 'w') as pluginFile:
     pluginFile.write(fileStr)

--- a/bin/meshroom_photogrammetry
+++ b/bin/meshroom_photogrammetry
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 import argparse
 import os
+import sys
 
 import meshroom
 meshroom.setupEnvironment()
@@ -63,7 +64,7 @@ def getOnlyNodeOfType(g, nodeType):
 
 if not args.input and not args.inputImages:
     print('Nothing to compute. You need to set --input or --inputImages.')
-    exit(1)
+    sys.exit(1)
 
 views, intrinsics = [], []
 # Build image files list from inputImages arguments
@@ -109,7 +110,7 @@ if args.scale > 0:
 if args.save:
     graph.save(args.save)
     print('File successfully saved:', args.save)
-    exit(0)
+    sys.exit(0)
 
 # setup cache directory
 graph.cacheDir = args.cache if args.cache else meshroom.core.defaultCacheFolder

--- a/bin/meshroom_statistics
+++ b/bin/meshroom_statistics
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 import argparse
 import os
+import sys
 from pprint import pprint
 from collections import Iterable, defaultdict
 
@@ -44,7 +45,7 @@ args = parser.parse_args()
 
 if not os.path.exists(args.graphFile):
     print('ERROR: No graph file "{}".'.format(args.graphFile))
-    exit(-1)
+    sys.exit(-1)
 
 graph = pg.loadGraph(args.graphFile)
 

--- a/bin/meshroom_status
+++ b/bin/meshroom_status
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 import argparse
 import os
+import sys
 from pprint import pprint
 
 import meshroom
@@ -22,7 +23,7 @@ args = parser.parse_args()
 
 if not os.path.exists(args.graphFile):
     print('ERROR: No graph file "{}".'.format(args.node, args.graphFile))
-    exit(-1)
+    sys.exit(-1)
 
 graph = meshroom.core.graph.loadGraph(args.graphFile)
 
@@ -32,7 +33,7 @@ if args.node:
     node = graph.node(args.node)
     if node is None:
         print('ERROR: node "{}" does not exist in file "{}".'.format(args.node, args.graphFile))
-        exit(-1)
+        sys.exit(-1)
     for chunk in node.chunks:
         print('{}: {}'.format(chunk.name, chunk.status.status.name))
     if args.verbose:

--- a/setup.py
+++ b/setup.py
@@ -113,6 +113,11 @@ meshroomPhotog = PlatformExecutable(
     "bin/meshroom_photogrammetry"
 )
 
+meshroomCompute = PlatformExecutable(
+    "bin/meshroom_compute"
+)
+
+
 setup(
     name="Meshroom",
     description="Meshroom",
@@ -127,5 +132,5 @@ setup(
     ],
     version=meshroom.__version__,
     options={"build_exe": build_exe_options},
-    executables=[meshroomExe, meshroomPhotog],
+    executables=[meshroomExe, meshroomPhotog, meshroomCompute],
 )


### PR DESCRIPTION
Fix #405 

- [X] cx_Freeze removes builtin 'exit' function, use sys.exit in executables instead
- [X] build: generate an executable for "meshroom_compute"