### PR TITLE
[WIP] Add file type selection for dense point cloud

### DIFF
--- a/meshroom/nodes/aliceVision/Meshing.py
+++ b/meshroom/nodes/aliceVision/Meshing.py
@@ -256,7 +256,7 @@ class Meshing(desc.CommandLineNode):
             name="output",
             label="Output Dense Point Cloud",
             description="Output dense point cloud with visibilities.",
-			value=desc.Node.internalFolder + 'densePointCloud.{outputSfMDataFilenameValue}',
+            value=desc.Node.internalFolder + 'densePointCloud.{outputSfMDataFilenameValue}',
             uid=[],
         ),
     ]

--- a/meshroom/nodes/aliceVision/Meshing.py
+++ b/meshroom/nodes/aliceVision/Meshing.py
@@ -225,7 +225,7 @@ class Meshing(desc.CommandLineNode):
             advanced=True,
         ),
         desc.ChoiceParam(
-            name='outputSfMDataFilename',
+            name='outputDensePointCloudFileType',
             label='Dense Point Cloud File Type',
             description='Dense Point Cloud File Type',
             value='abc',
@@ -255,8 +255,8 @@ class Meshing(desc.CommandLineNode):
         desc.File(
             name="output",
             label="Output Dense Point Cloud",
-            description="Output dense point cloud with visibilities (SfMData file format).",
-            value="{cache}/{nodeType}/{uid0}/'densePointCloud*.{outputSfMDataFilename}'",
+            description="Output dense point cloud with visibilities.",
+			value=desc.Node.internalFolder + 'densePointCloud.{outputDensePointCloudFileTypeValue}',
             uid=[],
         ),
     ]

--- a/meshroom/nodes/aliceVision/Meshing.py
+++ b/meshroom/nodes/aliceVision/Meshing.py
@@ -4,7 +4,7 @@ from meshroom.core import desc
 
 
 class Meshing(desc.CommandLineNode):
-    commandLine = 'aliceVision_meshing {allParams}'
+    commandLine = 'aliceVision_meshing --input {inputValue} --depthMapsFolder {depthMapsFolderValue} --depthMapsFilterFolder {depthMapsFilterFolderValue} --estimateSpaceFromSfM {estimateSpaceFromSfMValue} --estimateSpaceMinObservations	{estimateSpaceMinObservationsValue} --estimateSpaceMinObservationAngle {estimateSpaceMinObservationAngleValue} --maxInputPoints {maxInputPointsValue} --maxPoints {maxPointsValue} --maxPointsPerVoxel {maxPointsPerVoxelValue} --minStep {minStepValue} --partitioning	{partitioningValue} --repartition {repartitionValue} --angleFactor {angleFactorValue} --simFactor {simFactorValue} --pixSizeMarginInitCoef {pixSizeMarginInitCoefValue} --pixSizeMarginFinalCoef {pixSizeMarginFinalCoefValue} --voteMarginFactor {voteMarginFactorValue} --contributeMarginFactor {contributeMarginFactorValue} --simGaussianSizeInit {simGaussianSizeInitValue} --simGaussianSize {simGaussianSizeValue} --minAngleThreshold {minAngleThresholdValue} --refineFuse {refineFuseValue} --addLandmarksToTheDensePointCloud {addLandmarksToTheDensePointCloudValue} --colorizeOutput {colorizeOutputValue} --saveRawDensePointCloud {saveRawDensePointCloudValue} --outputMesh {outputMeshValue} --output	{outputValue} --verboseLevel {verboseLevelValue}'
 
     cpu = desc.Level.INTENSIVE
     ram = desc.Level.INTENSIVE
@@ -252,7 +252,7 @@ class Meshing(desc.CommandLineNode):
             value=desc.Node.internalFolder + 'mesh.obj',
             uid=[],
         ),
