### PR TITLE
Add GroupAttribute.childAttribute method

### DIFF
--- a/meshroom/core/attribute.py
+++ b/meshroom/core/attribute.py
@@ -4,7 +4,7 @@ import collections
 import re
 import weakref
 
-from meshroom.common import BaseObject, Property, Variant, Signal, ListModel, DictModel
+from meshroom.common import BaseObject, Property, Variant, Signal, ListModel, DictModel, Slot
 from meshroom.core import desc, pyCompatibility, hashValue
 
 
@@ -370,6 +370,22 @@ class GroupAttribute(Attribute):
         # set individual child attribute values
         for key, value in exportedValue.items():
             self._value.get(key).value = value
+
+    @Slot(str, result=Attribute)
+    def childAttribute(self, key):
+        """
+        Get child attribute by name or None if none was found.
+
+        Args:
+            key (str): the name of the child attribute
+
+        Returns:
+            Attribute: the child attribute or None
+        """
+        try:
+            return self._value.get(key)
+        except KeyError:
+            return None
 
     def uid(self, uidIndex):
         uids = []

--- a/meshroom/ui/qml/ImageGallery/ImageGallery.qml
+++ b/meshroom/ui/qml/ImageGallery/ImageGallery.qml
@@ -108,7 +108,7 @@ Panel {
 
                 // override modelData to return basename of viewpoint's path for sorting
                 function modelData(item, roleName) {
-                    var value = item.model.object.value.get(roleName).value
+                    var value = item.model.object.childAttribute(roleName).value
                     if(roleName == sortRole)
                         return Filepath.basename(value)
                     else
@@ -165,10 +165,10 @@ Panel {
                         // Rig indicator
                         Loader {
                             id: rigIndicator
-                            property int rigId: parent.valid ? object.value.get("rigId").value : -1
+                            property int rigId: parent.valid ? object.childAttribute("rigId").value : -1
                             active: rigId >= 0
                             sourceComponent: ImageBadge {
-                                property int rigSubPoseId: model.object.value.get("subPoseId").value
+                                property int rigSubPoseId: model.object.childAttribute("subPoseId").value
                                 text: MaterialIcons.link
                                 ToolTip.text: "<b>Rig: Initialized</b><br>" +
                                               "Rig ID: " + rigIndicator.rigId + " <br>" +

--- a/meshroom/ui/qml/ImageGallery/IntrinsicsIndicator.qml
+++ b/meshroom/ui/qml/ImageGallery/IntrinsicsIndicator.qml
@@ -35,7 +35,7 @@ ImageBadge {
     text: MaterialIcons.camera
     
     function childAttributeValue(attribute, childName, defaultValue) {
-        var attr = attribute.value.get(childName);
+        var attr = attribute.childAttribute(childName);
         return attr ? attr.value : defaultValue;
     }
 


### PR DESCRIPTION
- [x] easier access to a GroupAttribute child attributes (group.childAttribute("childName") instead of group.value.get("childName")) with a fallback to None when no child is found
- [x] use this method in UI to get an exception free method to retrieve child attributes 