### PR TITLE
Sync 3D camera with image selection

### DIFF
--- a/meshroom/nodes/aliceVision/StructureFromMotion.py
+++ b/meshroom/nodes/aliceVision/StructureFromMotion.py
@@ -267,19 +267,20 @@ class StructureFromMotion(desc.CommandLineNode):
     ]
 
     @staticmethod
-    def getViewsAndPoses(node):
+    def getResults(node):
         """
-        Parse SfM result and return views and poses as two dict with viewId and poseId as keys.
+        Parse SfM result and return views, poses and intrinsics as three dicts with viewId, poseId and intrinsicId as keys.
         """
         reportFile = node.outputViewsAndPoses.value
         if not os.path.exists(reportFile):
-            return {}, {}
+            return {}, {}, {}
 
         with open(reportFile) as jsonFile:
             report = json.load(jsonFile)
 
         views = dict()
         poses = dict()
+        intrinsics = dict()
 
         for view in report['views']:
             views[view['viewId']] = view
@@ -287,4 +288,7 @@ class StructureFromMotion(desc.CommandLineNode):
         for pose in report['poses']:
             poses[pose['poseId']] = pose['pose']
 
-        return views, poses
+        for intrinsic in report['intrinsics']:
+            intrinsics[intrinsic['intrinsicId']] = intrinsic
+
+        return views, poses, intrinsics

