### PR TITLE
[CLI] Added new options

### DIFF
--- a/bin/meshroom_photogrammetry
+++ b/bin/meshroom_photogrammetry
@@ -20,9 +20,12 @@ parser.add_argument('--inputImages', metavar='IMAGES', type=str, nargs='*',
 
 parser.add_argument('--pipeline', metavar='MESHROOM_FILE', type=str, required=False,
                     help='Meshroom file containing a pre-configured photogrammetry pipeline to run on input images. '
-                         'If not set, the default photogrammetry pipeline will be used. ' 
+                         'If not set, the default photogrammetry pipeline will be used. '
                          'Requirements: the graph must contain one CameraInit node, '
                          'and one Publish node if --output is set.')
+
+parser.add_argument('--overrides', metavar='SETTINGS', type=str, default=None,
+                    help='A JSON file containing the graph parameters override.')
 
 parser.add_argument('--output', metavar='FOLDER', type=str, required=False,
                     help='Output folder where results should be copied to. '
@@ -101,6 +104,15 @@ else:
 views, intrinsics = cameraInit.nodeDesc.buildIntrinsics(cameraInit, images)
 cameraInit.viewpoints.value = views
 cameraInit.intrinsics.value = intrinsics
+
+if args.overrides:
+    import io
+    import json
+    with io.open(args.overrides, 'r', encoding='utf-8', errors='ignore') as f:
+        data = json.load(f)
+        for nodeName, overrides in data.items():
+            for attrName, value in overrides.items():
+                graph.findNode(nodeName).attribute(attrName).value = value
 
 # setup DepthMap downscaling
 if args.scale > 0:

--- a/meshroom/nodes/aliceVision/PrepareDenseScene.py
+++ b/meshroom/nodes/aliceVision/PrepareDenseScene.py
@@ -73,5 +73,14 @@ class PrepareDenseScene(desc.CommandLineNode):
             description='''Output folder.''',
             value=desc.Node.internalFolder,
             uid=[],
-        )
+        ),
+        desc.File(
+            name='outputUndistorted',
+            label='Undistorted images',
+            description='List of undistorted images.',
+            value=desc.Node.internalFolder + '*.{outputFileTypeValue}',
+            uid=[],
+            group='',
+            advanced=True
+            ),
     ]

--- a/meshroom/ui/app.py
+++ b/meshroom/ui/app.py
@@ -1,7 +1,8 @@
 import logging
 import os
+import argparse
 
-from PySide2.QtCore import Qt, Slot, QJsonValue, Property, qInstallMessageHandler, QtMsgType
+from PySide2.QtCore import Qt, QUrl, Slot, QJsonValue, Property, qInstallMessageHandler, QtMsgType
 from PySide2.QtGui import QIcon
 from PySide2.QtWidgets import QApplication
 
@@ -53,8 +54,8 @@ class MessageHandler(object):
 class MeshroomApp(QApplication):
     """ Meshroom UI Application. """
     def __init__(self, args):
-        args = [args[0], '-style', 'fusion'] + args[1:]  # force Fusion style by default
-        super(MeshroomApp, self).__init__(args)
+        QtArgs = [args[0], '-style', 'fusion'] + args[1:]  # force Fusion style by default
+        super(MeshroomApp, self).__init__(QtArgs)
 
         self.setOrganizationName('AliceVision')
         self.setApplicationName('Meshroom')
@@ -94,6 +95,13 @@ class MeshroomApp(QApplication):
         self.engine.rootContext().setContextProperty("MeshroomApp", self)
         # Request any potential computation to stop on exit
         self.aboutToQuit.connect(r.stopExecution)
+
+        parser = argparse.ArgumentParser(prog=args[0], description='Launch Meshroom UI.')
+        parser.add_argument('--project', metavar='MESHROOM_FILE', type=str, required=False,
+                            help='Meshroom project file (e.g. myProject.mg).')
+        args = parser.parse_args(args[1:])
+        if args.pipeline:
+            r.loadUrl(QUrl.fromLocalFile(args.pipeline))
 
         self.engine.load(os.path.normpath(url))
 


### PR DESCRIPTION
This PR introduces two main options to the command line scripts.
* `meshroom_photogrammetry`, a `--overrides` parameter is added that enables the user to specify a json file containing parameters values to use for each node, thus overriding the default settings. The json file follows a similar structure of the `.mg` file containing the pipeline, ie:
```json
{
        "<node1Name>": {
                "<param1Name>": "<param1Value>"
                "<param2Name>": "<param2Value>"
        },
        "<node2Name>": {
                 "<param1Name>": "<param1Value>"
        },
...
}
```
For example one file setting file `settings.json` could be
```json
{
        "FeatureExtraction_1": {
                "describerPreset": "high"
        },
        "FeatureMatching_1": {
                "guidedMatching": "0"
        },
        "StructureFromMotion_1": {
                "useLocalBA": "0",
                "refineIntrinsics": "0"
        }
}
```

* `ui` can now take a parameter ~~`--pipeline`~~ `--project` that enables the user to specify a project file to load, i.e.
```bash
python meshroom/ui --project myProject.mg
```

Moreover, it add the possibility for the node `PrepareDenseScene` to export the list of undistorted images so they can, eg, published with the `Publish` node. This is because there was no other way of export the images since the suppression of the node `ExportUndistortedImages` (490ebfe63089026495bcc8cecd9834f023e686b1)