### PR TITLE
Make range complete block size accessible to command line nodes

### DIFF
--- a/meshroom/core/desc.py
+++ b/meshroom/core/desc.py
@@ -269,7 +269,8 @@ class Range:
             "rangeStart": self.start,
             "rangeEnd": self.end,
             "rangeLast": self.last,
-            "rangeBlockSize": self.effectiveBlockSize,
+            "rangeBlockSize": self.blockSize,
+            "rangeEffectiveBlockSize": self.effectiveBlockSize,
             "rangeFullSize": self.fullSize,
             }
 


### PR DESCRIPTION
Related to https://github.com/alicevision/AliceVision/pull/628

* range 'blockSize' is now the complete block size (equal for all iterations)
* command lines nodes can use this complete block size to compute the iteration number on software side; delegate range cropping for last iteration to software.
* 'effectiveBlockSize' is still accessible through 'rangeEffectiveBlockSize' parameter