### PR TITLE
Button to select the chunk being processed

### DIFF
--- a/meshroom/ui/qml/GraphEditor/NodeLog.qml
+++ b/meshroom/ui/qml/GraphEditor/NodeLog.qml
@@ -76,6 +76,7 @@ FocusScope {
             Button {
                 text: MaterialIcons.center_focus_strong
                 width: parent.width
+                visible: node.globalStatus == "RUNNING" // only show when node is running
                 ToolTip.text: "Select Running Chunk"
                 ToolTip.visible: hovered
                 font.family: MaterialIcons.fontFamily

--- a/meshroom/ui/qml/GraphEditor/NodeLog.qml
+++ b/meshroom/ui/qml/GraphEditor/NodeLog.qml
@@ -76,7 +76,7 @@ FocusScope {
             Button {
                 text: MaterialIcons.center_focus_strong
                 width: parent.width
-                visible: node.globalStatus == "RUNNING" // only show when node is running
+                visible: (node.globalStatus == "RUNNING") && (node.chunks.count > 1) // only show when node is running and has multiple chunks
                 ToolTip.text: "Select Running Chunk"
                 ToolTip.visible: hovered
                 font.family: MaterialIcons.fontFamily

--- a/meshroom/ui/qml/GraphEditor/NodeLog.qml
+++ b/meshroom/ui/qml/GraphEditor/NodeLog.qml
@@ -82,15 +82,27 @@ FocusScope {
                 font.family: MaterialIcons.fontFamily
                 anchors.bottom: chunksLV.bottom
                 onClicked: {
-                    for(var child in chunksLV.contentItem.children) {
-                        // make sure child object is a chunk
-                        if (chunksLV.contentItem.children[child].chunk != undefined) {
-                            if (chunksLV.contentItem.children[child].chunk.statusName == "RUNNING") {
-                                chunksLV.forceActiveFocus()
-                                chunksLV.currentIndex = chunksLV.contentItem.children[child].text
+                    let chunkIndex = 0;
+                    let foundChunk = false;
+                    // cycle through the listview until the chunk is found
+                    while (!foundChunk) {
+                        for(var child in chunksLV.contentItem.children) {
+                            // make sure child object is a chunk
+                            if (chunksLV.contentItem.children[child].chunk != undefined) {
+                                if (chunksLV.contentItem.children[child].chunk.statusName == "RUNNING") {
+                                    chunkIndex = chunksLV.contentItem.children[child].text
+                                    foundChunk = true
+                                }
                             }
                         }
+                        if (!foundChunk) {
+                            chunkIndex += 1
+                            chunksLV.positionViewAtIndex(chunkIndex, ListView.Visible)
+                        }
                     }
+                    chunksLV.forceActiveFocus()
+                    chunksLV.positionViewAtIndex(chunkIndex, ListView.Beginning)
+                    chunksLV.currentIndex = chunkIndex
                 }
             }
         }

--- a/meshroom/ui/qml/GraphEditor/NodeLog.qml
+++ b/meshroom/ui/qml/GraphEditor/NodeLog.qml
@@ -76,8 +76,8 @@ FocusScope {
             Button {
                 text: MaterialIcons.center_focus_strong
                 width: parent.width
-                visible: (node.globalStatus == "RUNNING") && (node.chunks.count > 1) // only show when node is running and has multiple chunks
-                ToolTip.text: "Select Running Chunk"
+                visible: (node.globalStatus == "RUNNING" || node.globalStatus == "ERROR") && (node.chunks.count > 1) // only show when node is running or has error and has multiple chunks
+                ToolTip.text: node.globalStatus == "ERROR" ? "Select Chunk With Error" : "Select Running Chunk"
                 ToolTip.visible: hovered
                 font.family: MaterialIcons.fontFamily
                 anchors.bottom: chunksLV.bottom
@@ -89,7 +89,7 @@ FocusScope {
                         for(var child in chunksLV.contentItem.children) {
                             // make sure child object is a chunk
                             if (chunksLV.contentItem.children[child].chunk != undefined) {
-                                if (chunksLV.contentItem.children[child].chunk.statusName == "RUNNING") {
+                                if (chunksLV.contentItem.children[child].chunk.statusName == node.globalStatus) {
                                     chunkIndex = chunksLV.contentItem.children[child].text
                                     foundChunk = true
                                 }

--- a/meshroom/ui/qml/GraphEditor/NodeLog.qml
+++ b/meshroom/ui/qml/GraphEditor/NodeLog.qml
@@ -72,6 +72,26 @@ FocusScope {
                     color: Common.getChunkColor(parent.chunk)
                 }
             }
+
+            Button {
+                text: MaterialIcons.center_focus_strong
+                width: parent.width
+                ToolTip.text: "Select Running Chunk"
+                ToolTip.visible: hovered
+                font.family: MaterialIcons.fontFamily
+                anchors.bottom: chunksLV.bottom
+                onClicked: {
+                    for(var child in chunksLV.contentItem.children) {
+                        // make sure child object is a chunk
+                        if (chunksLV.contentItem.children[child].chunk != undefined) {
+                            if (chunksLV.contentItem.children[child].chunk.statusName == "RUNNING") {
+                                chunksLV.forceActiveFocus()
+                                chunksLV.currentIndex = chunksLV.contentItem.children[child].text
+                            }
+                        }
+                    }
+                }
+            }
         }
 
         ColumnLayout {


### PR DESCRIPTION
Minor addition which adds a button in the list of chunks in the node log to select the chunk that is being processed, very useful when scrolling through lots of chunks to find it.

The button only shows when the node is running or has error and has multiple chunks.
![chunk_button](https://user-images.githubusercontent.com/32775248/61172012-054af300-a577-11e9-870f-b58e3abab0b9.gif)
