### PR TITLE
Improve command line arguments

### DIFF
--- a/bin/meshroom_photogrammetry
+++ b/bin/meshroom_photogrammetry
@@ -11,15 +11,15 @@ import meshroom.core.graph
 from meshroom import multiview
 
 parser = argparse.ArgumentParser(description='Launch the full photogrammetry pipeline.')
-parser.add_argument('-i', '--input', metavar='FOLDER_OR_SFM', type=str,
-                    default='',
-                    help='Input folder containing images or file (.sfm or .json) '
-                         'with images paths and optionally predefined camera intrinsics.')
-parser.add_argument('--inputImages', metavar='IMAGES', type=str, nargs='*',
+parser.add_argument('-i', '--input', metavar='SFM/FOLDERS/IMAGES', type=str, nargs='*',
                     default=[],
-                    help='Input images.')
+                    help='Input folder containing images or folders of images or file (.sfm or .json) '
+                         'with images paths and optionally predefined camera intrinsics.')
+parser.add_argument('-I', '--inputRecursive', metavar='FOLDERS/IMAGES', type=str, nargs='*',
+                    default=[],
+                    help='Input folders containing all images recursively.')
 
-parser.add_argument('--pipeline', metavar='MESHROOM_FILE', type=str, required=False,
+parser.add_argument('-p', '--pipeline', metavar='MESHROOM_FILE', type=str, required=False,
                     help='Meshroom file containing a pre-configured photogrammetry pipeline to run on input images. '
                          'If not set, the default photogrammetry pipeline will be used. '
                          'Requirements: the graph must contain one CameraInit node, '
@@ -72,24 +72,24 @@ def getOnlyNodeOfType(g, nodeType):
     return nodes[0]
 
 
-if not args.input and not args.inputImages:
-    print('Nothing to compute. You need to set --input or --inputImages.')
+if not args.input and not args.inputRecursive:
+    print('Nothing to compute. You need to set --input or --inputRecursive.')
     sys.exit(1)
 
 views, intrinsics = [], []
 # Build image files list from inputImages arguments
-images = [f for f in args.inputImages if multiview.isImageFile(f)]
+images = []
 
 if args.input:
-    if os.path.isdir(args.input):
-        # args.input is a folder: extend images list with images in that folder
-        images += multiview.findImageFiles(args.input)
-    elif os.path.isfile(args.input) and os.path.splitext(args.input)[-1] in ('.json', '.sfm'):
+    if len(args.input) == 1 and os.path.isfile(args.input[0]) and os.path.splitext(args.input[0])[-1] in ('.json', '.sfm'):
         # args.input is a sfmData file: setup pre-calibrated views and intrinsics
         from meshroom.nodes.aliceVision.CameraInit import readSfMData
-        views, intrinsics = readSfMData(args.input)
+        views, intrinsics = readSfMData(args.input[0])
     else:
-        raise RuntimeError(args.input + ': format not supported.')
+        images += multiview.findImageFiles(args.input, recursive=False)
+
+if args.inputRecursive:
+    images += multiview.findImageFiles(args.inputRecursive, recursive=True)
 
 # initialize photogrammetry pipeline
 if args.pipeline:

--- a/bin/meshroom_photogrammetry
+++ b/bin/meshroom_photogrammetry
@@ -38,7 +38,7 @@ parser.add_argument('--cache', metavar='FOLDER', type=str,
                          'If not set, the default cache folder will be used: ' + meshroom.core.defaultCacheFolder)
 
 parser.add_argument('--save', metavar='FILE', type=str, required=False,
-                    help='Save the configured Meshroom project to a file.')
+                    help='Save the configured Meshroom graph to a project file. It will setup the cache folder accordingly if not explicitly changed by --cache.')
 
 parser.add_argument('--compute', metavar='<yes/no>', type=lambda x: bool(distutils.util.strtobool(x)), default=True, required=False,
                     help='You can set it to <no/false/0> to disable the computation.')
@@ -130,12 +130,12 @@ if args.scale > 0:
     for node in graph.nodesByType('DepthMap'):
         node.downscale.value = args.scale
 
-if args.save:
-    graph.save(args.save)
-    print('File successfully saved:', args.save)
-
 # setup cache directory
 graph.cacheDir = args.cache if args.cache else meshroom.core.defaultCacheFolder
+
+if args.save:
+    graph.save(args.save, fileLink=not bool(args.cache))
+    print('File successfully saved: "{}"'.format(args.save))
 
 if not args.output:
     print('No output set, results will be available in the cache folder: "{}"'.format(graph.cacheDir))

--- a/bin/meshroom_photogrammetry
+++ b/bin/meshroom_photogrammetry
@@ -80,6 +80,8 @@ views, intrinsics = [], []
 # Build image files list from inputImages arguments
 images = []
 
+hasSearchedForImages = False
+
 if args.input:
     if len(args.input) == 1 and os.path.isfile(args.input[0]) and os.path.splitext(args.input[0])[-1] in ('.json', '.sfm'):
         # args.input is a sfmData file: setup pre-calibrated views and intrinsics
@@ -87,9 +89,15 @@ if args.input:
         views, intrinsics = readSfMData(args.input[0])
     else:
         images += multiview.findImageFiles(args.input, recursive=False)
+        hasSearchedForImages = True
 
 if args.inputRecursive:
     images += multiview.findImageFiles(args.inputRecursive, recursive=True)
+    hasSearchedForImages = True
+
+if hasSearchedForImages and not images:
+    print("No image found")
+    exit(-1)
 
 # initialize photogrammetry pipeline
 if args.pipeline:

--- a/bin/meshroom_photogrammetry
+++ b/bin/meshroom_photogrammetry
@@ -2,6 +2,7 @@
 import argparse
 import os
 import sys
+import distutils.util
 
 import meshroom
 meshroom.setupEnvironment()
@@ -10,7 +11,7 @@ import meshroom.core.graph
 from meshroom import multiview
 
 parser = argparse.ArgumentParser(description='Launch the full photogrammetry pipeline.')
-parser.add_argument('--input', metavar='FOLDER_OR_SFM', type=str,
+parser.add_argument('-i', '--input', metavar='FOLDER_OR_SFM', type=str,
                     default='',
                     help='Input folder containing images or file (.sfm or .json) '
                          'with images paths and optionally predefined camera intrinsics.')
@@ -27,7 +28,7 @@ parser.add_argument('--pipeline', metavar='MESHROOM_FILE', type=str, required=Fa
 parser.add_argument('--overrides', metavar='SETTINGS', type=str, default=None,
                     help='A JSON file containing the graph parameters override.')
 
-parser.add_argument('--output', metavar='FOLDER', type=str, required=False,
+parser.add_argument('-o', '--output', metavar='FOLDER', type=str, required=False,
                     help='Output folder where results should be copied to. '
                          'If not set, results will have to be retrieved directly from the cache folder.')
 
@@ -37,7 +38,10 @@ parser.add_argument('--cache', metavar='FOLDER', type=str,
                          'If not set, the default cache folder will be used: ' + meshroom.core.defaultCacheFolder)
 
 parser.add_argument('--save', metavar='FILE', type=str, required=False,
-                    help='Save the configured Meshroom project to a file (instead of running it).')
+                    help='Save the configured Meshroom project to a file.')
+
+parser.add_argument('--compute', metavar='<yes/no>', type=lambda x: bool(distutils.util.strtobool(x)), default=True, required=False,
+                    help='You can set it to <no/false/0> to disable the computation.')
 
 parser.add_argument('--scale', type=int, default=-1,
                     choices=[-1, 1, 2, 4, 8, 16],
@@ -129,16 +133,16 @@ if args.scale > 0:
 if args.save:
     graph.save(args.save)
     print('File successfully saved:', args.save)
-    sys.exit(0)
 
 # setup cache directory
 graph.cacheDir = args.cache if args.cache else meshroom.core.defaultCacheFolder
 
 if not args.output:
-    print('No output set, results will be available in {}'.format(graph.cacheDir))
+    print('No output set, results will be available in the cache folder: "{}"'.format(graph.cacheDir))
 
 # find end nodes (None will compute all graph)
 toNodes = graph.findNodes(args.toNode) if args.toNode else None
 
-# start computation
-meshroom.core.graph.executeGraph(graph, toNodes=toNodes, forceCompute=args.forceCompute, forceStatus=args.forceStatus)
+if args.compute:
+    # start computation
+    meshroom.core.graph.executeGraph(graph, toNodes=toNodes, forceCompute=args.forceCompute, forceStatus=args.forceStatus)

--- a/bin/meshroom_photogrammetry
+++ b/bin/meshroom_photogrammetry
@@ -28,6 +28,9 @@ parser.add_argument('--pipeline', metavar='MESHROOM_FILE', type=str, required=Fa
 parser.add_argument('--overrides', metavar='SETTINGS', type=str, default=None,
                     help='A JSON file containing the graph parameters override.')
 
+parser.add_argument('--paramOverrides', metavar='NODETYPE:param=value NODEINSTANCE.param=value', type=str, default=None, nargs='*',
+                    help='Override specific parameters directly from the command line (by node type or by node names).')
+
 parser.add_argument('-o', '--output', metavar='FOLDER', type=str, required=False,
                     help='Output folder where results should be copied to. '
                          'If not set, results will have to be retrieved directly from the cache folder.')
@@ -124,6 +127,29 @@ if args.overrides:
         for nodeName, overrides in data.items():
             for attrName, value in overrides.items():
                 graph.findNode(nodeName).attribute(attrName).value = value
+
+if args.paramOverrides:
+    print("\n")
+    import re
+    reExtract = re.compile('(\w+)([:.])(\w+)=(.*)')
+    for p in args.paramOverrides:
+        result = reExtract.match(p)
+        if not result:
+            raise ValueError('Invalid param override: ' + str(p))
+        node, t, param, value = result.groups()
+        if t == ':':
+            nodesByType = graph.nodesByType(node)
+            if not nodesByType:
+                raise ValueError('No node with the type "{}" in the scene.'.format(node))
+            for n in nodesByType:
+                print('Overrides {node}.{param}={value}'.format(node=node, param=param, value=value))
+                n.attribute(param).value = value
+        elif t == '.':
+            print('Overrides {node}.{param}={value}'.format(node=node, param=param, value=value))
+            graph.findNode(node).attribute(param).value = value
+        else:
+            raise ValueError('Invalid param override: ' + str(p))
+    print("\n")
 
 # setup DepthMap downscaling
 if args.scale > 0:

--- a/bin/meshroom_photogrammetry
+++ b/bin/meshroom_photogrammetry
@@ -134,7 +134,7 @@ if args.scale > 0:
 graph.cacheDir = args.cache if args.cache else meshroom.core.defaultCacheFolder
 
 if args.save:
-    graph.save(args.save, fileLink=not bool(args.cache))
+    graph.save(args.save, setupFileRef=not bool(args.cache))
     print('File successfully saved: "{}"'.format(args.save))
 
 if not args.output:

--- a/meshroom/core/__init__.py
+++ b/meshroom/core/__init__.py
@@ -240,7 +240,7 @@ def loadAllNodes(folder):
             nodeTypes = loadNodes(folder, package)
             for nodeType in nodeTypes:
                 registerNodeType(nodeType)
-            print('Plugins loaded: ', ', '.join([nodeType.__name__ for nodeType in nodeTypes]))
+            logging.debug('Plugins loaded: ', ', '.join([nodeType.__name__ for nodeType in nodeTypes]))
 
 
 def registerSubmitter(s):

--- a/meshroom/core/graph.py
+++ b/meshroom/core/graph.py
@@ -234,14 +234,14 @@ class Graph(BaseObject):
         return Graph.IO.getFeaturesForVersion(self.header.get(Graph.IO.Keys.FileVersion, "0.0"))
 
     @Slot(str)
-    def load(self, filepath, setupFileRef=True):
+    def load(self, filepath, setupProjectFile=True):
         """
         Load a meshroom graph ".mg" file.
 
         Args:
             filepath: project filepath to load
-            setupFileRef: Setup reference to the project file, like setup cacheDir, keep filepath for save, etc.
-                          This option allows to disable it, to only load the project file as a template.
+            setupProjectFile: Store the reference to the project file and setup the cache directory.
+                              If false, it only loads the graph of the project file as a template.
         """
         self.clear()
         with open(filepath) as jsonFile:
@@ -273,7 +273,7 @@ class Graph(BaseObject):
                 # Add node to the graph with raw attributes values
                 self._addNode(n, nodeName)
 
-        if setupFileRef:
+        if setupProjectFile:
             # Update filepath related members
             self._setFilepath(filepath)
 
@@ -905,7 +905,7 @@ class Graph(BaseObject):
     def asString(self):
         return str(self.toDict())
 
-    def save(self, filepath=None, setupFileRef=True):
+    def save(self, filepath=None, setupProjectFile=True):
         path = filepath or self._filepath
         if not path:
             raise ValueError("filepath must be specified for unsaved files.")
@@ -929,7 +929,7 @@ class Graph(BaseObject):
         with open(path, 'w') as jsonFile:
             json.dump(data, jsonFile, indent=4)
 
-        if path != self._filepath and setupFileRef:
+        if path != self._filepath and setupProjectFile:
             self._setFilepath(path)
 
     def _setFilepath(self, filepath):

--- a/meshroom/core/graph.py
+++ b/meshroom/core/graph.py
@@ -905,7 +905,7 @@ class Graph(BaseObject):
     def asString(self):
         return str(self.toDict())
 
-    def save(self, filepath=None):
+    def save(self, filepath=None, fileLink=True):
         path = filepath or self._filepath
         if not path:
             raise ValueError("filepath must be specified for unsaved files.")
@@ -929,7 +929,7 @@ class Graph(BaseObject):
         with open(path, 'w') as jsonFile:
             json.dump(data, jsonFile, indent=4)
 
-        if path != self._filepath:
+        if path != self._filepath and fileLink:
             self._setFilepath(path)
 
     def _setFilepath(self, filepath):
@@ -939,7 +939,9 @@ class Graph(BaseObject):
         Args:
             filepath: the graph file path
         """
-        assert os.path.isfile(filepath)
+        if not os.path.isfile(filepath):
+            self._unsetFilepath()
+            return
 
         if self._filepath == filepath:
             return
@@ -949,6 +951,12 @@ class Graph(BaseObject):
         #  * graph name if the basename of the graph file
         self.name = os.path.splitext(os.path.basename(filepath))[0]
         self.cacheDir = os.path.join(os.path.abspath(os.path.dirname(filepath)), meshroom.core.cacheFolderName)
+        self.filepathChanged.emit()
+
+    def _unsetFilepath(self):
+        self._filepath = ""
+        self.name = ""
+        self.cacheDir = meshroom.core.defaultCacheFolder
         self.filepathChanged.emit()
 
     def updateInternals(self, startNodes=None, force=False):

--- a/meshroom/core/graph.py
+++ b/meshroom/core/graph.py
@@ -234,14 +234,14 @@ class Graph(BaseObject):
         return Graph.IO.getFeaturesForVersion(self.header.get(Graph.IO.Keys.FileVersion, "0.0"))
 
     @Slot(str)
-    def load(self, filepath, fileLink=True):
+    def load(self, filepath, setupFileRef=True):
         """
         Load a meshroom graph ".mg" file.
 
         Args:
             filepath: project filepath to load
-            fileLink: Setup link to the project file, like setup cacheDir, keep filepath for save, etc.
-                      This option allows to disable it, to only load the project file as a template
+            setupFileRef: Setup reference to the project file, like setup cacheDir, keep filepath for save, etc.
+                          This option allows to disable it, to only load the project file as a template.
         """
         self.clear()
         with open(filepath) as jsonFile:
@@ -273,7 +273,7 @@ class Graph(BaseObject):
                 # Add node to the graph with raw attributes values
                 self._addNode(n, nodeName)
 
-        if fileLink:
+        if setupFileRef:
             # Update filepath related members
             self._setFilepath(filepath)
 
@@ -905,7 +905,7 @@ class Graph(BaseObject):
     def asString(self):
         return str(self.toDict())
 
-    def save(self, filepath=None, fileLink=True):
+    def save(self, filepath=None, setupFileRef=True):
         path = filepath or self._filepath
         if not path:
             raise ValueError("filepath must be specified for unsaved files.")
@@ -929,7 +929,7 @@ class Graph(BaseObject):
         with open(path, 'w') as jsonFile:
             json.dump(data, jsonFile, indent=4)
 
-        if path != self._filepath and fileLink:
+        if path != self._filepath and setupFileRef:
             self._setFilepath(path)
 
     def _setFilepath(self, filepath):

--- a/meshroom/core/graph.py
+++ b/meshroom/core/graph.py
@@ -234,7 +234,15 @@ class Graph(BaseObject):
         return Graph.IO.getFeaturesForVersion(self.header.get(Graph.IO.Keys.FileVersion, "0.0"))
 
     @Slot(str)
-    def load(self, filepath):
+    def load(self, filepath, fileLink=True):
+        """
+        Load a meshroom graph ".mg" file.
+
+        Args:
+            filepath: project filepath to load
+            fileLink: Setup link to the project file, like setup cacheDir, keep filepath for save, etc.
+                      This option allows to disable it, to only load the project file as a template
+        """
         self.clear()
         with open(filepath) as jsonFile:
             fileData = json.load(jsonFile)
@@ -265,8 +273,9 @@ class Graph(BaseObject):
                 # Add node to the graph with raw attributes values
                 self._addNode(n, nodeName)
 
-        # Update filepath related members
-        self._setFilepath(filepath)
+        if fileLink:
+            # Update filepath related members
+            self._setFilepath(filepath)
 
         # Create graph edges by resolving attributes expressions
         self._applyExpr()

--- a/meshroom/multiview.py
+++ b/meshroom/multiview.py
@@ -19,20 +19,31 @@ def findImageFiles(folder, recursive=False):
     Return all files that are images in 'folder' based on their extensions.
 
     Args:
-        folder (str): the folder to look into
+        folder (str): folder to look into or list of folder/files
 
     Returns:
-        list: the list of image files.
+        list: the list of image files with a supported extension.
     """
-    if recursive:
-        output = []
-        for root, directories, files in os.walk(folder):
-            for filename in files:
-                if isImageFile(filename):
-                    output.append(os.path.join(root, filename))
-        return output
+    inputFolders = []
+    if isinstance(folder, (list, tuple)):
+        inputFolders = folder
     else:
-         return [os.path.join(folder, filename) for filename in os.listdir(folder) if isImageFile(filename)]
+        inputFolders.append(folder)
+
+    output = []
+    for currentFolder in inputFolders:
+        if os.path.isfile(currentFolder):
+            if isImageFile(currentFolder):
+                output.append(currentFolder)
+            continue
+        if recursive:
+            for root, directories, files in os.walk(currentFolder):
+                for filename in files:
+                    if isImageFile(filename):
+                        output.append(os.path.join(root, filename))
+        else:
+             output.extend([os.path.join(currentFolder, filename) for filename in os.listdir(currentFolder) if isImageFile(filename)])
+    return output
 
 
 def photogrammetry(inputImages=list(), inputViewpoints=list(), inputIntrinsics=list(), output=''):

--- a/meshroom/multiview.py
+++ b/meshroom/multiview.py
@@ -47,11 +47,12 @@ def photogrammetry(inputImages=list(), inputViewpoints=list(), inputIntrinsics=l
         cameraInit.viewpoints.extend(inputViewpoints)
         cameraInit.intrinsics.extend(inputIntrinsics)
 
-    if output:
-        texturing = mvsNodes[-1]
-        graph.addNewNode('Publish', output=output, inputFiles=[texturing.outputMesh,
-                                                               texturing.outputMaterial,
-                                                               texturing.outputTextures])
+        if output:
+            texturing = mvsNodes[-1]
+            graph.addNewNode('Publish', output=output, inputFiles=[texturing.outputMesh,
+                                                                   texturing.outputMaterial,
+                                                                   texturing.outputTextures])
+
     return graph
 
 

--- a/meshroom/multiview.py
+++ b/meshroom/multiview.py
@@ -14,7 +14,7 @@ def isImageFile(filepath):
     return os.path.splitext(filepath)[1].lower() in imageExtensions
 
 
-def findImageFiles(folder):
+def findImageFiles(folder, recursive=False):
     """
     Return all files that are images in 'folder' based on their extensions.
 
@@ -24,7 +24,15 @@ def findImageFiles(folder):
     Returns:
         list: the list of image files.
     """
-    return [os.path.join(folder, filename) for filename in os.listdir(folder) if isImageFile(filename)]
+    if recursive:
+        output = []
+        for root, directories, files in os.walk(folder):
+            for filename in files:
+                if isImageFile(filename):
+                    output.append(os.path.join(root, filename))
+        return output
+    else:
+         return [os.path.join(folder, filename) for filename in os.listdir(folder) if isImageFile(filename)]
 
 
 def photogrammetry(inputImages=list(), inputViewpoints=list(), inputIntrinsics=list(), output=''):

--- a/meshroom/ui/app.py
+++ b/meshroom/ui/app.py
@@ -59,15 +59,13 @@ class MeshroomApp(QApplication):
 
         parser = argparse.ArgumentParser(prog=args[0], description='Launch Meshroom UI.', add_help=True)
 
-        parser.add_argument('input', metavar='INPUT', type=str, nargs='?',
+        parser.add_argument('project', metavar='PROJECT', type=str, nargs='?',
                             help='Meshroom project file (e.g. myProject.mg) or folder with images to reconstruct.')
         parser.add_argument('-i', '--import', metavar='IMAGES/FOLDERS', type=str, nargs='*',
                             help='Import images or folder with images to reconstruct.')
         parser.add_argument('-I', '--importRecursive', metavar='FOLDERS', type=str, nargs='*',
                             help='Import images to reconstruct from specified folder and sub-folders.')
-        parser.add_argument('-p', '--project', metavar='MESHROOM_FILE', type=str, required=False,
-                            help='Meshroom project file (e.g. myProject.mg).')
-        parser.add_argument('-P', '--pipeline', metavar='MESHROOM_FILE', type=str, required=False,
+        parser.add_argument('-p', '--pipeline', metavar='MESHROOM_FILE', type=str, required=False,
                             help='Override the default Meshroom pipeline with this external graph.')
 
         args = parser.parse_args(args[1:])
@@ -130,28 +128,13 @@ class MeshroomApp(QApplication):
             if defaultPipeline:
                 r.setDefaultPipeline(args.pipeline)
 
-        if args.input:
-            if not os.path.isfile(args.input) and not os.path.isdir(args.input):
-                raise RuntimeError(
-                    "Meshroom Command Line Error: 'INPUT' argument should be a Meshroom project file (.mg) or a folder with input images.\n"
-                    "Invalid value: '{}'".format(args.input))
         if args.project and not os.path.isfile(args.project):
             raise RuntimeError(
-                "Meshroom Command Line Error: '--project' argument should be a Meshroom project file (.mg).\n"
+                "Meshroom Command Line Error: 'PROJECT' argument should be a Meshroom project file (.mg).\n"
                 "Invalid value: '{}'".format(args.project))
-
-        if args.project and args.input and not os.path.isdir(args.input):
-            raise RuntimeError("Meshroom Command Line Error: 'INPUT' and '--project' arguments cannot both load a Meshroom project file (.mg).")
 
         if args.project:
             r.load(args.project)
-
-        if args.input:
-            if os.path.isfile(args.input):
-                # we assume that it is an ".mg" file.
-                r.load(args.input)
-            elif os.path.isdir(args.input):
-                r.importImagesFromFolder(args.input, recursive=False)
 
         # import is a python keyword, so we have to access the attribute by a string
         if getattr(args, "import", None):

--- a/meshroom/ui/graph.py
+++ b/meshroom/ui/graph.py
@@ -313,11 +313,11 @@ class UIGraph(QObject):
 
     def setDefaultPipeline(self, pipelineFilepath):
         self._defaultPipelineFilepath = pipelineFilepath
-        self._graph.load(pipelineFilepath, setupFileRef=False)
+        self._graph.load(pipelineFilepath, setupProjectFile=False)
 
-    def load(self, filepath, setupFileRef=True):
+    def load(self, filepath, setupProjectFile=True):
         g = Graph('')
-        g.load(filepath, setupFileRef)
+        g.load(filepath, setupProjectFile)
         if not os.path.exists(g.cacheDir):
             os.mkdir(g.cacheDir)
         self.setGraph(g)
@@ -372,7 +372,7 @@ class UIGraph(QObject):
     def submit(self, node=None):
         """ Submit the graph to the default Submitter.
         If a node is specified, submit this node and its uncomputed predecessors.
-        Otherwise, submit the whole 
+        Otherwise, submit the whole
 
         Notes:
             Default submitter is specified using the MESHROOM_DEFAULT_SUBMITTER environment variable.

--- a/meshroom/ui/graph.py
+++ b/meshroom/ui/graph.py
@@ -254,6 +254,7 @@ class UIGraph(QObject):
         self._layout = GraphLayout(self)
         self._selectedNode = None
         self._hoveredNode = None
+        self._defaultPipelineFilepath = None
         if filepath:
             self.load(filepath)
 
@@ -310,9 +311,13 @@ class UIGraph(QObject):
         self.stopExecution()
         self._chunksMonitor.stop()
 
-    def load(self, filepath):
+    def setDefaultPipeline(self, pipelineFilepath):
+        self._defaultPipelineFilepath = pipelineFilepath
+        self._graph.load(pipelineFilepath, fileLink=False)
+
+    def load(self, filepath, fileLink=True):
         g = Graph('')
-        g.load(filepath)
+        g.load(filepath, fileLink)
         if not os.path.exists(g.cacheDir):
             os.mkdir(g.cacheDir)
         self.setGraph(g)

--- a/meshroom/ui/graph.py
+++ b/meshroom/ui/graph.py
@@ -313,11 +313,11 @@ class UIGraph(QObject):
 
     def setDefaultPipeline(self, pipelineFilepath):
         self._defaultPipelineFilepath = pipelineFilepath
-        self._graph.load(pipelineFilepath, fileLink=False)
+        self._graph.load(pipelineFilepath, setupFileRef=False)
 
-    def load(self, filepath, fileLink=True):
+    def load(self, filepath, setupFileRef=True):
         g = Graph('')
-        g.load(filepath, fileLink)
+        g.load(filepath, setupFileRef)
         if not os.path.exists(g.cacheDir):
             os.mkdir(g.cacheDir)
         self.setGraph(g)

--- a/meshroom/ui/reconstruction.py
+++ b/meshroom/ui/reconstruction.py
@@ -197,14 +197,14 @@ class Reconstruction(UIGraph):
         """ Create a new photogrammetry pipeline. """
         if self._defaultPipelineFilepath:
             # use the user-provided default photogrammetry project file
-            self.load(self._defaultPipelineFilepath, setupFileRef=False)
+            self.load(self._defaultPipelineFilepath, setupProjectFile=False)
         else:
             # default photogrammetry pipeline
             self.setGraph(multiview.photogrammetry())
 
-    def load(self, filepath, setupFileRef=True):
+    def load(self, filepath, setupProjectFile=True):
         try:
-            super(Reconstruction, self).load(filepath, setupFileRef)
+            super(Reconstruction, self).load(filepath, setupProjectFile)
             # warn about pre-release projects being automatically upgraded
             if Version(self._graph.fileReleaseVersion).major == "0":
                 self.warning.emit(Message(

--- a/meshroom/ui/reconstruction.py
+++ b/meshroom/ui/reconstruction.py
@@ -197,14 +197,14 @@ class Reconstruction(UIGraph):
         """ Create a new photogrammetry pipeline. """
         if self._defaultPipelineFilepath:
             # use the user-provided default photogrammetry project file
-            self.load(self._defaultPipelineFilepath, fileLink=False)
+            self.load(self._defaultPipelineFilepath, setupFileRef=False)
         else:
             # default photogrammetry pipeline
             self.setGraph(multiview.photogrammetry())
 
-    def load(self, filepath, fileLink=True):
+    def load(self, filepath, setupFileRef=True):
         try:
-            super(Reconstruction, self).load(filepath, fileLink)
+            super(Reconstruction, self).load(filepath, setupFileRef)
             # warn about pre-release projects being automatically upgraded
             if Version(self._graph.fileReleaseVersion).major == "0":
                 self.warning.emit(Message(

--- a/meshroom/ui/reconstruction.py
+++ b/meshroom/ui/reconstruction.py
@@ -364,13 +364,27 @@ class Reconstruction(UIGraph):
                 images.append(localFile)
         return images
 
-    def importImagesFromFolder(self, path):
+    def importImagesFromFolder(self, path, recursive=False):
+        """
+
+        Args:
+            path: A path to a folder or file or a list of files/folders
+            recursive: List files in folders recursively.
+
+        """
         images = []
-        if os.path.isdir(path):  # get folder content
-            images.extend(multiview.findImageFiles(path))
-        elif multiview.isImageFile(path):
-            images.append(path)
-        self.buildIntrinsics(self.cameraInit, images)
+        paths = []
+        if isinstance(path, (list, tuple)):
+            paths = path
+        else:
+            paths.append(path)
+        for p in paths:
+            if os.path.isdir(p):  # get folder content
+                images.extend(multiview.findImageFiles(p, recursive))
+            elif multiview.isImageFile(p):
+                images.append(p)
+        if images:
+            self.buildIntrinsics(self.cameraInit, images)
 
     def importImagesAsync(self, images, cameraInit):
         """ Add the given list of images to the Reconstruction. """


### PR DESCRIPTION
## Description

This PR improves meshroom_photogrammetry and meshroom command lines.

## Features list

- meshroom_photogrammetry: "--save" does not disable the computation so you can save your batch reconstruction project and open it later interactively in meshroom. Additionnal --compute option if you need only to create a meshroom project file from this command line.
- "meshroom -h / --help": now provides command line documentation
- meshroom: new positional argument to set project file
- meshroom: new "--pipeline" option to override the default pipeline with your own project file. It also supports an environment variable MESHROOM_DEFAULT_PIPELINE.
- meshroom_photogrammetry: new "--paramOverrides NODE.param=value" allows to set a parameter directly from the command line.

## Implementation

- minor change in photogrammetry() to keep the whole graph creation in a single GraphModification.
