### PR TITLE
Fixing meshroom_photogrammetry --input cameras.sfm behaviour

### DIFF
--- a/bin/meshroom_photogrammetry
+++ b/bin/meshroom_photogrammetry
@@ -101,7 +101,8 @@ else:
     graph = multiview.photogrammetry(inputViewpoints=views, inputIntrinsics=intrinsics, output=args.output)
     cameraInit = getOnlyNodeOfType(graph, 'CameraInit')
 
-views, intrinsics = cameraInit.nodeDesc.buildIntrinsics(cameraInit, images)
+if not (views and intrinsics):
+    views, intrinsics = cameraInit.nodeDesc.buildIntrinsics(cameraInit, images)
 cameraInit.viewpoints.value = views
 cameraInit.intrinsics.value = intrinsics
 

--- a/bin/meshroom_photogrammetry
+++ b/bin/meshroom_photogrammetry
@@ -101,7 +101,7 @@ else:
     graph = multiview.photogrammetry(inputViewpoints=views, inputIntrinsics=intrinsics, output=args.output)
     cameraInit = getOnlyNodeOfType(graph, 'CameraInit')
 
-if not (views and intrinsics):
+if images:
     views, intrinsics = cameraInit.nodeDesc.buildIntrinsics(cameraInit, images)
 cameraInit.viewpoints.value = views
 cameraInit.intrinsics.value = intrinsics

--- a/bin/meshroom_photogrammetry
+++ b/bin/meshroom_photogrammetry
@@ -103,8 +103,8 @@ else:
 
 if images:
     views, intrinsics = cameraInit.nodeDesc.buildIntrinsics(cameraInit, images)
-cameraInit.viewpoints.value = views
-cameraInit.intrinsics.value = intrinsics
+    cameraInit.viewpoints.value = views
+    cameraInit.intrinsics.value = intrinsics
 
 if args.overrides:
     import io


### PR DESCRIPTION
When meshroom_photogrammetry is called with the --input parameter pointing to a SFM file, then the camera intrinsics and poses are loaded from that file. In this case we should not call CameraInit.buildIntrinsics()