### PR TITLE
[Texturing] Add option to correct exposure values during Texturing

### DIFF
--- a/meshroom/nodes/aliceVision/Texturing.py
+++ b/meshroom/nodes/aliceVision/Texturing.py
@@ -92,6 +92,14 @@ class Texturing(desc.CommandLineNode):
             advanced=True,
         ),
         desc.BoolParam(
+            name='correctEV',
+            label='Correct Exposure',
+            description='Uniformize images exposure values.',
+            value=False,
+            uid=[0],
+            advanced=True,
+        ),
+        desc.BoolParam(
             name='useScore',
             label='Use Score',
             description='Use triangles scores for multiband blending.',


### PR DESCRIPTION
Advanced parameter : boolean to choose whether or not to correct images exposure values (EV) during the Texturing.

See https://github.com/alicevision/AliceVision/pull/656.