### PR TITLE
[PrepareDenseScene] option to correct images exposure value

### DIFF
--- a/meshroom/nodes/aliceVision/PrepareDenseScene.py
+++ b/meshroom/nodes/aliceVision/PrepareDenseScene.py
@@ -55,6 +55,14 @@ class PrepareDenseScene(desc.CommandLineNode):
             uid=[0],
             advanced=True
         ),
+        desc.BoolParam(
+            name='evCorrection',
+            label='Correct images exposure',
+            description='Apply a correction on images Exposure Value',
+            value=False,
+            uid=[0],
+            advanced=True
+        ),
         desc.ChoiceParam(
             name='verboseLevel',
             label='Verbose Level',

--- a/meshroom/nodes/aliceVision/PrepareDenseScene.py
+++ b/meshroom/nodes/aliceVision/PrepareDenseScene.py
@@ -1,4 +1,4 @@
-__version__ = "2.0"
+__version__ = "3.0"
 
 from meshroom.core import desc
 


### PR DESCRIPTION
Advanced parameter : boolean to choose whether or not to correct images exposure values (EV) during the PrepareDenseScene. 