### PR TITLE
Allow List/GroupAttribute to be marked as advanced parameters

### DIFF
--- a/meshroom/core/desc.py
+++ b/meshroom/core/desc.py
@@ -49,13 +49,13 @@ class Attribute(BaseObject):
 
 class ListAttribute(Attribute):
     """ A list of Attributes """
-    def __init__(self, elementDesc, name, label, description, group='allParams', joinChar=' '):
+    def __init__(self, elementDesc, name, label, description, group='allParams', advanced=False, joinChar=' '):
         """
         :param elementDesc: the Attribute description of elements to store in that list
         """
         self._elementDesc = elementDesc
         self._joinChar = joinChar
-        super(ListAttribute, self).__init__(name=name, label=label, description=description, value=[], uid=(), group=group, advanced=False)
+        super(ListAttribute, self).__init__(name=name, label=label, description=description, value=[], uid=(), group=group, advanced=advanced)
 
     elementDesc = Property(Attribute, lambda self: self._elementDesc, constant=True)
     uid = Property(Variant, lambda self: self.elementDesc.uid, constant=True)
@@ -78,13 +78,13 @@ class ListAttribute(Attribute):
 
 class GroupAttribute(Attribute):
     """ A macro Attribute composed of several Attributes """
-    def __init__(self, groupDesc, name, label, description, group='allParams', joinChar=' '):
+    def __init__(self, groupDesc, name, label, description, group='allParams', advanced=False, joinChar=' '):
         """
         :param groupDesc: the description of the Attributes composing this group
         """
         self._groupDesc = groupDesc
         self._joinChar = joinChar
-        super(GroupAttribute, self).__init__(name=name, label=label, description=description, value={}, uid=(), group=group, advanced=False)
+        super(GroupAttribute, self).__init__(name=name, label=label, description=description, value={}, uid=(), group=group, advanced=advanced)
 
     groupDesc = Property(Variant, lambda self: self._groupDesc, constant=True)
 


### PR DESCRIPTION
Expose `advanced` constructor argument on List/GroupAttribute.

- [x] allow List/GroupAttributes to be marked as advanced parameters