### PR TITLE
More generic metadata support

### DIFF
--- a/meshroom/ui/qml/ImageGallery/IntrinsicsIndicator.qml
+++ b/meshroom/ui/qml/ImageGallery/IntrinsicsIndicator.qml
@@ -18,13 +18,22 @@ ImageBadge {
     readonly property string distortionModel: intrinsic ? childAttributeValue(intrinsic, "type", "") : ""
     property var metadata: ({})
 
+    function findMetadata(key) {
+        var keyLower = key.toLowerCase()
+        for(var mKey in metadata)
+        {
+            if(mKey.toLowerCase().endsWith(keyLower))
+                return metadata[mKey]
+        }
+        return ""
+    }
     // access useful metadata
-    readonly property var make: metadata["Make"]
-    readonly property var model: metadata["Model"]
-    readonly property var focalLength: metadata["Exif:FocalLength"]
-    readonly property var focalLength35: metadata["Exif:FocalLengthIn35mmFilm"]
-    readonly property var bodySerialNumber: metadata["Exif:BodySerialNumber"]
-    readonly property var lensSerialNumber: metadata["Exif:LensSerialNumber"]
+    readonly property var make: findMetadata("Make")
+    readonly property var model: findMetadata("Model")
+    readonly property var focalLength: findMetadata("FocalLength")
+    readonly property var focalLength35: findMetadata("FocalLengthIn35mmFilm")
+    readonly property var bodySerialNumber: findMetadata("BodySerialNumber")
+    readonly property var lensSerialNumber: findMetadata("LensSerialNumber")
     readonly property var sensorWidth: metadata["AliceVision:SensorWidth"]
     readonly property var sensorWidthEstimation: metadata["AliceVision:SensorWidthEstimation"]
 

--- a/meshroom/ui/qml/Viewer/ImageMetadataView.qml
+++ b/meshroom/ui/qml/Viewer/ImageMetadataView.qml
@@ -77,13 +77,16 @@ FloatingPane {
             for(var key in metadata)
             {
                 var entry = {}
-                entry["raw"] = key
                 // split on ":" to get group and key
-                var sKey = key.split(":", 2)
-                if(sKey.length === 2)
+                var i = key.lastIndexOf(":")
+                if(i == -1)
                 {
-                    entry["group"] = sKey[0]
-                    entry["key"] = sKey[1]
+                    i = key.lastIndexOf("/")
+                }
+                if(i != -1)
+                {
+                    entry["group"] = key.substr(0, i)
+                    entry["key"] = key.substr(i+1)
                 }
                 else
                 {


### PR DESCRIPTION
Recognize images with non standard metadata as exported by Nuke on EXR images.

- [x] Support metadata with a group defined by "/" instead of ":". Can contain multiple "/".
- [x] Case insensitive search for metadata.


https://github.com/alicevision/AliceVision/pull/820
