### PR TITLE
[build] fix cxFreeze version for Python 2.7 compatibility

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,5 +1,5 @@
 # packaging
-cx_Freeze
+cx_Freeze==5.1.1
 
 # testing
 pytest


### PR DESCRIPTION
## Description
Specify cx_Freeze version to 5.1.1 since latest 6.0 is not compatible with Python 2.7 and breaks tests. 


## Features list
- [X] Fix Python 2.7 tests
