### PR TITLE
[ui] Do not animate transformations between viewpoints

### DIFF
--- a/meshroom/ui/qml/Viewer3D/ViewpointCamera.qml
+++ b/meshroom/ui/qml/Viewer3D/ViewpointCamera.qml
@@ -28,16 +28,7 @@ Entity {
     }
 
     components: [
-        Transform {
-            id: transform
-
-            Behavior on rotation {
-                PropertyAnimation { duration: 200}
-            }
-            Behavior on translation {
-                Vector3dAnimation { duration: 200}
-            }
-        }
+        Transform { id: transform }
     ]
 
     StateGroup {


### PR DESCRIPTION
- perspective goes to the viewpoint instantly when 'Sync with image selection' is turned on and the selected image is changed
- fixes #1115