### PR TITLE
NodeEditor: minor improvements with single tab group and status table

### DIFF
--- a/meshroom/ui/qml/GraphEditor/ChunksListView.qml
+++ b/meshroom/ui/qml/GraphEditor/ChunksListView.qml
@@ -1,0 +1,66 @@
+import QtQuick 2.11
+import QtQuick.Controls 2.3
+import QtQuick.Controls 1.4 as Controls1 // SplitView
+import QtQuick.Layouts 1.3
+import MaterialIcons 2.2
+import Controls 1.0
+
+import "common.js" as Common
+
+/**
+ * ChunkListView
+ */
+ListView {
+    id: chunksLV
+
+    // model: node.chunks
+
+    property variant currentChunk: currentItem ? currentItem.chunk : undefined
+
+    width: 60
+    Layout.fillHeight: true
+    highlightFollowsCurrentItem: true
+    keyNavigationEnabled: true
+    focus: true
+    currentIndex: 0
+
+    signal changeCurrentChunk(int chunkIndex)
+
+    header: Component {
+        Label {
+            width: chunksLV.width
+            elide: Label.ElideRight
+            text: "Chunks"
+            padding: 4
+            z: 10
+            background: Rectangle { color: parent.palette.window }
+        }
+    }
+
+    highlight: Component {
+        Rectangle {
+            color: activePalette.highlight
+            opacity: 0.3
+            z: 2
+        }
+    }
+    highlightMoveDuration: 0
+    highlightResizeDuration: 0
+
+    delegate: ItemDelegate {
+        id: chunkDelegate
+        property var chunk: object
+        text: index
+        width: parent.width
+        leftPadding: 8
+        onClicked: {
+            chunksLV.forceActiveFocus()
+            chunksLV.changeCurrentChunk(index)
+        }
+        Rectangle {
+            width: 4
+            height: parent.height
+            color: Common.getChunkColor(parent.chunk)
+        }
+    }
+}

