### PR TITLE
[Texturing] Add option to choose the internal colorspace used for color fusion

### DIFF
--- a/meshroom/nodes/aliceVision/Texturing.py
+++ b/meshroom/nodes/aliceVision/Texturing.py
@@ -1,4 +1,4 @@
-__version__ = "4.0"
+__version__ = "5.0"
 
 from meshroom.core import desc
 

--- a/meshroom/nodes/aliceVision/Texturing.py
+++ b/meshroom/nodes/aliceVision/Texturing.py
@@ -99,6 +99,16 @@ class Texturing(desc.CommandLineNode):
             uid=[0],
             advanced=True,
         ),
+        desc.ChoiceParam(
+            name='processColorspace',
+            label='Process Colorspace',
+            description="Colorspace for the texturing internal computation (does not impact the output file colorspace).",
+            value='sRGB',
+            values=('sRGB', 'LAB', 'XYZ'),
+            exclusive=True,
+            uid=[0],
+            advanced=True,
+        ),
         desc.IntParam(
             name='multiBandDownscale',
             label='Multi Band Downscale',


### PR DESCRIPTION
Colorspace for the texturing internal computation (does not impact the output file colorspace). Choose between sRGB (default), LAB and XYZ.

See https://github.com/alicevision/AliceVision/pull/651