### PR TITLE
[core] GroupAttribute: check "enabled" property of child params in uid computation

### DIFF
--- a/meshroom/core/attribute.py
+++ b/meshroom/core/attribute.py
@@ -434,7 +434,7 @@ class GroupAttribute(Attribute):
     def uid(self, uidIndex):
         uids = []
         for k, v in self._value.items():
-            if uidIndex in v.desc.uid:
+            if v.enabled and uidIndex in v.desc.uid:
                 uids.append(v.uid(uidIndex))
         return hashValue(uids)
 


### PR DESCRIPTION
Disabled params should not be part of the UID computation, even for child attributes of an enabled GroupAttribute.

For instance, on the ImageProcessing node:

- Note the original "Output Folder"
- Enable "Sharpen Filter"
- Change "Width"
- Disable "Sharpen Filter"
- Should get the same value as the original "Output Folder" (even if the disabled "Sharpen Width" is not the same)