--- a/meshroom/ui/qml/GraphEditor/NodeEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/NodeEditor.qml
@@ -19,6 +19,15 @@ Panel {
     signal attributeDoubleClicked(var mouse, var attribute)
     signal upgradeRequest()
 
+    Item {
+        id: m
+        property int chunkCurrentIndex: 0
+    }
+
+    onNodeChanged: {
+        m.chunkCurrentIndex = 0  // Needed to avoid invalid state of ChunksListView
+    }
+
     title: "Node" + (node !== null ? " - <b>" + node.label + "</b>" : "")
     icon: MaterialLabel { text: MaterialIcons.tune }
 
@@ -113,7 +122,6 @@ Panel {
                         currentIndex: tabBar.currentIndex
 
                         AttributeEditor {
-                            Layout.fillWidth: true
                             attributes: root.node.attributes
                             readOnly: root.readOnly || root.isCompatibilityNode
                             onAttributeDoubleClicked: root.attributeDoubleClicked(mouse, attribute)
@@ -122,10 +130,23 @@ Panel {
 
                         NodeLog {
                             id: nodeLog
-
-                            Layout.fillHeight: true
-                            Layout.fillWidth: true
                             node: root.node
+                            chunkCurrentIndex: m.chunkCurrentIndex
+                            onChangeCurrentChunk: { m.chunkCurrentIndex = chunkIndex }
+                        }
+
+                        NodeStatistics {
+                            id: nodeStatistics
+                            node: root.node
+                            chunkCurrentIndex: m.chunkCurrentIndex
+                            onChangeCurrentChunk: { m.chunkCurrentIndex = chunkIndex }
+                        }
+
+                        NodeStatus {
+                            id: nodeStatus
+                            node: root.node
+                            chunkCurrentIndex: m.chunkCurrentIndex
+                            onChangeCurrentChunk: { m.chunkCurrentIndex = chunkIndex }
                         }
                     }
                 }
@@ -148,6 +169,18 @@ Panel {
             }
             TabButton {
                 text: "Log"
+                width: implicitWidth
+                leftPadding: 8
+                rightPadding: leftPadding
+            }
+            TabButton {
+                text: "Statistics"
+                width: implicitWidth
+                leftPadding: 8
+                rightPadding: leftPadding
+            }
+            TabButton {
+                text: "Status"
                 width: implicitWidth
                 leftPadding: 8
                 rightPadding: leftPadding

--- a/meshroom/ui/qml/GraphEditor/NodeStatistics.qml
+++ b/meshroom/ui/qml/GraphEditor/NodeStatistics.qml
@@ -39,7 +39,7 @@ FocusScope {
             Layout.fillHeight: true
             property url source
 
-            property string currentFile: chunksLV.currentChunk ? chunksLV.currentChunk["logFile"] : ""
+            property string currentFile: chunksLV.currentChunk ? chunksLV.currentChunk["statisticsFile"] : ""
             onCurrentFileChanged: {
                 // only set text file viewer source when ListView is fully ready
                 // (either empty or fully populated with a valid currentChunk)
@@ -47,21 +47,18 @@ FocusScope {
 
                 if(!chunksLV.count || chunksLV.currentChunk)
                     componentLoader.source = Filepath.stringToUrl(currentFile);
-
             }
 
-            sourceComponent: textFileViewerComponent
+            sourceComponent: statViewerComponent
         }
 
         Component {
-            id: textFileViewerComponent
-            TextFileViewer {
-                id: textFileViewer
-                source: componentLoader.source
+            id: statViewerComponent
+            StatViewer {
+                id: statViewer
                 Layout.fillWidth: true
                 Layout.fillHeight: true
-                autoReload: chunksLV.currentChunk !== undefined && chunksLV.currentChunk.statusName === "RUNNING"
-                // source is set in fileSelector
+                source: componentLoader.source
             }
         }
     }

--- a/meshroom/ui/qml/GraphEditor/NodeStatus.qml
+++ b/meshroom/ui/qml/GraphEditor/NodeStatus.qml
@@ -55,10 +55,7 @@ FocusScope {
         Component {
             id: statViewerComponent
             Item {
-
                 id: statusViewer
-                Layout.fillWidth: true
-                Layout.fillHeight: true
                 property url source: componentLoader.source
                 property var lastModified: undefined
 
@@ -120,26 +117,46 @@ FocusScope {
                 ListView {
                     id: statusListView
                     anchors.fill: parent
-                    // spacing: 3
+                    spacing: 3
                     model: statusListModel
 
                     delegate: Rectangle {
                         color: activePalette.window
-                        width: childrenRect.width
+                        width: parent.width
                         height: childrenRect.height
                         RowLayout {
-                            Label {
-                                text: key
-                                padding: 4
-                                leftPadding: 6
+                            width: parent.width
+                            Rectangle {
+                                id: statusKey
+                                anchors.margins: 2
+                                // height: statusValue.height
+                                color: Qt.darker(activePalette.window, 1.1)
                                 Layout.preferredWidth: sizeHandle.x
-                                elide: Text.ElideRight
-                                background: Rectangle { color: Qt.darker(activePalette.window, 1.1) }
+                                Layout.minimumWidth: 10.0 * Qt.application.font.pixelSize
+                                Layout.maximumWidth: 15.0 * Qt.application.font.pixelSize
+                                Layout.fillWidth: false
+                                Layout.fillHeight: true
+                                Label {
+                                    text: key
+                                    anchors.fill: parent
+                                    anchors.top: parent.top
+                                    topPadding: 4
+                                    leftPadding: 6
+                                    verticalAlignment: TextEdit.AlignTop
+                                    elide: Text.ElideRight
+                                }
                             }
                             TextArea {
+                                id: statusValue
                                 text: value
+                                anchors.margins: 2
                                 Layout.fillWidth: true
                                 wrapMode: Label.WrapAtWordBoundaryOrAnywhere
+                                textFormat: TextEdit.PlainText
+
+                                readOnly: true
+                                selectByMouse: true
+                                background: Rectangle { anchors.fill: parent; color: Qt.darker(activePalette.window, 1.05) }
                             }
                         }
                     }

--- a/meshroom/ui/qml/GraphEditor/NodeStatus.qml
+++ b/meshroom/ui/qml/GraphEditor/NodeStatus.qml
@@ -1,0 +1,170 @@
+import QtQuick 2.11
+import QtQuick.Controls 2.3
+import QtQuick.Controls 1.4 as Controls1 // SplitView
+import QtQuick.Layouts 1.3
+import MaterialIcons 2.2
+import Controls 1.0
+
+import "common.js" as Common
+
+/**
+ * NodeLog displays log and statistics data of Node's chunks (NodeChunks)
+ *
+ * To ease monitoring, it provides periodic auto-reload of the opened file
+ * if the related NodeChunk is being computed.
+ */
+FocusScope {
+    id: root
+    property variant node
+    property alias chunkCurrentIndex: chunksLV.currentIndex
+    signal changeCurrentChunk(int chunkIndex)
+
+    SystemPalette { id: activePalette }
+
+    Controls1.SplitView {
+        anchors.fill: parent
+
+        // The list of chunks
+        ChunksListView {
+            id: chunksLV
+            Layout.fillHeight: true
+            model: node.chunks
+            onChangeCurrentChunk: root.changeCurrentChunk(chunkIndex)
+        }
+
+        Loader {
+            id: componentLoader
+            clip: true
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+            property url source
+
+            property string currentFile: chunksLV.currentChunk ? chunksLV.currentChunk["statusFile"] : ""
+            onCurrentFileChanged: {
+                // only set text file viewer source when ListView is fully ready
+                // (either empty or fully populated with a valid currentChunk)
+                // to avoid going through an empty url when switching between two nodes
+
+                if(!chunksLV.count || chunksLV.currentChunk)
+                    componentLoader.source = Filepath.stringToUrl(currentFile);
+            }
+
+            sourceComponent: statViewerComponent
+        }
+
+        Component {
+            id: statViewerComponent
+            Item {
+
+                id: statusViewer
+                Layout.fillWidth: true
+                Layout.fillHeight: true
+                property url source: componentLoader.source
+                property var lastModified: undefined
+
+                onSourceChanged: {
+                    statusListModel.readSourceFile()
+                }
+
+                ListModel {
+                    id: statusListModel
+
+                    function readSourceFile() {
+                        // make sure we are trying to load a statistics file
+                        if(!Filepath.urlToString(source).endsWith("status"))
+                            return;
+
+                        var xhr = new XMLHttpRequest;
+                        xhr.open("GET", source);
+
+                        xhr.onreadystatechange = function() {
+                            if (xhr.readyState === XMLHttpRequest.DONE && xhr.status === 200) {
+                                // console.warn("StatusListModel: read valid file")
+                                if(lastModified === undefined || lastModified !== xhr.getResponseHeader('Last-Modified')) {
+                                    lastModified = xhr.getResponseHeader('Last-Modified')
+                                    try {
+                                        var jsonObject = JSON.parse(xhr.responseText);
+
+                                        var entries = [];
+                                        // prepare data to populate the ListModel from the input json object
+                                        for(var key in jsonObject)
+                                        {
+                                            var entry = {};
+                                            entry["key"] = key;
+                                            entry["value"] = String(jsonObject[key]);
+                                            entries.push(entry);
+                                        }
+                                        // reset the model with prepared data (limit to one update event)
+                                        statusListModel.clear();
+                                        statusListModel.append(entries);
+                                    }
+                                    catch(exc)
+                                    {
+                                        // console.warn("StatusListModel: failed to read file")
+                                        lastModified = undefined;
+                                        statusListModel.clear();
+                                    }
+                                }
+                            }
+                            else
+                            {
+                                // console.warn("StatusListModel: invalid file")
+                                lastModified = undefined;
+                                statusListModel.clear();
+                            }
+                        };
+                        xhr.send();
+                    }
+                }
+
+                ListView {
+                    id: statusListView
+                    anchors.fill: parent
+                    // spacing: 3
+                    model: statusListModel
+
+                    delegate: Rectangle {
+                        color: activePalette.window
+                        width: childrenRect.width
+                        height: childrenRect.height
+                        RowLayout {
+                            Label {
+                                text: key
+                                padding: 4
+                                leftPadding: 6
+                                Layout.preferredWidth: sizeHandle.x
+                                elide: Text.ElideRight
+                                background: Rectangle { color: Qt.darker(activePalette.window, 1.1) }
+                            }
+                            TextArea {
+                                text: value
+                                Layout.fillWidth: true
+                                wrapMode: Label.WrapAtWordBoundaryOrAnywhere
+                            }
+                        }
+                    }
+                }
+
+                // Categories resize handle
+                Rectangle {
+                    id: sizeHandle
+                    height: parent.contentHeight
+                    width: 1
+                    x: parent.width * 0.2
+                    MouseArea {
+                        anchors.fill: parent
+                        anchors.margins: -4
+                        cursorShape: Qt.SizeHorCursor
+                        drag {
+                            target: parent
+                            axis: Drag.XAxis
+                            threshold: 0
+                            minimumX: statusListView.width * 0.2
+                            maximumX: statusListView.width * 0.8
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
- [x] Use a single tab group for: Attributes, Log, Statistics, Status
- [x] Use a ListView with key/value to display the node status fields (instead of a file viewer)
