### PR TITLE
fix python nodes being blocked by log

### DIFF
--- a/meshroom/nodes/aliceVision/Publish.py
+++ b/meshroom/nodes/aliceVision/Publish.py
@@ -50,27 +50,29 @@ class Publish(desc.Node):
         return paths
 
     def processChunk(self, chunk):
-        chunk.logManager.waitUntilCleared()
-        chunk.logger.setLevel(chunk.logManager.textToLevel(chunk.node.verboseLevel.value))
-        
-        if not chunk.node.inputFiles:
-            chunk.logger.warning('Nothing to publish')
-            return
-        if not chunk.node.output.value:
-            return
+        try:
+            chunk.logManager.start(chunk.node.verboseLevel.value)
+            
+            if not chunk.node.inputFiles:
+                chunk.logger.warning('Nothing to publish')
+                return
+            if not chunk.node.output.value:
+                return
 
-        outFiles = self.resolvedPaths(chunk.node.inputFiles.value, chunk.node.output.value)
+            outFiles = self.resolvedPaths(chunk.node.inputFiles.value, chunk.node.output.value)
 
-        if not outFiles:
-            error = 'Publish: input files listed, but nothing to publish'
-            chunk.logger.error(error)
-            chunk.logger.info('Listed input files: {}'.format([i.value for i in chunk.node.inputFiles.value]))
-            raise RuntimeError(error)
+            if not outFiles:
+                error = 'Publish: input files listed, but nothing to publish'
+                chunk.logger.error(error)
+                chunk.logger.info('Listed input files: {}'.format([i.value for i in chunk.node.inputFiles.value]))
+                raise RuntimeError(error)
 
-        if not os.path.exists(chunk.node.output.value):
-            os.mkdir(chunk.node.output.value)
+            if not os.path.exists(chunk.node.output.value):
+                os.mkdir(chunk.node.output.value)
 
-        for iFile, oFile in outFiles.items():
-            chunk.logger.info('Publish file {} into {}'.format(iFile, oFile))
-            shutil.copyfile(iFile, oFile)
-        chunk.logger.info('Publish end')
+            for iFile, oFile in outFiles.items():
+                chunk.logger.info('Publish file {} into {}'.format(iFile, oFile))
+                shutil.copyfile(iFile, oFile)
+            chunk.logger.info('Publish end')
+        finally:
+            chunk.logManager.end()

--- a/meshroom/nodes/aliceVision/SketchfabUpload.py
+++ b/meshroom/nodes/aliceVision/SketchfabUpload.py
@@ -219,6 +219,7 @@ class SketchfabUpload(desc.Node):
         try:
             self._stopped = False
             chunk.logManager.start(chunk.node.verboseLevel.value)
+            uploadFile = ''
         
             if not chunk.node.inputFiles:
                 chunk.logger.warning('Nothing to upload')

--- a/meshroom/nodes/aliceVision/SketchfabUpload.py
+++ b/meshroom/nodes/aliceVision/SketchfabUpload.py
@@ -216,31 +216,30 @@ class SketchfabUpload(desc.Node):
         return self._stopped
 
     def processChunk(self, chunk):
-        self._stopped = False
-        chunk.logManager.waitUntilCleared()
-        chunk.logger.setLevel(chunk.logManager.textToLevel(chunk.node.verboseLevel.value))
-        
-        if not chunk.node.inputFiles:
-            chunk.logger.warning('Nothing to upload')
-            return
-        if chunk.node.apiToken.value == '':
-            chunk.logger.error('Need API token.')
-            raise RuntimeError()
-        if len(chunk.node.title.value) > 48:
-            chunk.logger.error('Title cannot be longer than 48 characters.')
-            raise RuntimeError()
-        if len(chunk.node.description.value) > 1024:
-            chunk.logger.error('Description cannot be longer than 1024 characters.')
-            raise RuntimeError()
-        tags = [ i.value.replace(' ', '-') for i in chunk.node.tags.value.values() ]
-        if all(len(i) > 48 for i in tags) and len(tags) > 0:
-            chunk.logger.error('Tags cannot be longer than 48 characters.')
-            raise RuntimeError()
-        if len(tags) > 42:
-            chunk.logger.error('Maximum of 42 separate tags.')
-            raise RuntimeError()
-
         try:
+            self._stopped = False
+            chunk.logManager.start(chunk.node.verboseLevel.value)
+        
+            if not chunk.node.inputFiles:
+                chunk.logger.warning('Nothing to upload')
+                return
+            if chunk.node.apiToken.value == '':
+                chunk.logger.error('Need API token.')
+                raise RuntimeError()
+            if len(chunk.node.title.value) > 48:
+                chunk.logger.error('Title cannot be longer than 48 characters.')
+                raise RuntimeError()
+            if len(chunk.node.description.value) > 1024:
+                chunk.logger.error('Description cannot be longer than 1024 characters.')
+                raise RuntimeError()
+            tags = [ i.value.replace(' ', '-') for i in chunk.node.tags.value.values() ]
+            if all(len(i) > 48 for i in tags) and len(tags) > 0:
+                chunk.logger.error('Tags cannot be longer than 48 characters.')
+                raise RuntimeError()
+            if len(tags) > 42:
+                chunk.logger.error('Maximum of 42 separate tags.')
+                raise RuntimeError()
+
             data = {
                 'name': chunk.node.title.value,
                 'description': chunk.node.description.value,
@@ -275,6 +274,8 @@ class SketchfabUpload(desc.Node):
             if os.path.isfile(uploadFile):
                 os.remove(uploadFile)
                 chunk.logger.debug('Deleted {}'.format(uploadFile))
+
+            chunk.logManager.end()
 
     def stopProcess(self, chunk):
         self._stopped = True

--- a/setup.py
+++ b/setup.py
@@ -41,8 +41,9 @@ class PlatformExecutable(Executable):
 build_exe_options = {
     # include dynamically loaded plugins
     "packages": ["meshroom.nodes", "meshroom.submitters"],
-    # cx_Freeze does not copy idnadata by default, so it needs to be added here
-    "includes": ["idna.idnadata"],
+    "includes": [
+        "idna.idnadata",  # Dependency needed by SketchfabUpload node, but not detected by cx_Freeze
+    ],
     "include_files": ["CHANGES.md", "COPYING.md", "LICENSE-MPL2.md", "README.md"]
 }
 

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,8 @@ class PlatformExecutable(Executable):
 build_exe_options = {
     # include dynamically loaded plugins
     "packages": ["meshroom.nodes", "meshroom.submitters"],
+    # cx_Freeze does not copy idnadata by default, so it needs to be added here
+    "includes": ["idna.idnadata"],
     "include_files": ["CHANGES.md", "COPYING.md", "LICENSE-MPL2.md", "README.md"]
 }
 


### PR DESCRIPTION
Fix for #780, the log is cleared directly from `processChunk` instead of relying on chunk.statusChanged