### PR TITLE
Viewer3D: add support for vertex-colored meshes

### DIFF
--- a/meshroom/nodes/aliceVision/Meshing.py
+++ b/meshroom/nodes/aliceVision/Meshing.py
@@ -210,6 +210,13 @@ class Meshing(desc.CommandLineNode):
             advanced=True,
         ),
         desc.BoolParam(
+            name='colorizeOutput',
+            label='Colorize Output',
+            description='Whether to colorize output dense point cloud and mesh.',
+            value=False,
+            uid=[0],
+        ),
+        desc.BoolParam(
             name='saveRawDensePointCloud',
             label='Save Raw Dense Point Cloud',
             description='Save dense point cloud before cut and filtering.',

--- a/meshroom/nodes/aliceVision/Meshing.py
+++ b/meshroom/nodes/aliceVision/Meshing.py
@@ -230,17 +230,17 @@ class Meshing(desc.CommandLineNode):
 
     outputs = [
         desc.File(
-            name="output",
-            label="Output Dense Point Cloud",
-            description="Output dense point cloud with visibilities (SfMData file format).",
-            value="{cache}/{nodeType}/{uid0}/densePointCloud.abc",
-            uid=[],
-        ),
-            desc.File(
             name="outputMesh",
             label="Output Mesh",
             description="Output mesh (OBJ file format).",
             value="{cache}/{nodeType}/{uid0}/mesh.obj",
+            uid=[],
+        ),
+        desc.File(
+            name="output",
+            label="Output Dense Point Cloud",
+            description="Output dense point cloud with visibilities (SfMData file format).",
+            value="{cache}/{nodeType}/{uid0}/densePointCloud.abc",
             uid=[],
         ),
     ]

--- a/meshroom/ui/components/scene3D.py
+++ b/meshroom/ui/components/scene3D.py
@@ -45,6 +45,13 @@ class Scene3DHelper(QObject):
             count += sum([attr.count() for attr in geo.attributes() if attr.name() == "vertexPosition"])
         return count / 3
 
+    @Slot(Qt3DCore.QEntity, result=int)
+    def vertexColorCount(self, entity):
+        count = 0
+        for geo in entity.findChildren(Qt3DRender.QGeometry):
+            count += sum([attr.count() for attr in geo.attributes() if attr.name() == "vertexColor"])
+        return count
+
 
 class TrackballController(QObject):
     """

--- a/meshroom/ui/qml/Viewer3D/MaterialSwitcher.qml
+++ b/meshroom/ui/qml/Viewer3D/MaterialSwitcher.qml
@@ -62,7 +62,11 @@ Entity {
             },
             State {
                 name: "Textured"
-                PropertyChanges { target: m; material: diffuseMap ? textured : solid }
+                PropertyChanges {
+                    target: m;
+                    // "textured" material resolution order: diffuse map > vertex color data >  no color info
+                    material: diffuseMap ? textured : (Scene3DHelper.vertexColorCount(root.parent) ? colored : solid)
+                }
             }
         ]
     }
@@ -78,6 +82,11 @@ Entity {
         shininess: root.shininess
         specular: root.specular
         diffuse: root.diffuseColor
+    }
+
+    PerVertexColorMaterial {
+        id: colored
+        objectName: "VertexColorMaterial"
     }
 
     DiffuseSpecularMaterial {


### PR DESCRIPTION
### Description
Related to https://github.com/alicevision/AliceVision/pull/661

Enables the display of vertex-colored meshes in the 3D Viewer, by using a `PerVertexColorMaterial` if vertex color data is available on a mesh without textures.