### PR TITLE
[ui] Viewer3D: fix Alembic visibility issues

### DIFF
--- a/meshroom/ui/qml/Viewer3D/AlembicLoader.qml
+++ b/meshroom/ui/qml/Viewer3D/AlembicLoader.qml
@@ -11,6 +11,7 @@ import Qt3D.Extras 2.1
 AlembicEntity {
     id: root
 
+    property bool cameraPickingEnabled: true
     // filter out non-reconstructed cameras
     skipHidden: true
 
@@ -52,9 +53,13 @@ AlembicEntity {
                 },
                 ObjectPicker {
                     id: cameraPicker
-                    enabled: root.enabled
-                    onClicked: _reconstruction.selectedViewId = camSelector.viewId
-                }
+                    onPressed: pick.accepted = cameraPickingEnabled
+                    onReleased: _reconstruction.selectedViewId = camSelector.viewId
+                },
+                // Qt 5.13: binding cameraPicker.enabled to cameraPickerEnabled
+                //          causes rendering issues when entity gets disabled.
+                //          Use a scale to 0 to disable picking.
+                Transform { scale: cameraPickingEnabled ? 1 : 0 }
             ]
         }
     }

--- a/meshroom/ui/qml/Viewer3D/MediaLibrary.qml
+++ b/meshroom/ui/qml/Viewer3D/MediaLibrary.qml
@@ -275,7 +275,7 @@ Entity {
 
             components: [
                 ObjectPicker {
-                    enabled: parent.enabled && pickingEnabled
+                    enabled: mediaLoader.enabled && pickingEnabled
                     hoverEnabled: false
                     onPressed: root.pressed(pick)
                 }

--- a/meshroom/ui/qml/Viewer3D/MediaLoader.qml
+++ b/meshroom/ui/qml/Viewer3D/MediaLoader.qml
@@ -80,14 +80,13 @@ import Utils 1.0
         id: abcLoaderEntityComponent
         MediaLoaderEntity {
             id: abcLoaderEntity
-            enabled: root.enabled
             Component.onCompleted: {
 
                 var obj = Viewer3DSettings.abcLoaderComp.createObject(abcLoaderEntity, {
                                                'source': source,
                                                'pointSize': Qt.binding(function() { return 0.01 * Viewer3DSettings.pointSize }),
                                                'locatorScale': Qt.binding(function() { return Viewer3DSettings.cameraScale }),
-                                               'enabled': Qt.binding(function() { return root.enabled })
+                                               'cameraPickingEnabled': Qt.binding(function() { return root.enabled })
                                            });
 
                 obj.statusChanged.connect(function() {


### PR DESCRIPTION
Binding the "enabled" property of AlembicLoader's ObjectPicker to the parent MediaLoader's own "enabled" property caused invalid state where the loaded AlembicEntity was partially visible when toggling object visibility (since Qt 5.13).
In order to disable camera picking when AlembicEntity is disable, scale the camSelector component to 0.