### PR TITLE
[bin] Fix project creation from custom pipeline

### DIFF
--- a/bin/meshroom_photogrammetry
+++ b/bin/meshroom_photogrammetry
@@ -80,6 +80,8 @@ elif os.path.isfile(args.input) and os.path.splitext(args.input)[-1] in ('.json'
     # args.input is a sfmData file: setup pre-calibrated views and intrinsics
     from meshroom.nodes.aliceVision.CameraInit import readSfMData
     views, intrinsics = readSfMData(args.input)
+else:
+    raise RuntimeError(args.input + ': format not supported')
 
 # initialize photogrammetry pipeline
 if args.pipeline:

--- a/bin/meshroom_photogrammetry
+++ b/bin/meshroom_photogrammetry
@@ -89,6 +89,9 @@ if args.pipeline:
     # reset graph inputs
     cameraInit.viewpoints.resetValue()
     cameraInit.intrinsics.resetValue()
+    # add views and intrinsics (if any) read from args.input
+    cameraInit.viewpoints.extend(views)
+    cameraInit.intrinsics.extend(intrinsics)
 
     if not graph.canComputeLeaves:
         raise RuntimeError("Graph cannot be computed. Check for compatibility issues.")


### PR DESCRIPTION
This PR fixes a problem when using a custom pipeline in meshroom_photogrammetry: the views and the intrinsics that might have been read before from the a json/sfm file were not added to the graph, thus leading to failure when calling cameraInit in AliceVision.
```
[11:25:25.780397][error] Program need -i or --imageFolder option
```