### PR TITLE
[cameraInit] new viewId generation and selection of allowed intrinsics

### DIFF
--- a/meshroom/nodes/aliceVision/CameraInit.py
+++ b/meshroom/nodes/aliceVision/CameraInit.py
@@ -137,7 +137,7 @@ class CameraInit(desc.CommandLineNode):
             value='folder',
             exclusive=True,
             uid=[0],
-            advanced=True
+            advanced=True,
         ),
         desc.ChoiceParam(
             name='allowedCameraModels',
@@ -148,7 +148,7 @@ class CameraInit(desc.CommandLineNode):
             exclusive=False,
             uid=[0],
             joinChar=',',
-            advanced= True
+            advanced=True,
         ),
         desc.ChoiceParam(
             name='viewIdMethod',
@@ -160,7 +160,7 @@ class CameraInit(desc.CommandLineNode):
             values=['metadata', 'filename'],
             exclusive=True,
             uid=[0],
-            advanced= True
+            advanced=True,
         ),
         desc.StringParam(
             name='viewIdRegex',
@@ -172,6 +172,7 @@ class CameraInit(desc.CommandLineNode):
                         ' - Match the first number found in filename : "(\d+).*"\n',
             value='.*?(\d+)',
             uid=[0],
+            advanced=True,
         ),
         desc.ChoiceParam(
             name='verboseLevel',

--- a/meshroom/nodes/aliceVision/CameraInit.py
+++ b/meshroom/nodes/aliceVision/CameraInit.py
@@ -140,6 +140,17 @@ class CameraInit(desc.CommandLineNode):
             advanced=True
         ),
         desc.ChoiceParam(
+            name='allowedCameraModels',
+            label='Allowed Camera Models',
+            description='the Camera Models that can be attributed.',
+            value=['pinhole', 'radial1', 'radial3', 'brown', 'fisheye4', 'fisheye1'],
+            values=['pinhole', 'radial1', 'radial3', 'brown', 'fisheye4', 'fisheye1'],
+            exclusive=False,
+            uid=[0],
+            joinChar=',',
+            advanced= True
+        ),
+        desc.ChoiceParam(
             name='verboseLevel',
             label='Verbose Level',
             description='''verbosity level (fatal, error, warning, info, debug, trace).''',

--- a/meshroom/nodes/aliceVision/CameraInit.py
+++ b/meshroom/nodes/aliceVision/CameraInit.py
@@ -151,6 +151,29 @@ class CameraInit(desc.CommandLineNode):
             advanced= True
         ),
         desc.ChoiceParam(
+            name='viewIdMethod',
+            label='ViewId Method',
+            description="Allows to choose the way the viewID is generated:\n"
+                        " * metadata : Generate viewId from image metadata.\n"
+                        " * filename : Generate viewId from file names using regex.",
+            value='metadata',
+            values=['metadata', 'filename'],
+            exclusive=True,
+            uid=[0],
+            advanced= True
+        ),
+        desc.StringParam(
+            name='viewIdRegex',
+            label='ViewId Regex',
+            description='Regex used to catch number used as viewId in filename.'
+                        'You should capture specific parts of the filename with parenthesis to define matching elements. (only number will works)\n'
+                        'Some examples of patterns:\n'
+                        ' - Match the longest number at the end of filename (default value): ".*?(\d+)"\n'
+                        ' - Match the first number found in filename : "(\d+).*"\n',
+            value='.*?(\d+)',
+            uid=[0],
+        ),
+        desc.ChoiceParam(
             name='verboseLevel',
             label='Verbose Level',
             description='''verbosity level (fatal, error, warning, info, debug, trace).''',


### PR DESCRIPTION
## Features list

- [x] Add an option to define viewId from filename (via regex) instead of generating a UID from metadata to enable evaluation tests on datasets with ground truth.
- [x] Allow to choose the intrinsics allowed in the init camera

https://github.com/alicevision/AliceVision/pull/823
