### PR TITLE
[nodes] Texturing: put downscale to 2 by default

### DIFF
--- a/meshroom/nodes/aliceVision/Texturing.py
+++ b/meshroom/nodes/aliceVision/Texturing.py
@@ -56,7 +56,7 @@ Many cameras are contributing to the low frequencies and only the best ones cont
             name='downscale',
             label='Texture Downscale',
             description='''Texture downscale factor''',
-            value=1,
+            value=2,
             values=(1, 2, 4, 8),
             exclusive=True,
             uid=[0],


### PR DESCRIPTION
Scale 1 could be better for objects, but is really too much for large environments.
It's better to have a default value which ensures that we can open the result.
