### PR TITLE
[core] Option to make chunks optional

### DIFF
--- a/meshroom/__init__.py
+++ b/meshroom/__init__.py
@@ -1,10 +1,11 @@
 __version__ = "2019.2.0"
 __version_name__ = __version__
 
+from distutils import util
+from enum import Enum
+import logging
 import os
 import sys
-import logging
-from enum import Enum
 
 # sys.frozen is initialized by cx_Freeze and identifies a release package
 isFrozen = getattr(sys, "frozen", False)
@@ -20,6 +21,8 @@ if not isFrozen:
 
 # Allow override from env variable
 __version_name__ = os.environ.get("REZ_MESHROOM_VERSION", __version_name__)
+
+useMultiChunks = util.strtobool(os.environ.get("MESHROOM_USE_MULTI_CHUNKS", "True"))
 
 
 class Backend(Enum):

--- a/meshroom/core/desc.py
+++ b/meshroom/core/desc.py
@@ -429,7 +429,7 @@ class CommandLineNode(Node):
             if not alreadyInEnv:
                 cmdPrefix = '{rez} {packageFullName} -- '.format(rez=os.environ.get('REZ_ENV'), packageFullName=chunk.node.packageFullName)
         cmdSuffix = ''
-        if chunk.range:
+        if chunk.node.isParallelized:
             cmdSuffix = ' ' + self.commandLineRange.format(**chunk.range.toDict())
         return cmdPrefix + chunk.node.nodeDesc.commandLine.format(**chunk.node._cmdVars) + cmdSuffix
 

--- a/meshroom/core/node.py
+++ b/meshroom/core/node.py
@@ -592,7 +592,7 @@ class BaseNode(BaseObject):
 
     @property
     def isParallelized(self):
-        return bool(self.nodeDesc.parallelization)
+        return bool(self.nodeDesc.parallelization) if meshroom.useMultiChunks else False
 
     @property
     def nbParallelizationBlocks(self):


### PR DESCRIPTION
When computing on a single machine with very large ressources, the chunks can limit the ressources used.
A new environment variable `MESHROOM_USE_MULTI_CHUNKS` can be set to 0 to disable it.

Warning: If you mix usage with and without this option, the nodes status will be incoherent.
