### PR TITLE
Avoid issue with use ==/!= to compare str, bytes, and int literals

### DIFF
--- a/meshroom/core/node.py
+++ b/meshroom/core/node.py
@@ -458,7 +458,7 @@ class BaseNode(BaseObject):
             self._cmdVars[name] = '--{name} {value}'.format(name=name, value=v)
             self._cmdVars[name + 'Value'] = str(v)
 
-            if v is not None and v is not '':
+            if v not in (None, ''):
                 self._cmdVars[attr.attributeDesc.group] = self._cmdVars.get(attr.attributeDesc.group, '') + \
                                                           ' ' + self._cmdVars[name]
 
@@ -477,7 +477,7 @@ class BaseNode(BaseObject):
             self._cmdVars[name] = '--{name} {value}'.format(name=name, value=v)
             self._cmdVars[name + 'Value'] = str(v)
 
-            if v is not None and v is not '':
+            if v not in (None, ''):
                 self._cmdVars[attr.attributeDesc.group] = self._cmdVars.get(attr.attributeDesc.group, '') + \
                                                           ' ' + self._cmdVars[name]
 

--- a/meshroom/core/node.py
+++ b/meshroom/core/node.py
@@ -458,7 +458,7 @@ class BaseNode(BaseObject):
             self._cmdVars[name] = '--{name} {value}'.format(name=name, value=v)
             self._cmdVars[name + 'Value'] = str(v)
 
-            if v not in (None, ''):
+            if v:
                 self._cmdVars[attr.attributeDesc.group] = self._cmdVars.get(attr.attributeDesc.group, '') + \
                                                           ' ' + self._cmdVars[name]
 
@@ -477,7 +477,7 @@ class BaseNode(BaseObject):
             self._cmdVars[name] = '--{name} {value}'.format(name=name, value=v)
             self._cmdVars[name + 'Value'] = str(v)
 
-            if v not in (None, ''):
+            if v:
                 self._cmdVars[attr.attributeDesc.group] = self._cmdVars.get(attr.attributeDesc.group, '') + \
                                                           ' ' + self._cmdVars[name]
 


### PR DESCRIPTION
[flake8](http://flake8.pycqa.org) testing of https://github.com/alicevision/meshroom on Python 3.7.1

$ __flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics__
```
./meshroom/core/node.py:461:34: F632 use ==/!= to compare str, bytes, and int literals
            if v is not None and v is not '':
                                 ^
./meshroom/core/node.py:480:34: F632 use ==/!= to compare str, bytes, and int literals
            if v is not None and v is not '':
                                 ^
2     F632 use ==/!= to compare str, bytes, and int literals
2
```