### PR TITLE
Add cli script to start Meshroom on Windows

### DIFF
--- a/start.bat
+++ b/start.bat
@@ -1,3 +1,4 @@
 # Windows
+# Add the aliceVision and qtPlugins folders with the binaries to this directory
 set MESHROOM_INSTALL_DIR=%CD%
 set PYTHONPATH=%CD% && python meshroom/ui

--- a/start.bat
+++ b/start.bat
@@ -1,2 +1,3 @@
+# Windows
 set MESHROOM_INSTALL_DIR=%CD%
 set PYTHONPATH=%CD% && python meshroom/ui

--- a/start.bat
+++ b/start.bat
@@ -1,0 +1,2 @@
+set MESHROOM_INSTALL_DIR=%CD%
+set PYTHONPATH=%CD% && python meshroom/ui


### PR DESCRIPTION
Simple .bat script to start Meshroom. Requires aliceVision and qtPlugins binaries in the same folder.