### PR TITLE
[Viewer3D] Input bounding box (Meshing) & manual transformation (SfMTransform) thanks to a new 3D Gizmo

### DIFF
--- a/meshroom/common/__init__.py
+++ b/meshroom/common/__init__.py
@@ -8,13 +8,14 @@ Property = None
 BaseObject = None
 Variant = None
 VariantList = None
+JSValue = None
 
 if meshroom.backend == meshroom.Backend.PYSIDE:
     # PySide types
-    from .qt import DictModel, ListModel, Slot, Signal, Property, BaseObject, Variant, VariantList
+    from .qt import DictModel, ListModel, Slot, Signal, Property, BaseObject, Variant, VariantList, JSValue
 elif meshroom.backend == meshroom.Backend.STANDALONE:
     # Core types
-    from .core import DictModel, ListModel, Slot, Signal, Property, BaseObject, Variant, VariantList
+    from .core import DictModel, ListModel, Slot, Signal, Property, BaseObject, Variant, VariantList, JSValue
 
 
 class _BaseModel:

--- a/meshroom/common/core.py
+++ b/meshroom/common/core.py
@@ -146,3 +146,4 @@ Property = CoreProperty
 BaseObject = CoreObject
 Variant = object
 VariantList = object
+JSValue = None

--- a/meshroom/common/qt.py
+++ b/meshroom/common/qt.py
@@ -1,4 +1,4 @@
-from PySide2 import QtCore
+from PySide2 import QtCore, QtQml
 
 
 class QObjectListModel(QtCore.QAbstractListModel):
@@ -374,3 +374,4 @@ Property = QtCore.Property
 BaseObject = QtCore.QObject
 Variant = "QVariant"
 VariantList = "QVariantList"
+JSValue = QtQml.QJSValue

--- a/meshroom/core/attribute.py
+++ b/meshroom/core/attribute.py
@@ -410,10 +410,16 @@ class GroupAttribute(Attribute):
                 raise AttributeError(key)
 
     def _set_value(self, exportedValue):
-        self.desc.validateValue(exportedValue)
-        # set individual child attribute values
-        for key, value in exportedValue.items():
-            self._value.get(key).value = value
+        value = self.desc.validateValue(exportedValue)
+        if isinstance(value, dict):
+            # set individual child attribute values
+            for key, v in exportedValue.items():
+                self._value.get(key).value = v
+        elif isinstance(value, (list, tuple)):
+            for attrDesc, v in zip(self.desc._groupDesc, value):
+                self._value.get(attrDesc.name).value = v
+        else:
+            raise AttributeError("Failed to set on GroupAttribute: {}".format(str(exportedValue)))
 
     @Slot(str, result=Attribute)
     def childAttribute(self, key):

--- a/meshroom/core/attribute.py
+++ b/meshroom/core/attribute.py
@@ -257,6 +257,7 @@ class Attribute(BaseObject):
     isLink = Property(bool, isLink.fget, notify=isLinkChanged)
     isDefault = Property(bool, _isDefault, notify=valueChanged)
     linkParam = Property(BaseObject, getLinkParam, notify=isLinkChanged)
+    rootLinkParam = Property(BaseObject, lambda self: self.getLinkParam(recursive=True), notify=isLinkChanged)
     node = Property(BaseObject, node.fget, constant=True)
     enabledChanged = Signal()
     enabled = Property(bool, getEnabled, setEnabled, notify=enabledChanged)

--- a/meshroom/core/attribute.py
+++ b/meshroom/core/attribute.py
@@ -300,8 +300,8 @@ class ListAttribute(Attribute):
             self._value = value
         # New value
         else:
-            self.desc.validateValue(value)
-            self.extend(value)
+            newValue = self.desc.validateValue(value)
+            self.extend(newValue)
         self.requestGraphUpdate()
 
     @raiseIfLink
@@ -413,13 +413,13 @@ class GroupAttribute(Attribute):
         value = self.desc.validateValue(exportedValue)
         if isinstance(value, dict):
             # set individual child attribute values
-            for key, v in exportedValue.items():
+            for key, v in value.items():
                 self._value.get(key).value = v
         elif isinstance(value, (list, tuple)):
             for attrDesc, v in zip(self.desc._groupDesc, value):
                 self._value.get(attrDesc.name).value = v
         else:
-            raise AttributeError("Failed to set on GroupAttribute: {}".format(str(exportedValue)))
+            raise AttributeError("Failed to set on GroupAttribute: {}".format(str(value)))
 
     @Slot(str, result=Attribute)
     def childAttribute(self, key):

--- a/meshroom/core/desc.py
+++ b/meshroom/core/desc.py
@@ -72,7 +72,7 @@ class ListAttribute(Attribute):
         if isinstance(value, PySide2.QtQml.QJSValue):
             # Note: we could use isArray(), property("length").toInt() to retrieve all values
             raise ValueError("ListAttribute.validateValue: cannot recognize QJSValue. Please, use JSON.stringify(value) in QML.")
-        elif isinstance(value, pyCompatibility.basestring):
+        if isinstance(value, pyCompatibility.basestring):
             # Alternative solution to set values from QML is to convert values to JSON string
             # In this case, it works with all data types
             value = ast.literal_eval(value)
@@ -108,7 +108,7 @@ class GroupAttribute(Attribute):
         if isinstance(value, PySide2.QtQml.QJSValue):
             # Note: we could use isArray(), property("length").toInt() to retrieve all values
             raise ValueError("GroupAttribute.validateValue: cannot recognize QJSValue. Please, use JSON.stringify(value) in QML.")
-        elif isinstance(value, pyCompatibility.basestring):
+        if isinstance(value, pyCompatibility.basestring):
             # Alternative solution to set values from QML is to convert values to JSON string
             # In this case, it works with all data types
             value = ast.literal_eval(value)

--- a/meshroom/core/desc.py
+++ b/meshroom/core/desc.py
@@ -1,10 +1,9 @@
-from meshroom.common import BaseObject, Property, Variant, VariantList
+from meshroom.common import BaseObject, Property, Variant, VariantList, JSValue
 from meshroom.core import pyCompatibility
 from enum import Enum  # available by default in python3. For python2: "pip install enum34"
 import math
 import os
 import psutil
-import PySide2
 import ast
 
 class Attribute(BaseObject):
@@ -69,7 +68,7 @@ class ListAttribute(Attribute):
     joinChar = Property(str, lambda self: self._joinChar, constant=True)
 
     def validateValue(self, value):
-        if isinstance(value, PySide2.QtQml.QJSValue):
+        if JSValue is not None and isinstance(value, JSValue):
             # Note: we could use isArray(), property("length").toInt() to retrieve all values
             raise ValueError("ListAttribute.validateValue: cannot recognize QJSValue. Please, use JSON.stringify(value) in QML.")
         if isinstance(value, pyCompatibility.basestring):
@@ -105,7 +104,7 @@ class GroupAttribute(Attribute):
 
     def validateValue(self, value):
         """ Ensure value is compatible with the group description and convert value if needed. """
-        if isinstance(value, PySide2.QtQml.QJSValue):
+        if JSValue is not None and isinstance(value, JSValue):
             # Note: we could use isArray(), property("length").toInt() to retrieve all values
             raise ValueError("GroupAttribute.validateValue: cannot recognize QJSValue. Please, use JSON.stringify(value) in QML.")
         if isinstance(value, pyCompatibility.basestring):

--- a/meshroom/core/graph.py
+++ b/meshroom/core/graph.py
@@ -223,8 +223,11 @@ class Graph(BaseObject):
     def clear(self):
         self.header.clear()
         self._compatibilityNodes.clear()
-        self._nodes.clear()
         self._edges.clear()
+        # Tell QML nodes are going to be deleted
+        for node in self._nodes:
+            node.alive = False
+        self._nodes.clear()
 
     @property
     def fileFeatures(self):
@@ -437,6 +440,7 @@ class Graph(BaseObject):
                 self.removeEdge(edge.dst)
                 inEdges[edge.dst.getFullName()] = edge.src.getFullName()
 
+            node.alive = False
             self._nodes.remove(node)
             self.update()
 

--- a/meshroom/core/node.py
+++ b/meshroom/core/node.py
@@ -442,6 +442,7 @@ class BaseNode(BaseObject):
         self._position = position or Position()
         self._attributes = DictModel(keyAttrName='name', parent=self)
         self.attributesPerUid = defaultdict(set)
+        self._alive = True  # for QML side to know if the node can be used or is going to be deleted
 
     def __getattr__(self, k):
         try:
@@ -525,6 +526,17 @@ class BaseNode(BaseObject):
             return
         self._position = value
         self.positionChanged.emit()
+
+    @property
+    def alive(self):
+        return self._alive
+
+    @alive.setter
+    def alive(self, value):
+        if self._alive == value:
+            return
+        self._alive = value
+        self.aliveChanged.emit()
 
     @property
     def depth(self):
@@ -792,6 +804,8 @@ class BaseNode(BaseObject):
     globalStatusChanged = Signal()
     globalStatus = Property(str, lambda self: self.getGlobalStatus().name, notify=globalStatusChanged)
     isComputed = Property(bool, _isComputed, notify=globalStatusChanged)
+    aliveChanged = Signal()
+    alive = Property(bool, alive.fget, alive.fset, notify=aliveChanged)
 
 
 class Node(BaseNode):

--- a/meshroom/nodes/aliceVision/Meshing.py
+++ b/meshroom/nodes/aliceVision/Meshing.py
@@ -1,4 +1,4 @@
-__version__ = "5.0"
+__version__ = "6.0"
 
 from meshroom.core import desc
 
@@ -128,7 +128,7 @@ A Graph Cut Max-Flow is applied to optimally cut the volume. This cut represents
                 )
             ],
             joinChar=",",