-        desc.File(
+		desc.File(
             name="output",
             label="Output Dense Point Cloud",
             description="Output dense point cloud with visibilities (SfMData file format).",

--- a/meshroom/nodes/aliceVision/Meshing.py
+++ b/meshroom/nodes/aliceVision/Meshing.py
@@ -225,6 +225,15 @@ class Meshing(desc.CommandLineNode):
             advanced=True,
         ),
         desc.ChoiceParam(
+            name='outputSfMDataFilename',
+            label='Dense Point Cloud File Type',
+            description='Dense Point Cloud File Type',
+            value='abc',
+            values=('abc', 'ply', 'json', 'xml', 'baf', 'bin'),
+            exclusive=True,
+            uid=[0],
+        ),
+        desc.ChoiceParam(
             name='verboseLevel',
             label='Verbose Level',
             description='''verbosity level (fatal, error, warning, info, debug, trace).''',
@@ -247,7 +256,7 @@ class Meshing(desc.CommandLineNode):
             name="output",
             label="Output Dense Point Cloud",
             description="Output dense point cloud with visibilities (SfMData file format).",
-            value="{cache}/{nodeType}/{uid0}/densePointCloud.abc",
+            value="{cache}/{nodeType}/{uid0}/'densePointCloud*.{outputSfMDataFilename}'",
             uid=[],
         ),
     ]

--- a/meshroom/nodes/aliceVision/Meshing.py
+++ b/meshroom/nodes/aliceVision/Meshing.py
@@ -225,7 +225,7 @@ class Meshing(desc.CommandLineNode):
             advanced=True,
         ),
         desc.ChoiceParam(
-            name='outputSfMDataFilename',
+            name='outputDenseFileType',
             label='Dense Point Cloud File Type',
             description='Dense Point Cloud File Type',
             value='abc',
@@ -255,8 +255,8 @@ class Meshing(desc.CommandLineNode):
         desc.File(
             name="output",
             label="Output Dense Point Cloud",
-            description="Output dense point cloud with visibilities.",
-            value=desc.Node.internalFolder + 'densePointCloud.{outputSfMDataFilenameValue}',
+            description="Output dense point cloud with visibilities (SfMData file format).",
+            value=desc.Node.internalFolder + 'densepointcloud.{outputDenseFileTypeValue}',
             uid=[],
         ),
     ]

--- a/meshroom/nodes/aliceVision/Meshing.py
+++ b/meshroom/nodes/aliceVision/Meshing.py
@@ -249,7 +249,7 @@ class Meshing(desc.CommandLineNode):
             name="outputMesh",
             label="Output Mesh",
             description="Output mesh (OBJ file format).",
-            value="{cache}/{nodeType}/{uid0}/mesh.obj",
+            value=desc.Node.internalFolder + 'mesh.obj',
             uid=[],
         ),
         desc.File(

--- a/meshroom/nodes/aliceVision/Meshing.py
+++ b/meshroom/nodes/aliceVision/Meshing.py
@@ -225,7 +225,7 @@ class Meshing(desc.CommandLineNode):
             advanced=True,
         ),
         desc.ChoiceParam(
-            name='outputDensePointCloudFileType',
+            name='outputSfMDataFilename',
             label='Dense Point Cloud File Type',
             description='Dense Point Cloud File Type',
             value='abc',
@@ -256,7 +256,7 @@ class Meshing(desc.CommandLineNode):
             name="output",
             label="Output Dense Point Cloud",
             description="Output dense point cloud with visibilities.",
-			value=desc.Node.internalFolder + 'densePointCloud.{outputDensePointCloudFileTypeValue}',
+			value=desc.Node.internalFolder + 'densePointCloud.{outputSfMDataFilenameValue}',
             uid=[],
         ),
     ]


### PR DESCRIPTION
## Description

This will (hopefully) add file type selection for dense point cloud

https://github.com/alicevision/meshroom/issues/690

https://github.com/alicevision/AliceVision/pull/597

## Implementation remarks

ToDo: 

[ ] find a way to exclude the file type drop down from the class
[ ] include rawPointCloud file type