--- a/meshroom/ui/qml/Controls/TextFileViewer.qml
+++ b/meshroom/ui/qml/Controls/TextFileViewer.qml
@@ -37,35 +37,28 @@ Item {
             background: Rectangle { color: Qt.darker(Colors.sysPalette.window, 1.2) }
             Column {
                 height: parent.height
-                ToolButton {
+                spacing: 1
+                MaterialToolButton {
                     text: MaterialIcons.refresh
                     ToolTip.text: "Reload"
-                    ToolTip.visible: hovered
-                    font.family: MaterialIcons.fontFamily
                     onClicked: loadSource()
                 }
-                ToolButton {
+                MaterialToolButton {
                     text: MaterialIcons.vertical_align_top
                     ToolTip.text: "Scroll to Top"
-                    ToolTip.visible: hovered
-                    font.family: MaterialIcons.fontFamily
                     onClicked: textView.positionViewAtBeginning()
                 }
-                ToolButton {
+                MaterialToolButton {
                     id: autoscroll
                     text: MaterialIcons.vertical_align_bottom
                     ToolTip.text: "Scroll to Bottom"
-                    ToolTip.visible: hovered
-                    font.family: MaterialIcons.fontFamily
                     onClicked: textView.positionViewAtEnd()
                     checkable: false
                     checked: textView.atYEnd
                 }
-                ToolButton {
+                MaterialToolButton {
                     text: MaterialIcons.assignment
                     ToolTip.text: "Copy"
-                    ToolTip.visible: hovered
-                    font.family: MaterialIcons.fontFamily
                     onClicked: copySubMenu.open()
                     Menu {
                         id: copySubMenu
@@ -88,11 +81,9 @@ Item {
                          }
                     }
                 }
-                ToolButton {
+                MaterialToolButton {
                     text: MaterialIcons.open_in_new
                     ToolTip.text: "Open Externally"
-                    ToolTip.visible: hovered
-                    font.family: MaterialIcons.fontFamily
                     enabled: root.source !== ""
                     onClicked: Qt.openUrlExternally(root.source)
                 }

--- a/meshroom/ui/qml/ImageGallery/ImageGallery.qml
+++ b/meshroom/ui/qml/ImageGallery/ImageGallery.qml
@@ -35,9 +35,11 @@ Panel {
             text: MaterialIcons.more_vert
             font.pointSize: 11
             padding: 2
-            onClicked: graphEditorMenu.open()
+            checkable: true
+            checked: galleryMenu.visible
+            onClicked: galleryMenu.open()
             Menu {
-                id: graphEditorMenu
+                id: galleryMenu
                 y: parent.height
                 x: -width + parent.width
                 MenuItem {

--- a/meshroom/ui/qml/MaterialIcons/MaterialToolButton.qml
+++ b/meshroom/ui/qml/MaterialIcons/MaterialToolButton.qml
@@ -12,4 +12,21 @@ ToolButton {
     font.pointSize: 13
     ToolTip.visible: ToolTip.text && hovered
     ToolTip.delay: 100
+    Component.onCompleted:  {
+        contentItem.color = Qt.binding(function() { return checked ? palette.highlight : palette.text })
+    }
+    background: Rectangle {
+        color: {
+            if(pressed || checked || hovered)
+            {
+                if(pressed || checked)
+                    return Qt.darker(parent.palette.base, 1.3)
+                if(hovered)
+                    return Qt.darker(parent.palette.base, 0.6)
+            }
+            return "transparent";
+        }
+
+        border.color: checked ? Qt.darker(parent.palette.base, 1.4) : "transparent"
+    }
 }

--- a/meshroom/ui/qml/Viewer3D/AlembicLoader.qml
+++ b/meshroom/ui/qml/Viewer3D/AlembicLoader.qml
@@ -43,9 +43,13 @@ AlembicEntity {
         Entity {
             id: camSelector
             property string viewId
+            // Qt 5.13: binding cameraPicker.enabled to cameraPickerEnabled
+            //          causes rendering issues when entity gets disabled.
+            //          set CuboidMesh extent to 0 to disable picking.
+            property real extent: cameraPickingEnabled ? 0.2 : 0
 
             components: [
-                CuboidMesh { xExtent: 0.2; yExtent: 0.2; zExtent: 0.2;},
+                CuboidMesh { xExtent: parent.extent; yExtent: xExtent; zExtent: xExtent },
                 PhongMaterial{
                     id: mat
                     ambient: viewId === _reconstruction.selectedViewId ? activePalette.highlight : "#CCC"
@@ -55,11 +59,7 @@ AlembicEntity {
                     id: cameraPicker
                     onPressed: pick.accepted = cameraPickingEnabled
                     onReleased: _reconstruction.selectedViewId = camSelector.viewId
-                },
-                // Qt 5.13: binding cameraPicker.enabled to cameraPickerEnabled
-                //          causes rendering issues when entity gets disabled.
-                //          Use a scale to 0 to disable picking.
-                Transform { scale: cameraPickingEnabled ? 1 : 0 }
+                }
             ]
         }
     }

--- a/meshroom/ui/qml/Viewer3D/AlembicLoader.qml
+++ b/meshroom/ui/qml/Viewer3D/AlembicLoader.qml
@@ -57,10 +57,22 @@ AlembicEntity {
                 },
                 ObjectPicker {
                     id: cameraPicker
-                    onPressed: pick.accepted = cameraPickingEnabled
-                    onReleased: _reconstruction.selectedViewId = camSelector.viewId
+                    property point pos
+                    onPressed: {
+                        pos = pick.position;
+                        pick.accepted = (pick.buttons & Qt.LeftButton) && cameraPickingEnabled
+                    }
+                    onReleased: {
+                        const delta = Qt.point(Math.abs(pos.x - pick.position.x), Math.abs(pos.y - pick.position.y));
+                        // only trigger picking when mouse has not moved between press and release
+                        if(delta.x + delta.y < 4)
+                        {
+                            _reconstruction.selectedViewId = camSelector.viewId;
+                        }
+                    }
                 }
             ]
         }
+
     }
 }

--- a/meshroom/ui/qml/Viewer3D/DefaultCameraController.qml
+++ b/meshroom/ui/qml/Viewer3D/DefaultCameraController.qml
@@ -25,7 +25,7 @@ Entity {
 
     readonly property alias pressed: mouseHandler._pressed
     signal mousePressed(var mouse)
-    signal mouseReleased(var mouse)
+    signal mouseReleased(var mouse, var moved)
     signal mouseClicked(var mouse)
     signal mouseWheeled(var wheel)
     signal mouseDoubleClicked(var mouse)
@@ -43,19 +43,24 @@ Entity {
         property bool _pressed
         property point lastPosition
         property point currentPosition
+        property bool hasMoved
         sourceDevice: mouseSourceDevice
         onPressed: {
             _pressed = true;
             currentPosition.x = lastPosition.x = mouse.x;
             currentPosition.y = lastPosition.y = mouse.y;
+            hasMoved = false;
             mousePressed(mouse);
         }
         onReleased: {
             _pressed = false;
-            mouseReleased(mouse);
+            mouseReleased(mouse, hasMoved);
         }
         onClicked: mouseClicked(mouse)
-        onPositionChanged: { currentPosition.x = mouse.x; currentPosition.y = mouse.y }
+        onPositionChanged: {
+            currentPosition.x = mouse.x;
+            currentPosition.y = mouse.y;
+        }
         onDoubleClicked: mouseDoubleClicked(mouse)
         onWheel: {
             var d = (root.camera.viewCenter.minus(root.camera.position)).length() * 0.2;
@@ -165,17 +170,20 @@ Entity {
                     var d = (root.camera.viewCenter.minus(root.camera.position)).length() * 0.03;
                     var tx = axisMX.value * root.translateSpeed * d;
                     var ty = axisMY.value * root.translateSpeed * d;
-                    root.camera.translate(Qt.vector3d(-tx, -ty, 0).times(dt))
+                    mouseHandler.hasMoved = true;
+                    root.camera.translate(Qt.vector3d(-tx, -ty, 0).times(dt));
                     return;
                 }
                 if(moving){ // trackball rotation
                     trackball.rotate(mouseHandler.lastPosition, mouseHandler.currentPosition, dt);
                     mouseHandler.lastPosition = mouseHandler.currentPosition;
+                    mouseHandler.hasMoved = true;
                     return;
                 }
                 if(zooming) { // zoom with alt + RMD
                     var d = (root.camera.viewCenter.minus(root.camera.position)).length() * 0.1;
                     var tz = axisMX.value * root.translateSpeed * d;
+                    mouseHandler.hasMoved = true;
                     root.camera.translate(Qt.vector3d(0, 0, tz).times(dt), Camera.DontTranslateViewCenter)
                     return;
                 }

--- a/meshroom/ui/qml/Viewer3D/ImageOverlay.qml
+++ b/meshroom/ui/qml/Viewer3D/ImageOverlay.qml
@@ -1,0 +1,99 @@
+import QtQuick 2.12
+import QtQuick.Layouts 1.12
+
+/**
+ * ImageOverlay enables to display a Viewpoint image on top of a 3D View.
+ * It takes the principal point correction into account and handle image ratio to
+ * correclty fit or crop according to original image ratio and parent Item ratio.
+ */
+Item {
+    id: root
+
+    /// The url of the image to display
+    property alias source: image.source
+    /// Source image ratio
+    property real imageRatio: 1.0
+    /// Principal Point correction as UV coordinates offset
+    property alias uvCenterOffset: shader.uvCenterOffset
+    /// Whether to display the frame around the image
+    property bool showFrame
+    /// Opacity of the image
+    property alias imageOpacity: shader.opacity
+
+    implicitWidth: 300
+    implicitHeight: 300
+
+    // Display frame
+    RowLayout {
+        id: frameBG
+        spacing: 1
+        anchors.fill: parent
+        visible: root.showFrame && image.status === Image.Ready
+        Rectangle {
+            color: "black"
+            opacity: 0.5
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+        }
+        Item {
+            Layout.preferredHeight: image.paintedHeight
+            Layout.preferredWidth: image.paintedWidth
+        }
+        Rectangle {
+            color: "black"
+            opacity: 0.5
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+        }
+    }
+
+    Image {
+        id: image
+        asynchronous: true
+        smooth: false
+        anchors.fill: parent
+        visible: false
+        // Preserver aspect fit while display ratio is aligned with image ratio, crop otherwise
+        fillMode: width/height >= imageRatio ? Image.PreserveAspectFit : Image.PreserveAspectCrop
+        autoTransform: true
+    }
+
+
+    // Custom shader for displaying undistorted images
+    // with principal point correction
+    ShaderEffect {
+        id: shader
+        anchors.centerIn: parent
+        visible: image.status === Image.Ready
+        width: image.paintedWidth
+        height: image.paintedHeight
+        property variant src: image
+        property variant uvCenterOffset
+
+        vertexShader: "
+          #version 330 core
+          uniform highp mat4 qt_Matrix;
+          attribute highp vec4 qt_Vertex;
+          attribute highp vec2 qt_MultiTexCoord0;
+          out highp vec2 coord;
+          void main() {
+              coord = qt_MultiTexCoord0;
+              gl_Position = qt_Matrix * qt_Vertex;
+          }"
+        fragmentShader: "
+         #version 330 core
+          in highp vec2 coord;
+          uniform sampler2D src;
+          uniform lowp vec2 uvCenterOffset;
+          uniform lowp float qt_Opacity;
+          out vec4 fragColor;
+          void main() {
+            vec2 xy = coord + uvCenterOffset;
+            fragColor = texture2D(src, xy);
+            fragColor.rgb *= qt_Opacity;
+            fragColor.a = qt_Opacity;
+            // remove undistortion black pixels
+            fragColor.a *= step(0.001, fragColor.r + fragColor.g + fragColor.b);
+          }"
+    }
+}

--- a/meshroom/ui/qml/Viewer3D/Inspector3D.qml
+++ b/meshroom/ui/qml/Viewer3D/Inspector3D.qml
@@ -32,15 +32,37 @@ FloatingPane {
 
         Group {
             Layout.fillWidth: true
-            title: "SETTINGS"
+            title: "DISPLAY"
 
             GridLayout {
                 width: parent.width
                 columns: 2
                 columnSpacing: 6
                 rowSpacing: 3
-
-                MaterialLabel { font.family: MaterialIcons.fontFamily; text: MaterialIcons.grain; padding: 2 }
+                Flow {
+                    Layout.columnSpan: 2
+                    Layout.fillWidth: true
+                    spacing: 1
+                    MaterialToolButton {
+                        text: MaterialIcons.grid_on
+                        ToolTip.text: "Display Grid"
+                        checked: Viewer3DSettings.displayGrid
+                        onClicked: Viewer3DSettings.displayGrid = !Viewer3DSettings.displayGrid
+                    }
+                    MaterialToolButton {
+                        text: MaterialIcons.adjust
+                        checked: Viewer3DSettings.displayGizmo
+                        ToolTip.text: "Display Trackball"
+                        onClicked: Viewer3DSettings.displayGizmo = !Viewer3DSettings.displayGizmo
+                    }
+                    MaterialToolButton {
+                        text: MaterialIcons.call_merge
+                        ToolTip.text: "Display Origin"
+                        checked: Viewer3DSettings.displayOrigin
+                        onClicked: Viewer3DSettings.displayOrigin = !Viewer3DSettings.displayOrigin
+                    }
+                }
+                MaterialLabel { text: MaterialIcons.grain; padding: 2 }
                 RowLayout {
                     Slider {
                         Layout.fillWidth: true; from: 0; to: 5; stepSize: 0.1
@@ -60,7 +82,7 @@ FloatingPane {
                     }
 
                 }
-                MaterialLabel { font.family: MaterialIcons.fontFamily; text: MaterialIcons.videocam; padding: 2 }
+                MaterialLabel { text: MaterialIcons.videocam; padding: 2 }
                 Slider {
                     value: Viewer3DSettings.cameraScale
                     from: 0
@@ -73,27 +95,60 @@ FloatingPane {
                     ToolTip.visible: hovered || pressed
                     ToolTip.delay: 150
                 }
+            }
+        }
+
+        Group {
+            Layout.fillWidth: true
+            title: "CAMERA"
+            ColumnLayout {
+                width: parent.width
+
+                // Image/Camera synchronization
                 Flow {
-                    Layout.columnSpan: 2
                     Layout.fillWidth: true
                     spacing: 2
-                    CheckBox {
-                        text: "Grid"
-                        padding: 2
-                        checked: Viewer3DSettings.displayGrid
-                        onClicked: Viewer3DSettings.displayGrid = !Viewer3DSettings.displayGrid
+                    // Synchronization
+                    MaterialToolButton {
+                        id: syncViewpointCamera
+                        enabled: _reconstruction.sfmReport
+                        text: MaterialIcons.linked_camera
+                        ToolTip.text: "Sync with Image Selection"
+                        checked: enabled && Viewer3DSettings.syncViewpointCamera
+                        onClicked: Viewer3DSettings.syncViewpointCamera = !Viewer3DSettings.syncViewpointCamera
                     }
-                    CheckBox {
-                        text: "Gizmo"
-                        padding: 2
-                        checked: Viewer3DSettings.displayGizmo
-                        onClicked: Viewer3DSettings.displayGizmo = !Viewer3DSettings.displayGizmo
+                    // Image Overlay controls
+                    RowLayout {
+                        visible: syncViewpointCamera.enabled && Viewer3DSettings.syncViewpointCamera
+                        spacing: 2
+                        // Activation
+                        MaterialToolButton {
+                            text: MaterialIcons.image
+                            ToolTip.text: "Image Overlay"
+                            checked: Viewer3DSettings.viewpointImageOverlay
+                            onClicked: Viewer3DSettings.viewpointImageOverlay = !Viewer3DSettings.viewpointImageOverlay
+                        }
+                        // Opacity
+                        Slider {
+                            visible: Viewer3DSettings.showViewpointImageOverlay
+                            implicitWidth: 60
+                            from: 0
+                            to: 100
+                            value: Viewer3DSettings.viewpointImageOverlayOpacity * 100
+                            onValueChanged: Viewer3DSettings.viewpointImageOverlayOpacity = value / 100
+                            ToolTip.text: "Image Opacity: " + Viewer3DSettings.viewpointImageOverlayOpacity.toFixed(2)
+                            ToolTip.visible: hovered || pressed
+                            ToolTip.delay: 100
+                        }
                     }
-                    CheckBox {
-                        text: "Origin"
-                        padding: 2
-                        checked: Viewer3DSettings.displayOrigin
-                        onClicked: Viewer3DSettings.displayOrigin = !Viewer3DSettings.displayOrigin
+                    // Image Frame control
+                    MaterialToolButton {
+                        visible: syncViewpointCamera.enabled && Viewer3DSettings.showViewpointImageOverlay
+                        enabled: Viewer3DSettings.syncViewpointCamera
+                        text: MaterialIcons.crop_free
+                        ToolTip.text: "Frame Overlay"
+                        checked: Viewer3DSettings.viewpointImageFrame
+                        onClicked: Viewer3DSettings.viewpointImageFrame = !Viewer3DSettings.viewpointImageFrame
                     }
                 }
             }
@@ -114,7 +169,6 @@ FloatingPane {
                 implicitHeight: parent.height
                 checkable: true
                 checked: true
-                padding: 0
             }
 
             ListView {
@@ -300,21 +354,13 @@ FloatingPane {
                         }
                     }
 
-                    // Media unavailability indicator
-                    MaterialToolButton {
-                        Layout.alignment: Qt.AlignTop
-                        enabled: false
-                        visible: !model.valid
-                        text: MaterialIcons.no_sim
-                        font.pointSize: 10
-                    }
-
                     // Remove media from library button
                     MaterialToolButton {
                         id: removeButton
                         Layout.alignment: Qt.AlignTop
+                        Layout.fillHeight: true
 
-                        visible: !loading
+                        visible: hovered || mouseArea.containsMouse && !loading
                         text: MaterialIcons.clear
                         font.pointSize: 10
                         ToolTip.text: "Remove"

--- a/meshroom/ui/qml/Viewer3D/Inspector3D.qml
+++ b/meshroom/ui/qml/Viewer3D/Inspector3D.qml
@@ -226,7 +226,7 @@ FloatingPane {
                     }
                     onDoubleClicked: {
                         model.visible = true;
-                        camera.viewEntity(root.mediaLibrary.entityAt(index));
+                        nodeActivated(model.attribute.node);
                     }
 
                     RowLayout {

--- a/meshroom/ui/qml/Viewer3D/Viewer3D.qml
+++ b/meshroom/ui/qml/Viewer3D/Viewer3D.qml
@@ -20,7 +20,6 @@ FocusScope {
 
     property int renderMode: 2
     property alias library: mediaLibrary
-    property alias inspector: inspector3d
 
     readonly property vector3d defaultCamPosition: Qt.vector3d(12.0, 10.0, -12.0)
     readonly property vector3d defaultCamUpVector: Qt.vector3d(0.0, 1.0, 0.0)
@@ -239,23 +238,6 @@ FocusScope {
         BusyIndicator {
             anchors.centerIn: parent
             running: parent.visible
-        }
-    }
-
-    //  UI Overlay
-    Controls1.SplitView {
-        id: overlaySplitView
-        anchors.fill: parent
-
-        Item { Layout.fillWidth: true; Layout.minimumWidth: parent.width * 0.5  }
-
-        Inspector3D {
-            id: inspector3d
-            width: 200
-            Layout.minimumWidth: 5
-
-            camera: mainCamera
-            mediaLibrary: mediaLibrary
         }
     }
 

--- a/meshroom/ui/qml/Viewer3D/Viewer3D.qml
+++ b/meshroom/ui/qml/Viewer3D/Viewer3D.qml
@@ -19,7 +19,8 @@ FocusScope {
     id: root
 
     property int renderMode: 2
-    property alias library: mediaLibrary
+    readonly property alias library: mediaLibrary
+    readonly property alias mainCamera: mainCamera
 
     readonly property vector3d defaultCamPosition: Qt.vector3d(12.0, 10.0, -12.0)
     readonly property vector3d defaultCamUpVector: Qt.vector3d(0.0, 1.0, 0.0)

--- a/meshroom/ui/qml/Viewer3D/Viewer3D.qml
+++ b/meshroom/ui/qml/Viewer3D/Viewer3D.qml
@@ -164,7 +164,7 @@ FocusScope {
                 onMouseReleased: {
                     if(moving)
                         return
-                    if(mouse.button == Qt.RightButton)
+                    if(!moved && mouse.button == Qt.RightButton)
                     {
                         contextMenu.popup()
                     }

--- a/meshroom/ui/qml/Viewer3D/Viewer3DSettings.qml
+++ b/meshroom/ui/qml/Viewer3D/Viewer3DSettings.qml
@@ -24,7 +24,7 @@ Item {
     // Available render modes
     readonly property var renderModes: [ // Can't use ListModel because of MaterialIcons expressions
                          {"name": "Solid", "icon": MaterialIcons.crop_din },
-                         {"name": "Wireframe", "icon": MaterialIcons.grid_on },
+                         {"name": "Wireframe", "icon": MaterialIcons.details },
                          {"name": "Textured", "icon": MaterialIcons.texture },
                      ]
     // Current render mode
@@ -39,4 +39,11 @@ Item {
     property bool displayGrid: true
     property bool displayGizmo: true
     property bool displayOrigin: false
+    // Camera
+    property bool syncViewpointCamera: false
+    property bool viewpointImageOverlay: true
+    property real viewpointImageOverlayOpacity: 0.5
+    readonly property bool showViewpointImageOverlay: syncViewpointCamera && viewpointImageOverlay
+    property bool viewpointImageFrame: false
+    readonly property bool showViewpointImageFrame: syncViewpointCamera && viewpointImageFrame
 }

--- a/meshroom/ui/qml/Viewer3D/ViewpointCamera.qml
+++ b/meshroom/ui/qml/Viewer3D/ViewpointCamera.qml
@@ -1,0 +1,62 @@
+import QtQuick 2.12
+import Qt3D.Core 2.12
+import Qt3D.Render 2.12
+
+
+/**
+ * ViewpointCamera sets up a Camera to match a Viewpoint's internal parameters.
+ */
+Entity {
+    id: root
+
+    property variant viewpoint
+
+    property Camera camera: Camera {
+
+        nearPlane : 0.1
+        farPlane : 10000.0
+        viewCenter: Qt.vector3d(0.0, 0.0, -1.0)
+
+        // Scene light, attached to the camera
+        Entity {
+            components: [
+                PointLight {
+                    color: "white"
+                }
+            ]
+        }
+    }
+
+    components: [
+        Transform {
+            id: transform
+
+            Behavior on rotation {
+                PropertyAnimation { duration: 200}
+            }
+            Behavior on translation {
+                Vector3dAnimation { duration: 200}
+            }
+        }
+    ]
+
+    StateGroup {
+        states: [
+            State {
+                name: "valid"
+                when: root.viewpoint !== null
+                PropertyChanges {
+                    target: camera
+                    fieldOfView: root.viewpoint.fieldOfView
+                    upVector: root.viewpoint.upVector
+                }
+                PropertyChanges {
+                    target: transform
+                    rotation: root.viewpoint.rotation
+                    translation: root.viewpoint.translation
+                }
+            }
+        ]
+    }
+
+}

--- a/meshroom/ui/qml/Viewer3D/qmldir
+++ b/meshroom/ui/qml/Viewer3D/qmldir
@@ -5,3 +5,4 @@ singleton Viewer3DSettings 1.0 Viewer3DSettings.qml
 DefaultCameraController 1.0 DefaultCameraController.qml
 Locator3D 1.0 Locator3D.qml
 Grid3D 1.0 Grid3D.qml
+Inspector3D 1.0 Inspector3D.qml

--- a/meshroom/ui/qml/WorkspaceView.qml
+++ b/meshroom/ui/qml/WorkspaceView.qml
@@ -116,33 +116,47 @@ Item {
             Layout.minimumWidth: 20
             Layout.minimumHeight: 80
 
-            Viewer3D {
-                id: viewer3D
-
+            Controls1.SplitView {
                 anchors.fill: parent
-                inspector.uigraph: reconstruction
+                Viewer3D {
+                    id: viewer3D
 
-                DropArea {
-                    anchors.fill: parent
-                    keys: ["text/uri-list"]
-                    onDropped: {
-                        drop.urls.forEach(function(url){ load3DMedia(url); });
+                    Layout.fillWidth: true
+                    Layout.fillHeight: true
+                    Layout.minimumWidth: 20
+
+                    DropArea {
+                        anchors.fill: parent
+                        keys: ["text/uri-list"]
+                        onDropped: {
+                            drop.urls.forEach(function(url){ load3DMedia(url); });
+                        }
+                    }
+
+                    // Load reconstructed model
+                    Button {
+                        readonly property var outputAttribute: _reconstruction.texturing ? _reconstruction.texturing.attribute("outputMesh") : null
+                        readonly property bool outputReady: outputAttribute && _reconstruction.texturing.globalStatus === "SUCCESS"
+                        readonly property int outputMediaIndex: viewer3D.library.find(outputAttribute)
+
+                        text: "Load Model"
+                        anchors.bottom: parent.bottom
+                        anchors.bottomMargin: 10
+                        anchors.horizontalCenter: parent.horizontalCenter
+                        visible: outputReady && outputMediaIndex == -1
+                        onClicked: viewer3D.view(_reconstruction.texturing.attribute("outputMesh"))
                     }
                 }
-            }
 
-            // Load reconstructed model
-            Button {
-                readonly property var outputAttribute: _reconstruction.texturing ? _reconstruction.texturing.attribute("outputMesh") : null
-                readonly property bool outputReady: outputAttribute && _reconstruction.texturing.globalStatus === "SUCCESS"
-                readonly property int outputMediaIndex: viewer3D.library.find(outputAttribute)
+                // Inspector Panel
+                Inspector3D {
+                    id: inspector3d
+                    width: 200
+                    Layout.minimumWidth: 5
 
-                text: "Load Model"
-                anchors.bottom: parent.bottom
-                anchors.bottomMargin: 10
-                anchors.horizontalCenter: parent.horizontalCenter
-                visible: outputReady && outputMediaIndex == -1
-                onClicked: viewer3D.view(_reconstruction.texturing.attribute("outputMesh"))
+                    mediaLibrary: viewer3D.library
+                    uigraph: reconstruction
+                }
             }
         }
     }

--- a/meshroom/ui/qml/WorkspaceView.qml
+++ b/meshroom/ui/qml/WorkspaceView.qml
@@ -157,6 +157,7 @@ Item {
                     mediaLibrary: viewer3D.library
                     camera: viewer3D.mainCamera
                     uigraph: reconstruction
+                    onNodeActivated: _reconstruction.setActiveNodeOfType(node)
                 }
             }
         }

--- a/meshroom/ui/qml/WorkspaceView.qml
+++ b/meshroom/ui/qml/WorkspaceView.qml
@@ -155,6 +155,7 @@ Item {
                     Layout.minimumWidth: 5
 
                     mediaLibrary: viewer3D.library
+                    camera: viewer3D.mainCamera
                     uigraph: reconstruction
                 }
             }

--- a/meshroom/ui/qml/main.qml
+++ b/meshroom/ui/qml/main.qml
@@ -552,6 +552,8 @@ ApplicationWindow {
                         font.pointSize: 11
                         padding: 2
                         onClicked: graphEditorMenu.open()
+                        checkable: true
+                        checked: graphEditorMenu.visible
                         Menu {
                             id: graphEditorMenu
                             y: parent.height
@@ -591,22 +593,8 @@ ApplicationWindow {
                     readOnly: graphLocked
 
                     onNodeDoubleClicked: {
-                        if(node.nodeType === "StructureFromMotion")
-                        {
-                            _reconstruction.sfm = node;
-                        }
-                        else if(node.nodeType === "FeatureExtraction")
-                        {
-                            _reconstruction.featureExtraction = node;
-                        }
-                        else if(node.nodeType === "CameraInit")
-                        {
-                            _reconstruction.cameraInit = node;
-                        }
-                        else if(node.nodeType === "PrepareDenseScene")
-                        {
-                            _reconstruction.prepareDenseScene = node;
-                        }
+                        _reconstruction.setActiveNodeOfType(node);
+
                         for(var i=0; i < node.attributes.count; ++i)
                         {
                             var attr = node.attributes.at(i)

--- a/meshroom/ui/qml/main.qml
+++ b/meshroom/ui/qml/main.qml
@@ -603,6 +603,10 @@ ApplicationWindow {
                         {
                             _reconstruction.cameraInit = node;
                         }
+                        else if(node.nodeType === "PrepareDenseScene")
+                        {
+                            _reconstruction.prepareDenseScene = node;
+                        }
                         for(var i=0; i < node.attributes.count; ++i)
                         {
                             var attr = node.attributes.at(i)

--- a/meshroom/ui/reconstruction.py
+++ b/meshroom/ui/reconstruction.py
@@ -332,7 +332,12 @@ class ViewpointWrapper(QObject):
         uvPP = QVector2D(float(pp[0]) / self.imageSize.width(), float(pp[1]) / self.imageSize.height())
         # convert to offset
         offset = uvPP - QVector2D(0.5, 0.5)
-        return offset if self.orientation == 1 else -offset
+        # apply orientation to principal point correction
+        if self.orientation == 6:
+            offset = QVector2D(-offset.y(), offset.x())
+        elif self.orientation == 8:
+            offset = QVector2D(offset.y(), -offset.x())
+        return offset
 
     @Property(type=float, notify=sfmParamsChanged)
     def fieldOfView(self):

--- a/meshroom/ui/reconstruction.py
+++ b/meshroom/ui/reconstruction.py
@@ -1,8 +1,11 @@
+import json
 import logging
+import math
 import os
 from threading import Thread
 
-from PySide2.QtCore import QObject, Slot, Property, Signal
+from PySide2.QtCore import QObject, Slot, Property, Signal, QUrl, QSizeF
+from PySide2.QtGui import QMatrix4x4, QMatrix3x3, QQuaternion, QVector3D, QVector2D
 
 from meshroom import multiview
 from meshroom.common.qt import QObjectListModel
@@ -154,6 +157,197 @@ class LiveSfmManager(QObject):
     folder = Property(str, lambda self: self._folder, notify=folderChanged)
 
 
+class ViewpointWrapper(QObject):
+    """
+    ViewpointWrapper is a high-level object that wraps an input image in the context of a Reconstruction.
+    It exposes the attributes of the image and its corresponding camera when reconstructed.
+    """
+
+    initialParamsChanged = Signal()
+    sfmParamsChanged = Signal()
+    denseSceneParamsChanged = Signal()
+    internalChanged = Signal()
+
+    def __init__(self, viewpointAttribute, reconstruction):
+        """
+        Viewpoint constructor
+
+        Args:
+            viewpointAttribute (GroupAttribute): viewpoint attribute
+            reconstruction (Reconstruction): owner reconstruction of this Viewpoint
+        """
+        super(ViewpointWrapper, self).__init__(parent=reconstruction)
+        self._viewpoint = viewpointAttribute
+        self._reconstruction = reconstruction
+
+        # CameraInit
+        self._initialIntrinsics = None
+        # StructureFromMotion
+        self._T = None  # translation
+        self._R = None  # rotation
+        self._solvedIntrinsics = {}
+        self._reconstructed = False
+        # PrepareDenseScene
+        self._undistortedImagePath = ''
+
+        # update internally cached variables
+        self._updateInitialParams()
+        self._updateSfMParams()
+        self._updateDenseSceneParams()
+
+        # trigger internal members updates when reconstruction members changes
+        self._reconstruction.cameraInitChanged.connect(self._updateInitialParams)
+        self._reconstruction.sfmReportChanged.connect(self._updateSfMParams)
+        self._reconstruction.prepareDenseSceneChanged.connect(self._updateDenseSceneParams)
+
+    def _updateInitialParams(self):
+        """ Update internal members depending on CameraInit. """
+        if not self._reconstruction.cameraInit:
+            self.initialIntrinsics = None
+            self._metadata = {}
+        else:
+            self._initialIntrinsics = self._reconstruction.getIntrinsic(self._viewpoint)
+            self._metadata = json.loads(self._viewpoint.metadata.value)
+        self.initialParamsChanged.emit()
+
+    def _updateSfMParams(self):
+        """ Update internal members depending on StructureFromMotion. """
+        if not self._reconstruction.sfm:
+            self._T = None
+            self._R = None
+            self._solvedIntrinsics = {}
+            self._reconstructed = False
+        else:
+            self._solvedIntrinsics = self._reconstruction.getSolvedIntrinsics(self._viewpoint)
+            self._R, self._T = self._reconstruction.getPoseRT(self._viewpoint)
+            self._reconstructed = self._R is not None
+        self.sfmParamsChanged.emit()
+
+    def _updateDenseSceneParams(self):
+        """ Update internal members depending on PrepareDenseScene. """
+        # undistorted image path
+        if not self._reconstruction.prepareDenseScene:
+            self._undistortedImagePath = ''
+        else:
+            filename = "{}.{}".format(self._viewpoint.viewId.value, self._reconstruction.prepareDenseScene.outputFileType.value)
+            self._undistortedImagePath = os.path.join(self._reconstruction.prepareDenseScene.output.value, filename)
+        self.denseSceneParamsChanged.emit()
+
+    @Property(type=QObject, constant=True)
+    def attribute(self):
+        """ Get the underlying Viewpoint attribute wrapped by this Viewpoint. """
+        return self._viewpoint
+
+    @Property(type="QVariant", notify=initialParamsChanged)
+    def initialIntrinsics(self):
+        """ Get viewpoint's initial intrinsics. """
+        return self._initialIntrinsics
+
+    @Property(type="QVariant", notify=initialParamsChanged)
+    def metadata(self):
+        """ Get image metadata. """
+        return self._metadata
+
+    @Property(type=QSizeF, notify=initialParamsChanged)
+    def imageSize(self):
+        """ Get image size (width as the largest dimension). """
+        if not self._initialIntrinsics:
+            return QSizeF(0, 0)
+        return QSizeF(self._initialIntrinsics.width.value, self._initialIntrinsics.height.value)
+
+    @Property(type=int, notify=initialParamsChanged)
+    def orientation(self):
+        """ Get image orientation based on its metadata. """
+        return int(self.metadata.get("Orientation", 1))
+
+    @Property(type=QSizeF, notify=initialParamsChanged)
+    def orientedImageSize(self):
+        """ Get image size taking into account its orientation. """
+        if self.orientation in (6, 8):
+            return QSizeF(self.imageSize.height(), self.imageSize.width())
+        else:
+            return self.imageSize
+
+    @Property(type=bool, notify=sfmParamsChanged)
+    def isReconstructed(self):
+        """ Return whether this viewpoint corresponds to a reconstructed camera. """
+        return self._reconstructed
+
+    @Property(type="QVariant", notify=sfmParamsChanged)
+    def solvedIntrinsics(self):
+        return self._solvedIntrinsics
+
+    @Property(type=QVector3D, notify=sfmParamsChanged)
+    def translation(self):
+        """ Get the camera translation as a 3D vector. """
+        if self._T is None:
+            return None
+        return QVector3D(*self._T)
+
+    @Property(type=QQuaternion, notify=sfmParamsChanged)
+    def rotation(self):
+        """ Get the camera rotation as a quaternion. """
+        if self._R is None:
+            return None
+
+        rot = QMatrix3x3([
+            self._R[0], -self._R[1], -self._R[2],
+            self._R[3], -self._R[4], -self._R[5],
+            self._R[6], -self._R[7], -self._R[8]]
+        )
+
+        return QQuaternion.fromRotationMatrix(rot)
+
+    @Property(type=QMatrix4x4, notify=sfmParamsChanged)
+    def pose(self):
+        """ Get the camera pose of 'viewpoint' as a 4x4 matrix. """
+        if self._R is None or self._T is None:
+            return None
+
+        # convert transform matrix for Qt
+        return QMatrix4x4(
+            self._R[0], -self._R[1], -self._R[2], self._T[0],
+            self._R[3], -self._R[4], -self._R[5], self._T[1],
+            self._R[6], -self._R[7], -self._R[8], self._T[2],
+            0,          0,           0,           1
+        )
+
+    @Property(type=QVector3D, notify=sfmParamsChanged)
+    def upVector(self):
+        """ Get camera up vector according to its orientation. """
+        if self.orientation == 6:
+            return QVector3D(-1.0, 0.0, 0.0)
+        elif self.orientation == 8:
+            return QVector3D(1.0, 0.0, 0.0)
+        else:
+            return QVector3D(0.0, 1.0, 0.0)
+
+    @Property(type=QVector2D, notify=sfmParamsChanged)
+    def uvCenterOffset(self):
+        """ Get UV offset corresponding to the camera principal point. """
+        if not self.solvedIntrinsics:
+            return None
+        pp = self.solvedIntrinsics["principalPoint"]
+        # compute principal point offset in UV space
+        uvPP = QVector2D(float(pp[0]) / self.imageSize.width(), float(pp[1]) / self.imageSize.height())
+        # convert to offset
+        offset = uvPP - QVector2D(0.5, 0.5)
+        return offset if self.orientation == 1 else -offset
+
+    @Property(type=float, notify=sfmParamsChanged)
+    def fieldOfView(self):
+        """ Get camera vertical field of view in degrees. """
+        if not self.solvedIntrinsics:
+            return None
+        pxFocalLength = float(self.solvedIntrinsics["pxFocalLength"])
+        return 2.0 * math.atan(self.orientedImageSize.height() / (2.0 * pxFocalLength)) * 180 / math.pi
+
+    @Property(type=QUrl, notify=denseSceneParamsChanged)
+    def undistortedImageSource(self):
+        """ Get path to undistorted image source if available. """
+        return QUrl.fromLocalFile(self._undistortedImagePath)
+
+
 class Reconstruction(UIGraph):
     """
     Specialization of a UIGraph designed to manage a 3D reconstruction.
@@ -180,6 +374,7 @@ class Reconstruction(UIGraph):
         self._poses = None
         self._solvedIntrinsics = None
         self._selectedViewId = None
+        self._selectedViewpoint = None
         self._liveSfmManager = LiveSfmManager(self)
 
         # - Prepare Dense Scene (undistorted images)
@@ -227,6 +422,7 @@ class Reconstruction(UIGraph):
     def onGraphChanged(self):
         """ React to the change of the internal graph. """
         self._liveSfmManager.reset()
+        self.selectedViewId = "-1"
         self.featureExtraction = None
         self.sfm = None
         self.prepareDenseScene = None
@@ -592,8 +788,32 @@ class Reconstruction(UIGraph):
             return None
         return self._solvedIntrinsics.get(str(viewpoint.intrinsicId.value), None)
 
+    def getPoseRT(self, viewpoint):
+        """ Get the camera pose as rotation and translation of the given viewpoint.
+
+        Args:
+            viewpoint: the viewpoint attribute to consider.
+        Returns:
+            R, T: the rotation and translation as lists of floats
+        """
+        if not viewpoint:
+            return None, None
+        view = self._views.get(str(viewpoint.viewId.value), None)
+        if not view:
+            return None, None
+        pose = self._poses.get(view.get('poseId', -1), None)
+        if not pose:
+            return None, None
+
+        pose = pose["transform"]
+        R = [float(i) for i in pose["rotation"]]
+        T = [float(i) for i in pose["center"]]
+
+        return R, T
+
     selectedViewIdChanged = Signal()
     selectedViewId = Property(str, lambda self: self._selectedViewId, setSelectedViewId, notify=selectedViewIdChanged)
+    selectedViewpoint = Property(ViewpointWrapper, lambda self: self._selectedViewpoint, notify=selectedViewIdChanged)
 
     sfmChanged = Signal()
     sfm = Property(QObject, getSfm, setSfm, notify=sfmChanged)

--- a/meshroom/ui/reconstruction.py
+++ b/meshroom/ui/reconstruction.py
@@ -666,6 +666,18 @@ class Reconstruction(UIGraph):
     buildingIntrinsics = Property(bool, lambda self: self._buildingIntrinsics, notify=buildingIntrinsicsChanged)
     liveSfmManager = Property(QObject, lambda self: self._liveSfmManager, constant=True)
 
+    @Slot(QObject)
+    def setActiveNodeOfType(self, node):
+        """ Set node as the active node of its type. """
+        if node.nodeType == "StructureFromMotion":
+            self.sfm = node
+        elif node.nodeType == "FeatureExtraction":
+            self.featureExtraction = node
+        elif node.nodeType == "CameraInit":
+            self.cameraInit = node
+        elif node.nodeType == "PrepareDenseScene":
+            self.prepareDenseScene = node
+
     def updateSfMResults(self):
         """
         Update internal views, poses and solved intrinsics based on the current SfM node.


### PR DESCRIPTION
## Description
This PR introduces a new feature that enables to synchronize 3D camera pose with the image selection. 
After the computation of the StructureFromMotion step, a dedicated 3D camera can be controlled by choosing an image from the input Images list, allowing to view the reconstruction from this image's POV (pose and field of view). 
![sync_cam2](https://user-images.githubusercontent.com/1674646/64849961-ca1b7d80-d614-11e9-832f-5f80cc1c7c06.gif)
If the PrepareDenseScene step is computed, the undistorted image can also be displayed as an overlay on the 3D view.
![sync_cam_overlay](https://user-images.githubusercontent.com/1674646/64850162-28e0f700-d615-11e9-92f2-9b8e76e4b8e3.gif)

## Features list

- [X] 3D View: new "Sync with image selection" mode
- [X] Fix issues related to 3D navigation
- [X] Inspector3D UI improvements

## Implementation remarks
- 3D camera's field of view is computed using intrinsics solved by the SfM step.
- a 2D shader handles the principal point correction for the image overlay
- add new ViewpointWrapper python class to easily get data related to a reconstructed image