-            advanced=True
+            enabled=lambda node: node.useBoundingBox.value,
         ),
         desc.BoolParam(
             name='estimateSpaceFromSfM',

--- a/meshroom/nodes/aliceVision/Meshing.py
+++ b/meshroom/nodes/aliceVision/Meshing.py
@@ -36,6 +36,101 @@ A Graph Cut Max-Flow is applied to optimally cut the volume. This cut represents
             uid=[0],
         ),
         desc.BoolParam(
+            name='useBoundingBox',
+            label='Custom Bounding Box',
+            description='Edit the meshing bounding box. If enabled, it takes priority over the Estimate From SfM option. Parameters can be adjusted in advanced settings.',
+            value=False,
+            uid=[0],
+            group=''
+        ),
+        desc.GroupAttribute(
+            name="boundingBox",
+            label="Bounding Box Settings",
+            description="Translation, rotation and scale of the bounding box.",
+            groupDesc=[
+                desc.GroupAttribute(
+                    name="bboxTranslation",
+                    label="Translation",
+                    description="Position in space.",
+                    groupDesc=[
+                        desc.FloatParam(
+                            name="x", label="x", description="X Offset",
+                            value=0.0,
+                            uid=[0],
+                            range=(-20.0, 20.0, 0.01)
+                        ),
+                        desc.FloatParam(
+                            name="y", label="y", description="Y Offset",
+                            value=0.0,
+                            uid=[0],
+                            range=(-20.0, 20.0, 0.01)
+                        ),
+                        desc.FloatParam(
+                            name="z", label="z", description="Z Offset",
+                            value=0.0,
+                            uid=[0],
+                            range=(-20.0, 20.0, 0.01)
+                        )
+                    ],
+                    joinChar=","
+                ),
+                desc.GroupAttribute(
+                    name="bboxRotation",
+                    label="Euler Rotation",
+                    description="Rotation in Euler degrees.",
+                    groupDesc=[
+                        desc.FloatParam(
+                            name="x", label="x", description="Euler X Rotation",
+                            value=0.0,
+                            uid=[0],
+                            range=(-90.0, 90.0, 1)
+                        ),
+                        desc.FloatParam(
+                            name="y", label="y", description="Euler Y Rotation",
+                            value=0.0,
+                            uid=[0],
+                            range=(-180.0, 180.0, 1)
+                        ),
+                        desc.FloatParam(
+                            name="z", label="z", description="Euler Z Rotation",
+                            value=0.0,
+                            uid=[0],
+                            range=(-180.0, 180.0, 1)
+                        )
+                    ],
+                    joinChar=","
+                ),
+                desc.GroupAttribute(
+                    name="bboxScale",
+                    label="Scale",
+                    description="Scale of the bounding box.",
+                    groupDesc=[
+                        desc.FloatParam(
+                            name="x", label="x", description="X Scale",
+                            value=1.0,
+                            uid=[0],
+                            range=(0.0, 20.0, 0.01)
+                        ),
+                        desc.FloatParam(
+                            name="y", label="y", description="Y Scale",
+                            value=1.0,
+                            uid=[0],
+                            range=(0.0, 20.0, 0.01)
+                        ),
+                        desc.FloatParam(
+                            name="z", label="z", description="Z Scale",
+                            value=1.0,
+                            uid=[0],
+                            range=(0.0, 20.0, 0.01)
+                        )
+                    ],
+                    joinChar=","
+                )
+            ],
+            joinChar=",",
+            advanced=True
+        ),
+        desc.BoolParam(
             name='estimateSpaceFromSfM',
             label='Estimate Space From SfM',
             description='Estimate the 3d space from the SfM',

--- a/meshroom/nodes/aliceVision/SfMTransform.py
+++ b/meshroom/nodes/aliceVision/SfMTransform.py
@@ -1,4 +1,4 @@
-__version__ = "2.0"
+__version__ = "3.0"
 
 from meshroom.core import desc
 
@@ -52,14 +52,15 @@ The transformation can be based on:
                         " * from_single_camera: Camera UID or image filename",
             value='',
             uid=[0],
+            enabled=lambda node: node.method.value == "transformation" or node.method.value == "from_single_camera",
         ),
         desc.GroupAttribute(
-            name="transformGizmo",
-            label="Transform Gizmo Settings",
-            description="Translation, rotation and scale defined by the gizmo.",
+            name="manualTransform",
+            label="Manual Transform (Gizmo)",
+            description="Translation, rotation (Euler ZXY) and uniform scale.",
             groupDesc=[
                 desc.GroupAttribute(
-                    name="gizmoTranslation",
+                    name="manualTranslation",
                     label="Translation",
                     description="Translation in space.",
                     groupDesc=[
@@ -85,7 +86,7 @@ The transformation can be based on:
                     joinChar=","
                 ),
                 desc.GroupAttribute(
-                    name="gizmoRotation",
+                    name="manualRotation",
                     label="Euler Rotation",
                     description="Rotation in Euler degrees.",
                     groupDesc=[
@@ -111,7 +112,7 @@ The transformation can be based on:
                     joinChar=","
                 ),
                 desc.FloatParam(
-                    name="gizmoScale", 
+                    name="manualScale", 
                     label="Scale", 
                     description="Uniform Scale.",
                     value=1.0,
@@ -120,7 +121,7 @@ The transformation can be based on:
                 )
             ],
             joinChar=",",
-            advanced=True
+            enabled=lambda node: node.method.value == "manual",
         ),
         desc.ChoiceParam(
             name='landmarksDescriberTypes',
@@ -158,21 +159,24 @@ The transformation can be based on:
             label='Scale',
             description='Apply scale transformation.',
             value=True,
-            uid=[0]
+            uid=[0],
+            enabled=lambda node: node.method.value != "manual",
         ),
         desc.BoolParam(
             name='applyRotation',
             label='Rotation',
             description='Apply rotation transformation.',
             value=True,
-            uid=[0]
+            uid=[0],
+            enabled=lambda node: node.method.value != "manual",
         ),
         desc.BoolParam(
             name='applyTranslation',
             label='Translation',
             description='Apply translation transformation.',
             value=True,
-            uid=[0]
+            uid=[0],
+            enabled=lambda node: node.method.value != "manual",
         ),
         desc.ChoiceParam(
             name='verboseLevel',

--- a/meshroom/nodes/aliceVision/SfMTransform.py
+++ b/meshroom/nodes/aliceVision/SfMTransform.py
@@ -34,7 +34,7 @@ The transformation can be based on:
             label='Transformation Method',
             description="Transformation method:\n"
                         " * transformation: Apply a given transformation\n"
-                        " * manual: Apply the gizmo transformation\n"
+                        " * manual: Apply the gizmo transformation (show the transformed input)\n"
                         " * auto_from_cameras: Use cameras\n"
                         " * auto_from_landmarks: Use landmarks\n"
                         " * from_single_camera: Use a specific camera as the origin of the coordinate system\n"

--- a/meshroom/nodes/aliceVision/SfMTransform.py
+++ b/meshroom/nodes/aliceVision/SfMTransform.py
@@ -34,12 +34,13 @@ The transformation can be based on:
             label='Transformation Method',
             description="Transformation method:\n"
                         " * transformation: Apply a given transformation\n"
+                        " * manual: Apply the gizmo transformation\n"
                         " * auto_from_cameras: Use cameras\n"
                         " * auto_from_landmarks: Use landmarks\n"
                         " * from_single_camera: Use a specific camera as the origin of the coordinate system\n"
                         " * from_markers: Align specific markers to custom coordinates",
             value='auto_from_landmarks',
-            values=['transformation', 'auto_from_cameras', 'auto_from_landmarks', 'from_single_camera', 'from_markers'],
+            values=['transformation', 'manual', 'auto_from_cameras', 'auto_from_landmarks', 'from_single_camera', 'from_markers'],
             exclusive=True,
             uid=[0],
         ),
@@ -51,6 +52,75 @@ The transformation can be based on:
                         " * from_single_camera: Camera UID or image filename",
             value='',
             uid=[0],
+        ),
+        desc.GroupAttribute(
+            name="transformGizmo",
+            label="Transform Gizmo Settings",
+            description="Translation, rotation and scale defined by the gizmo.",
+            groupDesc=[
+                desc.GroupAttribute(
+                    name="gizmoTranslation",
+                    label="Translation",
+                    description="Translation in space.",
+                    groupDesc=[
+                        desc.FloatParam(
+                            name="x", label="x", description="X Offset",
+                            value=0.0,
+                            uid=[0],
+                            range=(-20.0, 20.0, 0.01)
+                        ),
+                        desc.FloatParam(
+                            name="y", label="y", description="Y Offset",
+                            value=0.0,
+                            uid=[0],
+                            range=(-20.0, 20.0, 0.01)
+                        ),
+                        desc.FloatParam(
+                            name="z", label="z", description="Z Offset",
+                            value=0.0,
+                            uid=[0],
+                            range=(-20.0, 20.0, 0.01)
+                        )
+                    ],
+                    joinChar=","
+                ),
+                desc.GroupAttribute(
+                    name="gizmoRotation",
+                    label="Euler Rotation",
+                    description="Rotation in Euler degrees.",
+                    groupDesc=[
+                        desc.FloatParam(
+                            name="x", label="x", description="Euler X Rotation",
+                            value=0.0,
+                            uid=[0],
+                            range=(-90.0, 90.0, 1)
+                        ),
+                        desc.FloatParam(
+                            name="y", label="y", description="Euler Y Rotation",
+                            value=0.0,
+                            uid=[0],
+                            range=(-180.0, 180.0, 1)
+                        ),
+                        desc.FloatParam(
+                            name="z", label="z", description="Euler Z Rotation",
+                            value=0.0,
+                            uid=[0],
+                            range=(-180.0, 180.0, 1)
+                        )
+                    ],
+                    joinChar=","
+                ),
+                desc.FloatParam(
+                    name="gizmoScale", 
+                    label="Scale", 
+                    description="Uniform Scale.",
+                    value=1.0,
+                    uid=[0],
+                    range=(0.0, 20.0, 0.01)
+                )
+            ],
+            joinChar=",",
+            advanced=True
         ),
         desc.ChoiceParam(
             name='landmarksDescriberTypes',

--- a/meshroom/ui/app.py
+++ b/meshroom/ui/app.py
@@ -13,7 +13,7 @@ from meshroom.core import pyCompatibility
 from meshroom.ui import components
 from meshroom.ui.components.clipboard import ClipboardHelper
 from meshroom.ui.components.filepath import FilepathHelper
-from meshroom.ui.components.scene3D import Scene3DHelper
+from meshroom.ui.components.scene3D import Scene3DHelper, Transformations3DHelper
 from meshroom.ui.palette import PaletteManager
 from meshroom.ui.reconstruction import Reconstruction
 from meshroom.ui.utils import QmlInstantEngine
@@ -127,6 +127,7 @@ class MeshroomApp(QApplication):
         # => expose them as context properties instead
         self.engine.rootContext().setContextProperty("Filepath", FilepathHelper(parent=self))
         self.engine.rootContext().setContextProperty("Scene3DHelper", Scene3DHelper(parent=self))
+        self.engine.rootContext().setContextProperty("Transformations3DHelper", Transformations3DHelper(parent=self))
         self.engine.rootContext().setContextProperty("Clipboard", ClipboardHelper(parent=self))
 
         # additional context properties

--- a/meshroom/ui/components/__init__.py
+++ b/meshroom/ui/components/__init__.py
@@ -4,12 +4,13 @@ def registerTypes():
     from meshroom.ui.components.clipboard import ClipboardHelper
     from meshroom.ui.components.edge import EdgeMouseArea
     from meshroom.ui.components.filepath import FilepathHelper
-    from meshroom.ui.components.scene3D import Scene3DHelper, TrackballController
+    from meshroom.ui.components.scene3D import Scene3DHelper, TrackballController, Transformations3DHelper
     from meshroom.ui.components.csvData import CsvData
 
     qmlRegisterType(EdgeMouseArea, "GraphEditor", 1, 0, "EdgeMouseArea")
     qmlRegisterType(ClipboardHelper, "Meshroom.Helpers", 1, 0, "ClipboardHelper")  # TODO: uncreatable
     qmlRegisterType(FilepathHelper, "Meshroom.Helpers", 1, 0, "FilepathHelper")  # TODO: uncreatable
     qmlRegisterType(Scene3DHelper, "Meshroom.Helpers", 1, 0, "Scene3DHelper")  # TODO: uncreatable
+    qmlRegisterType(Transformations3DHelper, "Meshroom.Helpers", 1, 0, "Transformations3DHelper")  # TODO: uncreatable
     qmlRegisterType(TrackballController, "Meshroom.Helpers", 1, 0, "TrackballController")
     qmlRegisterType(CsvData, "DataObjects", 1, 0, "CsvData")

--- a/meshroom/ui/components/scene3D.py
+++ b/meshroom/ui/components/scene3D.py
@@ -111,7 +111,14 @@ class Transformations3DHelper(QObject):
 
     @Slot(QVector4D, Qt3DRender.QCamera, QSize, result=QVector2D)
     def pointFromWorldToScreen(self, point, camera, windowSize):
-        """ Compute the Screen point corresponding to a World Point. """
+        """ Compute the Screen point corresponding to a World Point.
+            Args:
+                point (QVector4D): point in world coordinates
+                camera (QCamera): camera viewing the scene
+                windowSize (QSize): size of the Scene3D window
+            Returns:
+                QVector2D: point in screen coordinates
+        """
         # Transform the point from World Coord to Normalized Device Coord
         viewMatrix = camera.transform().matrix().inverted()
         projectedPoint = (camera.projectionMatrix() * viewMatrix[0]).map(point)
@@ -130,7 +137,14 @@ class Transformations3DHelper(QObject):
 
     @Slot(Qt3DCore.QTransform, QMatrix4x4, QMatrix4x4, QMatrix4x4, QVector3D)
     def relativeLocalTranslate(self, transformQtInstance, initialPosMat, initialRotMat, initialScaleMat, translateVec):
-        """ Translate the QTransform in its local space relatively to an initial state. """
+        """ Translate the QTransform in its local space relatively to an initial state.
+            Args:
+                transformQtInstance (QTransform): reference to the Transform to modify
+                initialPosMat (QMatrix4x4): initial position matrix
+                initialRotMat (QMatrix4x4): initial rotation matrix
+                initialScaleMat (QMatrix4x4): initial scale matrix
+                translateVec (QVector3D): vector used for the local translation
+        """
         # Compute the translation transformation matrix 
         translationMat = QMatrix4x4()
         translationMat.translate(translateVec)
@@ -141,7 +155,15 @@ class Transformations3DHelper(QObject):
 
     @Slot(Qt3DCore.QTransform, QMatrix4x4, QQuaternion, QMatrix4x4, QVector3D, int)
     def relativeLocalRotate(self, transformQtInstance, initialPosMat, initialRotQuat, initialScaleMat, axis, degree):
-        """ Rotate the QTransform in its local space relatively to an initial state. """    
+        """ Rotate the QTransform in its local space relatively to an initial state.
+            Args:
+                transformQtInstance (QTransform): reference to the Transform to modify
+                initialPosMat (QMatrix4x4): initial position matrix
+                initialRotQuat (QQuaternion): initial rotation quaternion
+                initialScaleMat (QMatrix4x4): initial scale matrix
+                axis (QVector3D): axis to rotate around
+                degree (int): angle of rotation in degree
+        """
         # Compute the transformation quaternion from axis and angle in degrees
         transformQuat = QQuaternion.fromAxisAndAngle(axis, degree)
 
@@ -155,7 +177,14 @@ class Transformations3DHelper(QObject):
 
     @Slot(Qt3DCore.QTransform, QMatrix4x4, QMatrix4x4, QMatrix4x4, QVector3D)
     def relativeLocalScale(self, transformQtInstance, initialPosMat, initialRotMat, initialScaleMat, scaleVec):
-        """ Scale the QTransform in its local space relatively to an initial state. """
+        """ Scale the QTransform in its local space relatively to an initial state.
+            Args:
+                transformQtInstance (QTransform): reference to the Transform to modify
+                initialPosMat (QMatrix4x4): initial position matrix
+                initialRotMat (QMatrix4x4): initial rotation matrix
+                initialScaleMat (QMatrix4x4): initial scale matrix
+                scaleVec (QVector3D): vector used for the relative scale
+        """
         # Make a copy of the scale matrix (otherwise, it is a reference and it does not work as expected)
         scaleMat = self.copyMatrix4x4(initialScaleMat)
 
@@ -175,7 +204,12 @@ class Transformations3DHelper(QObject):
 
     @Slot(QMatrix4x4, result="QVariant")
     def modelMatrixToMatrices(self, modelMat):
-        """ Decompose a model matrix into individual matrices. """
+        """ Decompose a model matrix into individual matrices.
+            Args:
+                modelMat (QMatrix4x4): model matrix to decompose
+            Returns:
+                QVariant: object containing position, rotation and scale matrices + rotation quaternion
+        """
         decomposition = self.decomposeModelMatrix(modelMat)
 
         posMat = QMatrix4x4()
@@ -251,7 +285,12 @@ class Transformations3DHelper(QObject):
         return newMat
 
     def decomposeModelMatrix(self, modelMat):
-        """ Decompose a model matrix into individual component. """
+        """ Decompose a model matrix into individual component.
+            Args:
+                modelMat (QMatrix4x4): model matrix to decompose
+            Returns:
+                QVariant: object containing translation and scale vectors + rotation quaternion
+        """
         translation = modelMat.column(3).toVector3D()
         quaternion = QQuaternion.fromDirection(modelMat.column(2).toVector3D(), modelMat.column(1).toVector3D())
         scale = QVector3D(modelMat.column(0).length(), modelMat.column(1).length(), modelMat.column(2).length())

--- a/meshroom/ui/components/scene3D.py
+++ b/meshroom/ui/components/scene3D.py
@@ -3,7 +3,7 @@ from math import acos, pi, sqrt
 from PySide2.QtCore import QObject, Slot, QSize, Signal, QPointF
 from PySide2.Qt3DCore import Qt3DCore
 from PySide2.Qt3DRender import Qt3DRender
-from PySide2.QtGui import QVector3D, QQuaternion, QVector2D
+from PySide2.QtGui import QVector3D, QQuaternion, QVector2D, QVector4D, QMatrix4x4
 
 from meshroom.ui.utils import makeProperty
 
@@ -103,3 +103,115 @@ class TrackballController(QObject):
     trackballSize = makeProperty(float, '_trackballSize', trackballSizeChanged)
     rotationSpeedChanged = Signal()
     rotationSpeed = makeProperty(float, '_rotationSpeed', rotationSpeedChanged)
+
+
+class Transformations3DHelper(QObject):
+
+    #---------- Exposed to QML ----------#
+
+    @Slot(QVector4D, Qt3DRender.QCamera, QSize, result=QVector2D)
+    def pointFromWorldToScreen(self, point, camera, windowSize):
+        """ Compute the Screen point corresponding to a World Point. """
+        # Transform the point from World Coord to Normalized Device Coord
+        viewMatrix = camera.transform().matrix().inverted()
+        projectedPoint = (camera.projectionMatrix() * viewMatrix[0]).map(point)
+        projectedPoint2D = QVector2D(
+            projectedPoint.x()/projectedPoint.w(), 
+            projectedPoint.y()/projectedPoint.w()
+        )
+
+        # Transform the point from Normalized Device Coord to Screen Coord
+        screenPoint2D = QVector2D(
+            int((projectedPoint2D.x() + 1) * windowSize.width() / 2),
+            int((projectedPoint2D.y() - 1) * windowSize.height() / -2)
+        )
+
+        return screenPoint2D
+
+    @Slot(Qt3DCore.QTransform, QMatrix4x4, QMatrix4x4, QMatrix4x4, QVector3D)
+    def relativeLocalTranslate(self, transformQtInstance, initialPosMat, initialRotMat, initialScaleMat, translateVec):
+        """ Translate the QTransform in its local space relatively to an initial state. """
+        # Compute the translation transformation matrix 
+        translationMat = QMatrix4x4()
+        translationMat.translate(translateVec)
+
+        # Compute the new model matrix (POSITION * ROTATION * TRANSLATE * SCALE) and set it to the Transform
+        mat = initialPosMat * initialRotMat * translationMat * initialScaleMat
+        transformQtInstance.setMatrix(mat)
+
+    @Slot(Qt3DCore.QTransform, QMatrix4x4, QQuaternion, QMatrix4x4, QVector3D, int)
+    def relativeLocalRotate(self, transformQtInstance, initialPosMat, initialRotQuat, initialScaleMat, axis, degree):
+        """ Rotate the QTransform in its local space relatively to an initial state. """    
+        # Compute the transformation quaternion from axis and angle in degrees
+        transformQuat = QQuaternion.fromAxisAndAngle(axis, degree)
+
+        # Compute the new rotation quaternion and then calculate the matrix
+        newRotQuat = initialRotQuat * transformQuat # Order is important
+        newRotationMat = self.quaternionToRotationMatrix(newRotQuat)
+
+        # Compute the new model matrix (POSITION * NEW_COMPUTED_ROTATION * SCALE) and set it to the Transform
+        mat = initialPosMat * newRotationMat * initialScaleMat
+        transformQtInstance.setMatrix(mat)
+
+    @Slot(Qt3DCore.QTransform, QMatrix4x4, QMatrix4x4, QMatrix4x4, QVector3D)
+    def relativeLocalScale(self, transformQtInstance, initialPosMat, initialRotMat, initialScaleMat, scaleVec):
+        """ Scale the QTransform in its local space relatively to an initial state. """
+        # Make a copy of the scale matrix (otherwise, it is a reference and it does not work as expected)
+        scaleMat = self.copyMatrix4x4(initialScaleMat)
+
+        # Update the scale matrix copy (X then Y then Z) with the scaleVec values
+        scaleVecTuple = scaleVec.toTuple()
+        for i in range(3):
+            currentRow = list(scaleMat.row(i).toTuple()) # QVector3D does not implement [] operator or easy way to access value by index so this little hack is required
+            value = currentRow[i] + scaleVecTuple[i]
+            value = value if value >= 0 else -value # Make sure to have only positive scale (because negative scale can make issues with matrix decomposition)
+            currentRow[i] = value
+
+            scaleMat.setRow(i, QVector3D(currentRow[0], currentRow[1], currentRow[2])) # Apply the new row to the scale matrix
+
+        # Compute the new model matrix (POSITION * ROTATION * SCALE) and set it to the Transform
+        mat = initialPosMat * initialRotMat * scaleMat
+        transformQtInstance.setMatrix(mat)
+
+    @Slot(QMatrix4x4, result="QVariant")
+    def modelMatrixToMatrices(self, modelMat):
+        """ Decompose a model matrix into individual matrices. """
+        decomposition = self.decomposeModelMatrix(modelMat)
+
+        posMat = QMatrix4x4()
+        posMat.translate(decomposition.get("translation"))
+
+        rotMat = self.quaternionToRotationMatrix(decomposition.get("quaternion"))
+
+        scaleMat = QMatrix4x4()
+        scaleMat.scale(decomposition.get("scale"))
+
+        return { "position": posMat, "rotation": rotMat, "scale": scaleMat, "quaternion": decomposition.get("quaternion") }
+
+
+    #---------- "Private" Methods ----------#
+
+    def copyMatrix4x4(self, mat):
+        """ Make a deep copy of a QMatrix4x4. """
+        newMat = QMatrix4x4()
+        for i in range(4):
+            newMat.setRow(i, mat.row(i))
+        return newMat
+
+    def decomposeModelMatrix(self, modelMat):
+        """ Decompose a model matrix into individual component. """
+        translation = modelMat.column(3).toVector3D()
+        quaternion = QQuaternion.fromDirection(modelMat.column(2).toVector3D(), modelMat.column(1).toVector3D())
+        scale = QVector3D(modelMat.column(0).length(), modelMat.column(1).length(), modelMat.column(2).length())
+
+        return { "translation": translation, "quaternion": quaternion, "scale": scale }
+
+    def quaternionToRotationMatrix(self, q):
+        """ Return a rotation matrix from a quaternion. """
+        rotMat3x3 = q.toRotationMatrix()
+        return QMatrix4x4(
+            rotMat3x3(0,0), rotMat3x3(0,1), rotMat3x3(0,2), 0,
+            rotMat3x3(1,0), rotMat3x3(1,1), rotMat3x3(1,2), 0,
+            rotMat3x3(2,0), rotMat3x3(2,1), rotMat3x3(2,2), 0,
+            0,              0,              0,              1
+        )

--- a/meshroom/ui/components/scene3D.py
+++ b/meshroom/ui/components/scene3D.py
@@ -188,6 +188,29 @@ class Transformations3DHelper(QObject):
 
         return { "position": posMat, "rotation": rotMat, "scale": scaleMat, "quaternion": decomposition.get("quaternion") }
 
+    @Slot(QVector3D, QVector3D, QVector3D, result=QMatrix4x4)
+    def computeModelMatrixWithEuler(self, translation, rotation, scale):
+        """ Compute a model matrix from three Vector3D.
+            Args:
+                translation (QVector3D): position in space (x, y, z)
+                rotation (QVector3D): Euler angles in degrees (x, y, z)
+                scale (QVector3D): scale of the object (x, y, z)
+            Returns:
+                QMatrix4x4: corresponding model matrix
+        """
+        posMat = QMatrix4x4()
+        posMat.translate(translation)
+
+        quaternion = QQuaternion.fromEulerAngles(rotation)
+        rotMat = self.quaternionToRotationMatrix(quaternion)
+
+        scaleMat = QMatrix4x4()
+        scaleMat.scale(scale)
+
+        modelMat = posMat * rotMat * scaleMat
+
+        return modelMat
+
 
     #---------- "Private" Methods ----------#
 

--- a/meshroom/ui/components/scene3D.py
+++ b/meshroom/ui/components/scene3D.py
@@ -107,7 +107,7 @@ class TrackballController(QObject):
 
 class Transformations3DHelper(QObject):
 
-    #---------- Exposed to QML ----------#
+    # ---------- Exposed to QML ---------- #
 
     @Slot(QVector4D, Qt3DRender.QCamera, QSize, result=QVector2D)
     def pointFromWorldToScreen(self, point, camera, windowSize):
@@ -186,7 +186,7 @@ class Transformations3DHelper(QObject):
         scaleMat = QMatrix4x4()
         scaleMat.scale(decomposition.get("scale"))
 
-        return { "position": posMat, "rotation": rotMat, "scale": scaleMat, "quaternion": decomposition.get("quaternion") }
+        return {"position": posMat, "rotation": rotMat, "scale": scaleMat, "quaternion": decomposition.get("quaternion")}
 
     @Slot(QVector3D, QVector3D, QVector3D, result=QMatrix4x4)
     def computeModelMatrixWithEuler(self, translation, rotation, scale):
@@ -239,9 +239,9 @@ class Transformations3DHelper(QObject):
         screenVector = QVector2D(screenAxisUnitPoint2D.x() - screenCenter2D.x(), -(screenAxisUnitPoint2D.y() - screenCenter2D.y()))
 
         value = screenVector.length()
-        return value if (value and value > 10) else 10 # Threshold to avoid problems in extreme case
+        return value if (value and value > 10) else 10  # Threshold to avoid problems in extreme case
 
-    #---------- "Private" Methods ----------#
+    # ---------- "Private" Methods ---------- #
 
     def copyMatrix4x4(self, mat):
         """ Make a deep copy of a QMatrix4x4. """
@@ -256,14 +256,14 @@ class Transformations3DHelper(QObject):
         quaternion = QQuaternion.fromDirection(modelMat.column(2).toVector3D(), modelMat.column(1).toVector3D())
         scale = QVector3D(modelMat.column(0).length(), modelMat.column(1).length(), modelMat.column(2).length())
 
-        return { "translation": translation, "quaternion": quaternion, "scale": scale }
+        return {"translation": translation, "quaternion": quaternion, "scale": scale}
 
     def quaternionToRotationMatrix(self, q):
         """ Return a rotation matrix from a quaternion. """
         rotMat3x3 = q.toRotationMatrix()
         return QMatrix4x4(
-            rotMat3x3(0,0), rotMat3x3(0,1), rotMat3x3(0,2), 0,
-            rotMat3x3(1,0), rotMat3x3(1,1), rotMat3x3(1,2), 0,
-            rotMat3x3(2,0), rotMat3x3(2,1), rotMat3x3(2,2), 0,
-            0,              0,              0,              1
+            rotMat3x3(0, 0), rotMat3x3(0, 1), rotMat3x3(0, 2), 0,
+            rotMat3x3(1, 0), rotMat3x3(1, 1), rotMat3x3(1, 2), 0,
+            rotMat3x3(2, 0), rotMat3x3(2, 1), rotMat3x3(2, 2), 0,
+            0,               0,               0,               1
         )

--- a/meshroom/ui/graph.py
+++ b/meshroom/ui/graph.py
@@ -275,7 +275,11 @@ class UIGraph(QObject):
         if self._graph:
             self.stopExecution()
             self.clear()
+        oldGraph = self._graph
         self._graph = g
+        if oldGraph:
+            oldGraph.deleteLater()
+
         self._graph.updated.connect(self.onGraphUpdated)
         self._graph.update()
         # perform auto-layout if graph does not provide nodes positions
@@ -320,8 +324,7 @@ class UIGraph(QObject):
         if self._graph:
             self.clearNodeHover()
             self.clearNodeSelection()
-            self._graph.deleteLater()
-            self._graph = None
+            self._graph.clear()
         self._sortedDFSChunks.clear()
         self._undoStack.clear()
 

--- a/meshroom/ui/qml/GraphEditor/AttributePin.qml
+++ b/meshroom/ui/qml/GraphEditor/AttributePin.qml
@@ -16,15 +16,15 @@ RowLayout {
     readonly property point edgeAnchorPos: Qt.point(edgeAnchor.x + edgeAnchor.width/2,
                                                     edgeAnchor.y + edgeAnchor.height/2)
 
-    readonly property bool isList: attribute.type == "ListAttribute"
+    readonly property bool isList: attribute && attribute.type === "ListAttribute"
 
     signal childPinCreated(var childAttribute, var pin)
     signal childPinDeleted(var childAttribute, var pin)
 
     signal pressed(var mouse)
 
-    objectName: attribute.name + "."
-    layoutDirection: attribute.isOutput ? Qt.RightToLeft : Qt.LeftToRight
+    objectName: attribute ? attribute.name + "." : ""
+    layoutDirection: attribute && attribute.isOutput ? Qt.RightToLeft : Qt.LeftToRight
     spacing: 2
 
     // Instantiate empty Items for each child attribute
@@ -49,7 +49,7 @@ RowLayout {
         color: {
             if(connectMA.containsMouse || connectMA.drag.active || (dropArea.containsDrag && dropArea.acceptableDrop))
                 return nameLabel.palette.highlight
-            else if(attribute.isLink)
+            else if(attribute && attribute.isLink)
                 return "#3e3e3e"
             return "white"
         }
@@ -93,7 +93,7 @@ RowLayout {
             objectName: "edgeConnector"
             readonly property alias attribute: root.attribute
             readonly property alias nodeItem: root.nodeItem
-            readonly property bool isOutput: attribute.isOutput
+            readonly property bool isOutput: attribute && attribute.isOutput
             readonly property alias isList: root.isList
             anchors.centerIn: root.state == "Dragging" ? undefined : parent
             width: 4
@@ -155,12 +155,12 @@ RowLayout {
             id: nameLabel
 
             property bool hovered: (connectMA.containsMouse || connectMA.drag.active || dropArea.containsDrag)
-            text: attribute.name
+            text: attribute ? attribute.name : ""
             elide: hovered ? Text.ElideNone : Text.ElideMiddle
             width: hovered ? contentWidth : parent.width
             font.pointSize: 5
-            horizontalAlignment: attribute.isOutput ? Text.AlignRight : Text.AlignLeft
-            anchors.right: attribute.isOutput ? parent.right : undefined
+            horizontalAlignment: attribute && attribute.isOutput ? Text.AlignRight : Text.AlignLeft
+            anchors.right: attribute && attribute.isOutput ? parent.right : undefined
 
             background: Rectangle {
                 visible: parent.hovered && metrics.truncated

--- a/meshroom/ui/qml/GraphEditor/CompatibilityManager.qml
+++ b/meshroom/ui/qml/GraphEditor/CompatibilityManager.qml
@@ -91,15 +91,15 @@ MessageDialog {
 
                 Label {
                     Layout.preferredWidth: 130
-                    text: compatibilityNodeDelegate.node.nodeType
+                    text: compatibilityNodeDelegate.node ? compatibilityNodeDelegate.node.nodeType : ""
                 }
                 Label {
                     Layout.fillWidth: true
-                    text: compatibilityNodeDelegate.node.issueDetails
+                    text: compatibilityNodeDelegate.node ? compatibilityNodeDelegate.node.issueDetails : ""
                 }
                 Label {
-                    text: compatibilityNodeDelegate.node.canUpgrade ? MaterialIcons.check : MaterialIcons.clear
-                    color: compatibilityNodeDelegate.node.canUpgrade ? "#4CAF50" : "#F44336"
+                    text: compatibilityNodeDelegate.node && compatibilityNodeDelegate.node.canUpgrade ? MaterialIcons.check : MaterialIcons.clear
+                    color: compatibilityNodeDelegate.node && compatibilityNodeDelegate.node.canUpgrade ? "#4CAF50" : "#F44336"
                     font.family: MaterialIcons.fontFamily
                     font.pointSize: 14
                     font.bold: true

--- a/meshroom/ui/qml/GraphEditor/GraphEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/GraphEditor.qml
@@ -240,11 +240,11 @@ Item {
                 id: edgesRepeater
 
                 // delay edges loading after nodes (edges needs attribute pins to be created)
-                model: nodeRepeater.loaded ? root.graph.edges : undefined
+                model: nodeRepeater.loaded && root.graph ? root.graph.edges : undefined
 
                 delegate: Edge {
-                    property var src: root._attributeToDelegate[edge.src]
-                    property var dst: root._attributeToDelegate[edge.dst]
+                    property var src: edge ? root._attributeToDelegate[edge.src] : undefined
+                    property var dst: edge ? root._attributeToDelegate[edge.dst] : undefined
                     property var srcAnchor: src.nodeItem.mapFromItem(src, src.edgeAnchorPos.x, src.edgeAnchorPos.y)
                     property var dstAnchor: dst.nodeItem.mapFromItem(dst, dst.edgeAnchorPos.x, dst.edgeAnchorPos.y)
 
@@ -382,8 +382,8 @@ Item {
             Repeater {
                 id: nodeRepeater
 
-                model: root.graph.nodes
-                property bool loaded: count === model.count
+                model: root.graph ? root.graph.nodes : undefined
+                property bool loaded: model ? count === model.count : false
 
                 delegate: Node {
                     id: nodeDelegate

--- a/meshroom/ui/qml/GraphEditor/Node.qml
+++ b/meshroom/ui/qml/GraphEditor/Node.qml
@@ -10,7 +10,7 @@ Item {
     property bool readOnly: false
     property color baseColor: defaultColor
     property color shadowColor: "black"
-    readonly property bool isCompatibilityNode: node.hasOwnProperty("compatibilityIssue")
+    readonly property bool isCompatibilityNode: node ? node.hasOwnProperty("compatibilityIssue") : false
     readonly property color defaultColor: isCompatibilityNode ? "#444" : "#607D8B"
     property bool selected: false
     property bool hovered: false
@@ -24,13 +24,13 @@ Item {
     signal attributePinDeleted(var attribute, var pin)
 
     implicitHeight: childrenRect.height
-    objectName: node.name
+    objectName: node ? node.name : ""
 
     SystemPalette { id: activePalette }
 
     // initialize position with node coordinates
-    x: root.node.x
-    y: root.node.y
+    x: root.node ? root.node.x : undefined
+    y: root.node ? root.node.y : undefined
 
     Connections {
         target: root.node
@@ -93,7 +93,7 @@ Item {
                 width: parent.width
                 horizontalAlignment: Text.AlignHCenter
                 padding: 4
-                text: node.label
+                text: node ? node.label : ""
                 color: "#EEE"
                 font.pointSize: 8
                 background: Rectangle {
@@ -106,7 +106,7 @@ Item {
                 defaultColor: Qt.darker(baseColor, 1.3)
                 implicitHeight: 3
                 width: parent.width
-                model: node.chunks
+                model: node ? node.chunks : undefined
             }
 
             Item { width: 1; height: 2}
@@ -121,7 +121,7 @@ Item {
                     width: parent.width / 2
                     spacing: 1
                     Repeater {
-                        model: node.attributes
+                        model: node ? node.attributes : undefined
                         delegate: Loader {
                             active: !object.isOutput && isDisplayableAsPin(object)
                             width: inputs.width
@@ -146,7 +146,7 @@ Item {
                     anchors.right: parent.right
                     spacing: 1
                     Repeater {
-                        model: node.attributes
+                        model: node ? node.attributes : undefined
 
                         delegate: Loader {
                             active: object.isOutput && isDisplayableAsPin(object)

--- a/meshroom/ui/qml/ImageGallery/ImageGallery.qml
+++ b/meshroom/ui/qml/ImageGallery/ImageGallery.qml
@@ -76,7 +76,7 @@ Panel {
 
     SensorDBDialog {
         id: sensorDBDialog
-        sensorDatabase: Filepath.stringToUrl(cameraInit.attribute("sensorDatabase").value)
+        sensorDatabase: cameraInit ? Filepath.stringToUrl(cameraInit.attribute("sensorDatabase").value) : ""
         readOnly: _reconstruction.computing
         onUpdateIntrinsicsRequest: _reconstruction.rebuildIntrinsics(cameraInit)
     }

--- a/meshroom/ui/qml/Utils/Transformations3DHelper.qml
+++ b/meshroom/ui/qml/Utils/Transformations3DHelper.qml
@@ -1,0 +1,6 @@
+pragma Singleton
+import Meshroom.Helpers 1.0
+
+Transformations3DHelper {
+
+}

--- a/meshroom/ui/qml/Utils/qmldir
+++ b/meshroom/ui/qml/Utils/qmldir
@@ -8,3 +8,4 @@ Format 1.0 format.js
 # singleton Clipboard 1.0 Clipboard.qml
 # singleton Filepath 1.0 Filepath.qml
 # singleton Scene3DHelper 1.0 Scene3DHelper.qml
+# singleton Transformations3DHelper 1.0 Transformations3DHelper.qml

--- a/meshroom/ui/qml/Viewer3D/BoundingBox.qml
+++ b/meshroom/ui/qml/Viewer3D/BoundingBox.qml
@@ -7,19 +7,86 @@ import QtQuick 2.9
 Entity {
     id: root
     property Transform transform: Transform {}
-    components: [mesh, transform, material]
 
-    CuboidMesh {
-        id: mesh
-        property real edge : 2 // Important to have all the cube's vertices with a unit of 1
-        xExtent: edge
-        yExtent: edge
-        zExtent: edge
+    components: [transform]
+
+    Entity {
+        components: [cube, greyMaterial]
+
+        CuboidMesh {
+            id: cube
+            property real edge : 1.995 // Almost 2: important to have all the cube's vertices with a unit of 1
+            xExtent: edge
+            yExtent: edge
+            zExtent: edge
+        }
+        PhongAlphaMaterial {
+            id: greyMaterial
+            property color base: "#fff"
+            ambient: base
+            alpha: 0.15
+
+            // Pretty convincing combination
+            blendFunctionArg: BlendEquation.Add
+            sourceRgbArg: BlendEquationArguments.SourceAlpha
+            sourceAlphaArg: BlendEquationArguments.OneMinusSourceAlpha
+            destinationRgbArg: BlendEquationArguments.DestinationColor
+            destinationAlphaArg: BlendEquationArguments.OneMinusSourceAlpha
+        }
     }
-    PhongAlphaMaterial {
-        id: material
-        property color base: "#dfe233"
-        ambient: base
-        alpha: 0.3
+
+    Entity {
+        components: [edges, orangeMaterial]
+
+        PhongMaterial {
+            id: orangeMaterial
+            property color base: "#f49b2b"
+            ambient: base
+        }
+
+        GeometryRenderer {
+            id: edges
+            primitiveType: GeometryRenderer.Lines
+            geometry: Geometry {
+                Attribute {
+                    id: boundingBoxPosition
+                    attributeType: Attribute.VertexAttribute
+                    vertexBaseType: Attribute.Float
+                    vertexSize: 3
+                    count: 24
+                    name: defaultPositionAttributeName
+                    buffer: Buffer {
+                        type: Buffer.VertexBuffer
+                        data: new Float32Array([
+                            1.0, 1.0, 1.0,
+                            1.0, -1.0, 1.0,
+                            1.0, 1.0, 1.0,
+                            1.0, 1.0, -1.0,
+                            1.0, 1.0, 1.0,
+                            -1.0, 1.0, 1.0,
+                            -1.0, -1.0, -1.0,
+                            -1.0, 1.0, -1.0,
+                            -1.0, -1.0, -1.0,
+                            1.0, -1.0, -1.0,
+                            -1.0, -1.0, -1.0,
+                            -1.0, -1.0, 1.0,
+                            1.0, -1.0, 1.0,
+                            1.0, -1.0, -1.0,
+                            1.0, 1.0, -1.0,
+                            1.0, -1.0, -1.0,
+                            -1.0, 1.0, 1.0,
+                            -1.0, 1.0, -1.0,
+                            1.0, -1.0, 1.0,
+                            -1.0, -1.0, 1.0,
+                            -1.0, 1.0, 1.0,
+                            -1.0, -1.0, 1.0,
+                            -1.0, 1.0, -1.0,
+                            1.0, 1.0, -1.0
+                            ])
+                    }
+                }
+                boundingVolumePositionAttribute: boundingBoxPosition
+            }
+        }
     }
 }

--- a/meshroom/ui/qml/Viewer3D/BoundingBox.qml
+++ b/meshroom/ui/qml/Viewer3D/BoundingBox.qml
@@ -1,0 +1,25 @@
+import Qt3D.Core 2.0
+import Qt3D.Render 2.9
+import Qt3D.Input 2.0
+import Qt3D.Extras 2.10
+import QtQuick 2.9
+
+Entity {
+    id: root
+    property Transform transform: Transform {}
+    components: [mesh, transform, material]
+
+    CuboidMesh {
+        id: mesh
+        property real edge : 2 // Important to have all the cube's vertices with a unit of 1
+        xExtent: edge
+        yExtent: edge
+        zExtent: edge
+    }
+    PhongAlphaMaterial {
+        id: material
+        property color base: "#dfe233"
+        ambient: base
+        alpha: 0.3
+    }
+}

--- a/meshroom/ui/qml/Viewer3D/DefaultCameraController.qml
+++ b/meshroom/ui/qml/Viewer3D/DefaultCameraController.qml
@@ -23,6 +23,8 @@ Entity {
     property alias windowSize: trackball.windowSize
     property alias trackballSize: trackball.trackballSize
 
+    property bool loseMouseFocus: false // Must be changed by other entities when they want to take mouse focus
+
     readonly property alias pressed: mouseHandler._pressed
     signal mousePressed(var mouse)
     signal mouseReleased(var mouse, var moved)
@@ -166,6 +168,8 @@ Entity {
     components: [
         FrameAction {
             onTriggered: {
+                if(loseMouseFocus) return
+
                 if(panning) { // translate
                     var d = (root.camera.viewCenter.minus(root.camera.position)).length() * 0.03;
                     var tx = axisMX.value * root.translateSpeed * d;

--- a/meshroom/ui/qml/Viewer3D/DefaultCameraController.qml
+++ b/meshroom/ui/qml/Viewer3D/DefaultCameraController.qml
@@ -46,7 +46,7 @@ Entity {
         property point lastPosition
         property point currentPosition
         property bool hasMoved
-        sourceDevice: mouseSourceDevice
+        sourceDevice: loseMouseFocus ? null : mouseSourceDevice
         onPressed: {
             _pressed = true;
             currentPosition.x = lastPosition.x = mouse.x;
@@ -168,8 +168,6 @@ Entity {
     components: [
         FrameAction {
             onTriggered: {
-                if(loseMouseFocus) return
-
                 if(panning) { // translate
                     var d = (root.camera.viewCenter.minus(root.camera.position)).length() * 0.03;
                     var tx = axisMX.value * root.translateSpeed * d;

--- a/meshroom/ui/qml/Viewer3D/DefaultCameraController.qml
+++ b/meshroom/ui/qml/Viewer3D/DefaultCameraController.qml
@@ -62,6 +62,30 @@ Entity {
         onPositionChanged: {
             currentPosition.x = mouse.x;
             currentPosition.y = mouse.y;
+
+            const dt = 0.02
+
+            if(panning) { // translate
+                var d = (root.camera.viewCenter.minus(root.camera.position)).length() * 0.03;
+                var tx = axisMX.value * root.translateSpeed * d;
+                var ty = axisMY.value * root.translateSpeed * d;
+                mouseHandler.hasMoved = true;
+                root.camera.translate(Qt.vector3d(-tx, -ty, 0).times(dt));
+                return;
+            }
+            if(moving){ // trackball rotation
+                trackball.rotate(mouseHandler.lastPosition, mouseHandler.currentPosition, dt);
+                mouseHandler.lastPosition = mouseHandler.currentPosition;
+                mouseHandler.hasMoved = true;
+                return;
+            }
+            if(zooming) { // zoom with alt + RMD
+                var d = (root.camera.viewCenter.minus(root.camera.position)).length() * 0.1;
+                var tz = axisMX.value * root.translateSpeed * d;
+                mouseHandler.hasMoved = true;
+                root.camera.translate(Qt.vector3d(0, 0, tz).times(dt), Camera.DontTranslateViewCenter)
+                return;
+            }
         }
         onDoubleClicked: mouseDoubleClicked(mouse)
         onWheel: {
@@ -164,32 +188,4 @@ Entity {
             }
         ]
     }
-
-    components: [
-        FrameAction {
-            onTriggered: {
-                if(panning) { // translate
-                    var d = (root.camera.viewCenter.minus(root.camera.position)).length() * 0.03;
-                    var tx = axisMX.value * root.translateSpeed * d;
-                    var ty = axisMY.value * root.translateSpeed * d;
-                    mouseHandler.hasMoved = true;
-                    root.camera.translate(Qt.vector3d(-tx, -ty, 0).times(dt));
-                    return;
-                }
-                if(moving){ // trackball rotation
-                    trackball.rotate(mouseHandler.lastPosition, mouseHandler.currentPosition, dt);
-                    mouseHandler.lastPosition = mouseHandler.currentPosition;
-                    mouseHandler.hasMoved = true;
-                    return;
-                }
-                if(zooming) { // zoom with alt + RMD
-                    var d = (root.camera.viewCenter.minus(root.camera.position)).length() * 0.1;
-                    var tz = axisMX.value * root.translateSpeed * d;
-                    mouseHandler.hasMoved = true;
-                    root.camera.translate(Qt.vector3d(0, 0, tz).times(dt), Camera.DontTranslateViewCenter)
-                    return;
-                }
-            }
-        }
-    ]
 }

--- a/meshroom/ui/qml/Viewer3D/EntityWithGizmo.qml
+++ b/meshroom/ui/qml/Viewer3D/EntityWithGizmo.qml
@@ -7,33 +7,22 @@ import Qt3D.Logic 2.0
 
 Entity {
     id: root
-    property DefaultCameraController cameraController
+    property DefaultCameraController sceneCameraController
     property Layer frontLayerComponent
     property var window
-
-    readonly property Camera camera : cameraController.camera
-    readonly property var windowSize: cameraController.windowSize
-    readonly property alias objectTransform : transformGizmo.objectTransform // The Transform the object should use
-    readonly property alias updateTransformations: transformGizmo.updateTransformations // Function to update the transformations
-    
-    signal pickedChanged(bool pressed)
-    signal gizmoChanged(var translation, var rotation, var scale)
-
-    onPickedChanged: {
-        cameraController.loseMouseFocus = pressed // Notify the camera if the transform takes/releases the focus
-    }
-
-    TransformGizmo {
+    property TransformGizmo transformGizmo: TransformGizmo {
         id: transformGizmo
         camera: root.camera
         windowSize: root.windowSize
         frontLayerComponent: root.frontLayerComponent
         window: root.window
+
         onPickedChanged: {
-            root.pickedChanged(pressed)
-        }
-        onGizmoChanged: {
-            root.gizmoChanged(translation, rotation, scale)
+            sceneCameraController.loseMouseFocus = pressed // Notify the camera if the transform takes/releases the focus
         }
     }
+
+    readonly property Camera camera : sceneCameraController.camera
+    readonly property var windowSize: sceneCameraController.windowSize
+    readonly property alias objectTransform : transformGizmo.objectTransform // The Transform the object should use
 }

--- a/meshroom/ui/qml/Viewer3D/EntityWithGizmo.qml
+++ b/meshroom/ui/qml/Viewer3D/EntityWithGizmo.qml
@@ -10,6 +10,7 @@ Entity {
     property DefaultCameraController sceneCameraController
     property Layer frontLayerComponent
     property var window
+    property alias uniformScale: transformGizmo.uniformScale // by default, if not set, the value is: false
     property TransformGizmo transformGizmo: TransformGizmo {
         id: transformGizmo
         camera: root.camera

--- a/meshroom/ui/qml/Viewer3D/EntityWithGizmo.qml
+++ b/meshroom/ui/qml/Viewer3D/EntityWithGizmo.qml
@@ -5,12 +5,19 @@ import Qt3D.Extras 2.10
 import QtQuick 2.9
 import Qt3D.Logic 2.0
 
+/**
+ * Wrapper for TransformGizmo.
+ * Must be instantiated to control an other entity.
+ * The goal is to instantiate the other entity inside this wrapper to gather the object and the gizmo.
+ * objectTranform is the component the other entity should use as a Transform.
+ */
+
 Entity {
     id: root
     property DefaultCameraController sceneCameraController
     property Layer frontLayerComponent
     property var window
-    property alias uniformScale: transformGizmo.uniformScale // by default, if not set, the value is: false
+    property alias uniformScale: transformGizmo.uniformScale // By default, if not set, the value is: false
     property TransformGizmo transformGizmo: TransformGizmo {
         id: transformGizmo
         camera: root.camera

--- a/meshroom/ui/qml/Viewer3D/EntityWithGizmo.qml
+++ b/meshroom/ui/qml/Viewer3D/EntityWithGizmo.qml
@@ -1,0 +1,32 @@
+import Qt3D.Core 2.0
+import Qt3D.Render 2.9
+import Qt3D.Input 2.0
+import Qt3D.Extras 2.10
+import QtQuick 2.9
+import Qt3D.Logic 2.0
+
+Entity {
+    id: root
+    property DefaultCameraController cameraController
+    property Layer frontLayerComponent
+
+    readonly property Camera camera : cameraController.camera
+    readonly property var windowSize: cameraController.windowSize
+    readonly property alias objectTransform : transformGizmo.objectTransform // The Transform the object should use
+    
+    signal pickedChanged(bool pressed)
+
+    onPickedChanged: {
+        cameraController.loseMouseFocus = pressed // Notify the camera if the transform takes/releases the focus
+    }
+
+    TransformGizmo {
+        id: transformGizmo
+        camera: root.camera
+        windowSize: root.windowSize
+        frontLayerComponent: root.frontLayerComponent
+        onPickedChanged: {
+            root.pickedChanged(pressed)
+        }
+    }
+}

--- a/meshroom/ui/qml/Viewer3D/EntityWithGizmo.qml
+++ b/meshroom/ui/qml/Viewer3D/EntityWithGizmo.qml
@@ -9,6 +9,7 @@ Entity {
     id: root
     property DefaultCameraController cameraController
     property Layer frontLayerComponent
+    property var window
 
     readonly property Camera camera : cameraController.camera
     readonly property var windowSize: cameraController.windowSize
@@ -25,6 +26,7 @@ Entity {
         camera: root.camera
         windowSize: root.windowSize
         frontLayerComponent: root.frontLayerComponent
+        window: root.window
         onPickedChanged: {
             root.pickedChanged(pressed)
         }

--- a/meshroom/ui/qml/Viewer3D/EntityWithGizmo.qml
+++ b/meshroom/ui/qml/Viewer3D/EntityWithGizmo.qml
@@ -14,8 +14,10 @@ Entity {
     readonly property Camera camera : cameraController.camera
     readonly property var windowSize: cameraController.windowSize
     readonly property alias objectTransform : transformGizmo.objectTransform // The Transform the object should use
+    readonly property alias updateTransformations: transformGizmo.updateTransformations // Function to update the transformations
     
     signal pickedChanged(bool pressed)
+    signal gizmoChanged(var translation, var rotation, var scale)
 
     onPickedChanged: {
         cameraController.loseMouseFocus = pressed // Notify the camera if the transform takes/releases the focus
@@ -29,6 +31,9 @@ Entity {
         window: root.window
         onPickedChanged: {
             root.pickedChanged(pressed)
+        }
+        onGizmoChanged: {
+            root.gizmoChanged(translation, rotation, scale)
         }
     }
 }

--- a/meshroom/ui/qml/Viewer3D/Inspector3D.qml
+++ b/meshroom/ui/qml/Viewer3D/Inspector3D.qml
@@ -284,19 +284,19 @@ FloatingPane {
                             }
                         }
 
-                        // Transform visibility (bbox for meshing)
+                        // BoundingBox visibility (if meshing node)
                         MaterialToolButton {
-                            visible: model.hasTransform
+                            visible: model.hasBoundingBox
                             enabled: model.visible
                             Layout.alignment: Qt.AlignTop
                             Layout.fillHeight: true
                             text: MaterialIcons.transform
                             font.pointSize: 10
-                            ToolTip.text: model.displayTransform ? "Hide BBox" : "Show BBox"
+                            ToolTip.text: model.displayBoundingBox ? "Hide BBox" : "Show BBox"
                             flat: true
-                            opacity: model.visible ? (model.displayTransform ? 1.0 : 0.6) : 0.6
+                            opacity: model.visible ? (model.displayBoundingBox ? 1.0 : 0.6) : 0.6
                             onClicked: {
-                                model.displayTransform = !model.displayTransform
+                                model.displayBoundingBox = !model.displayBoundingBox
                             }
                         }
 

--- a/meshroom/ui/qml/Viewer3D/Inspector3D.qml
+++ b/meshroom/ui/qml/Viewer3D/Inspector3D.qml
@@ -284,6 +284,22 @@ FloatingPane {
                             }
                         }
 
+                        // Transform visibility (bbox for meshing)
+                        MaterialToolButton {
+                            visible: model.hasTransform
+                            enabled: model.visible
+                            Layout.alignment: Qt.AlignTop
+                            Layout.fillHeight: true
+                            text: MaterialIcons.transform
+                            font.pointSize: 10
+                            ToolTip.text: model.displayTransform ? "Hide BBox" : "Show BBox"
+                            flat: true
+                            opacity: model.visible ? (model.displayTransform ? 1.0 : 0.6) : 0.6
+                            onClicked: {
+                                model.displayTransform = !model.displayTransform
+                            }
+                        }
+
                         // Media label and info
                         Item {
                             implicitHeight: childrenRect.height

--- a/meshroom/ui/qml/Viewer3D/Inspector3D.qml
+++ b/meshroom/ui/qml/Viewer3D/Inspector3D.qml
@@ -300,6 +300,22 @@ FloatingPane {
                             }
                         }
 
+                        // Transform visibility (if SfMTransform node)
+                        MaterialToolButton {
+                            visible: model.hasTransform
+                            enabled: model.visible
+                            Layout.alignment: Qt.AlignTop
+                            Layout.fillHeight: true
+                            text: MaterialIcons._3d_rotation
+                            font.pointSize: 10
+                            ToolTip.text: model.displayTransform ? "Hide Gizmo" : "Show Gizmo"
+                            flat: true
+                            opacity: model.visible ? (model.displayTransform ? 1.0 : 0.6) : 0.6
+                            onClicked: {
+                                model.displayTransform = !model.displayTransform
+                            }
+                        }
+
                         // Media label and info
                         Item {
                             implicitHeight: childrenRect.height

--- a/meshroom/ui/qml/Viewer3D/MediaLibrary.qml
+++ b/meshroom/ui/qml/Viewer3D/MediaLibrary.qml
@@ -277,6 +277,10 @@ Entity {
 
                 onCurrentSourceChanged: {
                     updateCacheAndModel(false)
+
+                    // Avoid the bounding box to disappear when we move it after a mesh already computed
+                    if(instantiatedEntity.hasBoundingBox && !currentSource)
+                        model.visible = true
                 }
 
                 onFinalSourceChanged: {

--- a/meshroom/ui/qml/Viewer3D/MediaLibrary.qml
+++ b/meshroom/ui/qml/Viewer3D/MediaLibrary.qml
@@ -217,7 +217,7 @@ Entity {
                 // To use only if we want to draw the input source and not the current node output (Warning: to use with caution)
                 // There is maybe a better way to do this to avoid overwritting bindings which should be readonly properties
                 function drawInputSource() {
-                    rawSource = Qt.binding(() => instantiatedEntity.currentNode.attribute("input").value)
+                    rawSource = Qt.binding(() => instantiatedEntity.currentNode ? instantiatedEntity.currentNode.attribute("input").value: "")
                     currentSource = Qt.binding(() => rawSource)
                     finalSource = Qt.binding(() => rawSource)
                 }

--- a/meshroom/ui/qml/Viewer3D/MediaLibrary.qml
+++ b/meshroom/ui/qml/Viewer3D/MediaLibrary.qml
@@ -206,10 +206,10 @@ Entity {
                     if(!attribute)
                         // if the node is removed, the attribute will be invalid
                         return false
-                    if(attribute.isOutput)
-                        return attribute.node.globalStatus === "SUCCESS"
-                    if(attribute.isLink)
-                        return attribute.linkParam.node.globalStatus === "SUCCESS"
+
+                    const rootAttribute = attribute.isLink ? attribute.rootLinkParam : attribute
+                    if(rootAttribute.isOutput)
+                        return rootAttribute.node.globalStatus === "SUCCESS"
                     return true // is an input param so no dependency
                 }
                 // source based on raw source + dependency status

--- a/meshroom/ui/qml/Viewer3D/MediaLibrary.qml
+++ b/meshroom/ui/qml/Viewer3D/MediaLibrary.qml
@@ -155,204 +155,220 @@ Entity {
         id: instantiator
         model: m.mediaModel
 
-        delegate: MediaLoader {
-            id: mediaLoader
+        delegate: Entity {
+            id: instantiatedEntity
+            property alias fullyInstantiated: mediaLoader.fullyInstantiated
+            readonly property alias modelSource: mediaLoader.modelSource
 
             // Get the node
             property var currentNode: model.attribute ? model.attribute.node : null
             property string nodeType: currentNode ? currentNode.nodeType: null
 
-            // Specific properties to the Meshing node (declared and initialized for every MediaLoader anyway)
+            // Specific properties to the MESHING node (declared and initialized for every Entity anyway)
             property bool hasBoundingBox: {
-                if(nodeType === "Meshing") { // Can have a BoundingBox 
-                    const value = currentNode.attribute("useBoundingBox") ? currentNode.attribute("useBoundingBox").value : false
-                    model.hasBoundingBox = value
-                    return value
-                }
+                if(nodeType === "Meshing" && currentNode.attribute("useBoundingBox")) // Can have a BoundingBox 
+                    return currentNode.attribute("useBoundingBox").value
                 return false
             }
+            onHasBoundingBoxChanged: model.hasBoundingBox = hasBoundingBox
             property bool displayBoundingBox: model.displayBoundingBox
 
-            // Specific properties to the SfMTransform node (declared and initialized for every MediaLoader anyway)
+            // Specific properties to the SFMTRANSFORM node (declared and initialized for every Entity anyway)
             property bool hasTransform: {
-                if(nodeType === "SfMTransform") { // Can have a Transform 
-                    const value = currentNode.attribute("method") ? currentNode.attribute("method").value === "manual" : false
-                    model.hasTransform = value
-                    return value
-                }
+                if(nodeType === "SfMTransform" && currentNode.attribute("method")) // Can have a Transform 
+                    return currentNode.attribute("method").value === "manual"
                 return false
             }
+            onHasTransformChanged: model.hasTransform = hasTransform
             property bool displayTransform: model.displayTransform
 
-            // whether MediaLoader has been fully instantiated by the NodeInstantiator
-            property bool fullyInstantiated: false
 
-            // explicitely store some attached model properties for outside use and ease binding
-            readonly property var attribute: model.attribute
-            readonly property int idx: index
-            readonly property var modelSource: attribute || model.source
-            readonly property bool visible: model.visible
+            // Create the media
+            MediaLoader {
+                id: mediaLoader
 
-            // multi-step binding to ensure MediaLoader source is properly
-            // updated when needed, whether raw source is valid or not
+                // whether MediaLoader has been fully instantiated by the NodeInstantiator
+                property bool fullyInstantiated: false
 
-            // raw source path
-            readonly property string rawSource: attribute ? attribute.value : model.source
-            // whether dependencies are statified (applies for output/connected input attributes only)
-            readonly property bool dependencyReady: {
-                if(attribute && attribute.isOutput)
-                    return attribute.node.globalStatus === "SUCCESS";
-                if(attribute && attribute.isLink)
-                    return attribute.linkParam.node.globalStatus === "SUCCESS";
-                return true;
-            }
-            // source based on raw source + dependency status
-            readonly property string currentSource: dependencyReady ? rawSource : ""
-            // source based on currentSource + "requested" property
-            readonly property string finalSource: model.requested ? currentSource : ""
+                // explicitely store some attached model properties for outside use and ease binding
+                readonly property var attribute: model.attribute
+                readonly property int idx: index
+                readonly property var modelSource: attribute || model.source
+                readonly property bool visible: model.visible
 
-            camera: root.camera
-            renderMode: root.renderMode
-            enabled: visible
+                // multi-step binding to ensure MediaLoader source is properly
+                // updated when needed, whether raw source is valid or not
 
-            // QObject.destroyed signal is not accessible
-            // Use the object as NodeInstantiator model to be notified of its deletion
-            NodeInstantiator {
-                model: attribute
-                delegate: Entity { objectName: "DestructionWatcher [" + attribute.toString() + "]" }
-                onObjectRemoved: remove(idx)
-            }
-
-            // BoundingBox: display bounding box for MESHING computation
-            // note: use a NodeInstantiator to evaluate if the current node is a MESHING node and if the checkbox is active
-            NodeInstantiator {
-                id: boundingBoxInstantiator
-                property var currentNode: mediaLoader.currentNode
-                active: mediaLoader.hasBoundingBox
-                model: 1
-
-                MeshingBoundingBox {
-                    sceneCameraController: root.sceneCameraController
-                    frontLayerComponent: root.frontLayerComponent
-                    window: root.window
-                    currentMeshingNode: boundingBoxInstantiator.currentNode
-                    enabled: mediaLoader.displayBoundingBox
+                // raw source path
+                property string rawSource: attribute ? attribute.value : model.source
+                // whether dependencies are statified (applies for output/connected input attributes only)
+                readonly property bool dependencyReady: {
+                    if(attribute && attribute.isOutput)
+                        return attribute.node.globalStatus === "SUCCESS";
+                    if(attribute && attribute.isLink)
+                        return attribute.linkParam.node.globalStatus === "SUCCESS";
+                    return true;
                 }
+                // source based on raw source + dependency status
+                property string currentSource: dependencyReady ? rawSource : ""
+                // source based on currentSource + "requested" property
+                property string finalSource: model.requested ? currentSource : ""
+
+                // To use only if we want to draw the input source and not the current node output (Warning: to use with caution)
+                // There is maybe a better way to do this to avoid overwritting bindings which should be readonly properties
+                function drawInputSource() {
+                    rawSource = Qt.binding(() => instantiatedEntity.currentNode.attribute("input").value)
+                    currentSource = Qt.binding(() => rawSource)
+                    finalSource = Qt.binding(() => rawSource)
+                }
+
+                camera: root.camera
+                renderMode: root.renderMode
+                enabled: visible
+
+                // QObject.destroyed signal is not accessible
+                // Use the object as NodeInstantiator model to be notified of its deletion
+                NodeInstantiator {
+                    model: attribute
+                    delegate: Entity { objectName: "DestructionWatcher [" + attribute.toString() + "]" }
+                    onObjectRemoved: remove(idx)
+                }
+
+                // 'visible' property drives media loading request
+                onVisibleChanged: {
+                    // always request media loading if visible
+                    if(model.visible)
+                        model.requested = true;
+                    // only cancel loading request if media is not valid
+                    // (a media won't be unloaded if already loaded, only hidden)
+                    else if(!model.valid)
+                        model.requested = false;
+                }
+
+                function updateCacheAndModel(forceRequest) {
+                    // don't cache explicitely unloaded media
+                    if(model.requested && object && dependencyReady) {
+                        // cache current object
+                        if(cache.add(Filepath.urlToString(mediaLoader.source), object));
+                            object = null;
+                    }
+                    updateModel(forceRequest);
+                }
+
+                function updateModel(forceRequest) {
+                    // update model's source path if input is an attribute
+                    if(attribute) {
+                        model.source = rawSource;
+                    }
+                    // auto-restore entity if raw source is in cache
+                    model.requested = forceRequest || (!model.valid && model.requested) || cache.contains(rawSource);
+                    model.valid = Filepath.exists(rawSource) && dependencyReady;
+                }
+
+                Component.onCompleted: {
+                    // keep 'source' -> 'entity' reference
+                    m.sourceToEntity[modelSource] = mediaLoader;
+                    // always request media loading when delegate has been created
+                    updateModel(true);
+                    // if external media failed to open, remove element from model
+                    if(!attribute && !object)
+                        remove(index)
+                }
+
+                onCurrentSourceChanged: {
+                    updateCacheAndModel(false)
+                }
+
+                onFinalSourceChanged: {
+                    // update media visibility
+                    // (useful if media was explicitly unloaded or hidden but loaded back from cache)
+                    model.visible = model.requested;
+
+                    var cachedObject = cache.pop(rawSource);
+                    cached = cachedObject !== undefined;
+                    if(cached) {
+                        object = cachedObject;
+                        // only change cached object parent if mediaLoader has been fully instantiated
+                        // by the NodeInstantiator; otherwise re-parenting will fail silently and the object will disappear...
+                        // see "onFullyInstantiatedChanged" and parent NodeInstantiator's "onObjectAdded"
+                        if(fullyInstantiated) {
+                            object.parent = mediaLoader;
+                        }
+                    }
+                    mediaLoader.source = Filepath.stringToUrl(finalSource);
+                    if(object) {
+                        // bind media info to corresponding model roles
+                        // (test for object validity to avoid error messages right after object has been deleted)
+                        var boundProperties = ["vertexCount", "faceCount", "cameraCount", "textureCount"];
+                        boundProperties.forEach( function(prop){
+                            model[prop] = Qt.binding(function() { return object ? object[prop] : 0; });
+                        })
+                    }
+                    else if(finalSource) {
+                        // source was valid but no loader was created, remove element
+                        remove(index);
+                    }
+                }
+
+                onFullyInstantiatedChanged: {
+                    // delayed reparenting of object coming from the cache
+                    if(object)
+                        object.parent = mediaLoader;
+                }
+
+                onStatusChanged: {
+                    model.status = status
+                    // remove model entry for external media that failed to load
+                    if(status === SceneLoader.Error && !model.attribute)
+                        remove(index);
+                }
+
+                components: [
+                    ObjectPicker {
+                        enabled: mediaLoader.enabled && pickingEnabled
+                        hoverEnabled: false
+                        onPressed: root.pressed(pick)
+                    }
+                ]
             }
 
             // Transform: display a TransformGizmo for SfMTransform node only
             // note: use a NodeInstantiator to evaluate if the current node is a SfMTransform node and if the transform mode is set to Manual
             NodeInstantiator {
                 id: sfmTransformGizmoInstantiator
-                property var currentNode: mediaLoader.currentNode
-                active: mediaLoader.hasTransform
+                active: instantiatedEntity.hasTransform
                 model: 1
 
                 SfMTransformGizmo {
+                    id: sfmTransformGizmoEntity
                     sceneCameraController: root.sceneCameraController
                     frontLayerComponent: root.frontLayerComponent
                     window: root.window
-                    currentSfMTransformNode: sfmTransformGizmoInstantiator.currentNode
-                    enabled: mediaLoader.displayTransform
-                }
-            }
+                    currentSfMTransformNode: instantiatedEntity.currentNode
+                    enabled: mediaLoader.visible && instantiatedEntity.displayTransform
 
-            // 'visible' property drives media loading request
-            onVisibleChanged: {
-                // always request media loading if visible
-                if(model.visible)
-                    model.requested = true;
-                // only cancel loading request if media is not valid
-                // (a media won't be unloaded if already loaded, only hidden)
-                else if(!model.valid)
-                    model.requested = false;
-            }
-
-            function updateCacheAndModel(forceRequest) {
-                // don't cache explicitely unloaded media
-                if(model.requested && object && dependencyReady) {
-                    // cache current object
-                    if(cache.add(Filepath.urlToString(mediaLoader.source), object));
-                        object = null;
-                }
-                updateModel(forceRequest);
-            }
-
-            function updateModel(forceRequest) {
-                // update model's source path if input is an attribute
-                if(attribute) {
-                    model.source = rawSource;
-                }
-                // auto-restore entity if raw source is in cache
-                model.requested = forceRequest || (!model.valid && model.requested) || cache.contains(rawSource);
-                model.valid = Filepath.exists(rawSource) && dependencyReady;
-            }
-
-            Component.onCompleted: {
-                // keep 'source' -> 'entity' reference
-                m.sourceToEntity[modelSource] = mediaLoader;
-                // always request media loading when delegate has been created
-                updateModel(true);
-                // if external media failed to open, remove element from model
-                if(!attribute && !object)
-                    remove(index)
-            }
-
-            onCurrentSourceChanged: {
-                updateCacheAndModel(false)
-            }
-
-            onFinalSourceChanged: {
-                // update media visibility
-                // (useful if media was explicitly unloaded or hidden but loaded back from cache)
-                model.visible = model.requested;
-
-                var cachedObject = cache.pop(rawSource);
-                cached = cachedObject !== undefined;
-                if(cached) {
-                    object = cachedObject;
-                    // only change cached object parent if mediaLoader has been fully instantiated
-                    // by the NodeInstantiator; otherwise re-parenting will fail silently and the object will disappear...
-                    // see "onFullyInstantiatedChanged" and parent NodeInstantiator's "onObjectAdded"
-                    if(fullyInstantiated) {
-                        object.parent = mediaLoader;
+                    Component.onCompleted: {
+                        mediaLoader.drawInputSource() // Because we are sure we want to show the input in MANUAL mode only
+                        Scene3DHelper.addComponent(mediaLoader, sfmTransformGizmoEntity.objectTransform) // Add the transform to the media to see real-time transformations
                     }
                 }
-                mediaLoader.source = Filepath.stringToUrl(finalSource);
-                if(object) {
-                    // bind media info to corresponding model roles
-                    // (test for object validity to avoid error messages right after object has been deleted)
-                    var boundProperties = ["vertexCount", "faceCount", "cameraCount", "textureCount"];
-                    boundProperties.forEach( function(prop){
-                        model[prop] = Qt.binding(function() { return object ? object[prop] : 0; });
-                    })
-                }
-                else if(finalSource) {
-                    // source was valid but no loader was created, remove element
-                    remove(index);
-                }
             }
 
-            onFullyInstantiatedChanged: {
-                // delayed reparenting of object coming from the cache
-                if(object)
-                    object.parent = mediaLoader;
-            }
+            // BoundingBox: display bounding box for MESHING computation
+            // note: use a NodeInstantiator to evaluate if the current node is a MESHING node and if the checkbox is active
+            NodeInstantiator {
+                id: boundingBoxInstantiator
+                active: instantiatedEntity.hasBoundingBox
+                model: 1
 
-            onStatusChanged: {
-                model.status = status
-                // remove model entry for external media that failed to load
-                if(status === SceneLoader.Error && !model.attribute)
-                    remove(index);
-            }
-
-            components: [
-                ObjectPicker {
-                    enabled: mediaLoader.enabled && pickingEnabled
-                    hoverEnabled: false
-                    onPressed: root.pressed(pick)
+                MeshingBoundingBox {
+                    sceneCameraController: root.sceneCameraController
+                    frontLayerComponent: root.frontLayerComponent
+                    window: root.window
+                    currentMeshingNode: instantiatedEntity.currentNode
+                    enabled: mediaLoader.visible && instantiatedEntity.displayBoundingBox
                 }
-            ]
+            }
         }
 
         onObjectAdded: {

--- a/meshroom/ui/qml/Viewer3D/MediaLibrary.qml
+++ b/meshroom/ui/qml/Viewer3D/MediaLibrary.qml
@@ -317,9 +317,10 @@ Entity {
                             model[prop] = Qt.binding(function() { return object ? object[prop] : 0; });
                         })
                     }
-                    else if(finalSource) {
+                    else if(finalSource && status === Component.Ready) {
                         // source was valid but no loader was created, remove element
-                        remove(index);
+                        // check if component is ready to avoid removing element from the model before adding instance to the node
+                        remove(index)
                     }
                 }
 

--- a/meshroom/ui/qml/Viewer3D/MediaLibrary.qml
+++ b/meshroom/ui/qml/Viewer3D/MediaLibrary.qml
@@ -246,7 +246,7 @@ Entity {
                 }
 
                 function updateCacheAndModel(forceRequest) {
-                    // don't cache explicitely unloaded media
+                    // don't cache explicitly unloaded media
                     if(model.requested && object && dependencyReady) {
                         // cache current object
                         if(cache.add(Filepath.urlToString(mediaLoader.source), object));

--- a/meshroom/ui/qml/Viewer3D/MediaLibrary.qml
+++ b/meshroom/ui/qml/Viewer3D/MediaLibrary.qml
@@ -48,6 +48,8 @@ Entity {
             "visible": true,
             "hasBoundingBox": false, // for Meshing node only
             "displayBoundingBox": true, // for Meshing node only
+            "hasTransform": false, // for SfMTransform node only
+            "displayTransform": true, // for SfMTransform node only
             "section": "",
             "attribute": null,
             "entity": null,
@@ -160,7 +162,7 @@ Entity {
             property var currentNode: model.attribute ? model.attribute.node : null
             property string nodeType: currentNode ? currentNode.nodeType: null
 
-            // Specific properties to the Meshing node (declared and initialiazed for every MediaLoader anyway)
+            // Specific properties to the Meshing node (declared and initialized for every MediaLoader anyway)
             property bool hasBoundingBox: {
                 if(nodeType === "Meshing") { // Can have a BoundingBox 
                     const value = currentNode.attribute("useBoundingBox") ? currentNode.attribute("useBoundingBox").value : false
@@ -170,6 +172,17 @@ Entity {
                 return false
             }
             property bool displayBoundingBox: model.displayBoundingBox
+
+            // Specific properties to the SfMTransform node (declared and initialized for every MediaLoader anyway)
+            property bool hasTransform: {
+                if(nodeType === "SfMTransform") { // Can have a Transform 
+                    const value = currentNode.attribute("method") ? currentNode.attribute("method").value === "manual" : false
+                    model.hasTransform = value
+                    return value
+                }
+                return false
+            }
+            property bool displayTransform: model.displayTransform
 
             // whether MediaLoader has been fully instantiated by the NodeInstantiator
             property bool fullyInstantiated: false
@@ -224,6 +237,23 @@ Entity {
                     window: root.window
                     currentMeshingNode: boundingBoxInstantiator.currentNode
                     enabled: mediaLoader.displayBoundingBox
+                }
+            }
+
+            // Transform: display a TransformGizmo for SfMTransform node only
+            // note: use a NodeInstantiator to evaluate if the current node is a SfMTransform node and if the transform mode is set to Manual
+            NodeInstantiator {
+                id: sfmTransformGizmoInstantiator
+                property var currentNode: mediaLoader.currentNode
+                active: mediaLoader.hasTransform
+                model: 1
+
+                SfMTransformGizmo {
+                    sceneCameraController: root.sceneCameraController
+                    frontLayerComponent: root.frontLayerComponent
+                    window: root.window
+                    currentSfMTransformNode: sfmTransformGizmoInstantiator.currentNode
+                    enabled: mediaLoader.displayTransform
                 }
             }
 

--- a/meshroom/ui/qml/Viewer3D/MediaLoader.qml
+++ b/meshroom/ui/qml/Viewer3D/MediaLoader.qml
@@ -31,7 +31,7 @@ import Utils 1.0
             return;
         }
 
-        // clear previously created objet if any
+        // clear previously created object if any
         if(object) {
             object.destroy();
             object = null;

--- a/meshroom/ui/qml/Viewer3D/MeshingBoundingBox.qml
+++ b/meshroom/ui/qml/Viewer3D/MeshingBoundingBox.qml
@@ -18,22 +18,45 @@ Entity {
         frontLayerComponent: root.frontLayerComponent
         window: root.window
 
-        // Update node meshing slider values when the gizmo has changed: translation, rotation, scale
+        // Update node meshing slider values when the gizmo has changed: translation, rotation, scale, type
         transformGizmo.onGizmoChanged: {
-            _reconstruction.setAttribute(root.currentMeshingNode.attribute("boundingBox.bboxTranslation.x"), translation.x)
-            _reconstruction.setAttribute(root.currentMeshingNode.attribute("boundingBox.bboxTranslation.y"), translation.y)
-            _reconstruction.setAttribute(root.currentMeshingNode.attribute("boundingBox.bboxTranslation.z"), translation.z)
-
-            _reconstruction.setAttribute(root.currentMeshingNode.attribute("boundingBox.bboxRotation.x"), rotation.x)
-            _reconstruction.setAttribute(root.currentMeshingNode.attribute("boundingBox.bboxRotation.y"), rotation.y)
-            _reconstruction.setAttribute(root.currentMeshingNode.attribute("boundingBox.bboxRotation.z"), rotation.z)
-
-            _reconstruction.setAttribute(root.currentMeshingNode.attribute("boundingBox.bboxScale.x"), scale.x)
-            _reconstruction.setAttribute(root.currentMeshingNode.attribute("boundingBox.bboxScale.y"), scale.y)
-            _reconstruction.setAttribute(root.currentMeshingNode.attribute("boundingBox.bboxScale.z"), scale.z)
+            switch(type) {
+                case TransformGizmo.Type.TRANSLATION: {
+                    _reconstruction.setAttribute(
+                        root.currentMeshingNode.attribute("boundingBox.bboxTranslation"),
+                        JSON.stringify([translation.x, translation.y, translation.z])
+                    )
+                    break
+                }
+                case TransformGizmo.Type.ROTATION: {
+                    _reconstruction.setAttribute(
+                        root.currentMeshingNode.attribute("boundingBox.bboxRotation"),
+                        JSON.stringify([rotation.x, rotation.y, rotation.z])
+                    )
+                    break
+                }
+                case TransformGizmo.Type.SCALE: {
+                    _reconstruction.setAttribute(
+                        root.currentMeshingNode.attribute("boundingBox.bboxScale"),
+                        JSON.stringify([scale.x, scale.y, scale.z])
+                    )
+                    break
+                }
+                case TransformGizmo.Type.ALL: {
+                    _reconstruction.setAttribute(
+                        root.currentMeshingNode.attribute("boundingBox"),
+                        JSON.stringify([
+                            [translation.x, translation.y, translation.z],
+                            [rotation.x, rotation.y, rotation.z],
+                            [scale.x, scale.y, scale.z]
+                        ])
+                    )
+                    break
+                }
+            }
         }
 
-        // Automatically evalutate the Transform: value is taken from the node OR from the actual modification if the gizmo is moved by mouse.
+        // Automatically evaluate the Transform: value is taken from the node OR from the actual modification if the gizmo is moved by mouse.
         // When the gizmo has changed (with mouse), the new values are set to the node, the priority is given back to the node and the Transform is re-evaluated once with those values.
         property var nodeTranslation : Qt.vector3d(
             root.currentMeshingNode.attribute("boundingBox.bboxTranslation.x").value,

--- a/meshroom/ui/qml/Viewer3D/MeshingBoundingBox.qml
+++ b/meshroom/ui/qml/Viewer3D/MeshingBoundingBox.qml
@@ -1,0 +1,61 @@
+import Qt3D.Core 2.0
+import Qt3D.Render 2.9
+import Qt3D.Input 2.0
+import Qt3D.Extras 2.10
+import QtQuick 2.9
+
+Entity {
+    id: root
+    property DefaultCameraController sceneCameraController
+    property Layer frontLayerComponent
+    property var window
+    property var currentMeshingNode: null
+    enabled: true
+
+    EntityWithGizmo {
+        id: boundingBoxEntity
+        sceneCameraController: root.sceneCameraController
+        frontLayerComponent: root.frontLayerComponent
+        window: root.window
+
+        // Update node meshing slider values when the gizmo has changed: translation, rotation, scale
+        transformGizmo.onGizmoChanged: {
+            _reconstruction.setAttribute(root.currentMeshingNode.attribute("boundingBox.bboxTranslation.x"), translation.x)
+            _reconstruction.setAttribute(root.currentMeshingNode.attribute("boundingBox.bboxTranslation.y"), translation.y)
+            _reconstruction.setAttribute(root.currentMeshingNode.attribute("boundingBox.bboxTranslation.z"), translation.z)
+
+            _reconstruction.setAttribute(root.currentMeshingNode.attribute("boundingBox.bboxRotation.x"), rotation.x)
+            _reconstruction.setAttribute(root.currentMeshingNode.attribute("boundingBox.bboxRotation.y"), rotation.y)
+            _reconstruction.setAttribute(root.currentMeshingNode.attribute("boundingBox.bboxRotation.z"), rotation.z)
+
+            _reconstruction.setAttribute(root.currentMeshingNode.attribute("boundingBox.bboxScale.x"), scale.x)
+            _reconstruction.setAttribute(root.currentMeshingNode.attribute("boundingBox.bboxScale.y"), scale.y)
+            _reconstruction.setAttribute(root.currentMeshingNode.attribute("boundingBox.bboxScale.z"), scale.z)
+        }
+
+        // Automatically evalutate the Transform: value is taken from the node OR from the actual modification if the gizmo is moved by mouse.
+        // When the gizmo has changed (with mouse), the new values are set to the node, the priority is given back to the node and the Transform is re-evaluated once with those values.
+        property var nodeTranslation : Qt.vector3d(
+            root.currentMeshingNode.attribute("boundingBox.bboxTranslation.x").value,
+            root.currentMeshingNode.attribute("boundingBox.bboxTranslation.y").value,
+            root.currentMeshingNode.attribute("boundingBox.bboxTranslation.z").value
+        )
+        property var nodeRotationX: root.currentMeshingNode.attribute("boundingBox.bboxRotation.x").value
+        property var nodeRotationY: root.currentMeshingNode.attribute("boundingBox.bboxRotation.y").value
+        property var nodeRotationZ: root.currentMeshingNode.attribute("boundingBox.bboxRotation.z").value
+        property var nodeScale: Qt.vector3d(
+            root.currentMeshingNode.attribute("boundingBox.bboxScale.x").value,
+            root.currentMeshingNode.attribute("boundingBox.bboxScale.y").value,
+            root.currentMeshingNode.attribute("boundingBox.bboxScale.z").value
+        )
+
+        transformGizmo.gizmoDisplayTransform.translation: transformGizmo.focusGizmoPriority ? transformGizmo.gizmoDisplayTransform.translation : nodeTranslation
+        transformGizmo.gizmoDisplayTransform.rotationX: transformGizmo.focusGizmoPriority ? transformGizmo.gizmoDisplayTransform.rotationX : nodeRotationX
+        transformGizmo.gizmoDisplayTransform.rotationY: transformGizmo.focusGizmoPriority ? transformGizmo.gizmoDisplayTransform.rotationY : nodeRotationY
+        transformGizmo.gizmoDisplayTransform.rotationZ: transformGizmo.focusGizmoPriority ? transformGizmo.gizmoDisplayTransform.rotationZ : nodeRotationZ
+        transformGizmo.objectTransform.scale3D: transformGizmo.focusGizmoPriority ? transformGizmo.objectTransform.scale3D : nodeScale
+
+        // The entity
+        BoundingBox { transform: boundingBoxEntity.objectTransform }
+    }
+}

--- a/meshroom/ui/qml/Viewer3D/MeshingBoundingBox.qml
+++ b/meshroom/ui/qml/Viewer3D/MeshingBoundingBox.qml
@@ -62,19 +62,19 @@ Entity {
 
         // Translation values from node (vector3d because this is the type of QTransform.translation)
         property var nodeTranslation : Qt.vector3d(
-            root.currentMeshingNode.attribute("boundingBox.bboxTranslation.x").value,
-            root.currentMeshingNode.attribute("boundingBox.bboxTranslation.y").value,
-            root.currentMeshingNode.attribute("boundingBox.bboxTranslation.z").value
+            root.currentMeshingNode ? root.currentMeshingNode.attribute("boundingBox.bboxTranslation.x").value : 0,
+            root.currentMeshingNode ? root.currentMeshingNode.attribute("boundingBox.bboxTranslation.y").value : 0,
+            root.currentMeshingNode ? root.currentMeshingNode.attribute("boundingBox.bboxTranslation.z").value : 0
         )
         // Rotation values from node (3 separated values because QTransform stores Euler angles like this)
-        property var nodeRotationX: root.currentMeshingNode.attribute("boundingBox.bboxRotation.x").value
-        property var nodeRotationY: root.currentMeshingNode.attribute("boundingBox.bboxRotation.y").value
-        property var nodeRotationZ: root.currentMeshingNode.attribute("boundingBox.bboxRotation.z").value
+        property var nodeRotationX: root.currentMeshingNode ? root.currentMeshingNode.attribute("boundingBox.bboxRotation.x").value : 0
+        property var nodeRotationY: root.currentMeshingNode ? root.currentMeshingNode.attribute("boundingBox.bboxRotation.y").value : 0
+        property var nodeRotationZ: root.currentMeshingNode ? root.currentMeshingNode.attribute("boundingBox.bboxRotation.z").value : 0
         // Scale values from node (vector3d because this is the type of QTransform.scale3D)
         property var nodeScale: Qt.vector3d(
-            root.currentMeshingNode.attribute("boundingBox.bboxScale.x").value,
-            root.currentMeshingNode.attribute("boundingBox.bboxScale.y").value,
-            root.currentMeshingNode.attribute("boundingBox.bboxScale.z").value
+            root.currentMeshingNode ? root.currentMeshingNode.attribute("boundingBox.bboxScale.x").value : 1,
+            root.currentMeshingNode ? root.currentMeshingNode.attribute("boundingBox.bboxScale.y").value : 1,
+            root.currentMeshingNode ? root.currentMeshingNode.attribute("boundingBox.bboxScale.z").value : 1
         )
 
         // Automatically evaluate the Transform: value is taken from the node OR from the actual modification if the gizmo is moved by mouse.

--- a/meshroom/ui/qml/Viewer3D/MeshingBoundingBox.qml
+++ b/meshroom/ui/qml/Viewer3D/MeshingBoundingBox.qml
@@ -4,6 +4,10 @@ import Qt3D.Input 2.0
 import Qt3D.Extras 2.10
 import QtQuick 2.9
 
+/**
+ * BoundingBox entity for Meshing node. Used to define the area to reconstruct.
+ * Simple box controlled by a gizmo to give easy and visual representation.
+ */
 Entity {
     id: root
     property DefaultCameraController sceneCameraController
@@ -56,22 +60,25 @@ Entity {
             }
         }
 
-        // Automatically evaluate the Transform: value is taken from the node OR from the actual modification if the gizmo is moved by mouse.
-        // When the gizmo has changed (with mouse), the new values are set to the node, the priority is given back to the node and the Transform is re-evaluated once with those values.
+        // Translation values from node (vector3d because this is the type of QTransform.translation)
         property var nodeTranslation : Qt.vector3d(
             root.currentMeshingNode.attribute("boundingBox.bboxTranslation.x").value,
             root.currentMeshingNode.attribute("boundingBox.bboxTranslation.y").value,
             root.currentMeshingNode.attribute("boundingBox.bboxTranslation.z").value
         )
+        // Rotation values from node (3 separated values because QTransform stores Euler angles like this)
         property var nodeRotationX: root.currentMeshingNode.attribute("boundingBox.bboxRotation.x").value
         property var nodeRotationY: root.currentMeshingNode.attribute("boundingBox.bboxRotation.y").value
         property var nodeRotationZ: root.currentMeshingNode.attribute("boundingBox.bboxRotation.z").value
+        // Scale values from node (vector3d because this is the type of QTransform.scale3D)
         property var nodeScale: Qt.vector3d(
             root.currentMeshingNode.attribute("boundingBox.bboxScale.x").value,
             root.currentMeshingNode.attribute("boundingBox.bboxScale.y").value,
             root.currentMeshingNode.attribute("boundingBox.bboxScale.z").value
         )
 
+        // Automatically evaluate the Transform: value is taken from the node OR from the actual modification if the gizmo is moved by mouse.
+        // When the gizmo has changed (with mouse), the new values are set to the node, the priority is given back to the node and the Transform is re-evaluated once with those values.
         transformGizmo.gizmoDisplayTransform.translation: transformGizmo.focusGizmoPriority ? transformGizmo.gizmoDisplayTransform.translation : nodeTranslation
         transformGizmo.gizmoDisplayTransform.rotationX: transformGizmo.focusGizmoPriority ? transformGizmo.gizmoDisplayTransform.rotationX : nodeRotationX
         transformGizmo.gizmoDisplayTransform.rotationY: transformGizmo.focusGizmoPriority ? transformGizmo.gizmoDisplayTransform.rotationY : nodeRotationY

--- a/meshroom/ui/qml/Viewer3D/SfMTransformGizmo.qml
+++ b/meshroom/ui/qml/Viewer3D/SfMTransformGizmo.qml
@@ -11,8 +11,11 @@ Entity {
     property var window
     property var currentSfMTransformNode: null
     enabled: true
+    
+    readonly property alias objectTransform: sfmTranformGizmoEntity.objectTransform // The Transform the object should use
 
     EntityWithGizmo {
+        id: sfmTranformGizmoEntity
         sceneCameraController: root.sceneCameraController
         frontLayerComponent: root.frontLayerComponent
         window: root.window

--- a/meshroom/ui/qml/Viewer3D/SfMTransformGizmo.qml
+++ b/meshroom/ui/qml/Viewer3D/SfMTransformGizmo.qml
@@ -66,16 +66,16 @@ Entity {
 
         // Translation values from node (vector3d because this is the type of QTransform.translation)
         property var nodeTranslation : Qt.vector3d(
-            root.currentSfMTransformNode.attribute("manualTransform.manualTranslation.x").value,
-            root.currentSfMTransformNode.attribute("manualTransform.manualTranslation.y").value,
-            root.currentSfMTransformNode.attribute("manualTransform.manualTranslation.z").value
+            root.currentSfMTransformNode ? root.currentSfMTransformNode.attribute("manualTransform.manualTranslation.x").value : 0,
+            root.currentSfMTransformNode ? root.currentSfMTransformNode.attribute("manualTransform.manualTranslation.y").value : 0,
+            root.currentSfMTransformNode ? root.currentSfMTransformNode.attribute("manualTransform.manualTranslation.z").value : 0
         )
         // Rotation values from node (3 separated values because QTransform stores Euler angles like this)
-        property var nodeRotationX: root.currentSfMTransformNode.attribute("manualTransform.manualRotation.x").value
-        property var nodeRotationY: root.currentSfMTransformNode.attribute("manualTransform.manualRotation.y").value
-        property var nodeRotationZ: root.currentSfMTransformNode.attribute("manualTransform.manualRotation.z").value
+        property var nodeRotationX: root.currentSfMTransformNode ? root.currentSfMTransformNode.attribute("manualTransform.manualRotation.x").value : 0
+        property var nodeRotationY: root.currentSfMTransformNode ? root.currentSfMTransformNode.attribute("manualTransform.manualRotation.y").value : 0
+        property var nodeRotationZ: root.currentSfMTransformNode ? root.currentSfMTransformNode.attribute("manualTransform.manualRotation.z").value : 0
         // Scale value from node (simple number because we use uniform scale)
-        property var nodeScale: root.currentSfMTransformNode.attribute("manualTransform.manualScale").value
+        property var nodeScale: root.currentSfMTransformNode ? root.currentSfMTransformNode.attribute("manualTransform.manualScale").value : 1
 
         // Automatically evaluate the Transform: value is taken from the node OR from the actual modification if the gizmo is moved by mouse.
         // When the gizmo has changed (with mouse), the new values are set to the node, the priority is given back to the node and the Transform is re-evaluated once with those values.

--- a/meshroom/ui/qml/Viewer3D/SfMTransformGizmo.qml
+++ b/meshroom/ui/qml/Viewer3D/SfMTransformGizmo.qml
@@ -23,29 +23,29 @@ Entity {
 
         // Update node SfMTransform slider values when the gizmo has changed: translation, rotation, scale
         transformGizmo.onGizmoChanged: {
-            _reconstruction.setAttribute(root.currentSfMTransformNode.attribute("transformGizmo.gizmoTranslation.x"), translation.x)
-            _reconstruction.setAttribute(root.currentSfMTransformNode.attribute("transformGizmo.gizmoTranslation.y"), translation.y)
-            _reconstruction.setAttribute(root.currentSfMTransformNode.attribute("transformGizmo.gizmoTranslation.z"), translation.z)
+            _reconstruction.setAttribute(root.currentSfMTransformNode.attribute("manualTransform.manualTranslation.x"), translation.x)
+            _reconstruction.setAttribute(root.currentSfMTransformNode.attribute("manualTransform.manualTranslation.y"), translation.y)
+            _reconstruction.setAttribute(root.currentSfMTransformNode.attribute("manualTransform.manualTranslation.z"), translation.z)
 
-            _reconstruction.setAttribute(root.currentSfMTransformNode.attribute("transformGizmo.gizmoRotation.x"), rotation.x)
-            _reconstruction.setAttribute(root.currentSfMTransformNode.attribute("transformGizmo.gizmoRotation.y"), rotation.y)
-            _reconstruction.setAttribute(root.currentSfMTransformNode.attribute("transformGizmo.gizmoRotation.z"), rotation.z)
+            _reconstruction.setAttribute(root.currentSfMTransformNode.attribute("manualTransform.manualRotation.x"), rotation.x)
+            _reconstruction.setAttribute(root.currentSfMTransformNode.attribute("manualTransform.manualRotation.y"), rotation.y)
+            _reconstruction.setAttribute(root.currentSfMTransformNode.attribute("manualTransform.manualRotation.z"), rotation.z)
 
             // Only one scale is needed since the scale is uniform
-            _reconstruction.setAttribute(root.currentSfMTransformNode.attribute("transformGizmo.gizmoScale"), scale.x)
+            _reconstruction.setAttribute(root.currentSfMTransformNode.attribute("manualTransform.manualScale"), scale.x)
         }
 
         // Automatically evalutate the Transform: value is taken from the node OR from the actual modification if the gizmo is moved by mouse.
         // When the gizmo has changed (with mouse), the new values are set to the node, the priority is given back to the node and the Transform is re-evaluated once with those values.
         property var nodeTranslation : Qt.vector3d(
-            root.currentSfMTransformNode.attribute("transformGizmo.gizmoTranslation.x").value,
-            root.currentSfMTransformNode.attribute("transformGizmo.gizmoTranslation.y").value,
-            root.currentSfMTransformNode.attribute("transformGizmo.gizmoTranslation.z").value
+            root.currentSfMTransformNode.attribute("manualTransform.manualTranslation.x").value,
+            root.currentSfMTransformNode.attribute("manualTransform.manualTranslation.y").value,
+            root.currentSfMTransformNode.attribute("manualTransform.manualTranslation.z").value
         )
-        property var nodeRotationX: root.currentSfMTransformNode.attribute("transformGizmo.gizmoRotation.x").value
-        property var nodeRotationY: root.currentSfMTransformNode.attribute("transformGizmo.gizmoRotation.y").value
-        property var nodeRotationZ: root.currentSfMTransformNode.attribute("transformGizmo.gizmoRotation.z").value
-        property var nodeScale: root.currentSfMTransformNode.attribute("transformGizmo.gizmoScale").value
+        property var nodeRotationX: root.currentSfMTransformNode.attribute("manualTransform.manualRotation.x").value
+        property var nodeRotationY: root.currentSfMTransformNode.attribute("manualTransform.manualRotation.y").value
+        property var nodeRotationZ: root.currentSfMTransformNode.attribute("manualTransform.manualRotation.z").value
+        property var nodeScale: root.currentSfMTransformNode.attribute("manualTransform.manualScale").value
 
         transformGizmo.gizmoDisplayTransform.translation: transformGizmo.focusGizmoPriority ? transformGizmo.gizmoDisplayTransform.translation : nodeTranslation
         transformGizmo.gizmoDisplayTransform.rotationX: transformGizmo.focusGizmoPriority ? transformGizmo.gizmoDisplayTransform.rotationX : nodeRotationX

--- a/meshroom/ui/qml/Viewer3D/SfMTransformGizmo.qml
+++ b/meshroom/ui/qml/Viewer3D/SfMTransformGizmo.qml
@@ -4,6 +4,10 @@ import Qt3D.Input 2.0
 import Qt3D.Extras 2.10
 import QtQuick 2.9
 
+/**
+ * Gizmo for SfMTransform node.
+ * Uses EntityWithGizmo wrapper because we should not instantiate TransformGizmo alone.
+ */
 Entity {
     id: root
     property DefaultCameraController sceneCameraController
@@ -60,18 +64,21 @@ Entity {
             }
         }
 
-        // Automatically evaluate the Transform: value is taken from the node OR from the actual modification if the gizmo is moved by mouse.
-        // When the gizmo has changed (with mouse), the new values are set to the node, the priority is given back to the node and the Transform is re-evaluated once with those values.
+        // Translation values from node (vector3d because this is the type of QTransform.translation)
         property var nodeTranslation : Qt.vector3d(
             root.currentSfMTransformNode.attribute("manualTransform.manualTranslation.x").value,
             root.currentSfMTransformNode.attribute("manualTransform.manualTranslation.y").value,
             root.currentSfMTransformNode.attribute("manualTransform.manualTranslation.z").value
         )
+        // Rotation values from node (3 separated values because QTransform stores Euler angles like this)
         property var nodeRotationX: root.currentSfMTransformNode.attribute("manualTransform.manualRotation.x").value
         property var nodeRotationY: root.currentSfMTransformNode.attribute("manualTransform.manualRotation.y").value
         property var nodeRotationZ: root.currentSfMTransformNode.attribute("manualTransform.manualRotation.z").value
+        // Scale value from node (simple number because we use uniform scale)
         property var nodeScale: root.currentSfMTransformNode.attribute("manualTransform.manualScale").value
 
+        // Automatically evaluate the Transform: value is taken from the node OR from the actual modification if the gizmo is moved by mouse.
+        // When the gizmo has changed (with mouse), the new values are set to the node, the priority is given back to the node and the Transform is re-evaluated once with those values.
         transformGizmo.gizmoDisplayTransform.translation: transformGizmo.focusGizmoPriority ? transformGizmo.gizmoDisplayTransform.translation : nodeTranslation
         transformGizmo.gizmoDisplayTransform.rotationX: transformGizmo.focusGizmoPriority ? transformGizmo.gizmoDisplayTransform.rotationX : nodeRotationX
         transformGizmo.gizmoDisplayTransform.rotationY: transformGizmo.focusGizmoPriority ? transformGizmo.gizmoDisplayTransform.rotationY : nodeRotationY

--- a/meshroom/ui/qml/Viewer3D/SfMTransformGizmo.qml
+++ b/meshroom/ui/qml/Viewer3D/SfMTransformGizmo.qml
@@ -1,0 +1,53 @@
+import Qt3D.Core 2.0
+import Qt3D.Render 2.9
+import Qt3D.Input 2.0
+import Qt3D.Extras 2.10
+import QtQuick 2.9
+
+Entity {
+    id: root
+    property DefaultCameraController sceneCameraController
+    property Layer frontLayerComponent
+    property var window
+    property var currentSfMTransformNode: null
+    enabled: true
+
+    EntityWithGizmo {
+        sceneCameraController: root.sceneCameraController
+        frontLayerComponent: root.frontLayerComponent
+        window: root.window
+        uniformScale: true // We want to make uniform scale transformations
+
+        // Update node SfMTransform slider values when the gizmo has changed: translation, rotation, scale
+        transformGizmo.onGizmoChanged: {
+            _reconstruction.setAttribute(root.currentSfMTransformNode.attribute("transformGizmo.gizmoTranslation.x"), translation.x)
+            _reconstruction.setAttribute(root.currentSfMTransformNode.attribute("transformGizmo.gizmoTranslation.y"), translation.y)
+            _reconstruction.setAttribute(root.currentSfMTransformNode.attribute("transformGizmo.gizmoTranslation.z"), translation.z)
+
+            _reconstruction.setAttribute(root.currentSfMTransformNode.attribute("transformGizmo.gizmoRotation.x"), rotation.x)
+            _reconstruction.setAttribute(root.currentSfMTransformNode.attribute("transformGizmo.gizmoRotation.y"), rotation.y)
+            _reconstruction.setAttribute(root.currentSfMTransformNode.attribute("transformGizmo.gizmoRotation.z"), rotation.z)
+
+            // Only one scale is needed since the scale is uniform
+            _reconstruction.setAttribute(root.currentSfMTransformNode.attribute("transformGizmo.gizmoScale"), scale.x)
+        }
+
+        // Automatically evalutate the Transform: value is taken from the node OR from the actual modification if the gizmo is moved by mouse.
+        // When the gizmo has changed (with mouse), the new values are set to the node, the priority is given back to the node and the Transform is re-evaluated once with those values.
+        property var nodeTranslation : Qt.vector3d(
+            root.currentSfMTransformNode.attribute("transformGizmo.gizmoTranslation.x").value,
+            root.currentSfMTransformNode.attribute("transformGizmo.gizmoTranslation.y").value,
+            root.currentSfMTransformNode.attribute("transformGizmo.gizmoTranslation.z").value
+        )
+        property var nodeRotationX: root.currentSfMTransformNode.attribute("transformGizmo.gizmoRotation.x").value
+        property var nodeRotationY: root.currentSfMTransformNode.attribute("transformGizmo.gizmoRotation.y").value
+        property var nodeRotationZ: root.currentSfMTransformNode.attribute("transformGizmo.gizmoRotation.z").value
+        property var nodeScale: root.currentSfMTransformNode.attribute("transformGizmo.gizmoScale").value
+
+        transformGizmo.gizmoDisplayTransform.translation: transformGizmo.focusGizmoPriority ? transformGizmo.gizmoDisplayTransform.translation : nodeTranslation
+        transformGizmo.gizmoDisplayTransform.rotationX: transformGizmo.focusGizmoPriority ? transformGizmo.gizmoDisplayTransform.rotationX : nodeRotationX
+        transformGizmo.gizmoDisplayTransform.rotationY: transformGizmo.focusGizmoPriority ? transformGizmo.gizmoDisplayTransform.rotationY : nodeRotationY
+        transformGizmo.gizmoDisplayTransform.rotationZ: transformGizmo.focusGizmoPriority ? transformGizmo.gizmoDisplayTransform.rotationZ : nodeRotationZ
+        transformGizmo.objectTransform.scale3D: transformGizmo.focusGizmoPriority ? transformGizmo.objectTransform.scale3D : Qt.vector3d(nodeScale, nodeScale, nodeScale)
+    }
+}

--- a/meshroom/ui/qml/Viewer3D/SfMTransformGizmo.qml
+++ b/meshroom/ui/qml/Viewer3D/SfMTransformGizmo.qml
@@ -21,21 +21,46 @@ Entity {
         window: root.window
         uniformScale: true // We want to make uniform scale transformations
 
-        // Update node SfMTransform slider values when the gizmo has changed: translation, rotation, scale
+        // Update node SfMTransform slider values when the gizmo has changed: translation, rotation, scale, type
         transformGizmo.onGizmoChanged: {
-            _reconstruction.setAttribute(root.currentSfMTransformNode.attribute("manualTransform.manualTranslation.x"), translation.x)
-            _reconstruction.setAttribute(root.currentSfMTransformNode.attribute("manualTransform.manualTranslation.y"), translation.y)
-            _reconstruction.setAttribute(root.currentSfMTransformNode.attribute("manualTransform.manualTranslation.z"), translation.z)
-
-            _reconstruction.setAttribute(root.currentSfMTransformNode.attribute("manualTransform.manualRotation.x"), rotation.x)
-            _reconstruction.setAttribute(root.currentSfMTransformNode.attribute("manualTransform.manualRotation.y"), rotation.y)
-            _reconstruction.setAttribute(root.currentSfMTransformNode.attribute("manualTransform.manualRotation.z"), rotation.z)
-
-            // Only one scale is needed since the scale is uniform
-            _reconstruction.setAttribute(root.currentSfMTransformNode.attribute("manualTransform.manualScale"), scale.x)
+            switch(type) {
+                case TransformGizmo.Type.TRANSLATION: {
+                    _reconstruction.setAttribute(
+                        root.currentSfMTransformNode.attribute("manualTransform.manualTranslation"),
+                        JSON.stringify([translation.x, translation.y, translation.z])
+                    )
+                    break
+                }
+                case TransformGizmo.Type.ROTATION: {
+                    _reconstruction.setAttribute(
+                        root.currentSfMTransformNode.attribute("manualTransform.manualRotation"),
+                        JSON.stringify([rotation.x, rotation.y, rotation.z])
+                    )
+                    break
+                }
+                case TransformGizmo.Type.SCALE: {
+                    // Only one scale is needed since the scale is uniform
+                    _reconstruction.setAttribute(
+                        root.currentSfMTransformNode.attribute("manualTransform.manualScale"),
+                        scale.x
+                    )
+                    break
+                }
+                case TransformGizmo.Type.ALL: {
+                    _reconstruction.setAttribute(
+                        root.currentSfMTransformNode.attribute("manualTransform"),
+                        JSON.stringify([
+                            [translation.x, translation.y, translation.z],
+                            [rotation.x, rotation.y, rotation.z],
+                            scale.x
+                        ])
+                    )
+                    break
+                }
+            }
         }
 
-        // Automatically evalutate the Transform: value is taken from the node OR from the actual modification if the gizmo is moved by mouse.
+        // Automatically evaluate the Transform: value is taken from the node OR from the actual modification if the gizmo is moved by mouse.
         // When the gizmo has changed (with mouse), the new values are set to the node, the priority is given back to the node and the Transform is re-evaluated once with those values.
         property var nodeTranslation : Qt.vector3d(
             root.currentSfMTransformNode.attribute("manualTransform.manualTranslation.x").value,

--- a/meshroom/ui/qml/Viewer3D/TransformGizmo.qml
+++ b/meshroom/ui/qml/Viewer3D/TransformGizmo.qml
@@ -7,14 +7,15 @@ import Qt3D.Logic 2.0
 
 Entity {
     id: root
-    property real gizmoScale: 0.20
+    property real gizmoScale: 0.15
     property Camera camera
     property var windowSize
+    property var frontLayerComponent
     readonly property Transform objectTransform : Transform {}
     
     signal pickedChanged(bool pressed)
 
-    components: [gizmoDisplayTransform, mouseHandler]
+    components: [gizmoDisplayTransform, mouseHandler, frontLayerComponent]
 
 
     /***** ENUMS *****/
@@ -194,7 +195,7 @@ Entity {
 
     Entity {
         id: centerSphereEntity
-        components: [centerSphereMesh, centerSphereMaterial]
+        components: [centerSphereMesh, centerSphereMaterial, frontLayerComponent]
 
         SphereMesh {
             id: centerSphereMesh
@@ -238,7 +239,7 @@ Entity {
 
                 Entity {
                     id: axisCylinder
-                    components: [cylinderMesh, cylinderTransform, scaleMaterial]
+                    components: [cylinderMesh, cylinderTransform, scaleMaterial, frontLayerComponent]
 
                     CylinderMesh {
                         id: cylinderMesh
@@ -275,7 +276,7 @@ Entity {
 
                 Entity {
                     id: axisScaleBox
-                    components: [cubeScaleMesh, cubeScaleTransform, scaleMaterial, scalePicker]
+                    components: [cubeScaleMesh, cubeScaleTransform, scaleMaterial, scalePicker, frontLayerComponent]
 
                     CuboidMesh {
                         id: cubeScaleMesh
@@ -334,7 +335,7 @@ Entity {
             // POSITION ENTITY
             Entity {
                 id: positionEntity
-                components: [coneMesh, coneTransform, positionMaterial, positionPicker]
+                components: [coneMesh, coneTransform, positionMaterial, positionPicker, frontLayerComponent]
 
                 ConeMesh {
                     id: coneMesh
@@ -394,7 +395,7 @@ Entity {
             // ROTATION ENTITY
             Entity {
                 id: rotationEntity
-                components: [torusMesh, torusTransform, rotationMaterial, rotationPicker]
+                components: [torusMesh, torusTransform, rotationMaterial, rotationPicker, frontLayerComponent]
 
                 TorusMesh {
                     id: torusMesh

--- a/meshroom/ui/qml/Viewer3D/TransformGizmo.qml
+++ b/meshroom/ui/qml/Viewer3D/TransformGizmo.qml
@@ -14,6 +14,7 @@ Entity {
     property var windowSize
     property var frontLayerComponent
     property var window
+    property bool uniformScale: false // by default, the scale is not uniform
     property bool focusGizmoPriority: false // If true, it is used to give the priority to the current transformation (and not to a upper-level binding)
     property Transform gizmoDisplayTransform: Transform {
         id: gizmoDisplayTransform
@@ -146,10 +147,15 @@ Entity {
                     const offset = cosAngle * mouseVector.length() / objectPicker.scaleUnit
 
                     // Do the transformation
-                    if(objectPicker.gizmoType === TransformGizmo.Type.POSITION && offset !== 0)
+                    if(objectPicker.gizmoType === TransformGizmo.Type.POSITION && offset !== 0) {   
                         doRelativeTranslation(objectPicker.modelMatrix, pickedAxis.times(offset)) // Do a translation from the initial Object Model Matrix when we picked the gizmo
-                    else if (objectPicker.gizmoType === TransformGizmo.Type.SCALE && offset !== 0)
-                        doRelativeScale(objectPicker.modelMatrix, pickedAxis.times(offset)) // Do a scale from the initial Object Model Matrix when we picked the gizmo
+                    }
+                    else if(objectPicker.gizmoType === TransformGizmo.Type.SCALE && offset !== 0) {
+                        if(root.uniformScale)
+                            doRelativeScale(objectPicker.modelMatrix, Qt.vector3d(1,1,1).times(offset)) // Do a uniform scale from the initial Object Model Matrix when we picked the gizmo
+                        else
+                            doRelativeScale(objectPicker.modelMatrix, pickedAxis.times(offset)) // Do a scale on one axis from the initial Object Model Matrix when we picked the gizmo
+                    }
 
                     return
                 }

--- a/meshroom/ui/qml/Viewer3D/TransformGizmo.qml
+++ b/meshroom/ui/qml/Viewer3D/TransformGizmo.qml
@@ -54,6 +54,14 @@ Entity {
         SCALE
     }
 
+    function convertAxisEnum(axis) {
+        switch(axis) {
+            case TransformGizmo.Axis.X: return Qt.vector3d(1,0,0)
+            case TransformGizmo.Axis.Y: return Qt.vector3d(0,1,0)
+            case TransformGizmo.Axis.Z: return Qt.vector3d(0,0,1)
+        }
+    }
+
     /***** TRANSFORMATIONS (using local vars) *****/
 
     function doRelativeTranslation(initialModelMatrix, translateVec) {
@@ -121,81 +129,55 @@ Entity {
                 root.focusGizmoPriority = true
 
                 // Get the selected axis
-                let pickedAxis
-                switch(objectPicker.gizmoAxis) {
-                    case TransformGizmo.Axis.X: pickedAxis = Qt.vector3d(1,0,0); break
-                    case TransformGizmo.Axis.Y: pickedAxis = Qt.vector3d(0,1,0); break
-                    case TransformGizmo.Axis.Z: pickedAxis = Qt.vector3d(0,0,1); break
+                const pickedAxis = convertAxisEnum(objectPicker.gizmoAxis)
+
+                // If it is a TRANSLATION or a SCALE
+                if(objectPicker.gizmoType === TransformGizmo.Type.POSITION || objectPicker.gizmoType === TransformGizmo.Type.SCALE) {
+                    // Compute the current vector PickedPoint -> CurrentMousePoint
+                    const pickedPosition = objectPicker.screenPoint
+                    const mouseVector = Qt.vector2d(mouse.x - pickedPosition.x, -(mouse.y - pickedPosition.y))
+
+                    // Transform the positive picked axis vector from World Coord to Screen Coord
+                    const gizmoLocalPointOnAxis = gizmoDisplayTransform.matrix.times(Qt.vector4d(pickedAxis.x, pickedAxis.y, pickedAxis.z, 1))
+                    const gizmoCenterPoint = gizmoDisplayTransform.matrix.times(Qt.vector4d(0, 0, 0, 1))
+                    const screenPoint2D = Transformations3DHelper.pointFromWorldToScreen(gizmoLocalPointOnAxis, camera, windowSize)
+                    const screenCenter2D = Transformations3DHelper.pointFromWorldToScreen(gizmoCenterPoint, camera, windowSize)
+                    const screenAxisVector = Qt.vector2d(screenPoint2D.x - screenCenter2D.x, -(screenPoint2D.y - screenCenter2D.y))
+
+                    // Get the cosinus of the angle from the screenAxisVector to the mouseVector
+                    const cosAngle = screenAxisVector.dotProduct(mouseVector) / (screenAxisVector.length() * mouseVector.length())
+                    const offset = cosAngle * mouseVector.length() / objectPicker.scaleUnit
+
+                    // Do the transformation
+                    if(objectPicker.gizmoType === TransformGizmo.Type.POSITION && offset !== 0)
+                        doRelativeTranslation(objectPicker.modelMatrix, pickedAxis.times(offset)) // Do a translation from the initial Object Model Matrix when we picked the gizmo
+                    else if (objectPicker.gizmoType === TransformGizmo.Type.SCALE && offset !== 0)
+                        doRelativeScale(objectPicker.modelMatrix, pickedAxis.times(offset)) // Do a scale from the initial Object Model Matrix when we picked the gizmo
+
+                    return
                 }
+                else if(objectPicker.gizmoType === TransformGizmo.Type.ROTATION) {
+                    // Get Screen Coordinates of the gizmo center
+                    const gizmoCenterPoint = gizmoDisplayTransform.matrix.times(Qt.vector4d(0, 0, 0, 1))
+                    const screenCenter2D = Transformations3DHelper.pointFromWorldToScreen(gizmoCenterPoint, camera, root.windowSize)
 
-                switch(objectPicker.gizmoType) {
-                    case TransformGizmo.Type.POSITION: {
-                        const sensibility = 0.02
+                    // Get the vector screenCenter2D -> PickedPoint
+                    const originalVector = Qt.vector2d(objectPicker.screenPoint.x - screenCenter2D.x, -(objectPicker.screenPoint.y - screenCenter2D.y))
 
-                        // Compute the current vector PickedPoint -> CurrentMousePoint
-                        const pickedPosition = objectPicker.screenPoint
-                        const mouseVector = Qt.vector2d(mouse.x - pickedPosition.x, -(mouse.y - pickedPosition.y))
+                    // Compute the current vector screenCenter2D -> CurrentMousePoint
+                    const mouseVector = Qt.vector2d(mouse.x - screenCenter2D.x, -(mouse.y - screenCenter2D.y))
 
-                        // Transform the positive picked axis vector from World Coord to Screen Coord
-                        const gizmoLocalPointOnAxis = gizmoDisplayTransform.matrix.times(Qt.vector4d(pickedAxis.x, pickedAxis.y, pickedAxis.z, 1))
-                        const gizmoCenterPoint = gizmoDisplayTransform.matrix.times(Qt.vector4d(0, 0, 0, 1))
-                        const screenPoint2D = Transformations3DHelper.pointFromWorldToScreen(gizmoLocalPointOnAxis, camera, windowSize)
-                        const screenCenter2D = Transformations3DHelper.pointFromWorldToScreen(gizmoCenterPoint, camera, windowSize)
-                        const screenAxisVector = Qt.vector2d(screenPoint2D.x - screenCenter2D.x, -(screenPoint2D.y - screenCenter2D.y))
+                    // Get the angle from the originalVector to the mouseVector
+                    const angle = Math.atan2(-originalVector.y*mouseVector.x + originalVector.x*mouseVector.y, originalVector.x*mouseVector.x + originalVector.y*mouseVector.y) * 180 / Math.PI
 
-                        // Get the cosinus of the angle from the screenAxisVector to the mouseVector
-                        const cosAngle = screenAxisVector.dotProduct(mouseVector) / (screenAxisVector.length() * mouseVector.length())
-                        const offset = cosAngle * mouseVector.length() * sensibility
+                    // Get the orientation of the gizmo in function of the camera
+                    const gizmoLocalAxisVector = gizmoDisplayTransform.matrix.times(Qt.vector4d(pickedAxis.x, pickedAxis.y, pickedAxis.z, 0))
+                    const gizmoToCameraVector = camera.position.toVector4d().minus(gizmoCenterPoint)
+                    const orientation = gizmoLocalAxisVector.dotProduct(gizmoToCameraVector) > 0 ? 1 : -1
 
-                        // If the mouse is not at the same spot as the pickedPoint, we do translation
-                        if (offset) doRelativeTranslation(objectPicker.modelMatrix, pickedAxis.times(offset)) // Do a translation from the initial Object Model Matrix when we picked the gizmo
+                    if (angle !== 0) doRelativeRotation(objectPicker.modelMatrix, pickedAxis, angle*orientation) // Do a rotation from the initial Object Model Matrix when we picked the gizmo
 
-                        return
-                    }
-
-                    case TransformGizmo.Type.ROTATION: {
-                        // Get Screen Coordinates of the gizmo center
-                        const gizmoCenterPoint = gizmoDisplayTransform.matrix.times(Qt.vector4d(0, 0, 0, 1))
-                        const screenCenter2D = Transformations3DHelper.pointFromWorldToScreen(gizmoCenterPoint, camera, root.windowSize)
-
-                        // Get the vector screenCenter2D -> PickedPoint
-                        const originalVector = Qt.vector2d(objectPicker.screenPoint.x - screenCenter2D.x, -(objectPicker.screenPoint.y - screenCenter2D.y))
-
-                        // Compute the current vector screenCenter2D -> CurrentMousePoint
-                        const mouseVector = Qt.vector2d(mouse.x - screenCenter2D.x, -(mouse.y - screenCenter2D.y))
-
-                        // Get the angle from the originalVector to the mouseVector
-                        const angle = Math.atan2(-originalVector.y*mouseVector.x + originalVector.x*mouseVector.y, originalVector.x*mouseVector.x + originalVector.y*mouseVector.y) * 180 / Math.PI
-
-                        // Get the orientation of the gizmo in function of the camera
-                        const gizmoLocalAxisVector = gizmoDisplayTransform.matrix.times(Qt.vector4d(pickedAxis.x, pickedAxis.y, pickedAxis.z, 0))
-                        const gizmoToCameraVector = camera.position.toVector4d().minus(gizmoCenterPoint)
-                        const orientation = gizmoLocalAxisVector.dotProduct(gizmoToCameraVector) > 0 ? 1 : -1
-
-                        if (angle !== 0) doRelativeRotation(objectPicker.modelMatrix, pickedAxis, angle*orientation) // Do a rotation from the initial Object Model Matrix when we picked the gizmo
-
-                        return
-                    }
-
-                    case TransformGizmo.Type.SCALE: {
-                        const sensibility = 0.05
-
-                        // Get Screen Coordinates of the gizmo center
-                        const gizmoCenterPoint = gizmoDisplayTransform.matrix.times(Qt.vector4d(0, 0, 0, 1))
-                        const screenCenter2D = Transformations3DHelper.pointFromWorldToScreen(gizmoCenterPoint, camera, root.windowSize)
-
-                        // Compute the scale unit
-                        const scaleUnit = screenCenter2D.minus(Qt.vector2d(objectPicker.screenPoint.x, objectPicker.screenPoint.y)).length()
-
-                        // Compute the current vector screenCenter2D -> CurrentMousePoint
-                        const mouseVector = Qt.vector2d(mouse.x - screenCenter2D.x, -(mouse.y - screenCenter2D.y))
-                        let offset = (mouseVector.length() - scaleUnit) * sensibility
-                        offset = (offset < 0) ? offset * 3 : offset // Used to make it more sensible when we want to reduce the scale (because the action field is shorter)
-
-                        if (offset) doRelativeScale(objectPicker.modelMatrix, pickedAxis.times(offset)) // Do a scale from the initial Object Model Matrix when we picked the gizmo
-                        
-                        return
-                    }
+                    return
                 }
             }
 
@@ -272,7 +254,7 @@ Entity {
                     case TransformGizmo.Axis.Z: return "#3387e2" // Blue
                 }
             }
-            property real lineRadius: 0.015
+            property real lineRadius: 0.011
 
             // SCALE ENTITY
             Entity {
@@ -321,7 +303,7 @@ Entity {
 
                     CuboidMesh {
                         id: cubeScaleMesh
-                        property real edge: 0.07
+                        property real edge: 0.06
                         xExtent: edge
                         yExtent: edge
                         zExtent: edge
@@ -366,7 +348,8 @@ Entity {
                     gizmoType: TransformGizmo.Type.SCALE
 
                     onPickedChanged: {
-                        this.modelMatrix = Transformations3DHelper.modelMatrixToMatrices(objectTransform.matrix) // Save the current transformations
+                        this.modelMatrix = Transformations3DHelper.modelMatrixToMatrices(objectTransform.matrix) // Save the current transformations of the OBJECT
+                        this.scaleUnit = Transformations3DHelper.computeScaleUnitFromModelMatrix(convertAxisEnum(gizmoAxis), gizmoDisplayTransform.matrix, camera, root.windowSize) // Compute a scale unit at picking time
                         root.pickedChanged(picker.isPressed) // Used to prevent camera transformations
                     }
                 }
@@ -379,11 +362,11 @@ Entity {
 
                 ConeMesh {
                     id: coneMesh
-                    bottomRadius : 0.04
+                    bottomRadius : 0.035
                     topRadius : 0.001
                     hasBottomEndcap : true
                     hasTopEndcap : true
-                    length : 0.15
+                    length : 0.13
                     rings : 2
                     slices : 8
                 }
@@ -425,8 +408,8 @@ Entity {
                     gizmoType: TransformGizmo.Type.POSITION
 
                     onPickedChanged: {
-                        // this.modelMatrix = copyMatrix(objectTransform.matrix) // Save the current transformations
-                        this.modelMatrix = Transformations3DHelper.modelMatrixToMatrices(objectTransform.matrix) // Save the current transformations
+                        this.modelMatrix = Transformations3DHelper.modelMatrixToMatrices(objectTransform.matrix) // Save the current transformations of the OBJECT
+                        this.scaleUnit = Transformations3DHelper.computeScaleUnitFromModelMatrix(convertAxisEnum(gizmoAxis), gizmoDisplayTransform.matrix, camera, root.windowSize) // Compute a scale unit at picking time
                         root.pickedChanged(picker.isPressed) // Used to prevent camera transformations
                     }
                 }
@@ -471,7 +454,7 @@ Entity {
                     gizmoType: TransformGizmo.Type.ROTATION
 
                     onPickedChanged: {
-                        this.modelMatrix = Transformations3DHelper.modelMatrixToMatrices(objectTransform.matrix) // Save the current transformations
+                        this.modelMatrix = Transformations3DHelper.modelMatrixToMatrices(objectTransform.matrix) // Save the current transformations of the OBJECT
                         root.pickedChanged(picker.isPressed) // Used to prevent camera transformations
                     }
                 }

--- a/meshroom/ui/qml/Viewer3D/TransformGizmo.qml
+++ b/meshroom/ui/qml/Viewer3D/TransformGizmo.qml
@@ -1,0 +1,223 @@
+import Qt3D.Core 2.0
+import Qt3D.Render 2.9
+import Qt3D.Input 2.0
+import Qt3D.Extras 2.10
+import QtQuick 2.9
+import Qt3D.Logic 2.0
+
+Entity {
+    id: root
+    property real gizmoScale: 0.15
+    property Camera camera
+
+    components: [gizmoTransform]
+
+    enum Axis {
+        X,
+        Y,
+        Z
+    }
+
+    Transform {
+        id: gizmoTransform
+        scale: {
+            return root.gizmoScale * (camera.position.minus(gizmoTransform.translation)).length()
+        }
+    }
+
+    Entity {
+        id: centerSphereEntity
+        components: [centerSphereMesh, centerSphereMaterial]
+
+        SphereMesh {
+            id: centerSphereMesh
+            radius: 0.04
+            rings: 8
+            slices: 8
+        }
+        PhongMaterial {
+            id: centerSphereMaterial
+            property color base: "white"
+            ambient: base
+            shininess: 0.2
+        }
+    }
+
+    // AXIS GIZMO INSTANTIATOR => X, Y and Z
+    NodeInstantiator {
+        model: 3
+
+        Entity {
+            id: axisContainer
+            property int axis : {
+                switch(index) {
+                    case 0: return TransformGizmo.Axis.X
+                    case 1: return TransformGizmo.Axis.Y
+                    case 2: return TransformGizmo.Axis.Z
+                }                
+            }
+            property color baseColor: {
+                switch(axis) {
+                    case TransformGizmo.Axis.X: return "#e63b55"
+                    case TransformGizmo.Axis.Y: return "#83c414"
+                    case TransformGizmo.Axis.Z: return "#3387e2"
+                }
+            }
+            property real lineRadius: 0.015
+
+            PhongMaterial {
+                id: material
+                ambient: baseColor
+                shininess: 0.2
+            }
+
+            // SCALE ENTITY
+            Entity {
+                id: scaleEntity
+                components: [material]
+
+                Entity {
+                    id: axisCylinder
+                    components: [cylinderMesh, cylinderTransform, material]
+
+                    CylinderMesh {
+                        id: cylinderMesh
+                        length: 0.5
+                        radius: axisContainer.lineRadius
+                        rings: 2
+                        slices: 16
+                    }
+                    Transform {
+                        id: cylinderTransform
+                        matrix: {
+                            const offset = cylinderMesh.length/2 + centerSphereMesh.radius
+                            const m = Qt.matrix4x4()
+                            switch(axis) {
+                                case TransformGizmo.Axis.X: {
+                                    m.translate(Qt.vector3d(offset, 0, 0))
+                                    m.rotate(90, Qt.vector3d(0,0,1)) 
+                                    break
+                                }   
+                                case TransformGizmo.Axis.Y: {
+                                    m.translate(Qt.vector3d(0, offset, 0))
+                                    break
+                                }
+                                case TransformGizmo.Axis.Z: {
+                                    m.translate(Qt.vector3d(0, 0, offset))
+                                    m.rotate(90, Qt.vector3d(1,0,0))
+                                    break
+                                }
+                            }
+                            return m
+                        }
+                    }
+                }
+
+                Entity {
+                    id: axisScaleBox
+                    components: [cubeScaleMesh, cubeScaleTransform, material]
+
+                    CuboidMesh {
+                        id: cubeScaleMesh
+                        property real edge: 0.07
+                        xExtent: edge
+                        yExtent: edge
+                        zExtent: edge
+                    }
+                    Transform {
+                        id: cubeScaleTransform
+                        matrix: {
+                            const offset = cylinderMesh.length + centerSphereMesh.radius
+                            const m = Qt.matrix4x4()
+                            switch(axis) {
+                                case TransformGizmo.Axis.X: {
+                                    m.translate(Qt.vector3d(offset, 0, 0))
+                                    m.rotate(90, Qt.vector3d(0,0,1))
+                                    break
+                                }
+                                case TransformGizmo.Axis.Y: {
+                                    m.translate(Qt.vector3d(0, offset, 0))
+                                    break
+                                }
+                                case TransformGizmo.Axis.Z: {
+                                    m.translate(Qt.vector3d(0, 0, offset))
+                                    m.rotate(90, Qt.vector3d(1,0,0))
+                                    break
+                                }
+                            }
+                            return m
+                        }
+                    }
+                } 
+            }
+
+            // POSITION ENTITY
+            Entity {
+                id: positionEntity
+                components: [coneMesh, coneTransform, material]
+
+                ConeMesh {
+                    id: coneMesh
+                    bottomRadius : 0.04
+                    topRadius : 0.001
+                    hasBottomEndcap : true
+                    hasTopEndcap : true
+                    length : 0.15
+                    rings : 2
+                    slices : 8
+                }
+                Transform {
+                    id: coneTransform
+                    matrix: {
+                        const offset = cylinderMesh.length + centerSphereMesh.radius + 0.4
+                        const m = Qt.matrix4x4()
+                        switch(axis) {
+                            case TransformGizmo.Axis.X: {
+                                m.translate(Qt.vector3d(offset, 0, 0))
+                                m.rotate(-90, Qt.vector3d(0,0,1))
+                                break
+                            }
+                            case TransformGizmo.Axis.Y: {
+                                m.translate(Qt.vector3d(0, offset, 0))
+                                break
+                            }
+                            case TransformGizmo.Axis.Z: {
+                                m.translate(Qt.vector3d(0, 0, offset))
+                                m.rotate(90, Qt.vector3d(1,0,0))
+                                break
+                            }
+                        }
+                        return m
+                    }
+                }
+            }
+
+            // ROTATION ENTITY
+            Entity {
+                id: rotationEntity
+                components: [torusMesh, torusTransform, material]
+
+                TorusMesh {
+                    id: torusMesh
+                    radius: cylinderMesh.length + 0.25
+                    minorRadius: axisContainer.lineRadius
+                    slices: 8
+                    rings: 32
+                }
+                Transform {
+                    id: torusTransform
+                    matrix: {
+                        const scaleDiff = 2*torusMesh.minorRadius + 0.01 // Just to make sure there is no face overlapping
+                        const m = Qt.matrix4x4()
+                        switch(axis) {
+                            case TransformGizmo.Axis.X: m.rotate(90, Qt.vector3d(0,1,0)); break
+                            case TransformGizmo.Axis.Y: m.rotate(90, Qt.vector3d(1,0,0)); m.scale(Qt.vector3d(1-scaleDiff, 1-scaleDiff, 1-scaleDiff)); break
+                            case TransformGizmo.Axis.Z: m.scale(Qt.vector3d(1-2*scaleDiff, 1-2*scaleDiff, 1-2*scaleDiff)); break
+                        }
+                        return m
+                    }
+                }
+            }
+        }
+    }
+}

--- a/meshroom/ui/qml/Viewer3D/TransformGizmo.qml
+++ b/meshroom/ui/qml/Viewer3D/TransformGizmo.qml
@@ -105,20 +105,20 @@ Entity {
 
         const rotQuat = Qt.quaternion(rotation.scalar, rotation.x, rotation.y, rotation.z)
 
-        return { position: posMat, rotation: rotMat, scale: scaleMat, quaternion: rotQuat }
+        return { positionMat: posMat, rotationMat: rotMat, scaleMat: scaleMat, quaternion: rotQuat }
     }
 
     function decomposeModelMatrixFromTransform(transformQtInstance) {
         return decomposeModelMatrixFromTransformations(transformQtInstance.translation, transformQtInstance.rotation, transformQtInstance.scale3D)
     }
 
-    function localTranslateFrom(transformQtInstance, initialDecomposedModelMat, translateVec) {
+    function localTranslate(transformQtInstance, initialDecomposedModelMat, translateVec) {
         // Compute the translation transformation matrix 
         const translationMat = Qt.matrix4x4()
         translationMat.translate(translateVec)
 
         // Compute the new model matrix (POSITION * ROTATION * TRANSLATE * SCALE) and set it to the Transform
-        const mat = initialDecomposedModelMat.position.times(initialDecomposedModelMat.rotation.times(translationMat.times(initialDecomposedModelMat.scale)))
+        const mat = initialDecomposedModelMat.positionMat.times(initialDecomposedModelMat.rotationMat.times(translationMat.times(initialDecomposedModelMat.scaleMat)))
         transformQtInstance.setMatrix(mat)
     }
 
@@ -133,7 +133,7 @@ Entity {
         const newRotationMat = quaternionToRotationMatrix(newRotQuat)
 
         // Compute the new model matrix (POSITION * NEW_COMPUTED_ROTATION * SCALE) and set it to the Transform
-        const mat = initialDecomposedModelMat.position.times(newRotationMat.times(initialDecomposedModelMat.scale))
+        const mat = initialDecomposedModelMat.positionMat.times(newRotationMat.times(initialDecomposedModelMat.scaleMat))
         transformQtInstance.setMatrix(mat)
     }
 
@@ -141,7 +141,7 @@ Entity {
         // Make a copy of the scale matrix (otherwise, it is a reference and it does not work as expected)
         // Unfortunately, we have to proceed like this because, in QML, Qt.matrix4x4(Qt.matrix4x4) does not work
         const scaleMat = Qt.matrix4x4()
-        scaleMat.scale(Qt.vector3d(initialDecomposedModelMat.scale.m11, initialDecomposedModelMat.scale.m22, initialDecomposedModelMat.scale.m33))
+        scaleMat.scale(Qt.vector3d(initialDecomposedModelMat.scaleMat.m11, initialDecomposedModelMat.scaleMat.m22, initialDecomposedModelMat.scaleMat.m33))
 
         // Update the scale matrix copy
         scaleMat.m11 += scaleVec.x
@@ -149,15 +149,15 @@ Entity {
         scaleMat.m33 += scaleVec.z
 
         // Compute the new model matrix (POSITION * ROTATION * SCALE) and set it to the Transform
-        const mat = initialDecomposedModelMat.position.times(initialDecomposedModelMat.rotation.times(scaleMat))
+        const mat = initialDecomposedModelMat.positionMat.times(initialDecomposedModelMat.rotationMat.times(scaleMat))
         transformQtInstance.setMatrix(mat)
     }
 
     /***** SPECIFIC MATRIX TRANSFORMATIONS (using local vars) *****/
 
     function doTranslation(initialDecomposedModelMat, translateVec) {
-        localTranslateFrom(gizmoDisplayTransform, initialDecomposedModelMat, translateVec) // Update gizmo matrix
-        localTranslateFrom(objectTransform, initialDecomposedModelMat, translateVec) // Update object matrix
+        localTranslate(gizmoDisplayTransform, initialDecomposedModelMat, translateVec) // Update gizmo matrix
+        localTranslate(objectTransform, initialDecomposedModelMat, translateVec) // Update object matrix
     }
 
     function doRotation(initialDecomposedModelMat, axis, degree) {
@@ -176,7 +176,6 @@ Entity {
     MouseHandler {
         id: mouseHandler
         sourceDevice: mouseSourceDevice
-        property point lastPosition
         property point currentPosition
         onPositionChanged: {
             currentPosition.x = mouse.x
@@ -226,9 +225,9 @@ Entity {
             }
             property color baseColor: {
                 switch(axis) {
-                    case TransformGizmo.Axis.X: return "#e63b55"
-                    case TransformGizmo.Axis.Y: return "#83c414"
-                    case TransformGizmo.Axis.Z: return "#3387e2"
+                    case TransformGizmo.Axis.X: return "#e63b55" // Red
+                    case TransformGizmo.Axis.Y: return "#83c414" // Green
+                    case TransformGizmo.Axis.Z: return "#3387e2" // Blue
                 }
             }
             property real lineRadius: 0.015

--- a/meshroom/ui/qml/Viewer3D/TransformGizmo.qml
+++ b/meshroom/ui/qml/Viewer3D/TransformGizmo.qml
@@ -466,16 +466,15 @@ Entity {
                         const pickedPosition = objectPicker.screenPoint
                         const mouseVector = Qt.vector2d(mouseHandler.currentPosition.x - pickedPosition.x, -(mouseHandler.currentPosition.y - pickedPosition.y))
 
-                        // Transform the positive picked axis vector from World Coord to Normalized Device Coord
-                        const viewMatrix = camera.transform.matrix.inverted()
+                        // Transform the positive picked axis vector from World Coord to Screen Coord
                         const gizmoLocalPointOnAxis = gizmoDisplayTransform.matrix.times(Qt.vector4d(pickedAxis.x, pickedAxis.y, pickedAxis.z, 1))
                         const gizmoCenterPoint = gizmoDisplayTransform.matrix.times(Qt.vector4d(0, 0, 0, 1))
-                        const projectedPointOnAxis = camera.projectionMatrix.times(viewMatrix.times(gizmoLocalPointOnAxis))
-                        const projectedCenter = camera.projectionMatrix.times(viewMatrix.times(gizmoCenterPoint))
-                        const projectedAxisVector = Qt.vector2d(projectedPointOnAxis.x/projectedPointOnAxis.w - projectedCenter.x/projectedCenter.w, projectedPointOnAxis.y/projectedPointOnAxis.w - projectedCenter.y/projectedCenter.w)
+                        const screenPoint2D = pointFromWorldToScreen(gizmoLocalPointOnAxis, camera, windowSize)
+                        const screenCenter2D = pointFromWorldToScreen(gizmoCenterPoint, camera, windowSize)
+                        const screenAxisVector = Qt.vector2d(screenPoint2D.x - screenCenter2D.x, -(screenPoint2D.y - screenCenter2D.y))
 
-                        // Get the cosinus of the angle from the projectedAxisVector to the mouseVector
-                        const cosAngle = projectedAxisVector.dotProduct(mouseVector) / (projectedAxisVector.length() * mouseVector.length())
+                        // Get the cosinus of the angle from the screenAxisVector to the mouseVector
+                        const cosAngle = screenAxisVector.dotProduct(mouseVector) / (screenAxisVector.length() * mouseVector.length())
                         const offset = cosAngle * mouseVector.length() * sensibility
 
                         // If the mouse is not at the same spot as the pickedPoint, we do translation

--- a/meshroom/ui/qml/Viewer3D/TransformGizmo.qml
+++ b/meshroom/ui/qml/Viewer3D/TransformGizmo.qml
@@ -69,10 +69,16 @@ Entity {
     }
 
     function resetTranslation() {
-        // We have to make the opposite translation because we cannot override gizmoDisplayTransform.translation (because it can be used in upper-level binding)
-        // The object translation will also be updated because of the binding
-        const modelMat = Transformations3DHelper.modelMatrixToMatrices(gizmoDisplayTransform.matrix)
-        doRelativeTranslation(modelMat, gizmoDisplayTransform.translation.times(-1))
+        // We have to reset the translation inside the matrix because we cannot override gizmoDisplayTransform.translation (because it can be used in upper-level binding)
+        // The object matrix will also be updated because of the binding with the translation property
+        const mat = gizmoDisplayTransform.matrix
+        const newMat = Qt.matrix4x4(
+            mat.m11, mat.m12, mat.m13, 0,
+            mat.m21, mat.m22, mat.m23, 0,
+            mat.m31, mat.m32, mat.m33, 0,
+            mat.m41, mat.m42, mat.m43, 1
+        )
+        gizmoDisplayTransform.setMatrix(newMat)
     }
 
     function resetRotation() {
@@ -214,14 +220,14 @@ Entity {
         function updateTypeBeforePopup(type) {
             resetMenu.transformType = type
             switch(type) {
-                case TransformGizmo.Type.POSITION: resetMenu.transformTypeToDisplay = "position"; break
-                case TransformGizmo.Type.ROTATION: resetMenu.transformTypeToDisplay = "rotation"; break
-                case TransformGizmo.Type.SCALE: resetMenu.transformTypeToDisplay = "scale"; break
+                case TransformGizmo.Type.POSITION: resetMenu.transformTypeToDisplay = "Translation"; break
+                case TransformGizmo.Type.ROTATION: resetMenu.transformTypeToDisplay = "Rotation"; break
+                case TransformGizmo.Type.SCALE: resetMenu.transformTypeToDisplay = "Scale"; break
             }    
         }
 
         MenuItem {
-            text: `Reset ${resetMenu.transformTypeToDisplay}?`
+            text: `Reset ${resetMenu.transformTypeToDisplay}`
             onTriggered: resetATransformType(resetMenu.transformType)
         }
     }

--- a/meshroom/ui/qml/Viewer3D/TransformGizmo.qml
+++ b/meshroom/ui/qml/Viewer3D/TransformGizmo.qml
@@ -212,20 +212,13 @@ Entity {
             }
             property real lineRadius: 0.015
 
-            PhongMaterial {
-                id: material
-                ambient: baseColor
-                shininess: 0.2
-            }
-
             // SCALE ENTITY
             Entity {
                 id: scaleEntity
-                components: [material]
 
                 Entity {
                     id: axisCylinder
-                    components: [cylinderMesh, cylinderTransform, material]
+                    components: [cylinderMesh, cylinderTransform, scaleMaterial]
 
                     CylinderMesh {
                         id: cylinderMesh
@@ -262,7 +255,7 @@ Entity {
 
                 Entity {
                     id: axisScaleBox
-                    components: [cubeScaleMesh, cubeScaleTransform, material, scalePicker]
+                    components: [cubeScaleMesh, cubeScaleTransform, scaleMaterial, scalePicker]
 
                     CuboidMesh {
                         id: cubeScaleMesh
@@ -297,8 +290,17 @@ Entity {
                     }
                 }
 
+                PhongMaterial {
+                    id: scaleMaterial
+                    ambient: baseColor
+                }
+
                 TransformGizmoPicker { 
-                    id: scalePicker 
+                    id: scalePicker
+                    mouseController : mouseHandler
+                    objectMaterial : scaleMaterial
+                    objectBaseColor : baseColor
+                    
                     onPickedChanged: {
                         root.pickedChanged(picked)
                     }
@@ -308,7 +310,7 @@ Entity {
             // POSITION ENTITY
             Entity {
                 id: positionEntity
-                components: [coneMesh, coneTransform, material, positionPicker]
+                components: [coneMesh, coneTransform, positionMaterial, positionPicker]
 
                 ConeMesh {
                     id: coneMesh
@@ -344,9 +346,17 @@ Entity {
                         return m
                     }
                 }
+                PhongMaterial {
+                    id: positionMaterial
+                    ambient: baseColor
+                }
 
                 TransformGizmoPicker { 
-                    id: positionPicker 
+                    id: positionPicker
+                    mouseController : mouseHandler
+                    objectMaterial : positionMaterial
+                    objectBaseColor : baseColor
+
                     onPickedChanged: {
                         root.pickedChanged(picked)
                     }
@@ -356,7 +366,7 @@ Entity {
             // ROTATION ENTITY
             Entity {
                 id: rotationEntity
-                components: [torusMesh, torusTransform, material, rotationPicker]
+                components: [torusMesh, torusTransform, rotationMaterial, rotationPicker]
 
                 TorusMesh {
                     id: torusMesh
@@ -378,8 +388,17 @@ Entity {
                         return m
                     }
                 }
+                PhongMaterial {
+                    id: rotationMaterial
+                    ambient: baseColor
+                }
+
                 TransformGizmoPicker { 
-                    id: rotationPicker 
+                    id: rotationPicker
+                    mouseController: mouseHandler
+                    objectMaterial: rotationMaterial
+                    objectBaseColor: baseColor
+
                     onPickedChanged: {
                         root.pickedChanged(picked)
                     }

--- a/meshroom/ui/qml/Viewer3D/TransformGizmo.qml
+++ b/meshroom/ui/qml/Viewer3D/TransformGizmo.qml
@@ -9,7 +9,7 @@ import Utils 1.0
 
 Entity {
     id: root
-    property real gizmoScale: 0.15
+    readonly property alias gizmoScale: gizmoScaleLookSlider.value
     property Camera camera
     property var windowSize
     property var frontLayerComponent
@@ -87,11 +87,15 @@ Entity {
             mat.m41, mat.m42, mat.m43, 1
         )
         gizmoDisplayTransform.setMatrix(newMat)
+
+        emitGizmoChanged()
     }
 
     function resetRotation() {
         // Here, we can change the rotation property (but not rotationX, rotationY and rotationZ because they can be used in upper-level bindings)
         gizmoDisplayTransform.rotation = Qt.quaternion(1,0,0,0) // Reset gizmo matrix and object matrix with binding
+
+        emitGizmoChanged()
     }
 
     function resetScale() {
@@ -103,14 +107,7 @@ Entity {
             -(objectTransform.scale3D.z - 1)
         )
         doRelativeScale(modelMat, scaleDiff)
-    }
 
-    function resetATransformType(transformType) {
-        switch(transformType) {
-            case TransformGizmo.Type.POSITION: resetTranslation(); break
-            case TransformGizmo.Type.ROTATION: resetRotation(); break
-            case TransformGizmo.Type.SCALE: resetScale(); break
-        }
         emitGizmoChanged()
     }
 
@@ -182,7 +179,6 @@ Entity {
             }
 
             if(objectPicker && objectPicker.button === Qt.RightButton) {
-                resetMenu.updateTypeBeforePopup(objectPicker.gizmoType)
                 resetMenu.popup(window)
             }
         }
@@ -196,21 +192,41 @@ Entity {
 
     Menu {
         id: resetMenu
-        property int transformType
-        property string transformTypeToDisplay
-
-        function updateTypeBeforePopup(type) {
-            resetMenu.transformType = type
-            switch(type) {
-                case TransformGizmo.Type.POSITION: resetMenu.transformTypeToDisplay = "Translation"; break
-                case TransformGizmo.Type.ROTATION: resetMenu.transformTypeToDisplay = "Rotation"; break
-                case TransformGizmo.Type.SCALE: resetMenu.transformTypeToDisplay = "Scale"; break
-            }    
-        }
 
         MenuItem {
-            text: `Reset ${resetMenu.transformTypeToDisplay}`
-            onTriggered: resetATransformType(resetMenu.transformType)
+            text: `Reset Translation`
+            onTriggered: resetTranslation()
+        }
+        MenuItem {
+            text: `Reset Rotation`
+            onTriggered: resetRotation()
+        }
+        MenuItem {
+            text: `Reset Scale`
+            onTriggered: resetScale()
+        }
+        MenuItem {
+            text: `Reset All`
+            onTriggered: {
+                resetTranslation()
+                resetRotation()
+                resetScale()
+            }
+        }
+        MenuItem {
+            text: "Gizmo Scale Look"
+            Slider {
+                id: gizmoScaleLookSlider
+                anchors.right: parent.right
+                anchors.rightMargin: 10
+                height: parent.height
+                width: parent.width * 0.40
+
+                from: 0.06
+                to: 0.30
+                stepSize: 0.01
+                value: 0.15
+            }
         }
     }
 

--- a/meshroom/ui/qml/Viewer3D/TransformGizmoPicker.qml
+++ b/meshroom/ui/qml/Viewer3D/TransformGizmoPicker.qml
@@ -24,7 +24,7 @@ ObjectPicker {
         root.isPressed = true
         pickedChanged(this)
         screenPoint = pick.position
-        mouseController.currentPosition = mouseController.lastPosition = pick.position
+        mouseController.currentPosition = pick.position
     }
     onEntered: {
         gizmoMaterial.ambient = "white"

--- a/meshroom/ui/qml/Viewer3D/TransformGizmoPicker.qml
+++ b/meshroom/ui/qml/Viewer3D/TransformGizmoPicker.qml
@@ -14,7 +14,7 @@ ObjectPicker {
     property int gizmoAxis
     property int gizmoType
     property point screenPoint
-    property var decomposedObjectModelMat
+    property var modelMatrix
     
     signal pickedChanged(var picker)
     

--- a/meshroom/ui/qml/Viewer3D/TransformGizmoPicker.qml
+++ b/meshroom/ui/qml/Viewer3D/TransformGizmoPicker.qml
@@ -9,21 +9,25 @@ ObjectPicker {
     id: root
     hoverEnabled: true
     property bool isPressed : false
+    property MouseHandler mouseController
+    property var objectMaterial
+    property color objectBaseColor
+    
     signal pickedChanged(bool picked)
 
     onPressed: {
         root.isPressed = true
         pickedChanged(true)
-        mouseHandler.currentPosition = mouseHandler.lastPosition = pick.position
+        mouseController.currentPosition = mouseController.lastPosition = pick.position
     }
     onEntered: {
-        material.ambient = "white"
+        objectMaterial.ambient = "white"
     }
     onExited: {
-        if(!isPressed) material.ambient = baseColor
+        if(!isPressed) objectMaterial.ambient = objectBaseColor
     }
     onReleased: {
-        material.ambient = baseColor
+        objectMaterial.ambient = objectBaseColor
         root.isPressed = false
         pickedChanged(false)
     }

--- a/meshroom/ui/qml/Viewer3D/TransformGizmoPicker.qml
+++ b/meshroom/ui/qml/Viewer3D/TransformGizmoPicker.qml
@@ -15,6 +15,7 @@ ObjectPicker {
     property int gizmoType
     property point screenPoint
     property var modelMatrix
+    property int button
     
     signal pickedChanged(var picker)
     
@@ -25,6 +26,7 @@ ObjectPicker {
         mouseController.objectPicker = this
         root.isPressed = true
         screenPoint = pick.position
+        button = pick.button
         pickedChanged(this)
     }
     onEntered: {

--- a/meshroom/ui/qml/Viewer3D/TransformGizmoPicker.qml
+++ b/meshroom/ui/qml/Viewer3D/TransformGizmoPicker.qml
@@ -13,6 +13,8 @@ ObjectPicker {
     property color gizmoBaseColor
     property int gizmoAxis
     property int gizmoType
+    property point screenPoint
+    property var decomposedObjectModelMat
     
     signal pickedChanged(var picker)
     
@@ -21,6 +23,7 @@ ObjectPicker {
     onPressed: {
         root.isPressed = true
         pickedChanged(this)
+        screenPoint = pick.position
         mouseController.currentPosition = mouseController.lastPosition = pick.position
     }
     onEntered: {

--- a/meshroom/ui/qml/Viewer3D/TransformGizmoPicker.qml
+++ b/meshroom/ui/qml/Viewer3D/TransformGizmoPicker.qml
@@ -21,10 +21,11 @@ ObjectPicker {
     hoverEnabled: true
 
     onPressed: {
+        mouseController.enabled = true
+        mouseController.objectPicker = this
         root.isPressed = true
-        pickedChanged(this)
         screenPoint = pick.position
-        mouseController.currentPosition = pick.position
+        pickedChanged(this)
     }
     onEntered: {
         gizmoMaterial.ambient = "white"
@@ -35,6 +36,8 @@ ObjectPicker {
     onReleased: {
         gizmoMaterial.ambient = gizmoBaseColor
         root.isPressed = false
+        mouseController.objectPicker = null
+        mouseController.enabled = false
         pickedChanged(this)
     }
 }

--- a/meshroom/ui/qml/Viewer3D/TransformGizmoPicker.qml
+++ b/meshroom/ui/qml/Viewer3D/TransformGizmoPicker.qml
@@ -15,6 +15,7 @@ ObjectPicker {
     property int gizmoType
     property point screenPoint
     property var modelMatrix
+    property real scaleUnit
     property int button
     
     signal pickedChanged(var picker)

--- a/meshroom/ui/qml/Viewer3D/TransformGizmoPicker.qml
+++ b/meshroom/ui/qml/Viewer3D/TransformGizmoPicker.qml
@@ -1,0 +1,30 @@
+import Qt3D.Core 2.0
+import Qt3D.Render 2.9
+import Qt3D.Input 2.0
+import Qt3D.Extras 2.10
+import QtQuick 2.9
+import Qt3D.Logic 2.0
+
+ObjectPicker {
+    id: root
+    hoverEnabled: true
+    property bool isPressed : false
+    signal pickedChanged(bool picked)
+
+    onPressed: {
+        root.isPressed = true
+        pickedChanged(true)
+        mouseHandler.currentPosition = mouseHandler.lastPosition = pick.position
+    }
+    onEntered: {
+        material.ambient = "white"
+    }
+    onExited: {
+        if(!isPressed) material.ambient = baseColor
+    }
+    onReleased: {
+        material.ambient = baseColor
+        root.isPressed = false
+        pickedChanged(false)
+    }
+}

--- a/meshroom/ui/qml/Viewer3D/TransformGizmoPicker.qml
+++ b/meshroom/ui/qml/Viewer3D/TransformGizmoPicker.qml
@@ -7,28 +7,31 @@ import Qt3D.Logic 2.0
 
 ObjectPicker {
     id: root
-    hoverEnabled: true
     property bool isPressed : false
     property MouseHandler mouseController
-    property var objectMaterial
-    property color objectBaseColor
+    property var gizmoMaterial
+    property color gizmoBaseColor
+    property int gizmoAxis
+    property int gizmoType
     
-    signal pickedChanged(bool picked)
+    signal pickedChanged(var picker)
+    
+    hoverEnabled: true
 
     onPressed: {
         root.isPressed = true
-        pickedChanged(true)
+        pickedChanged(this)
         mouseController.currentPosition = mouseController.lastPosition = pick.position
     }
     onEntered: {
-        objectMaterial.ambient = "white"
+        gizmoMaterial.ambient = "white"
     }
     onExited: {
-        if(!isPressed) objectMaterial.ambient = objectBaseColor
+        if(!isPressed) gizmoMaterial.ambient = gizmoBaseColor
     }
     onReleased: {
-        objectMaterial.ambient = objectBaseColor
+        gizmoMaterial.ambient = gizmoBaseColor
         root.isPressed = false
-        pickedChanged(false)
+        pickedChanged(this)
     }
 }

--- a/meshroom/ui/qml/Viewer3D/Viewer3D.qml
+++ b/meshroom/ui/qml/Viewer3D/Viewer3D.qml
@@ -139,63 +139,6 @@ FocusScope {
                 }
             }
 
-            // BoundingBox: display bounding box for meshing computation
-            // note: use a NodeInstantiator to evaluate if a Meshing node exists at runtime
-            NodeInstantiator {
-                id: boundingBoxInstantiator
-                property var activeNode: _reconstruction.activeNodes.get("Meshing").node
-                active: activeNode && activeNode.attribute("useBoundingBox").value
-                model: 1
-
-                EntityWithGizmo {
-                    id: boundingBoxEntity
-                    sceneCameraController: cameraController
-                    frontLayerComponent: drawOnFront
-                    window: root
-                    enabled: boundingBoxVisibility.checked
-
-                    // Update node meshing slider values when the gizmo has changed: translation, rotation, scale
-                    transformGizmo.onGizmoChanged: {
-                        _reconstruction.setAttribute(boundingBoxInstantiator.activeNode.attribute("boundingBox.bboxTranslation.x"), translation.x)
-                        _reconstruction.setAttribute(boundingBoxInstantiator.activeNode.attribute("boundingBox.bboxTranslation.y"), translation.y)
-                        _reconstruction.setAttribute(boundingBoxInstantiator.activeNode.attribute("boundingBox.bboxTranslation.z"), translation.z)
-
-                        _reconstruction.setAttribute(boundingBoxInstantiator.activeNode.attribute("boundingBox.bboxRotation.x"), rotation.x)
-                        _reconstruction.setAttribute(boundingBoxInstantiator.activeNode.attribute("boundingBox.bboxRotation.y"), rotation.y)
-                        _reconstruction.setAttribute(boundingBoxInstantiator.activeNode.attribute("boundingBox.bboxRotation.z"), rotation.z)
-
-                        _reconstruction.setAttribute(boundingBoxInstantiator.activeNode.attribute("boundingBox.bboxScale.x"), scale.x)
-                        _reconstruction.setAttribute(boundingBoxInstantiator.activeNode.attribute("boundingBox.bboxScale.y"), scale.y)
-                        _reconstruction.setAttribute(boundingBoxInstantiator.activeNode.attribute("boundingBox.bboxScale.z"), scale.z)
-                    }
-
-                    // Automatically evalutate the Transform: value is taken from the node OR from the actual modification if the gizmo is moved by mouse.
-                    // When the gizmo has changed (with mouse), the new values are set to the node, the priority is given back to the node and the Transform is re-evaluated once with those values.
-                    property var nodeTranslation : Qt.vector3d(
-                        boundingBoxInstantiator.activeNode.attribute("boundingBox.bboxTranslation.x").value,
-                        boundingBoxInstantiator.activeNode.attribute("boundingBox.bboxTranslation.y").value,
-                        boundingBoxInstantiator.activeNode.attribute("boundingBox.bboxTranslation.z").value
-                    )
-                    property var nodeRotationX: boundingBoxInstantiator.activeNode.attribute("boundingBox.bboxRotation.x").value
-                    property var nodeRotationY: boundingBoxInstantiator.activeNode.attribute("boundingBox.bboxRotation.y").value
-                    property var nodeRotationZ: boundingBoxInstantiator.activeNode.attribute("boundingBox.bboxRotation.z").value
-                    property var nodeScale: Qt.vector3d(
-                        boundingBoxInstantiator.activeNode.attribute("boundingBox.bboxScale.x").value,
-                        boundingBoxInstantiator.activeNode.attribute("boundingBox.bboxScale.y").value,
-                        boundingBoxInstantiator.activeNode.attribute("boundingBox.bboxScale.z").value
-                    )
-
-                    transformGizmo.gizmoDisplayTransform.translation: transformGizmo.focusGizmoPriority ? transformGizmo.gizmoDisplayTransform.translation : nodeTranslation
-                    transformGizmo.gizmoDisplayTransform.rotationX: transformGizmo.focusGizmoPriority ? transformGizmo.gizmoDisplayTransform.rotationX : nodeRotationX
-                    transformGizmo.gizmoDisplayTransform.rotationY: transformGizmo.focusGizmoPriority ? transformGizmo.gizmoDisplayTransform.rotationY : nodeRotationY
-                    transformGizmo.gizmoDisplayTransform.rotationZ: transformGizmo.focusGizmoPriority ? transformGizmo.gizmoDisplayTransform.rotationZ : nodeRotationZ
-                    transformGizmo.objectTransform.scale3D: transformGizmo.focusGizmoPriority ? transformGizmo.objectTransform.scale3D : nodeScale
-
-                    // The entity
-                    BoundingBox { transform: boundingBoxEntity.objectTransform }
-                }
-            }
-
             DefaultCameraController {
                 id: cameraController
                 enabled: cameraSelector.camera == mainCamera
@@ -291,6 +234,11 @@ FocusScope {
                 pickingEnabled: cameraController.pickingActive || doubleClickTimer.running
                 camera: cameraSelector.camera
 
+                // Used for TransformGizmo in BoundingBox
+                sceneCameraController: cameraController
+                frontLayerComponent: drawOnFront
+                window: root
+
                 components: [
                     Transform {
                         id: transform
@@ -359,21 +307,6 @@ FocusScope {
                     checkable: !checked // hack to disabled check on toggle
                 }
             }
-        }
-    }
-
-    FloatingPane {
-        anchors.bottom: root.bottom
-        anchors.right: root.right
-        padding: 4
-        visible: boundingBoxInstantiator.active
-
-        MaterialToolButton {
-            id: boundingBoxVisibility
-            text: MaterialIcons.transform
-            ToolTip.text: "Show BoundingBox"
-            font.pointSize: 11
-            checked: true
         }
     }
 

--- a/meshroom/ui/qml/Viewer3D/Viewer3D.qml
+++ b/meshroom/ui/qml/Viewer3D/Viewer3D.qml
@@ -207,6 +207,17 @@ FocusScope {
                                             ]
                                         }
                                     }
+                                    LayerFilter {
+                                        filterMode: LayerFilter.DiscardAnyMatchingLayers
+                                        layers: Layer {id: drawOnFront}
+                                    }
+                                    LayerFilter {
+                                        filterMode: LayerFilter.AcceptAnyMatchingLayers
+                                        layers: [drawOnFront]
+                                        RenderStateSet {
+                                            renderStates: DepthTest { depthFunction: DepthTest.Equal }
+                                        }
+                                    }
                                 }
                             }
                         }

--- a/meshroom/ui/qml/Viewer3D/Viewer3D.qml
+++ b/meshroom/ui/qml/Viewer3D/Viewer3D.qml
@@ -139,6 +139,63 @@ FocusScope {
                 }
             }
 
+            // BoundingBox: display bounding box for meshing computation
+            // note: use a NodeInstantiator to evaluate if a Meshing node exists at runtime
+            NodeInstantiator {
+                id: boundingBoxInstantiator
+                property var activeNode: _reconstruction.activeNodes.get("Meshing").node
+                active: activeNode && activeNode.attribute("useBoundingBox").value
+                model: 1
+
+                EntityWithGizmo {
+                    id: boundingBoxEntity
+                    sceneCameraController: cameraController
+                    frontLayerComponent: drawOnFront
+                    window: root
+                    enabled: boundingBoxVisibility.checked
+
+                    // Update node meshing slider values when the gizmo has changed: translation, rotation, scale
+                    transformGizmo.onGizmoChanged: {
+                        _reconstruction.setAttribute(boundingBoxInstantiator.activeNode.attribute("boundingBox.bboxTranslation.x"), translation.x)
+                        _reconstruction.setAttribute(boundingBoxInstantiator.activeNode.attribute("boundingBox.bboxTranslation.y"), translation.y)
+                        _reconstruction.setAttribute(boundingBoxInstantiator.activeNode.attribute("boundingBox.bboxTranslation.z"), translation.z)
+
+                        _reconstruction.setAttribute(boundingBoxInstantiator.activeNode.attribute("boundingBox.bboxRotation.x"), rotation.x)
+                        _reconstruction.setAttribute(boundingBoxInstantiator.activeNode.attribute("boundingBox.bboxRotation.y"), rotation.y)
+                        _reconstruction.setAttribute(boundingBoxInstantiator.activeNode.attribute("boundingBox.bboxRotation.z"), rotation.z)
+
+                        _reconstruction.setAttribute(boundingBoxInstantiator.activeNode.attribute("boundingBox.bboxScale.x"), scale.x)
+                        _reconstruction.setAttribute(boundingBoxInstantiator.activeNode.attribute("boundingBox.bboxScale.y"), scale.y)
+                        _reconstruction.setAttribute(boundingBoxInstantiator.activeNode.attribute("boundingBox.bboxScale.z"), scale.z)
+                    }
+
+                    // Automatically evalutate the Transform: value is taken from the node OR from the actual modification if the gizmo is moved by mouse.
+                    // When the gizmo has changed (with mouse), the new values are set to the node, the priority is given back to the node and the Transform is re-evaluated once with those values.
+                    property var nodeTranslation : Qt.vector3d(
+                        boundingBoxInstantiator.activeNode.attribute("boundingBox.bboxTranslation.x").value,
+                        boundingBoxInstantiator.activeNode.attribute("boundingBox.bboxTranslation.y").value,
+                        boundingBoxInstantiator.activeNode.attribute("boundingBox.bboxTranslation.z").value
+                    )
+                    property var nodeRotationX: boundingBoxInstantiator.activeNode.attribute("boundingBox.bboxRotation.x").value
+                    property var nodeRotationY: boundingBoxInstantiator.activeNode.attribute("boundingBox.bboxRotation.y").value
+                    property var nodeRotationZ: boundingBoxInstantiator.activeNode.attribute("boundingBox.bboxRotation.z").value
+                    property var nodeScale: Qt.vector3d(
+                        boundingBoxInstantiator.activeNode.attribute("boundingBox.bboxScale.x").value,
+                        boundingBoxInstantiator.activeNode.attribute("boundingBox.bboxScale.y").value,
+                        boundingBoxInstantiator.activeNode.attribute("boundingBox.bboxScale.z").value
+                    )
+
+                    transformGizmo.gizmoDisplayTransform.translation: transformGizmo.focusGizmoPriority ? transformGizmo.gizmoDisplayTransform.translation : nodeTranslation
+                    transformGizmo.gizmoDisplayTransform.rotationX: transformGizmo.focusGizmoPriority ? transformGizmo.gizmoDisplayTransform.rotationX : nodeRotationX
+                    transformGizmo.gizmoDisplayTransform.rotationY: transformGizmo.focusGizmoPriority ? transformGizmo.gizmoDisplayTransform.rotationY : nodeRotationY
+                    transformGizmo.gizmoDisplayTransform.rotationZ: transformGizmo.focusGizmoPriority ? transformGizmo.gizmoDisplayTransform.rotationZ : nodeRotationZ
+                    transformGizmo.objectTransform.scale3D: transformGizmo.focusGizmoPriority ? transformGizmo.objectTransform.scale3D : nodeScale
+
+                    // The entity
+                    BoundingBox { transform: boundingBoxEntity.objectTransform }
+                }
+            }
+
             DefaultCameraController {
                 id: cameraController
                 enabled: cameraSelector.camera == mainCamera
@@ -302,6 +359,21 @@ FocusScope {
                     checkable: !checked // hack to disabled check on toggle
                 }
             }
+        }
+    }
+
+    FloatingPane {
+        anchors.bottom: root.bottom
+        anchors.right: root.right
+        padding: 4
+        visible: boundingBoxInstantiator.active
+
+        MaterialToolButton {
+            id: boundingBoxVisibility
+            text: MaterialIcons.transform
+            ToolTip.text: "Show BoundingBox"
+            font.pointSize: 11
+            checked: true
         }
     }
 

--- a/meshroom/ui/qml/Viewer3D/Viewer3D.qml
+++ b/meshroom/ui/qml/Viewer3D/Viewer3D.qml
@@ -215,7 +215,7 @@ FocusScope {
                                         filterMode: LayerFilter.AcceptAnyMatchingLayers
                                         layers: [drawOnFront]
                                         RenderStateSet {
-                                            renderStates: DepthTest { depthFunction: DepthTest.Equal }
+                                            renderStates: DepthTest { depthFunction: DepthTest.GreaterOrEqual }
                                         }
                                     }
                                 }

--- a/meshroom/ui/reconstruction.py
+++ b/meshroom/ui/reconstruction.py
@@ -453,6 +453,10 @@ class Reconstruction(UIGraph):
 
         self.setDefaultPipeline(defaultPipeline)
 
+    def clear(self):
+        self.clearActiveNodes()
+        super(Reconstruction, self).clear()
+
     def setDefaultPipeline(self, defaultPipeline):
         self._defaultPipeline = defaultPipeline
 
@@ -462,6 +466,10 @@ class Reconstruction(UIGraph):
             self._activeNodes.add(ActiveNode(category, self))
         for nodeType, _ in meshroom.core.nodesDesc.items():
             self._activeNodes.add(ActiveNode(nodeType, self))
+
+    def clearActiveNodes(self):
+        for key in self._activeNodes.keys():
+            self._activeNodes.get(key).node = None
 
     def onCameraInitChanged(self):
         # Update active nodes when CameraInit changes
@@ -559,7 +567,7 @@ class Reconstruction(UIGraph):
     def getViewpoints(self):
         """ Return the Viewpoints model. """
         # TODO: handle multiple Viewpoints models
-        return self._cameraInit.viewpoints.value if self._cameraInit else None
+        return self._cameraInit.viewpoints.value if self._cameraInit else QObjectListModel(parent=self)
 
     def updateCameraInits(self):
         cameraInits = self._graph.nodesByType("CameraInit", sortedByIndex=True)


### PR DESCRIPTION
## Description

- Add a Transform Gizmo to control Qt3D entities inside the 3D Viewer (generic).
- Add an input Bounding Box inside the Meshing node to customize the area to reconstruct.
- Add a new transformation mode to SfMTransform using the Transform Gizmo.

Needs https://github.com/alicevision/AliceVision/pull/846

## Features list
- [X] 3D Gizmo
  - [X] Basic visual entity
  - [X] Picking interaction & object transformations
  - [X] Mouse handling orientation
  - [X] Display on top of everything
  - [X] Improve performances
  - [X] Attach the Gizmo directly inside an object (using a special container entity)
  - [X] Adjust manipulator sensitivity
- [X] Bounding Box
  - [X] New bounding box parameter in AliceVision
  - [X] New bounding box parameter in Meshroom's Meshing node
  - [X] Display BBox edges/faces
- [X] SfMTransform
  - [X] New transformation mode (manual) + new manualTransform parameter in AliceVision
  - [X] New transformation mode (manual) + new manualTransform parameter in Meshroom's SfMTransform node
- [X] Integrate Transform/BoundingBox input in the 3D Inspector

To do later: use BoundingBox struct instead of Hexah in AliceVision meshing process.

## Transform Gizmo

![TransformGizmo_Complete_01](https://user-images.githubusercontent.com/44610840/88182288-4c5ed000-cc30-11ea-8cf9-cc269f20a7a0.png)

### Implementation remarks

The gizmo is entirely done with Qt3D in QML. To be able to get local transformations (and not global ones), we have to deal with matrix operations. Not all the methods/functions exist in QML, so we have to implement our own functions using PySide2 in Python.
The gizmo is made with meshes. Maybe it would be better to draw it on screen directly?

The controls are pretty similar to the Blender's gizmo ones. By the way, the visual is strongly inspired by the Blender 2.8+ gizmo.
It is quite user-friendly.

### How to use

#### EntityWithGizmo

Inside Viewer3D.qml :

```js
EntityWithGizmo {
    id: entityWithGizmoID
    sceneCameraController: cameraController // The id of the current DefaultCameraController
    frontLayerComponent: drawOnFront // The id of the Layer we want to draw on top of everything
    window: root // The id of the current FocusScope Item (acting as a window)

    // The entity
    Entity { components: [entityWithGizmoID.objectTransform, ...] } // The Transform of the Entity needs to be this attribute
}
```

## Bounding Box

![MeshingWithBBoxComparison](https://user-images.githubusercontent.com/44610840/88182073-06a20780-cc30-11ea-8907-cc2d3200e524.png)

*On the left, Meshing with default option. On the right, Meshing with the custom Bounding Box.*

### Implementation remarks

The Bounding Box is a simple Qt3D entity representing a box in the style of Blender. The transformations of this box are stored in the Meshing node. When we use the gizmo inside the 3D Viewer to adjust the box, the changes are sent to the Meshing node when we release the mouse button. Like this, we ensure data is stored in Python and not in QML. We can activate the use of the custom Bounding Box in the node and then adjust the parameters. In the 3D Inspector, on the right, we can show/hide the Bounding Box.

## SfMTransform

To activate the gizmo, you must choose the manual mode inside *method* parameter. You can then adjust the parameters with the sliders and/or the gizmo.

### Implementation remarks

When *manual* mode is set, the point cloud you see in the 3D Viewer is actually the input with a real-time Transform applied to it. Even when the node is computed, this is the transformed input which is displayed.
Fix https://github.com/alicevision/meshroom/issues/994
