### PR TITLE
Add SfM Statistics

### DIFF
--- a/meshroom/ui/qml/Charts/InteractiveChartView.qml
+++ b/meshroom/ui/qml/Charts/InteractiveChartView.qml
@@ -1,0 +1,57 @@
+import QtQuick 2.9
+import QtQuick.Controls 2.3
+import QtQuick.Layouts 1.3
+import MaterialIcons 2.2
+import QtPositioning 5.8
+import QtLocation 5.9
+
+import QtCharts 2.13
+
+import Controls 1.0
+import Utils 1.0
+
+
+ChartView {
+    id: root
+    antialiasing: true
+
+    Rectangle {
+        id: plotZone
+        x: root.plotArea.x
+        y: root.plotArea.y
+        width: root.plotArea.width
+        height: root.plotArea.height
+        color: "transparent"
+
+        MouseArea {
+            anchors.fill: parent
+
+            property double degreeToScale: 1.0 / 120.0 // default mouse scroll is 15 degree
+            acceptedButtons: Qt.LeftButton | Qt.RightButton | Qt.MiddleButton
+            // onWheel: {
+            //     console.warn("root.plotArea before: " + root.plotArea)
+            //     var zoomFactor = wheel.angleDelta.y > 0 ? 1.0 / (1.0 + wheel.angleDelta.y * degreeToScale) : (1.0 + Math.abs(wheel.angleDelta.y) * degreeToScale)
+
+            //     // var mouse_screen = Qt.point(wheel.x, wheel.y)
+            //     var mouse_screen = mapToItem(root, wheel.x, wheel.y)
+            //     var mouse_normalized = Qt.point(mouse_screen.x / plotZone.width, mouse_screen.y / plotZone.height)
+            //     var mouse_plot = Qt.point(mouse_normalized.x * plotZone.width, mouse_normalized.y * plotZone.height)
+
+            //     // var p = mapToValue(mouse_screen, root.series(0))
+            //     // var pMin = mapToValue(mouse_screen, Qt.point(root.axisX().min, root.axisY().min))
+            //     // var pMax = mapToValue(mouse_screen, Qt.point(root.axisX().max, root.axisY().max))
+            //     // console.warn("p: " + p)
+
+            //     // Qt.rect()
+            //     var r = Qt.rect(mouse_plot.x, mouse_plot.y, plotZone.width * zoomFactor, plotZone.height * zoomFactor)
+            //     //var r = Qt.rect(pMin.x, pMin.y, (pMax.x-pMin.x) / 2, (pMax.y-pMin.y) / 2)
+            //     root.zoomIn(r)
+            // }
+            onClicked: {
+                    root.zoomReset();
+            }
+        }
+    }
+
+
+}

--- a/meshroom/ui/qml/Charts/qmldir
+++ b/meshroom/ui/qml/Charts/qmldir
@@ -2,3 +2,4 @@ module Charts
 
 ChartViewLegend 1.0 ChartViewLegend.qml
 ChartViewCheckBox 1.0 ChartViewCheckBox.qml
+InteractiveChartView 1.0 InteractiveChartView.qml

--- a/meshroom/ui/qml/Controls/Panel.qml
+++ b/meshroom/ui/qml/Controls/Panel.qml
@@ -18,6 +18,8 @@ Page {
     property alias headerBar: headerLayout.data
     property alias footerContent: footerLayout.data
     property alias icon: iconPlaceHolder.data
+    property alias loading: loadingIndicator.running
+    property alias loadingText: loadingLabal.text
 
     clip: true
 
@@ -46,18 +48,37 @@ Page {
                 width: childrenRect.width
                 height: childrenRect.height
                 Layout.alignment: Qt.AlignVCenter
-                visible: icon != ""
+                visible: icon !== ""
             }
 
             // Title
             Label {
                 text: root.title
-                Layout.fillWidth: true
                 elide: Text.ElideRight
                 topPadding: m.vPadding
                 bottomPadding: m.vPadding
             }
-            //
+            Item {
+                width: 10
+            }
+            // Feature loading status
+            BusyIndicator {
+                id: loadingIndicator
+                padding: 0
+                implicitWidth: 12
+                implicitHeight: 12
+                running: false
+            }
+            Label {
+                id: loadingLabal
+                text: ""
+                font.italic: true
+            }
+            Item {
+                Layout.fillWidth: true
+            }
+
+            // Header menu
             Row { id: headerLayout }
         }
     }

--- a/meshroom/ui/qml/GraphEditor/StatViewer.qml
+++ b/meshroom/ui/qml/GraphEditor/StatViewer.qml
@@ -6,6 +6,7 @@ import Utils 1.0
 import Charts 1.0
 import MaterialIcons 2.2
 
+
 Item {
     id: root
 
@@ -364,7 +365,7 @@ Item {
                     }
                 }
 
