### PR TITLE
Automatically update layout when needed

### DIFF
--- a/meshroom/nodes/aliceVision/LdrToHdrCalibration.py
+++ b/meshroom/nodes/aliceVision/LdrToHdrCalibration.py
@@ -11,7 +11,7 @@ def findMetadata(d, keys, defaultValue):
         k = key.lower()
         if v is not None:
             return v
-        for dk, dv in d.iteritems():
+        for dk, dv in d.items():
             dkm = dk.lower().replace(" ", "")
             if dkm == key.lower():
                 return dv

--- a/meshroom/nodes/aliceVision/LdrToHdrMerge.py
+++ b/meshroom/nodes/aliceVision/LdrToHdrMerge.py
@@ -11,7 +11,7 @@ def findMetadata(d, keys, defaultValue):
         k = key.lower()
         if v is not None:
             return v
-        for dk, dv in d.iteritems():
+        for dk, dv in d.items():
             dkm = dk.lower().replace(" ", "")
             if dkm == key.lower():
                 return dv

--- a/meshroom/nodes/aliceVision/LdrToHdrSampling.py
+++ b/meshroom/nodes/aliceVision/LdrToHdrSampling.py
@@ -12,7 +12,7 @@ def findMetadata(d, keys, defaultValue):
         k = key.lower()
         if v is not None:
             return v
-        for dk, dv in d.iteritems():
+        for dk, dv in d.items():
             dkm = dk.lower().replace(" ", "")
             if dkm == key.lower():
                 return dv

--- a/meshroom/ui/graph.py
+++ b/meshroom/ui/graph.py
@@ -194,6 +194,30 @@ class GraphLayout(QObject):
         """ Perform auto-layout on the whole graph. """
         self.autoLayout()
 
+    def positionBoundingBox(self, nodes=None):
+        """
+        Return bounding box for a set of nodes as (x, y, width, height).
+
+        Args:
+            nodes (list of Node): the list of nodes or the whole graph if None
+
+        Returns:
+            list of int: the resulting bounding box (x, y, width, height)
+        """
+        if nodes is None:
+            nodes = self.graph.nodes.values()
+        first = nodes[0]
+        bbox = [first.x, first.y, first.x, first.y]
+        for n in nodes:
+            bbox[0] = min(bbox[0], n.x)
+            bbox[1] = min(bbox[1], n.y)
+            bbox[2] = max(bbox[2], n.x)
+            bbox[3] = max(bbox[3], n.y)
+
+        bbox[2] -= bbox[0]
+        bbox[3] -= bbox[1]
+        return bbox
+
     def boundingBox(self, nodes=None):
         """
         Return bounding box for a set of nodes as (x, y, width, height).
@@ -202,22 +226,12 @@ class GraphLayout(QObject):
             nodes (list of Node): the list of nodes or the whole graph if None
 
         Returns:
-            tuple of int: the resulting bounding box (x, y, width, height)
+            list of int: the resulting bounding box (x, y, width, height)
         """
-        if nodes is None:
-            nodes = self.graph.nodes.values()
-        first = nodes[0]
-        bbox = [first.x, first.y, first.x + self._nodeWidth, first.y + self._nodeHeight]
-        for n in nodes:
-            bbox[0] = min(bbox[0], n.x)
-            bbox[1] = min(bbox[1], n.y)
-            bbox[2] = max(bbox[2], n.x + self._nodeWidth)
-            bbox[3] = max(bbox[3], n.y + self._nodeHeight)
-
-        bbox[2] -= bbox[0]
-        bbox[3] -= bbox[1]
-
-        return tuple(bbox)
+        bbox = self.positionBoundingBox(nodes)
+        bbox[2] += self._nodeWidth
+        bbox[3] += self._nodeHeight
+        return bbox
 
     def setDepthMode(self, mode):
         """ Set node depth mode to use. """
@@ -267,7 +281,14 @@ class UIGraph(QObject):
         # perform auto-layout if graph does not provide nodes positions
         if Graph.IO.Features.NodesPositions not in self._graph.fileFeatures:
             self._layout.reset()
-            self._undoStack.clear()  # clear undo-stack after layout
+            # clear undo-stack after layout
+            self._undoStack.clear()
+        else:
+            bbox = self._layout.positionBoundingBox()
+            if bbox[2] == 0 and bbox[3] == 0:
+                self._layout.reset()
+                # clear undo-stack after layout
+                self._undoStack.clear()
         self.graphChanged.emit()
 
     def onGraphUpdated(self):


### PR DESCRIPTION
When a scene is generated from a script, the positions of the nodes are not initialized.
So when we load the scene in Meshroom UI, all nodes are in (0,0).
This PR recognize this particular case, and update the nodes layout automatically.
