### PR TITLE
Bugfix for MESHROOM_SUBMITTERS_PATH env variable

### DIFF
--- a/meshroom/core/__init__.py
+++ b/meshroom/core/__init__.py
@@ -260,10 +260,7 @@ meshroomFolder = os.path.dirname(os.path.dirname(__file__))
 # - Nodes
 loadAllNodes(folder=os.path.join(meshroomFolder, 'nodes'))
 # - Submitters
-subs = loadSubmitters(meshroomFolder, 'submitters')
-# -  additional 3rd party submitters
-if "MESHROOM_SUBMITTERS_PATH" in os.environ:
-    subs += loadSubmitters(os.environ["MESHROOM_SUBMITTERS_PATH"], 'submitters')
+subs = loadSubmitters(os.environ.get("MESHROOM_SUBMITTERS_PATH", meshroomFolder), 'submitters')
 
 for sub in subs:
     registerSubmitter(sub())


### PR DESCRIPTION
Setting MESHROOM_SUBMITTERS_PATH caused meshroom to try to load the bundled
simpleFarmSubmitter plugin twice, ignoring the path in the variable.

I believe the problem lies with the way loadPlugins() works in meshroom.core,
because it's trying to import the package name "submitters" more than once.  The
second time, import_module() just returns a reference to the

This is a revised PR based on feedback from the first one I submitted last year,
which went stale and then got erased as I was stumbling my way through git.

<!-- Checklist before submission:

 - I have read the [contribution guidelines](../CONTRIBUTING.md).
 - I have updated the documentation, if applicable.
 - I have ensured that the change is tested somewhere.
 - I have followed the prevailing code style (for history readability and limit conflicts for maintainance).

-->
## Description



## Features list

<!--
- [ ] Feature one. Fix #XXX
- [ ] Improve something else
- [ ] Connect to #3 (to declare link to issues without closing it when the PR is merged).
- [X] Add "X" when it is done.
-->


## Implementation remarks


<!--
Explain main implementation choices.
It is also the right place to ask for feedback and help when you hesitate on the implementation.
-->
