### PR TITLE
Travis CI: Update environment, remove Python 2.7 & add 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,11 @@
 language: python
-
-dist: xenial  # required for Python >= 3.7
+dist: bionic
 
 python:
-  - "2.7"
   - "3.6"
   - "3.7"
-
+  - "3.8"
+  
 install:
   - "pip install -r requirements.txt -r dev_requirements.txt --timeout 45"
   - pip install flake8


### PR DESCRIPTION
 - Updates the build environment from Ubuntu 16.04 Xenial to Ubuntu 18.04 Bionic
 - Removes Python 2.7 from the build matrix (since support has ended)
 - Adds Python 3.8 to the build matrix