-                ChartView {
+                InteractiveChartView {
                     id: cpuChart
 
                     Layout.fillWidth: true
@@ -419,7 +420,7 @@ Item {
 
             ColumnLayout {
 
-                ChartView {
+                InteractiveChartView {
                     id: ramChart
                     margins.top: 0
                     margins.bottom: 0
@@ -487,7 +488,7 @@ Item {
             ColumnLayout {
 
 
-                ChartView {
+                InteractiveChartView {
                     id: gpuChart
 
                     Layout.fillWidth: true

--- a/meshroom/ui/qml/Viewer/FeaturesInfoOverlay.qml
+++ b/meshroom/ui/qml/Viewer/FeaturesInfoOverlay.qml
@@ -18,7 +18,6 @@ FloatingPane {
     property var featureExtractionNode: null
 
     ColumnLayout {
-
         // Header
         RowLayout {
             // FeatureExtraction node name
@@ -77,12 +76,12 @@ FloatingPane {
 
                 spacing: 4
 
-                // Features visibility toogle (features)
+                // Features visibility toogle
                 MaterialToolButton {
                     id: featuresVisibilityButton
                     checkable: true
                     checked: true
-                    text: featuresVisibilityButton.checked ? MaterialIcons.visibility : MaterialIcons.visibility_off
+                    text: MaterialIcons.center_focus_strong
                     onClicked: {
                         console.warn("featuresVisibilityButton.checked: " + featuresVisibilityButton.checked)
                         featureType.viewer.displayfeatures = featuresVisibilityButton.checked;
@@ -91,20 +90,30 @@ FloatingPane {
                     opacity: featureType.viewer.visible ? 1.0 : 0.6
                 }
 
-                // Landmarks visibility toogle (sfmData)
+                // Tracks visibility toogle
+                MaterialToolButton {
+                    id: tracksVisibilityButton
+                    checkable: true
+                    checked: true
+                    text: MaterialIcons.timeline
+                    onClicked: {
+                        console.warn("tracksVisibilityButton.checked: " + tracksVisibilityButton.checked)
+                        featureType.viewer.displayTracks = tracksVisibilityButton.checked;
+                    }
+                    font.pointSize: 10
+                }
+
+                // Landmarks visibility toogle
                 MaterialToolButton {
                     id: landmarksVisibilityButton
                     checkable: true
                     checked: true
-                    text: checked ? MaterialIcons.location_on : MaterialIcons.location_off
+                    text: MaterialIcons.fiber_manual_record
                     onClicked: {
                         console.warn("landmarksVisibilityButton.checked: " + landmarksVisibilityButton.checked)
                         featureType.viewer.displayLandmarks = landmarksVisibilityButton.checked;
                     }
                     font.pointSize: 10
-                    // checkable: enabled
-                    // enabled: landmarks !== false
-                    // opacity: featureType.viewer.visible ? 1.0 : 0.6
                 }
 
                 // ColorChart picker
@@ -118,7 +127,7 @@ FloatingPane {
                 }
                 // Feature type name
                 Label {
-                    text: featureType.viewer.describerType + (featureType.viewer.loadingFeatures ? "" : ": " + featureType.viewer.features.length)
+                    text: featureType.viewer.describerType + (featureType.viewer.loadingFeatures ? "" : ": " + featureType.viewer.features.length + " / " + featureType.viewer.nbTracks + " / " + featureType.viewer.nbLandmarks )
                 }
                 // Feature loading status
                 Loader {

--- a/meshroom/ui/qml/Viewer/FeaturesInfoOverlay.qml
+++ b/meshroom/ui/qml/Viewer/FeaturesInfoOverlay.qml
@@ -47,6 +47,7 @@ FloatingPane {
                                 flat: true
                                 Layout.fillWidth: true
                                 model: root.featuresViewer.displayModes
+                                currentIndex: root.featuresViewer.displayMode
                                 onActivated: root.featuresViewer.displayMode = currentIndex
                             }
                         }
@@ -73,15 +74,39 @@ FloatingPane {
                 id: featureType
 
                 property var viewer: root.featuresViewer.itemAt(index)
+
                 spacing: 4
 
-                // Visibility toogle
+                // Features visibility toogle (features)
                 MaterialToolButton {
-                    text: featureType.viewer.visible ? MaterialIcons.visibility : MaterialIcons.visibility_off
-                    onClicked: featureType.viewer.visible = !featureType.viewer.visible
+                    id: featuresVisibilityButton
+                    checkable: true
+                    checked: true
+                    text: featuresVisibilityButton.checked ? MaterialIcons.visibility : MaterialIcons.visibility_off
+                    onClicked: {
+                        console.warn("featuresVisibilityButton.checked: " + featuresVisibilityButton.checked)
+                        featureType.viewer.displayfeatures = featuresVisibilityButton.checked;
+                    }
                     font.pointSize: 10
                     opacity: featureType.viewer.visible ? 1.0 : 0.6
                 }
+
+                // Landmarks visibility toogle (sfmData)
+                MaterialToolButton {
+                    id: landmarksVisibilityButton
+                    checkable: true
+                    checked: true
+                    text: checked ? MaterialIcons.location_on : MaterialIcons.location_off
+                    onClicked: {
+                        console.warn("landmarksVisibilityButton.checked: " + landmarksVisibilityButton.checked)
+                        featureType.viewer.displayLandmarks = landmarksVisibilityButton.checked;
+                    }
+                    font.pointSize: 10
+                    // checkable: enabled
+                    // enabled: landmarks !== false
+                    // opacity: featureType.viewer.visible ? 1.0 : 0.6
+                }
+
                 // ColorChart picker
                 ColorChart {
                     implicitWidth: 12
@@ -89,7 +114,7 @@ FloatingPane {
                     colors: root.featuresViewer.colors
                     currentIndex: featureType.viewer.colorIndex
                     // offset featuresViewer color set when changing the color of one feature type
-                    onColorPicked: root.featuresViewer.colorOffset = colorIndex - index
+                    onColorPicked: featureType.viewer.colorOffset = colorIndex - index
                 }
                 // Feature type name
                 Label {
@@ -105,6 +130,7 @@ FloatingPane {
                         running: true
                     }
                 }
+
             }
         }
     }

--- a/meshroom/ui/qml/Viewer/FeaturesInfoOverlay.qml
+++ b/meshroom/ui/qml/Viewer/FeaturesInfoOverlay.qml
@@ -93,11 +93,11 @@ FloatingPane {
                 }
                 // Feature type name
                 Label {
-                    text: featureType.viewer.describerType + (featureType.viewer.loading ? "" : ": " + featureType.viewer.features.length)
+                    text: featureType.viewer.describerType + (featureType.viewer.loadingFeatures ? "" : ": " + featureType.viewer.features.length)
                 }
                 // Feature loading status
                 Loader {
-                    active: featureType.viewer.loading
+                    active: featureType.viewer.loadingFeatures
                     sourceComponent: BusyIndicator {
                         padding: 0
                         implicitWidth: 12

--- a/meshroom/ui/qml/Viewer/FeaturesInfoOverlay.qml
+++ b/meshroom/ui/qml/Viewer/FeaturesInfoOverlay.qml
@@ -22,7 +22,7 @@ FloatingPane {
         RowLayout {
             // FeatureExtraction node name
             Label {
-                text: featureExtractionNode.label
+                text: featureExtractionNode ? featureExtractionNode.label : ""
                 Layout.fillWidth: true
             }
             // Settings menu
@@ -127,7 +127,14 @@ FloatingPane {
                 }
                 // Feature type name
                 Label {
-                    text: featureType.viewer.describerType + (featureType.viewer.loadingFeatures ? "" : ": " + featureType.viewer.features.length + " / " + featureType.viewer.nbTracks + " / " + featureType.viewer.nbLandmarks )
+                    text: {
+                        if(featureType.viewer.loadingFeatures)
+                            return  featureType.viewer.describerType;
+                        return featureType.viewer.describerType + ": " +
+                                featureType.viewer.features.length + " / " +
+                                (featureType.viewer.haveValidTracks ? featureType.viewer.nbTracks  : " - ") + " / " +
+                                (featureType.viewer.haveValidLandmarks ? featureType.viewer.nbLandmarks : " - ");
+                    }
                 }
                 // Feature loading status
                 Loader {

--- a/meshroom/ui/qml/Viewer/FeaturesViewer.qml
+++ b/meshroom/ui/qml/Viewer/FeaturesViewer.qml
@@ -12,6 +12,8 @@ Repeater {
 
     /// ViewID to display the features of
     property int viewId
+    /// SfMData to display the data of SfM
+    property var sfmData
     /// Folder containing the features files
     property string folder
     /// The list of describer types to load
@@ -35,6 +37,7 @@ Repeater {
         viewId: root.viewId
         color: root.colors[colorIndex]
         displayMode: root.displayMode
+        msfmData: root.sfmData
     }
 
 }

--- a/meshroom/ui/qml/Viewer/FeaturesViewer.qml
+++ b/meshroom/ui/qml/Viewer/FeaturesViewer.qml
@@ -15,7 +15,9 @@ Repeater {
     /// SfMData to display the data of SfM
     property var sfmData
     /// Folder containing the features files
-    property string folder
+    property string featureFolder
+    /// Folder containing the matches files
+    property var tracks
     /// The list of describer types to load
     property alias describerTypes: root.model
     /// List of available display modes
@@ -32,7 +34,8 @@ Repeater {
         readonly property int colorIndex: (index + colorOffset) % root.colors.length
         property int colorOffset: 0
         describerType: modelData
-        folder: root.folder
+        featureFolder: root.featureFolder
+        mtracks: root.tracks
         viewId: root.viewId
         color: root.colors[colorIndex]
         landmarkColor: Colors.red

--- a/meshroom/ui/qml/Viewer/FeaturesViewer.qml
+++ b/meshroom/ui/qml/Viewer/FeaturesViewer.qml
@@ -21,21 +21,21 @@ Repeater {
     /// List of available display modes
     readonly property var displayModes: ['Points', 'Squares', 'Oriented Squares']
     /// Current display mode index
-    property int displayMode: 0
+    property int displayMode: 2
     /// The list of colors used for displaying several describers
-    property var colors: [Colors.blue, Colors.red, Colors.yellow, Colors.green, Colors.orange, Colors.cyan, Colors.pink, Colors.lime]
-    /// Offset the color list
-    property int colorOffset: 0
+    property var colors: [Colors.blue, Colors.green, Colors.yellow, Colors.orange, Colors.cyan, Colors.pink, Colors.lime] //, Colors.red
 
     model: root.describerTypes
 
     // instantiate one FeaturesViewer by describer type
     delegate: AliceVision.FeaturesViewer {
-        readonly property int colorIndex: (index+root.colorOffset)%root.colors.length
+        readonly property int colorIndex: (index + colorOffset) % root.colors.length
+        property int colorOffset: 0
         describerType: modelData
         folder: root.folder
         viewId: root.viewId
         color: root.colors[colorIndex]
+        landmarkColor: Colors.red
         displayMode: root.displayMode
         msfmData: root.sfmData
     }

--- a/meshroom/ui/qml/Viewer/ImageMetadataView.qml
+++ b/meshroom/ui/qml/Viewer/ImageMetadataView.qml
@@ -19,6 +19,7 @@ FloatingPane {
 
     clip: true
     padding: 4
+    anchors.rightMargin: 0
 
     /**
      * Convert GPS metadata to degree coordinates.

--- a/meshroom/ui/qml/Viewer/MSfMData.qml
+++ b/meshroom/ui/qml/Viewer/MSfMData.qml
@@ -1,0 +1,7 @@
+import QtQuick 2.11
+import AliceVision 1.0 as AliceVision
+
+// Data from the SfM 
+AliceVision.MSfMData {
+    id: root
+}

--- a/meshroom/ui/qml/Viewer/MTracks.qml
+++ b/meshroom/ui/qml/Viewer/MTracks.qml
@@ -1,0 +1,6 @@
+import QtQuick 2.11
+import AliceVision 1.0 as AliceVision
+
+AliceVision.MTracks {
+    id: root
+}

--- a/meshroom/ui/qml/Viewer/SfmGlobalStats.qml
+++ b/meshroom/ui/qml/Viewer/SfmGlobalStats.qml
@@ -17,8 +17,10 @@ FloatingPane {
     id: root
 
     property var msfmData
+    property var mTracks
     property color textColor: Colors.sysPalette.text
 
+    visible: (_reconstruction.sfm && _reconstruction.sfm.isComputed()) ? root.visible : false
     clip: true
     padding: 4
 
@@ -259,12 +261,6 @@ FloatingPane {
             name: "Landmarks"
         }
         LineSeries {
-            id: featuresPerViewLineSerie
-            axisX: landmarksPerViewValueAxisX
-            axisY: landmarksPerViewValueAxisY
-            name: "Features"
-        }
-        LineSeries {
             id: tracksPerViewLineSerie
             axisX: landmarksPerViewValueAxisX
             axisY: landmarksPerViewValueAxisY
@@ -308,11 +304,11 @@ FloatingPane {
     // Stats from the sfmData
     AliceVision.MSfMDataStats {
         id: sfmDataStat
-        msfmData: (root.visible && root.msfmData && root.msfmData.status === AliceVision.MSfMData.Ready) ? root.msfmData : null
-        onStatsChanged: {
-            console.warn("QML AliceVision.MSfMDataStats statsChanged: " + sfmDataStat.msfmData);
+        msfmData: root.msfmData
+        mTracks: root.mTracks
+
+        onAxisChanged: {
             fillLandmarksPerViewSerie(landmarksPerViewLineSerie);
-            fillFeaturesPerViewSerie(featuresPerViewLineSerie);
             fillTracksPerViewSerie(tracksPerViewLineSerie);
             fillResidualsMinPerViewSerie(residualsMinPerViewLineSerie);
             fillResidualsMaxPerViewSerie(residualsMaxPerViewLineSerie);
@@ -326,7 +322,6 @@ FloatingPane {
             fillObservationsLengthsMedianPerViewSerie(observationsLengthsMedianPerViewLineSerie);
             fillObservationsLengthsFirstQuartilePerViewSerie(observationsLengthsFirstQuartilePerViewLineSerie);
             fillObservationsLengthsThirdQuartilePerViewSerie(observationsLengthsThirdQuartilePerViewLineSerie);
-
         }
     }
 }

--- a/meshroom/ui/qml/Viewer/SfmGlobalStats.qml
+++ b/meshroom/ui/qml/Viewer/SfmGlobalStats.qml
@@ -1,0 +1,162 @@
+import QtQuick 2.9
+import QtQuick.Controls 2.3
+import QtQuick.Layouts 1.3
+import MaterialIcons 2.2
+import QtPositioning 5.8
+import QtLocation 5.9
+import QtCharts 2.13
+import Charts 1.0
+
+import Controls 1.0
+import Utils 1.0
+
+import AliceVision 1.0 as AliceVision
+
+
+FloatingPane {
+    id: root
+
+    property var msfmData
+    property color textColor: Colors.sysPalette.text
+
+    clip: true
+    padding: 4
+
+    // To avoid interaction with components in background
+    MouseArea {
+        anchors.fill: parent
+        acceptedButtons: Qt.LeftButton | Qt.RightButton | Qt.MiddleButton
+        onPressed: {}
+        onReleased: {}
+        onWheel: {}
+    }
+
+    InteractiveChartView {
+        id: landmarksPerViewChart
+        width: parent.width * 0.5
+        height: parent.height * 0.5
+
+        title: "Landmarks Per View"
+        legend.visible: false
+        antialiasing: true
+
+        ValueAxis {
+            id: landmarksPerViewValueAxisX
+            titleText: "Ordered Views"
+            min: 0.0
+            max: sfmDataStat.landmarksPerViewMaxAxisX
+        }
+        ValueAxis {
+            id: landmarksPerViewValueAxisY
+            labelFormat: "%i"
+            titleText: "Number of Landmarks"
+            min: 0
+            max: sfmDataStat.landmarksPerViewMaxAxisY
+        }
+        LineSeries {
+            id: landmarksPerViewLineSerie
+            axisX: landmarksPerViewValueAxisX
+            axisY: landmarksPerViewValueAxisY
+        }
+    }
+
+    InteractiveChartView {
+        id: residualsPerViewChart
+        width: parent.width * 0.5
+        height: parent.height * 0.5
+        anchors.top: parent.top
+        anchors.topMargin: (parent.height) * 0.5
+
+        title: "Residuals Per View"
+        legend.visible: false
+        antialiasing: true
+
+        ValueAxis {
+            id: residualsPerViewValueAxisX
+            labelFormat: "%i"
+            titleText: "Ordered Views"
+            min: 0
+            max: sfmDataStat.residualsPerViewMaxAxisX
+        }
+        ValueAxis {
+            id: residualsPerViewValueAxisY
+            titleText: "Percentage of residuals"
+            min: 0
+            max: sfmDataStat.residualsPerViewMaxAxisY
+            tickAnchor: 0
+            tickInterval: 0.50
+            tickCount: sfmDataStat.residualsPerViewMaxAxisY * 2
+        }
+        LineSeries {
+            id: residualsMinPerViewLineSerie
+            axisX: residualsPerViewValueAxisX
+            axisY: residualsPerViewValueAxisY
+            name: "Min"
+        }
+        LineSeries {
+            id: residualsMaxPerViewLineSerie
+            axisX: residualsPerViewValueAxisX
+            axisY: residualsPerViewValueAxisY
+            name: "Max"
+        }
+        LineSeries {
+            id: residualsMeanPerViewLineSerie
+            axisX: residualsPerViewValueAxisX
+            axisY: residualsPerViewValueAxisY
+            name: "Mean"
+        }
+        LineSeries {
+            id: residualsMedianPerViewLineSerie
+            axisX: residualsPerViewValueAxisX
+            axisY: residualsPerViewValueAxisY
+            name: "Median"
+        }
+    }
+
+    Item {
+        id: residualsPerViewBtnContainer
+
+        Layout.fillWidth: true
+        anchors.bottom: residualsPerViewChart.bottom
+        anchors.bottomMargin: 35
+        anchors.left: residualsPerViewChart.left
+        anchors.leftMargin: residualsPerViewChart.width * 0.25
+
+        RowLayout {
+
+            ChartViewCheckBox {
+                id: allObservations
+                text: "ALL"
+                color: textColor
+                checkState: residualsPerViewLegend.buttonGroup.checkState
+                onClicked: {
+                    var _checked = checked;
+                    for(var i = 0; i < residualsPerViewChart.count; ++i)
+                    {
+                        residualsPerViewChart.series(i).visible = _checked;
+                    }
+                }
+            }
+
+            ChartViewLegend {
+                id: residualsPerViewLegend
+                chartView: residualsPerViewChart
+            }
+
+        }
+    }
+
+    // Stats from the sfmData
+    AliceVision.MSfMDataStats {
+        id: sfmDataStat
+        msfmData: (root.visible && root.msfmData && root.msfmData.status === AliceVision.MSfMData.Ready) ? root.msfmData : null
+        onStatsChanged: {
+            console.warn("QML AliceVision.MSfMDataStats statsChanged: " + sfmDataStat.msfmData);
+            fillLandmarksPerViewSerie(landmarksPerViewLineSerie);
+            fillResidualsMinPerViewSerie(residualsMinPerViewLineSerie);
+            fillResidualsMaxPerViewSerie(residualsMaxPerViewLineSerie);
+            fillResidualsMeanPerViewSerie(residualsMeanPerViewLineSerie);
+            fillResidualsMedianPerViewSerie(residualsMedianPerViewLineSerie);
+        }
+    }
+}

--- a/meshroom/ui/qml/Viewer/SfmGlobalStats.qml
+++ b/meshroom/ui/qml/Viewer/SfmGlobalStats.qml
@@ -31,41 +31,11 @@ FloatingPane {
         onWheel: {}
     }
 
-    InteractiveChartView {
-        id: landmarksPerViewChart
-        width: parent.width * 0.5
-        height: parent.height * 0.5
 
-        title: "Landmarks Per View"
-        legend.visible: false
-        antialiasing: true
-
-        ValueAxis {
-            id: landmarksPerViewValueAxisX
-            titleText: "Ordered Views"
-            min: 0.0
-            max: sfmDataStat.landmarksPerViewMaxAxisX
-        }
-        ValueAxis {
-            id: landmarksPerViewValueAxisY
-            labelFormat: "%i"
-            titleText: "Number of Landmarks"
-            min: 0
-            max: sfmDataStat.landmarksPerViewMaxAxisY
-        }
-        LineSeries {
-            id: landmarksPerViewLineSerie
-            axisX: landmarksPerViewValueAxisX
-            axisY: landmarksPerViewValueAxisY
-        }
-    }
-
-    InteractiveChartView {
+   InteractiveChartView {
         id: residualsPerViewChart
         width: parent.width * 0.5
         height: parent.height * 0.5
-        anchors.top: parent.top
-        anchors.topMargin: (parent.height) * 0.5
 
         title: "Residuals Per View"
         legend.visible: false
@@ -80,7 +50,7 @@ FloatingPane {
         }
         ValueAxis {
             id: residualsPerViewValueAxisY
-            titleText: "Percentage of residuals"
+            titleText: "Reprojection Error (pix)"
             min: 0
             max: sfmDataStat.residualsPerViewMaxAxisY
             tickAnchor: 0
@@ -110,6 +80,18 @@ FloatingPane {
             axisX: residualsPerViewValueAxisX
             axisY: residualsPerViewValueAxisY
             name: "Median"
+        }
+        LineSeries {
+            id: residualsFirstQuartilePerViewLineSerie
+            axisX: residualsPerViewValueAxisX
+            axisY: residualsPerViewValueAxisY
+            name: "Q1"
+        }
+        LineSeries {
+            id: residualsThirdQuartilePerViewLineSerie
+            axisX: residualsPerViewValueAxisX
+            axisY: residualsPerViewValueAxisY
+            name: "Q3"
         }
     }
 
@@ -146,6 +128,183 @@ FloatingPane {
         }
     }
 
+    InteractiveChartView {
+        id: observationsLengthsPerViewChart
+        width: parent.width * 0.5
+        height: parent.height * 0.5
+        anchors.top: parent.top
+        anchors.topMargin: (parent.height) * 0.5
+
+        title: "Observations Lengths Per View"
+        legend.visible: false
+        antialiasing: true
+
+        ValueAxis {
+            id: observationsLengthsPerViewValueAxisX
+            labelFormat: "%i"
+            titleText: "Ordered Views"
+            min: 0
+            max: sfmDataStat.observationsLengthsPerViewMaxAxisX
+        }
+        ValueAxis {
+            id: observationsLengthsPerViewValueAxisY
+            titleText: "Observations Lengths"
+            min: 0
+            max: sfmDataStat.observationsLengthsPerViewMaxAxisY
+            tickAnchor: 0
+            tickInterval: 0.50
+            tickCount: sfmDataStat.observationsLengthsPerViewMaxAxisY * 2
+        }
+
+        LineSeries {
+            id: observationsLengthsMinPerViewLineSerie
+            axisX: observationsLengthsPerViewValueAxisX
+            axisY: observationsLengthsPerViewValueAxisY
+            name: "Min"
+        }
+        LineSeries {
+            id: observationsLengthsMaxPerViewLineSerie
+            axisX: observationsLengthsPerViewValueAxisX
+            axisY: observationsLengthsPerViewValueAxisY
+            name: "Max"
+        }
+        LineSeries {
+            id: observationsLengthsMeanPerViewLineSerie
+            axisX: observationsLengthsPerViewValueAxisX
+            axisY: observationsLengthsPerViewValueAxisY
+            name: "Mean"
+        }
+        LineSeries {
+            id: observationsLengthsMedianPerViewLineSerie
+            axisX: observationsLengthsPerViewValueAxisX
+            axisY: observationsLengthsPerViewValueAxisY
+            name: "Median"
+        }
+        LineSeries {
+            id: observationsLengthsFirstQuartilePerViewLineSerie
+            axisX: observationsLengthsPerViewValueAxisX
+            axisY: observationsLengthsPerViewValueAxisY
+            name: "Q1"
+        }
+        LineSeries {
+            id: observationsLengthsThirdQuartilePerViewLineSerie
+            axisX: observationsLengthsPerViewValueAxisX
+            axisY: observationsLengthsPerViewValueAxisY
+            name: "Q3"
+        }
+    }
+
+    Item {
+        id: observationsLengthsPerViewBtnContainer
+
+        Layout.fillWidth: true
+        anchors.bottom: observationsLengthsPerViewChart.bottom
+        anchors.bottomMargin: 35
+        anchors.left: observationsLengthsPerViewChart.left
+        anchors.leftMargin: observationsLengthsPerViewChart.width * 0.25
+
+        RowLayout {
+
+            ChartViewCheckBox {
+                id: allModes
+                text: "ALL"
+                color: textColor
+                checkState: observationsLengthsPerViewLegend.buttonGroup.checkState
+                onClicked: {
+                    var _checked = checked;
+                    for(var i = 0; i < observationsLengthsPerViewChart.count; ++i)
+                    {
+                        observationsLengthsPerViewChart.series(i).visible = _checked;
+                    }
+                }
+            }
+
+            ChartViewLegend {
+                id: observationsLengthsPerViewLegend
+                chartView: observationsLengthsPerViewChart
+            }
+
+        }
+    }
+
+    InteractiveChartView {
+        id: landmarksPerViewChart
+        width: parent.width * 0.5
+        height: parent.height * 0.5
+        anchors.left: parent.left
+        anchors.leftMargin: (parent.width) * 0.5
+        anchors.top: parent.top
+
+        title: "Landmarks Per View"
+        legend.visible: false
+        antialiasing: true
+
+        ValueAxis {
+            id: landmarksPerViewValueAxisX
+            titleText: "Ordered Views"
+            min: 0.0
+            max: sfmDataStat.landmarksPerViewMaxAxisX
+        }
+        ValueAxis {
+            id: landmarksPerViewValueAxisY
+            labelFormat: "%i"
+            titleText: "Number of Landmarks"
+            min: 0
+            max: sfmDataStat.landmarksPerViewMaxAxisY
+        }
+        LineSeries {
+            id: landmarksPerViewLineSerie
+            axisX: landmarksPerViewValueAxisX
+            axisY: landmarksPerViewValueAxisY
+            name: "Landmarks"
+        }
+        LineSeries {
+            id: featuresPerViewLineSerie
+            axisX: landmarksPerViewValueAxisX
+            axisY: landmarksPerViewValueAxisY
+            name: "Features"
+        }
+        LineSeries {
+            id: tracksPerViewLineSerie
+            axisX: landmarksPerViewValueAxisX
+            axisY: landmarksPerViewValueAxisY
+            name: "Tracks"
+        }
+    }
+
+    Item {
+        id: landmarksFeatTracksPerViewBtnContainer
+
+        Layout.fillWidth: true
+        anchors.bottom: landmarksPerViewChart.bottom
+        anchors.bottomMargin: 35
+        anchors.left: landmarksPerViewChart.left
+        anchors.leftMargin: landmarksPerViewChart.width * 0.25
+
+        RowLayout {
+
+            ChartViewCheckBox {
+                id: allFeatures
+                text: "ALL"
+                color: textColor
+                checkState: landmarksFeatTracksPerViewLegend.buttonGroup.checkState
+                onClicked: {
+                    var _checked = checked;
+                    for(var i = 0; i < landmarksPerViewChart.count; ++i)
+                    {
+                        landmarksPerViewChart.series(i).visible = _checked;
+                    }
+                }
+            }
+
+            ChartViewLegend {
+                id: landmarksFeatTracksPerViewLegend
+                chartView: landmarksPerViewChart
+            }
+
+        }
+    }
+
     // Stats from the sfmData
     AliceVision.MSfMDataStats {
         id: sfmDataStat
@@ -153,10 +312,21 @@ FloatingPane {
         onStatsChanged: {
             console.warn("QML AliceVision.MSfMDataStats statsChanged: " + sfmDataStat.msfmData);
             fillLandmarksPerViewSerie(landmarksPerViewLineSerie);
+            fillFeaturesPerViewSerie(featuresPerViewLineSerie);
+            fillTracksPerViewSerie(tracksPerViewLineSerie);
             fillResidualsMinPerViewSerie(residualsMinPerViewLineSerie);
             fillResidualsMaxPerViewSerie(residualsMaxPerViewLineSerie);
             fillResidualsMeanPerViewSerie(residualsMeanPerViewLineSerie);
             fillResidualsMedianPerViewSerie(residualsMedianPerViewLineSerie);
+            fillResidualsFirstQuartilePerViewSerie(residualsFirstQuartilePerViewLineSerie);
+            fillResidualsThirdQuartilePerViewSerie(residualsThirdQuartilePerViewLineSerie);
+            fillObservationsLengthsMinPerViewSerie(observationsLengthsMinPerViewLineSerie);
+            fillObservationsLengthsMaxPerViewSerie(observationsLengthsMaxPerViewLineSerie);
+            fillObservationsLengthsMeanPerViewSerie(observationsLengthsMeanPerViewLineSerie);
+            fillObservationsLengthsMedianPerViewSerie(observationsLengthsMedianPerViewLineSerie);
+            fillObservationsLengthsFirstQuartilePerViewSerie(observationsLengthsFirstQuartilePerViewLineSerie);
+            fillObservationsLengthsThirdQuartilePerViewSerie(observationsLengthsThirdQuartilePerViewLineSerie);
+
         }
     }
 }

--- a/meshroom/ui/qml/Viewer/SfmStatsView.qml
+++ b/meshroom/ui/qml/Viewer/SfmStatsView.qml
@@ -98,7 +98,6 @@ FloatingPane {
                 id: residualLegend
                 chartView: residualChart
             }
-
         }
     }
 

--- a/meshroom/ui/qml/Viewer/SfmStatsView.qml
+++ b/meshroom/ui/qml/Viewer/SfmStatsView.qml
@@ -21,6 +21,7 @@ FloatingPane {
     property int viewId
     property color textColor: Colors.sysPalette.text
 
+    visible: (_reconstruction.sfm && _reconstruction.sfm.isComputed()) ? root.visible : false
     clip: true
     padding: 4
 

--- a/meshroom/ui/qml/Viewer/SfmStatsView.qml
+++ b/meshroom/ui/qml/Viewer/SfmStatsView.qml
@@ -1,0 +1,263 @@
+import QtQuick 2.9
+import QtQuick.Controls 2.3
+import QtQuick.Layouts 1.3
+import MaterialIcons 2.2
+import QtPositioning 5.8
+import QtLocation 5.9
+import QtCharts 2.13
+import Charts 1.0
+
+import Controls 1.0
+import Utils 1.0
+
+import AliceVision 1.0 as AliceVision
+
+
+
+FloatingPane {
+    id: root
+
+    property var msfmData: null
+    property int viewId
+    property color textColor: Colors.sysPalette.text
+
+    clip: true
+    padding: 4
+
+    // To avoid interaction with components in background
+    MouseArea {
+        anchors.fill: parent
+        acceptedButtons: Qt.LeftButton | Qt.RightButton | Qt.MiddleButton
+        onPressed: {}
+        onReleased: {}
+        onWheel: {}
+    }
+
+    InteractiveChartView {
+        id: residualChart
+        width: parent.width * 0.5
+        height: parent.height * 0.5
+
+        title: "Reprojection Errors"
+        legend.visible: false
+        antialiasing: true
+
+        ValueAxis {
+            id: residualValueAxisX
+            titleText: "Reprojection Error"
+            min: 0.0
+            max: viewStat.residualMaxAxisX
+        }
+        ValueAxis {
+            id: residualValueAxisY
+            labelFormat: "%i"
+            titleText: "Number of Points"
+            min: 0
+            max: viewStat.residualMaxAxisY
+        }
+        LineSeries {
+            id: residualFullLineSerie
+            axisX: residualValueAxisX
+            axisY: residualValueAxisY
+            name: "Average on All Cameras"
+        }
+        LineSeries {
+            id: residualViewLineSerie
+            axisX: residualValueAxisX
+            axisY: residualValueAxisY
+            name: "Current"
+        }
+    }
+
+    Item {
+        id: residualBtnContainer
+
+        Layout.fillWidth: true
+        anchors.bottom: residualChart.bottom
+        anchors.bottomMargin: 35
+        anchors.left: residualChart.left
+        anchors.leftMargin: residualChart.width * 0.15
+
+        RowLayout {
+
+            ChartViewCheckBox {
+                id: allResiduals
+                text: "ALL"
+                color: textColor
+                checkState: residualLegend.buttonGroup.checkState
+                onClicked: {
+                    var _checked = checked;
+                    for(var i = 0; i < residualChart.count; ++i)
+                    {
+                        residualChart.series(i).visible = _checked;
+                    }
+                }
+            }
+
+            ChartViewLegend {
+                id: residualLegend
+                chartView: residualChart
+            }
+
+        }
+    }
+
+    InteractiveChartView {
+        id: observationsLengthsChart
+        width: parent.width * 0.5
+        height: parent.height * 0.5
+        anchors.top: parent.top
+        anchors.topMargin: (parent.height) * 0.5
+
+        legend.visible: false
+        title: "Observations Lengths"
+
+        ValueAxis {
+            id: observationsLengthsvalueAxisX
+            labelFormat: "%i"
+            titleText: "Observations Length"
+            min: 2
+            max: viewStat.observationsLengthsMaxAxisX
+            tickAnchor: 2
+            tickInterval: 1
+            tickCount: 5
+        }
+        ValueAxis {
+            id: observationsLengthsvalueAxisY
+            labelFormat: "%i"
+            titleText: "Number of Points"
+            min: 0
+            max: viewStat.observationsLengthsMaxAxisY
+        }
+        LineSeries {
+            id: observationsLengthsFullLineSerie
+            axisX: observationsLengthsvalueAxisX
+            axisY: observationsLengthsvalueAxisY
+            name: "All Cameras"
+        }
+        LineSeries {
+            id: observationsLengthsViewLineSerie
+            axisX: observationsLengthsvalueAxisX
+            axisY: observationsLengthsvalueAxisY
+            name: "Current"
+        }
+
+        }
+
+    Item {
+        id: observationsLengthsBtnContainer
+
+        Layout.fillWidth: true
+        anchors.bottom: observationsLengthsChart.bottom
+        anchors.bottomMargin: 35
+        anchors.left: observationsLengthsChart.left
+        anchors.leftMargin: observationsLengthsChart.width * 0.25
+
+        RowLayout {
+
+            ChartViewCheckBox {
+                id: allObservations
+                text: "ALL"
+                color: textColor
+                checkState: observationsLengthsLegend.buttonGroup.checkState
+                onClicked: {
+                    var _checked = checked;
+                    for(var i = 0; i < observationsLengthsChart.count; ++i)
+                    {
+                        observationsLengthsChart.series(i).visible = _checked;
+                    }
+                }
+            }
+
+            ChartViewLegend {
+                id: observationsLengthsLegend
+                chartView: observationsLengthsChart
+            }
+
+        }
+    }
+
+    InteractiveChartView {
+        id: observationsScaleChart
+        width: parent.width * 0.5
+        height: parent.height * 0.5
+        anchors.left: parent.left
+        anchors.leftMargin: (parent.width) * 0.5
+        anchors.top: parent.top
+
+        legend.visible: false
+        title: "Observations Scale"
+
+        ValueAxis {
+            id: observationsScaleValueAxisX
+            titleText: "Scale"
+            min: 0
+            max: viewStat.observationsScaleMaxAxisX
+        }
+        ValueAxis {
+            id: observationsScaleValueAxisY
+            titleText: "Number of Points"
+            min: 0
+            max: viewStat.observationsScaleMaxAxisY
+        }
+        LineSeries {
+            id: observationsScaleFullLineSerie
+            axisX: observationsScaleValueAxisX
+            axisY: observationsScaleValueAxisY
+            name: " Average on All Cameras"
+        }
+        LineSeries {
+            id: observationsScaleViewLineSerie
+            axisX: observationsScaleValueAxisX
+            axisY: observationsScaleValueAxisY
+            name: "Current"
+        }
+    }
+
+    Item {
+        id: observationsScaleBtnContainer
+
+        Layout.fillWidth: true
+        anchors.bottom: observationsScaleChart.bottom
+        anchors.bottomMargin: 35
+        anchors.left: observationsScaleChart.left
+        anchors.leftMargin: observationsScaleChart.width * 0.15
+
+        RowLayout {
+
+            ChartViewCheckBox {
+                id: allObservationsScales
+                text: "ALL"
+                color: textColor
+                checkState: observationsScaleLegend.buttonGroup.checkState
+                onClicked: {
+                    var _checked = checked;
+                    for(var i = 0; i < observationsScaleChart.count; ++i)
+                    {
+                        observationsScaleChart.series(i).visible = _checked;
+                    }
+                }
+            }
+
+            ChartViewLegend {
+                id: observationsScaleLegend
+                chartView: observationsScaleChart
+            }
+        }
+    }
+
+    // Stats from a view the sfmData
+    AliceVision.MViewStats {
+        id: viewStat
+        msfmData: (root.visible && root.msfmData && root.msfmData.status === AliceVision.MSfMData.Ready) ? root.msfmData : null
+        viewId: root.viewId
+        onViewStatsChanged: {
+            fillResidualFullSerie(residualFullLineSerie);
+            fillResidualViewSerie(residualViewLineSerie);
+            fillObservationsLengthsFullSerie(observationsLengthsFullLineSerie);
+            fillObservationsLengthsViewSerie(observationsLengthsViewLineSerie);
+            fillObservationsScaleFullSerie(observationsScaleFullLineSerie);
+            fillObservationsScaleViewSerie(observationsScaleViewLineSerie);
+        }
+    }
+}

--- a/meshroom/ui/qml/Viewer/Viewer2D.qml
+++ b/meshroom/ui/qml/Viewer/Viewer2D.qml
@@ -17,6 +17,35 @@ FocusScope {
     readonly property bool floatViewerAvailable: floatViewerComp.status === Component.Ready
     property alias useFloatImageViewer: displayHDR.checked
 
+    property string loadingModules: {
+        var res = ""
+        if(imgContainer.image.status === Image.Loading)
+            res += " Image";
+        if(featuresViewerLoader.status === Loader.Ready)
+        {
+            for (var i = 0; i < featuresViewerLoader.item.count; ++i) {
+                if(featuresViewerLoader.item.itemAt(i).loadingFeatures)
+                {
+                    res += " Features";
+                    break;
+                }
+            }
+        }
+        if(msfmDataLoader.status === Loader.Ready)
+        {
+            if(msfmDataLoader.item.status === MSfMData.Loading)
+            {
+                res += " SfMData";
+            }
+        }
+        if(mtracksLoader.status === Loader.Ready)
+        {
+            if(mtracksLoader.item.status === MTracks.Loading)
+                res += " Tracks";
+        }
+        return res;
+    }
+
     function clear()
     {
         source = ''
@@ -421,7 +450,7 @@ FocusScope {
 
                         // zoom label
                         Label {
-                            text: ((imgContainer.image && (imgContainer.image.status == Image.Ready)) ? imgContainer.scale.toFixed(2) : "1.00") + "x"
+                            text: ((imgContainer.image && (imgContainer.image.status === Image.Ready)) ? imgContainer.scale.toFixed(2) : "1.00") + "x"
                             state: "xsmall"
                             MouseArea {
                                 anchors.fill: parent
@@ -470,7 +499,6 @@ FocusScope {
                             checkable: true
                             checked: false
                         }
-
                         Label {
                             id: resolutionLabel
                             Layout.fillWidth: true
@@ -534,6 +562,7 @@ FocusScope {
                                 }
                             }
                         }
+
                         MaterialToolButton {
                             id: displaySfmDataGlobalStats
 

--- a/meshroom/ui/qml/Viewer/Viewer2D.qml
+++ b/meshroom/ui/qml/Viewer/Viewer2D.qml
@@ -225,14 +225,19 @@ FocusScope {
                     x: (imgContainer.image && rotation === 90) ? imgContainer.image.paintedWidth : 0
                     y: (imgContainer.image && rotation === -90) ? imgContainer.image.paintedHeight : 0
 
-                    Component.onCompleted: {
-                        // instantiate and initialize a FeaturesViewer component dynamically using Loader.setSource
-                        setSource("FeaturesViewer.qml", {
-                            'viewId': Qt.binding(function() { return _reconstruction.selectedViewId; }),
-                            'model': Qt.binding(function() { return _reconstruction.featureExtraction.attribute("describerTypes").value; }),
-                            'folder': Qt.binding(function() { return Filepath.stringToUrl(_reconstruction.featureExtraction.attribute("output").value); }),
-                            'sfmData': Qt.binding(function() { return msfmDataLoader.status === Loader.Ready ? msfmDataLoader.item : null; }),
-                        })
+                    onActiveChanged: {
+                        if(active) {
+                            // instantiate and initialize a FeaturesViewer component dynamically using Loader.setSource
+                            setSource("FeaturesViewer.qml", {
+                                'viewId': Qt.binding(function() { return _reconstruction.selectedViewId; }),
+                                'model': Qt.binding(function() { return _reconstruction.featureExtraction.attribute("describerTypes").value; }),
+                                'folder': Qt.binding(function() { return Filepath.stringToUrl(_reconstruction.featureExtraction.attribute("output").value); }),
+                                'sfmData': Qt.binding(function() { return msfmDataLoader.status === Loader.Ready ? msfmDataLoader.item : null; }),
+                            })
+                        } else {
+                            // Force the unload (instead of using Component.onCompleted to load it once and for all) is necessary since Qt 5.14
+                            setSource("", {})
+                        }
                     }
                 }
             }

--- a/meshroom/ui/qml/Viewer/Viewer2D.qml
+++ b/meshroom/ui/qml/Viewer/Viewer2D.qml
@@ -231,7 +231,8 @@ FocusScope {
                             setSource("FeaturesViewer.qml", {
                                 'viewId': Qt.binding(function() { return _reconstruction.selectedViewId; }),
                                 'model': Qt.binding(function() { return _reconstruction.featureExtraction.attribute("describerTypes").value; }),
-                                'folder': Qt.binding(function() { return Filepath.stringToUrl(_reconstruction.featureExtraction.attribute("output").value); }),
+                                'featureFolder': Qt.binding(function() { return Filepath.stringToUrl(_reconstruction.featureExtraction.attribute("output").value); }),
+                                'tracks': Qt.binding(function() { return mtracksLoader.status === Loader.Ready ? mtracksLoader.item : null; }),
                                 'sfmData': Qt.binding(function() { return msfmDataLoader.status === Loader.Ready ? msfmDataLoader.item : null; }),
                             })
                         } else {
@@ -311,6 +312,18 @@ FocusScope {
                             // so it can fail safely if the c++ plugin is not available
                             setSource("MSfMData.qml", {
                                 'sfmDataPath': Qt.binding(function() { return Filepath.stringToUrl(_reconstruction.sfm.attribute("output").value); }),
+                            })
+                        }
+                    }
+                    Loader {
+                        id: mtracksLoader
+                        active: displayFeatures.checked // || displaySfmStatsView.checked || displaySfmDataGlobalStats.checked
+
+                        Component.onCompleted: {
+                            // instantiate and initialize a SfmStatsView component dynamically using Loader.setSource
+                            // so it can fail safely if the c++ plugin is not available
+                            setSource("MTracks.qml", {
+                                'matchingFolder': Qt.binding(function() { return Filepath.stringToUrl(_reconstruction.featureMatching.attribute("output").value); }),
                             })
                         }
                     }

--- a/meshroom/ui/qml/Viewer/Viewer2D.qml
+++ b/meshroom/ui/qml/Viewer/Viewer2D.qml
@@ -305,7 +305,26 @@ FocusScope {
 
                     Loader {
                         id: msfmDataLoader
-                        active: displaySfmStatsView.checked || displayFeatures.checked || displaySfmDataGlobalStats.checked
+                        //active: _reconstruction.sfm && _reconstruction.sfm.isComputed()
+
+                        property bool isUsed: displayFeatures.checked || displaySfmStatsView.checked || displaySfmDataGlobalStats.checked
+                        property var activeNode: _reconstruction.sfm
+
+                        active: false
+                        // It takes time to load tracks, so keep them looaded, if we may use it again.
+                        // If we load another node, we can trash them (to eventually load the new node data).
+                        onIsUsedChanged: {
+                            if(!active && isUsed && activeNode)
+                                active = true;
+                        }
+                        onActiveNodeChanged: {
+                            if(!isUsed)
+                                active = false;
+                            else if(!activeNode)
+                                active = false;
+                            else
+                                active = true;
+                        }
 
                         Component.onCompleted: {
                             // instantiate and initialize a SfmStatsView component dynamically using Loader.setSource
@@ -317,7 +336,25 @@ FocusScope {
                     }
                     Loader {
                         id: mtracksLoader
-                        active: displayFeatures.checked // || displaySfmStatsView.checked || displaySfmDataGlobalStats.checked
+                        // active: _reconstruction.featureMatching
+
+                        property bool isUsed: displayFeatures.checked || displaySfmStatsView.checked || displaySfmDataGlobalStats.checked
+                        property var activeNode: _reconstruction.featureMatching
+                        active: false
+                        // It takes time to load tracks, so keep them looaded, if we may use it again.
+                        // If we load another node, we can trash them (to eventually load the new node data).
+                        onIsUsedChanged: {
+                            if(!active && isUsed && activeNode)
+                                active = true;
+                        }
+                        onActiveNodeChanged: {
+                            if(!isUsed)
+                                active = false;
+                            else if(!activeNode)
+                                active = false;
+                            else
+                                active = true;
+                        }
 
                         Component.onCompleted: {
                             // instantiate and initialize a SfmStatsView component dynamically using Loader.setSource

--- a/meshroom/ui/qml/Viewer/Viewer2D.qml
+++ b/meshroom/ui/qml/Viewer/Viewer2D.qml
@@ -388,6 +388,8 @@ FocusScope {
                             // so it can fail safely if the c++ plugin is not available
                             setSource("SfmGlobalStats.qml", {
                                 'msfmData': Qt.binding(function() { return msfmDataLoader.item; }),
+                                'mTracks': Qt.binding(function() { return mtracksLoader.item; }),
+
                             })
                         }
                     }

--- a/meshroom/ui/qml/WorkspaceView.qml
+++ b/meshroom/ui/qml/WorkspaceView.qml
@@ -82,6 +82,8 @@ Item {
             Layout.fillHeight: true
             Layout.fillWidth: true
             Layout.minimumWidth: 50
+            loading: viewer2D.loadingModules.length > 0
+            loadingText: loading ? "Loading " + viewer2D.loadingModules : ""
 
             headerBar: RowLayout {
                 MaterialToolButton {

--- a/meshroom/ui/reconstruction.py
+++ b/meshroom/ui/reconstruction.py
@@ -380,6 +380,10 @@ class Reconstruction(UIGraph):
         self._featureExtraction = None
         self.cameraInitChanged.connect(self.updateFeatureExtraction)
 
+        # - Feature Matching
+        self._featureMatching = None
+        self.cameraInitChanged.connect(self.updateFeatureMatching)
+
         # - SfM
         self._sfm = None
         self._views = None
@@ -455,6 +459,7 @@ class Reconstruction(UIGraph):
         self._liveSfmManager.reset()
         self.selectedViewId = "-1"
         self.featureExtraction = None
+        self.featureMatching = None
         self.sfm = None
         self.prepareDenseScene = None
         self.depthMap = None
@@ -504,6 +509,10 @@ class Reconstruction(UIGraph):
     def updateFeatureExtraction(self):
         """ Set the current FeatureExtraction node based on the current CameraInit node. """
         self.featureExtraction = self.lastNodeOfType('FeatureExtraction', self.cameraInit) if self.cameraInit else None
+
+    def updateFeatureMatching(self):
+        """ Set the current FeatureMatching node based on the current CameraInit node. """
+        self.featureMatching = self.lastNodeOfType('FeatureMatching', self.cameraInit) if self.cameraInit else None
 
     def updateDepthMapNode(self):
         """ Set the current FeatureExtraction node based on the current CameraInit node. """
@@ -830,6 +839,8 @@ class Reconstruction(UIGraph):
             self.sfm = node
         elif node.nodeType == "FeatureExtraction":
             self.featureExtraction = node
+        elif node.nodeType == "FeatureMatching":
+            self.featureMatching = node
         elif node.nodeType == "CameraInit":
             self.cameraInit = node
         elif node.nodeType == "PrepareDenseScene":
@@ -991,6 +1002,9 @@ class Reconstruction(UIGraph):
 
     featureExtractionChanged = Signal()
     featureExtraction = makeProperty(QObject, "_featureExtraction", featureExtractionChanged, resetOnDestroy=True)
+
+    featureMatchingChanged = Signal()
+    featureMatching = makeProperty(QObject, "_featureMatching", featureMatchingChanged, resetOnDestroy=True)
 
     sfmReportChanged = Signal()
     # convenient property for QML binding re-evaluation when sfm report changes


### PR DESCRIPTION
## Description

Add widgets to display SfM statistics.

## Features list

- [X] Display stats per view
- [X] Display global SfM stats
- [X] Display landmarks with reprojection errors
- [X] Display features associated to a track but not reconstructed as a 3D landmark

## Bugs to fix

 - [X] disable display View/Global stats button should close the window
 - [X] update of tracks/landmarks are not updated when empty

Based on https://github.com/alicevision/QtAliceVision/pull/5
![globalstats](https://user-images.githubusercontent.com/45872178/81913650-8d06f100-95d0-11ea-8386-53d60da97215.png)
![meshroom_display_features](https://user-images.githubusercontent.com/45872178/81913652-8d9f8780-95d0-11ea-9263-395d5a7a098d.png)
![reprojectionserrors](https://user-images.githubusercontent.com/45872178/81913653-8e381e00-95d0-11ea-8eed-608c7b050986.png)
![viewstatswithoutscale](https://user-images.githubusercontent.com/45872178/81913657-8ed0b480-95d0-11ea-822c-12114ef2deb8.png)
