### PR TITLE
[ui] Camera Response Function display: fix instabilities on linux

### DIFF
--- a/meshroom/core/node.py
+++ b/meshroom/core/node.py
@@ -499,6 +499,7 @@ class BaseNode(BaseObject):
     def getAttributes(self):
         return self._attributes
 
+    @Slot(str, result=bool)
     def hasAttribute(self, name):
         return name in self._attributes.keys()
 

--- a/meshroom/ui/components/csvData.py
+++ b/meshroom/ui/components/csvData.py
@@ -1,6 +1,6 @@
 from meshroom.common.qt import QObjectListModel
 
-from PySide2.QtCore import QObject, Slot, Signal, Property, Qt
+from PySide2.QtCore import QObject, Slot, Signal, Property
 from PySide2.QtCharts import QtCharts
 
 import csv
@@ -76,8 +76,8 @@ class CsvData(QObject):
             for elt in csvRows[1:]:
                 for idx, value in enumerate(elt):
                     dataList[idx].appendValue(value)
-        except:
-            logging.error("CsvData: Failed to load file: {}".format(self._filepath))
+        except Exception as e:
+            logging.error("CsvData: Failed to load file: {}\n{}".format(self._filepath, str(e)))
 
         return dataList
 

--- a/meshroom/ui/components/csvData.py
+++ b/meshroom/ui/components/csvData.py
@@ -1,10 +1,12 @@
 from meshroom.common.qt import QObjectListModel
 
-from PySide2.QtCore import QObject, Slot, Signal, Property
+from PySide2.QtCore import QObject, Slot, Signal, Property, Qt
 from PySide2.QtCharts import QtCharts
 
 import csv
 import os
+import logging
+
 
 class CsvData(QObject):
     """Store data from a CSV file."""
@@ -20,13 +22,18 @@ class CsvData(QObject):
     def getColumn(self, index):
         return self._data.at(index)
 
+    @Slot(result=str)
     def getFilepath(self):
         return self._filepath
 
     @Slot(result=int)
     def getNbColumns(self):
-        return len(self._data) if self._ready else 0
+        if self._ready:
+            return len(self._data)
+        else:
+            return 0
 
+    @Slot(str)
     def setFilepath(self, filepath):
         if self._filepath == filepath:
             return
@@ -40,6 +47,7 @@ class CsvData(QObject):
         self._ready = ready
         self.readyChanged.emit()
 
+    @Slot()
     def updateData(self):
         self.setReady(False)
         self._data.clear()
@@ -53,23 +61,23 @@ class CsvData(QObject):
         if not self._filepath or not self._filepath.lower().endswith(".csv") or not os.path.isfile(self._filepath):
             return []
 
-        csvRows = []
-        with open(self._filepath, "r") as fp:
-            reader = csv.reader(fp)
-            for row in reader:
-                csvRows.append(row)
-
         dataList = []
-
-        # Create the objects in dataList
-        # with the first line elements as objects' title
-        for elt in csvRows[0]:
-            dataList.append(CsvColumn(elt, parent=self._data))
-
-        # Populate the content attribute
-        for elt in csvRows[1:]:
-            for idx, value in enumerate(elt):
-                dataList[idx].appendValue(value)
+        try:
+            csvRows = []
+            with open(self._filepath, "r") as fp:
+                reader = csv.reader(fp)
+                for row in reader:
+                    csvRows.append(row)
+            # Create the objects in dataList
+            # with the first line elements as objects' title
+            for elt in csvRows[0]:
+                dataList.append(CsvColumn(elt)) # , parent=self._data
+            # Populate the content attribute
+            for elt in csvRows[1:]:
+                for idx, value in enumerate(elt):
+                    dataList[idx].appendValue(value)
+        except:
+            logging.error("CsvData: Failed to load file: {}".format(self._filepath))
 
         return dataList
 

--- a/meshroom/ui/qml/Viewer/CameraResponseGraph.qml
+++ b/meshroom/ui/qml/Viewer/CameraResponseGraph.qml
@@ -22,7 +22,8 @@ FloatingPane {
 
     CsvData {
         id: csvData
-        filepath: ldrHdrCalibrationNode ? ldrHdrCalibrationNode.attribute("response").value : ""
+        property bool hasAttr: (ldrHdrCalibrationNode && ldrHdrCalibrationNode.hasAttribute("response"))
+        filepath: hasAttr ? ldrHdrCalibrationNode.attribute("response").value : ""
     }
 
     // To avoid interaction with components in background
@@ -34,7 +35,8 @@ FloatingPane {
         onWheel: {}
     }
 
-    property bool crfReady: csvData.ready && csvData.nbColumns >= 4
+    // note: We need to use csvData.getNbColumns() slot instead of the csvData.nbColumns property to avoid a crash on linux.
+    property bool crfReady: csvData.ready && (csvData.getNbColumns() >= 4)
     onCrfReadyChanged: {
         if(crfReady)
         {

--- a/meshroom/ui/qml/Viewer/CameraResponseGraph.qml
+++ b/meshroom/ui/qml/Viewer/CameraResponseGraph.qml
@@ -36,7 +36,7 @@ FloatingPane {
     }
 
     // note: We need to use csvData.getNbColumns() slot instead of the csvData.nbColumns property to avoid a crash on linux.
-    property bool crfReady: csvData.ready && (csvData.getNbColumns() >= 4)
+    property bool crfReady: csvData && csvData.ready && (csvData.getNbColumns() >= 4)
     onCrfReadyChanged: {
         if(crfReady)
         {

--- a/meshroom/ui/qml/Viewer/Viewer2D.qml
+++ b/meshroom/ui/qml/Viewer/Viewer2D.qml
@@ -558,10 +558,15 @@ FocusScope {
                         anchors.fill: parent
 
                         property var activeNode: _reconstruction.activeNodes.get('LdrToHdrCalibration').node
-                        active: activeNode && activeNode.isComputed && displayLdrHdrCalibrationGraph.checked
+                        property var isEnabled: displayLdrHdrCalibrationGraph.checked && activeNode && activeNode.isComputed
+                        // active: isEnabled
+                        // Setting "active" from true to false creates a crash on linux with Qt 5.14.2.
+                        // As a workaround, we clear the CameraResponseGraph with an empty node
+                        // and hide the loader content.
+                        visible: isEnabled
 
                         sourceComponent: CameraResponseGraph {
-                            ldrHdrCalibrationNode: activeNode
+                            ldrHdrCalibrationNode: isEnabled ? activeNode : null
                         }
                     }
                 }


### PR DESCRIPTION
## Description

Camera Response Function display crashes on linux with Qt 5.14.2.

## Features list

- [X] More checks on file content and catch exceptions.
- [X] Check nbColumns using a slot instead of using the property.
- [X] Use a workaround on the CSV loader to avoid a crash (do not set active
to False but use visibility instead).
