### PR TITLE
[GitHub] add template for questions / help only 

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -24,15 +24,15 @@ A clear and concise description of what you expected to happen.
 If applicable, add screenshots to help explain your problem.
 
 **Log**
-If applicable, copy paste the relevant log output (please embed the text in a markdown code tag "```" )
+If applicable, copy paste the relevant log output (please embed the text in a markdown code tag "\`\`\`" )
 
 **Desktop (please complete the following and other pertinent information):**
  - OS: [e.g. win 10, osx, ]
- - Version [e.g. 2019.1]
  - Python version [e.g. 2.6]
  - Qt/PySide version [e.g. 5.12.4]
- - Binary version (if applicable) [e.g. 2019.1]
- - Commit reference (if applicable) [e.g. 08ddbe2]
+ - Meshroom version: please specify if you are using a release version or your own build
+   - Binary version (if applicable) [e.g. 2019.1]
+   - Commit reference (if applicable) [e.g. 08ddbe2]
 
 **Additional context**
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/question_help.md
+++ b/.github/ISSUE_TEMPLATE/question_help.md
@@ -1,0 +1,31 @@
+---
+name: Question or help needed
+about: Ask question or for help for issues not related to program failures (e.g. "where I can find this feature", "my dataset is not reconstructed properly", "which parameter setting shall I use" etc...)
+title: "[question]"
+labels: type:question
+assignees: ''
+
+---
+
+**Describe the problem**
+A clear and concise description of what the problem is.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Dataset**
+If applicable, add a link or *few* images to help better understand where the problem may come from.
+
+**Log**
+If applicable, copy paste the relevant log output (please embed the text in a markdown code tag "\`\`\`" )
+
+**Desktop (please complete the following and other pertinent information):**
+ - OS: [e.g. win 10, osx, ]
+ - Python version [e.g. 2.6]
+ - Qt/PySide version [e.g. 5.12.4]
+ - Meshroom version: please specify if you are using a release version or your own build
+   - Binary version (if applicable) [e.g. 2019.1]
+   - Commit reference (if applicable) [e.g. 08ddbe2]
+
+**Additional context**
+Add any other context about the problem here.


### PR DESCRIPTION
Add a template only for questions and help needed, not related to program crashes and failures.