### PR TITLE
Viewer3D: Display equirectangular images as environment maps

### DIFF
--- a/meshroom/ui/components/filepath.py
+++ b/meshroom/ui/components/filepath.py
@@ -78,3 +78,14 @@ class FilepathHelper(QObject):
     def normpath(self, path):
         """ Returns native normalized path """
         return os.path.normpath(self.asStr(path))
+
+    @Slot(str, result=str)
+    @Slot(QUrl, result=str)
+    def globFirst(self, path):
+        """ Returns the first from a list of paths matching a pathname pattern. """
+        import glob
+        fileList = glob.glob(self.asStr(path))
+        fileList.sort()
+        if fileList:
+          return fileList[0]
+        return ""

--- a/meshroom/ui/qml/Viewer3D/DepthMapLoader.qml
+++ b/meshroom/ui/qml/Viewer3D/DepthMapLoader.qml
@@ -1,4 +1,4 @@
-import DepthMapEntity 2.0
+import DepthMapEntity 2.1
 
 /**
  * Support for Depth Map files (EXR) in Qt3d.

--- a/meshroom/ui/qml/Viewer3D/EnvironmentMapEntity.qml
+++ b/meshroom/ui/qml/Viewer3D/EnvironmentMapEntity.qml
@@ -1,0 +1,48 @@
+import QtQuick 2.9
+import Qt3D.Core 2.1
+import Qt3D.Render 2.1
+import Qt3D.Extras 2.10
+
+
+/**
+ * EnvironmentMap maps an equirectangular image on a Sphere.
+ * The 'position' property can be used to virually attach it to a camera
+ * and get the impression of an environment at an infinite distance.
+ */
+Entity {
+    id: root
+
+    /// Source of the equirectangular image
+    property url source
+    /// Radius of the sphere
+    property alias radius: sphereMesh.radius
+    /// Number of slices of the sphere
+    property alias slices: sphereMesh.slices
+    /// Number of rings of the sphere
+    property alias rings: sphereMesh.rings
+    /// Position of the sphere
+    property alias position: transform.translation
+
+    components: [
+        SphereMesh {
+            id: sphereMesh
+            radius: 1000
+            slices: 50
+            rings: 50
+        },
+        Transform {
+            id: transform
+            translation: root.position
+        },
+        DiffuseMapMaterial {
+            ambient: "#FFF"
+            shininess: 0
+            specular: "#000"
+            diffuse: TextureLoader {
+                magnificationFilter: Texture.Linear
+                mirrored: true
+                source: root.source
+            }
+        }
+    ]
+}

