### PR TITLE
[nodes] PanoramaInit: New parameter to set an extra image rotation to each camera declared the input xml

### DIFF
--- a/meshroom/nodes/aliceVision/PanoramaInit.py
+++ b/meshroom/nodes/aliceVision/PanoramaInit.py
@@ -96,7 +96,8 @@ This node allows to setup the Panorama:
             description='Add a rotation to the input XML given poses.',
             value='None',
             values=['None', 'rotate90', 'rotate180', 'rotate270'],
-            uid=[],
+            exclusive=True,
+            uid=[0]
         ),
         desc.ChoiceParam(
             name='verboseLevel',

--- a/meshroom/nodes/aliceVision/PanoramaInit.py
+++ b/meshroom/nodes/aliceVision/PanoramaInit.py
@@ -96,7 +96,6 @@ This node allows to setup the Panorama:
             description='Add a rotation to the input XML given poses.',
             value='None',
             values=['None', 'rotate90', 'rotate180', 'rotate270'],
-            exclusive=True,
             uid=[],
         ),
         desc.ChoiceParam(

--- a/meshroom/nodes/aliceVision/PanoramaInit.py
+++ b/meshroom/nodes/aliceVision/PanoramaInit.py
@@ -91,6 +91,15 @@ This node allows to setup the Panorama:
             enabled=lambda node: node.useFisheye.value and not node.estimateFisheyeCircle.value,
         ),
         desc.ChoiceParam(
+            name='inputAngle',
+            label='input Angle offset',
+            description='Add a rotation to the input XML given poses.',
+            value='None',
+            values=['None', 'rotate90', 'rotate180', 'rotate270'],
+            exclusive=True,
+            uid=[],
+        ),
+        desc.ChoiceParam(
             name='verboseLevel',
             label='Verbose Level',
             description='Verbosity level (fatal, error, warning, info, debug, trace).',


### PR DESCRIPTION
Add a parameter to panoramaInit :

XML input is giving a pose.
This parameter will update the input pose such that it adapts to a rotated image input.

Based on https://github.com/alicevision/AliceVision/pull/867