### PR TITLE
[core] new "Node Update Hooks" mechanism

### DIFF
--- a/meshroom/core/desc.py
+++ b/meshroom/core/desc.py
@@ -318,13 +318,14 @@ class DynamicNodeSize(object):
 
     def computeSize(self, node):
         param = node.attribute(self._param)
-        assert param.isInput
         # Link: use linked node's size
         if param.isLink:
             return param.getLinkParam().node.size
         # ListAttribute: use list size
         if isinstance(param.desc, ListAttribute):
             return len(param)
+        if isinstance(param.desc, IntParam):
+            return param.value
         return 1
 
 

--- a/meshroom/core/desc.py
+++ b/meshroom/core/desc.py
@@ -383,7 +383,26 @@ class Node(object):
     def __init__(self):
         pass
 
-    def updateInternals(self, node):
+    @classmethod
+    def update(cls, node):
+        """ Method call before node's internal update on invalidation.
+
+        Args:
+            node: the BaseNode instance being updated
+        See Also:
+            BaseNode.updateInternals
+        """
+        pass
+
+    @classmethod
+    def postUpdate(cls, node):
+        """ Method call after node's internal update on invalidation.
+
+        Args:
+            node: the BaseNode instance being updated
+        See Also:
+            NodeBase.updateInternals
+        """
         pass
 
     def stopProcess(self, chunk):

--- a/meshroom/core/node.py
+++ b/meshroom/core/node.py
@@ -474,6 +474,11 @@ class BaseNode(BaseObject):
         for name, attr in self._attributes.objects.items():
             if attr.isInput:
                 continue  # skip inputs
+
+            # Only consider File attributes for command output parameters
+            if not isinstance(attr.attributeDesc, desc.File):
+                continue
+
             attr.value = attr.attributeDesc.value.format(**self._cmdVars)
             attr._invalidationValue = attr.attributeDesc.value.format(**cmdVarsNoCache)
             v = attr.getValueStr()
@@ -555,6 +560,8 @@ class BaseNode(BaseObject):
         Args:
             cacheDir (str): (optional) override graph's cache directory with custom path
         """
+        if self.nodeDesc:
+            self.nodeDesc.update(self)
         # Update chunks splitting
         self._updateChunks()
         # Retrieve current internal folder (if possible)
@@ -569,6 +576,8 @@ class BaseNode(BaseObject):
         }
         self._computeUids()
         self._buildCmdVars()
+        if self.nodeDesc:
+            self.nodeDesc.postUpdate(self)
         # Notify internal folder change if needed
         if self.internalFolder != folder:
             self.internalFolderChanged.emit()

--- a/meshroom/ui/qml/GraphEditor/Node.qml
+++ b/meshroom/ui/qml/GraphEditor/Node.qml
@@ -41,6 +41,14 @@ Item {
         }
     }
 
+    // Whether an attribute can be displayed as an attribute pin on the node
+    function isDisplayableAsPin(attribute) {
+        // ATM, only File attributes are meant to be connected
+        // TODO: review this if we want to connect something else
+        return attribute.type == "File"
+               || (attribute.type == "ListAttribute" && attribute.desc.elementDesc.type == "File")
+    }
+
     MouseArea {
         width: parent.width
         height: body.height
@@ -115,8 +123,7 @@ Item {
                     Repeater {
                         model: node.attributes
                         delegate: Loader {
-                            active: !object.isOutput && object.type == "File"
-                                    || (object.type == "ListAttribute" && object.desc.elementDesc.type == "File") // TODO: review this
+                            active: !object.isOutput && isDisplayableAsPin(object)
                             width: inputs.width
 
                             sourceComponent: AttributePin {
@@ -142,7 +149,7 @@ Item {
                         model: node.attributes
 
                         delegate: Loader {
-                            active: object.isOutput
+                            active: object.isOutput && isDisplayableAsPin(object)
                             anchors.right: parent.right
                             width: outputs.width
 


### PR DESCRIPTION
## Description
The goal of this PR is to be able to react to node's update to dynamically modify output parameters / node's size (in terms of parallelization).

## Features list

- [X] desc.Node: add update/postUpdate hooks 
- [X] desc.Node: allow usage of DynamicNodeSize on output attributes 
- [X] Node: only display File attributes as pins