--- a/meshroom/ui/qml/Viewer3D/EnvironmentMapEntity.qml
+++ b/meshroom/ui/qml/Viewer3D/EnvironmentMapEntity.qml
@@ -22,6 +22,8 @@ Entity {
     property alias rings: sphereMesh.rings
     /// Position of the sphere
     property alias position: transform.translation
+    /// Texture loading status
+    property alias status: textureLoader.status
 
     components: [
         SphereMesh {
@@ -39,6 +41,7 @@ Entity {
             shininess: 0
             specular: "#000"
             diffuse: TextureLoader {
+                id: textureLoader
                 magnificationFilter: Texture.Linear
                 mirrored: true
                 source: root.source

--- a/meshroom/ui/qml/Viewer3D/MediaLibrary.qml
+++ b/meshroom/ui/qml/Viewer3D/MediaLibrary.qml
@@ -16,6 +16,9 @@ Entity {
     property bool pickingEnabled: false
     readonly property alias count: instantiator.count // number of instantiated media delegates
 
+    /// Camera to consider for positionning
+    property Camera camera: null
+
     /// True while at least one media is being loaded
     readonly property bool loading: {
         for(var i=0; i<m.mediaModel.count; ++i) {
@@ -173,6 +176,7 @@ Entity {
             // source based on currentSource + "requested" property
             readonly property string finalSource: model.requested ? currentSource : ""
 
+            camera: root.camera
             renderMode: root.renderMode
             enabled: visible
 

--- a/meshroom/ui/qml/Viewer3D/MediaLoader.qml
+++ b/meshroom/ui/qml/Viewer3D/MediaLoader.qml
@@ -125,13 +125,16 @@ import Utils 1.0
                 }
 
                 //   - [2] as an environment map
-                obj.destroy()
+                obj.destroy();
+                root.status = SceneLoader.Loading;
                 obj = Qt.createComponent("EnvironmentMapEntity.qml").createObject(
                             exrLoaderEntity, {
                                 'source': source,
                                 'position': Qt.binding(function() { return root.camera.position })
                             });
-                root.status = SceneLoader.Ready;
+                obj.statusChanged.connect(function() {
+                    root.status = obj.status;
+                });
             }
         }
     }

--- a/meshroom/ui/qml/Viewer3D/Viewer3D.qml
+++ b/meshroom/ui/qml/Viewer3D/Viewer3D.qml
@@ -221,6 +221,7 @@ FocusScope {
                 // Picking to set focus point (camera view center)
                 // Only activate it when a double click may happen or when the 'Control' key is pressed
                 pickingEnabled: cameraController.pickingActive || doubleClickTimer.running
+                camera: cameraSelector.camera
 
                 components: [
                     Transform {

--- a/meshroom/ui/qml/WorkspaceView.qml
+++ b/meshroom/ui/qml/WorkspaceView.qml
@@ -23,7 +23,7 @@ Item {
     readonly property variant cameraInits: _reconstruction.cameraInits
     property bool readOnly: false
     readonly property Viewer3D viewer3D: viewer3D
-
+    readonly property Viewer2D viewer2D: viewer2D
 
     implicitWidth: 300
     implicitHeight: 400

--- a/meshroom/ui/qml/main.qml
+++ b/meshroom/ui/qml/main.qml
@@ -531,6 +531,28 @@ ApplicationWindow {
                         viewer3D.solo(attribute);
                     return loaded;
                 }
+                function viewIn2D(attribute) {
+                    var imageExts = ['.exr', '.jpg', '.tif', '.png'];
+                    var ext = Filepath.extension(attribute.value);
+                    if(imageExts.indexOf(ext) == -1)
+                    {
+                        return false;
+                    }
+
+                    if(attribute.value.includes('*'))
+                    {
+                        // For now, the viewer only supports a single image.
+                        var firstFile = Filepath.globFirst(attribute.value)
+                        viewer2D.source = Filepath.stringToUrl(firstFile);
+                    }
+                    else
+                    {
+                        viewer2D.source = Filepath.stringToUrl(attribute.value);
+                        return true;
+                    }
+
+                    return false;
+                }
             }
         }
 
@@ -598,10 +620,16 @@ ApplicationWindow {
                         for(var i=0; i < node.attributes.count; ++i)
                         {
                             var attr = node.attributes.at(i)
-                            if(attr.isOutput
-                               && workspaceView.viewIn3D(attr, mouse))
+                            if(attr.isOutput)
                             {
-                                break;
+                                if(workspaceView.viewIn2D(attr))
+                                {
+                                    break;
+                                }
+                                if(workspaceView.viewIn3D(attr, mouse))
+                                {
+                                    break;
+                                }
                             }
                         }
                     }
@@ -615,7 +643,16 @@ ApplicationWindow {
                 node: _reconstruction.selectedNode
                 // Make NodeEditor readOnly when computing
                 readOnly: graphLocked
-                onAttributeDoubleClicked: workspaceView.viewIn3D(attribute, mouse)
+                onAttributeDoubleClicked: {
+                    if(workspaceView.viewIn2D(attribute))
+                    {
+                        return;
+                    }
+                    if(workspaceView.viewIn3D(attribute, mouse))
+                    {
+                        return;
+                    }
+                }
                 onUpgradeRequest: {
                     var n = _reconstruction.upgradeNode(node);
                     _reconstruction.selectedNode = n;

--- a/meshroom/ui/qml/main.qml
+++ b/meshroom/ui/qml/main.qml
@@ -524,6 +524,13 @@ ApplicationWindow {
                 reconstruction: _reconstruction
                 readOnly: _reconstruction.computing
 
+                function viewAttribute(attribute, mouse) {
+                    let viewable = false;
+                    viewable = workspaceView.viewIn2D(attribute);
+                    viewable |= workspaceView.viewIn3D(attribute, mouse);
+                    return viewable;
+                }
+
                 function viewIn3D(attribute, mouse) {
                     var loaded = viewer3D.view(attribute);
                     // solo media if Control modifier was held
@@ -531,6 +538,7 @@ ApplicationWindow {
                         viewer3D.solo(attribute);
                     return loaded;
                 }
+
                 function viewIn2D(attribute) {
                     var imageExts = ['.exr', '.jpg', '.tif', '.png'];
                     var ext = Filepath.extension(attribute.value);
@@ -617,20 +625,12 @@ ApplicationWindow {
                     onNodeDoubleClicked: {
                         _reconstruction.setActiveNodeOfType(node);
 
+                        let viewable = false;
                         for(var i=0; i < node.attributes.count; ++i)
                         {
                             var attr = node.attributes.at(i)
-                            if(attr.isOutput)
-                            {
-                                if(workspaceView.viewIn2D(attr))
-                                {
-                                    break;
-                                }
-                                if(workspaceView.viewIn3D(attr, mouse))
-                                {
-                                    break;
-                                }
-                            }
+                            if(attr.isOutput && workspaceView.viewAttribute(attr))
+                                break;
                         }
                     }
                     onComputeRequest: computeManager.compute(node)
@@ -644,14 +644,7 @@ ApplicationWindow {
                 // Make NodeEditor readOnly when computing
                 readOnly: graphLocked
                 onAttributeDoubleClicked: {
-                    if(workspaceView.viewIn2D(attribute))
-                    {
-                        return;
-                    }
-                    if(workspaceView.viewIn3D(attribute, mouse))
-                    {
-                        return;
-                    }
+                     workspaceView.viewAttribute(attribute);
                 }
                 onUpgradeRequest: {
                     var n = _reconstruction.upgradeNode(node);


### PR DESCRIPTION
## Description
Add support for displaying equirectangular images as environment maps in the 3D viewer.
Requires https://github.com/alicevision/QtOIIO/pull/13.
![pano2](https://user-images.githubusercontent.com/1674646/70794474-fa062880-1d9d-11ea-81df-5575ddf22d03.gif)


## Features list
- [X] new EnvironmentMap entity mapping a texture on a Sphere
- [X] Handle non-depth maps EXR files as panoramas
