### PR TITLE
Add option to include 'unknown' feature types in ConvertSfMFormat

### DIFF
--- a/meshroom/nodes/aliceVision/ConvertSfMFormat.py
+++ b/meshroom/nodes/aliceVision/ConvertSfMFormat.py
@@ -30,7 +30,7 @@ class ConvertSfMFormat(desc.CommandLineNode):
             label='Describer Types',
             description='Describer types to keep.',
             value=['sift'],
-            values=['sift', 'sift_float', 'sift_upright', 'akaze', 'akaze_liop', 'akaze_mldb', 'cctag3', 'cctag4', 'sift_ocv', 'akaze_ocv'],
+            values=['sift', 'sift_float', 'sift_upright', 'akaze', 'akaze_liop', 'akaze_mldb', 'cctag3', 'cctag4', 'sift_ocv', 'akaze_ocv', 'unknown'],
             exclusive=False,
             uid=[0],
             joinChar=',',


### PR DESCRIPTION
The new ability to output dense point clouds via AliceVision's meshing utility produces an Alembic file that seems to look identical to the normal SfM Alembic files except that the `mvgPointCloud` entries have their feature type set to `unknown`. However, this option isn't set as one of the parameters in the `ConvertSfMFormat` meshroom wrapper.   As a result the node always strips out the points.  Adding an "unknown" feature type option to the wrapper allows the dense cloud to be converted properly.

If there's a better way, or a different change needed to save dense clouds to non-Alembic formats let me know and can take a look.  Thanks for all the great work on AliceVision, I'm a huge fan.