### PR TITLE
Feature fileselection

### DIFF
--- a/meshroom/ui/qml/ImageGallery/ImageGallery.qml
+++ b/meshroom/ui/qml/ImageGallery/ImageGallery.qml
@@ -1,6 +1,7 @@
 import QtQuick 2.7
 import QtQuick.Controls 2.3
 import QtQuick.Layouts 1.3
+import QtQuick.Dialogs 1.1
 import MaterialIcons 2.2
 import QtQml.Models 2.2
 
@@ -26,12 +27,25 @@ Panel {
 
     signal removeImageRequest(var attribute)
     signal filesDropped(var drop, var augmentSfm)
+    signal filesAdded(var fileUrls, var augmentSfm)
 
     title: "Images"
     implicitWidth: (root.defaultCellSize + 2) * 2
 
     function changeCurrentIndex(newIndex) {
         _reconstruction.cameraInitIndex = newIndex
+    }
+
+    FileDialog {
+        id: addFileDialog
+        title: "Add Files"
+        nameFilters: ["Images (*.jpg *.jpeg *.tif *.tiff *.png *.exr *.rw2 *.cr2 *.nef *.arw)"]
+        selectMultiple: true
+        onAccepted: {
+            root.filesAdded(fileUrls, false)
+            closed(Platform.Dialog.Accepted)
+        }
+        onRejected: closed(Platform.Dialog.Rejected)
     }
 
     QtObject {
@@ -229,9 +243,19 @@ Panel {
                     text: MaterialIcons.photo_library
                     font.pointSize: 24
                     font.family: MaterialIcons.fontFamily
+
+                    MouseArea {
+                        anchors.fill: parent
+                        onClicked: { addFileDialog.open() }
+                    }
                 }
                 Label {
                     text: "Drop Image Files / Folders"
+
+                    MouseArea {
+                        anchors.fill: parent
+                        onClicked: { addFileDialog.open() }
+                    }
                 }
             }
 

--- a/meshroom/ui/qml/WorkspaceView.qml
+++ b/meshroom/ui/qml/WorkspaceView.qml
@@ -69,6 +69,7 @@ Item {
                 currentIndex: reconstruction.cameraInitIndex
                 onRemoveImageRequest: reconstruction.removeAttribute(attribute)
                 onFilesDropped: reconstruction.handleFilesDrop(drop, augmentSfm ? null : cameraInit)
+                onFilesAdded: reconstruction.handleFilesUrls(fileUrls, augmentSfm ? null : cameraInit)
             }
             LiveSfmView {
                 visible: settings_UILayout.showLiveReconstruction

--- a/meshroom/ui/qml/main.qml
+++ b/meshroom/ui/qml/main.qml
@@ -1,6 +1,7 @@
 import QtQuick 2.7
 import QtQuick.Controls 2.3
 import QtQuick.Controls 1.4 as Controls1 // For SplitView
+import QtQuick.Dialogs 1.1
 import QtQuick.Layouts 1.1
 import QtQuick.Window 2.3
 import QtQml.Models 2.2
@@ -136,6 +137,36 @@ ApplicationWindow {
             _reconstruction.saveAs(file)
             closed(Platform.Dialog.Accepted)
             MeshroomApp.addRecentProjectFile(file.toString())
+        }
+        onRejected: closed(Platform.Dialog.Rejected)
+    }
+
+    FileDialog {
+        id: addFileDialog
+
+        signal closed(var result)
+
+        title: "Add Images"
+        nameFilters: ["Images (*.jpg *.jpeg *.tif *.tiff *.png *.exr *.rw2 *.cr2 *.nef *.arw)"]
+        selectMultiple: true
+        onAccepted: {
+            _reconstruction.handleFilesUrls(fileUrls, _reconstruction.cameraInit)
+            closed(Platform.Dialog.Accepted)
+        }
+        onRejected: closed(Platform.Dialog.Rejected)
+    }
+
+    FileDialog {
+        id: addFileAugmentDialog
+
+        signal closed(var result)
+
+        title: "Add Images (Augment)"
+        nameFilters: ["Images (*.jpg *.jpeg *.tif *.tiff *.png *.exr *.rw2 *.cr2 *.nef *.arw)"]
+        selectMultiple: true
+        onAccepted: {
+            _reconstruction.handleFilesUrls(fileUrls, null)
+            closed(Platform.Dialog.Accepted)
         }
         onRejected: closed(Platform.Dialog.Rejected)
     }
@@ -379,6 +410,20 @@ ApplicationWindow {
                 text: "Save As..."
                 shortcut: "Ctrl+Shift+S"
                 onTriggered: saveFileDialog.open()
+            }
+            MenuSeparator { }
+            Action {
+                id: addFilesAction
+                text: "Add Images..."
+                shortcut: "Ctrl+I"
+                onTriggered: addFileDialog.open()
+            }
+            Action {
+                id: addFilesAugmentAction
+                text: "Add Images (Augment)..."
+                shortcut: "Ctrl+Shift+I"
+                enabled: computeManager.canStartComputation
+                onTriggered: addFileAugmentDialog.open()
             }
             MenuSeparator { }
             Action {

--- a/meshroom/ui/reconstruction.py
+++ b/meshroom/ui/reconstruction.py
@@ -605,7 +605,14 @@ class Reconstruction(UIGraph):
         Fetching urls from dropEvent is generally expensive in QML/JS (bug ?).
         This method allows to reduce process time by doing it on Python side.
         """
-        filesByType = self.getFilesByTypeFromDrop(drop)
+        urls = drop.property("urls")
+        return self.handleFilesUrls(urls, cameraInit)
+
+    @Slot("QList<QUrl>", Node)
+    def handleFilesUrls(self, urls, cameraInit):
+        """ Handle generic urls aiming to add images to the Reconstruction.
+        """
+        filesByType = self.getFilesByTypeFromUrls(urls)
         if filesByType.images:
             self.importImagesAsync(filesByType.images, cameraInit)
         if filesByType.videos:
@@ -665,16 +672,15 @@ class Reconstruction(UIGraph):
                 )
 
     @staticmethod
-    def getFilesByTypeFromDrop(drop):
+    def getFilesByTypeFromUrls(urls):
         """
 
         Args:
-            drop:
+            urls:
 
         Returns:
             <images, otherFiles> List of recognized images and list of other files
         """
-        urls = drop.property("urls")
         # Build the list of images paths
         filesByType = multiview.FilesByType()
         for url in urls:


### PR DESCRIPTION
## Description
https://github.com/alicevision/meshroom/wiki/Good-first-contributions point that _Add file picker to add images_ would be a good start for development. This would Fix #461 and Fix #825 

## Features list

- [X] Feature click on Drop Images Files (and icon). Fix #461, Fix #825 
- [X] Feature menu entries to in addition support augmenting.

## Implementation remarks

I would like to put down in this pull request has been my first contribution, and first QML work, which I found challenging. The first commit updates the Python interface, which splits the drag and drop slot to a drag and drop, and a more generic list of URLs.

The second commit adds the ability to be able to click on both the icon as the drop label. I choose this approach to prevent issues when clicking on any image later, this allowing the most obvious place a user would be able to click first. I added the new signal in because the different object type QObject vs  QList<QUrl>. I used FileDialog from QtQuick.Dialogs to allow a multifile selection. I wonder if the other Platform.FileDialog's should be updated in the future.

The third commit adds two menu entries, in order to add images dragless. As programmer I would have liked to reuse the same FileDialog, I don't know if this would be an anti-pattern in QML. I found it very hard to just reuse the FileDialog from one of the files. I would love to hear if it this is possible at all.