### PR TITLE
[ui] add support for selecting multiple nodes at once

### DIFF
--- a/meshroom/common/qt.py
+++ b/meshroom/common/qt.py
@@ -113,6 +113,7 @@ class QObjectListModel(QtCore.QAbstractListModel):
     ############
     # List API #
     ############
+    @QtCore.Slot(QtCore.QObject)
     def append(self, obj):
         """ Insert object at the end of the model. """
         self.extend([obj])
@@ -182,6 +183,7 @@ class QObjectListModel(QtCore.QAbstractListModel):
         self.endRemoveRows()
         self.countChanged.emit()
 
+    @QtCore.Slot(QtCore.QObject)
     def remove(self, obj):
         """ Removes the first occurrence of the given object. Raises a ValueError if not in list. """
         if not self.contains(obj):

--- a/meshroom/core/graph.py
+++ b/meshroom/core/graph.py
@@ -385,6 +385,22 @@ class Graph(BaseObject):
             OrderedDict[Node, Node]: the source->duplicate map
         """
         srcNodes, srcEdges = self.dfsOnDiscover(startNodes=[fromNode], reverse=True, dependenciesOnly=True)
+        return self.duplicateNodes(srcNodes, srcEdges)
+
+    def duplicateNodesFromList(self, nodes):
+        """
+        Duplicate 'nodes'.
+
+        Args:
+            nodes (list[Node]): the nodes to duplicate
+
+        Returns:
+            OrderedDict[Node, Node]: the source->duplicate map
+        """
+        srcEdges = [ self.nodeInEdges(n) for n in nodes ]
+        return self.duplicateNodes(nodes, srcEdges)
+
+    def duplicateNodes(self, srcNodes, srcEdges):
         # use OrderedDict to keep duplicated nodes creation order
         duplicates = OrderedDict()
 

--- a/meshroom/core/graph.py
+++ b/meshroom/core/graph.py
@@ -362,45 +362,15 @@ class Graph(BaseObject):
                                 child.resetValue()
         return node, skippedEdges
 
-    def duplicateNode(self, srcNode):
-        """ Duplicate a node in the graph with its connections.
+    def duplicateNodes(self, srcNodes):
+        """ Duplicate nodes in the graph with their connections.
 
         Args:
-            srcNode: the node to duplicate
-
-        Returns:
-            Node: the created node
-        """
-        node, edges = self.copyNode(srcNode, withEdges=True)
-        return self.addNode(node)
-
-    def duplicateNodesFromNode(self, fromNode):
-        """
-        Duplicate 'fromNode' and all the following nodes towards graph's leaves.
-
-        Args:
-            fromNode (Node): the node to start the duplication from
+            srcNodes: the nodes to duplicate
 
         Returns:
             OrderedDict[Node, Node]: the source->duplicate map
         """
-        srcNodes, srcEdges = self.dfsOnDiscover(startNodes=[fromNode], reverse=True, dependenciesOnly=True)
-        return self.duplicateNodes(srcNodes, srcEdges)
-
-    def duplicateNodesFromList(self, nodes):
-        """
-        Duplicate 'nodes'.
-
-        Args:
-            nodes (list[Node]): the nodes to duplicate
-
-        Returns:
-            OrderedDict[Node, Node]: the source->duplicate map
-        """
-        srcEdges = [ self.nodeInEdges(n) for n in nodes ]
-        return self.duplicateNodes(nodes, srcEdges)
-
-    def duplicateNodes(self, srcNodes, srcEdges):
         # use OrderedDict to keep duplicated nodes creation order
         duplicates = OrderedDict()
 

--- a/meshroom/core/graph.py
+++ b/meshroom/core/graph.py
@@ -1132,11 +1132,6 @@ class Graph(BaseObject):
         for node in self.nodes:
             node.clearSubmittedChunks()
 
-    @Slot(Node)
-    def clearDataFrom(self, startNode):
-        for node in self.dfsOnDiscover(startNodes=[startNode], reverse=True, dependenciesOnly=True)[0]:
-            node.clearData()
-
     def iterChunksByStatus(self, status):
         """ Iterate over NodeChunks with the given status """
         for node in self.nodes:

--- a/meshroom/core/node.py
+++ b/meshroom/core/node.py
@@ -684,7 +684,6 @@ class BaseNode(BaseObject):
     def _isComputed(self):
         return self.hasStatus(Status.SUCCESS)
 
-    @Slot()
     def clearData(self):
         """ Delete this Node internal folder.
         Status will be reset to Status.NONE

--- a/meshroom/ui/commands.py
+++ b/meshroom/ui/commands.py
@@ -159,7 +159,7 @@ class RemoveNodeCommand(GraphCommand):
 
     def redoImpl(self):
         # only keep outEdges since inEdges are serialized in nodeDict
-        inEdges, self.outEdges = self.graph.removeNode(self.nodeName)
+        _, self.outEdges = self.graph.removeNode(self.nodeName)
         return True
 
     def undoImpl(self):
@@ -173,54 +173,25 @@ class RemoveNodeCommand(GraphCommand):
                                    self.graph.attribute(dstAttr))
 
 
-class _DuplicateNodes(GraphCommand):
-    def __init__(self, graph, parent=None):
-        super(_DuplicateNodes, self).__init__(graph, parent)
-        self.duplicates = []
-
-    def undoImpl(self):
-        # delete all the duplicated nodes
-        for nodeName in self.duplicates:
-            self.graph.removeNode(nodeName)
-
-
-class DuplicateNodeCommand(_DuplicateNodes):
-    """
-    Handle node duplication in a Graph.
-    """
-    def __init__(self, graph, srcNode, duplicateFollowingNodes, parent=None):
-        super(DuplicateNodeCommand, self).__init__(graph, parent)
-        self.srcNodeName = srcNode.name
-        self.duplicateFollowingNodes = duplicateFollowingNodes
-
-    def redoImpl(self):
-        srcNode = self.graph.node(self.srcNodeName)
-
-        if self.duplicateFollowingNodes:
-            duplicates = list(self.graph.duplicateNodesFromNode(srcNode).values())
-            self.setText("Duplicate {} nodes from {}".format(len(duplicates), self.srcNodeName))
-        else:
-            duplicates = [self.graph.duplicateNode(srcNode)]
-            self.setText("Duplicate {}".format(self.srcNodeName))
-
-        self.duplicates = [n.name for n in duplicates]
-        return duplicates
-
-
-class DuplicateNodeListCommand(_DuplicateNodes):
+class DuplicateNodesCommand(GraphCommand):
     """
     Handle node duplication in a Graph.
     """
     def __init__(self, graph, srcNodes, parent=None):
-        super(DuplicateNodeListCommand, self).__init__(graph, parent)
-        self.srcNodeNames = [ srcNode.name for srcNode in srcNodes ]
-        self.setText("Duplicate selected nodes")
+        super(DuplicateNodesCommand, self).__init__(graph, parent)
+        self.srcNodeNames = [ n.name for n in srcNodes ]
+        self.setText("Duplicate Nodes")
 
     def redoImpl(self):
-        srcNodes = [ self.graph.node(srcNodeName) for srcNodeName in self.srcNodeNames ]
-        duplicates = list(self.graph.duplicateNodesFromList(srcNodes).values())
+        srcNodes = [ self.graph.node(i) for i in self.srcNodeNames ]
+        duplicates = list(self.graph.duplicateNodes(srcNodes).values())
         self.duplicates = [ n.name for n in duplicates ]
         return duplicates
+
+    def undoImpl(self):
+        # remove all duplicates
+        for duplicate in self.duplicates:
+            self.graph.removeNode(duplicate)
 
 
 class SetAttributeCommand(GraphCommand):

--- a/meshroom/ui/graph.py
+++ b/meshroom/ui/graph.py
@@ -662,6 +662,17 @@ class UIGraph(QObject):
     def removeAttribute(self, attribute):
         self.push(commands.ListAttributeRemoveCommand(self._graph, attribute))
 
+    @Slot(Node)
+    def appendSelection(self, node):
+        if not self._selectedNodes.contains(node):
+            self._selectedNodes.append(node)
+
+    @Slot(Node)
+    def selectFollowing(self, node):
+        for n in self._graph.dfsOnDiscover(startNodes=[node], reverse=True, dependenciesOnly=True)[0]:
+            self.appendSelection(n)
+        self.selectedNodesChanged.emit()
+
     @Slot(QObject, QObject)
     def boxSelect(self, selection, draggable):
         x = selection.x() - draggable.x()
@@ -675,8 +686,7 @@ class UIGraph(QObject):
             bbox = self._layout.boundingBox([n])
             # evaluate if the selection and node intersect
             if not (x > bbox[2] + bbox[0] or otherX < bbox[0] or y > bbox[3] + bbox[1] or otherY < bbox[1]):
-                if not self._selectedNodes.contains(n):
-                    self._selectedNodes.append(n)
+                self.appendSelection(n)
         self.selectedNodesChanged.emit()
 
     @Slot()

--- a/meshroom/ui/graph.py
+++ b/meshroom/ui/graph.py
@@ -679,14 +679,12 @@ class UIGraph(QObject):
                     self._selectedNodes.append(n)
         self.selectedNodesChanged.emit()
 
-    def clearNodeSelection(self):
-        """ Clear node selection. """
-        self.selectedNode = None
-
     @Slot()
-    def clearNodesSelections(self):
-        """ Clear multiple nodes selection. """
+    def clearNodeSelection(self):
+        """Clear all node selection."""
+        self.selectedNode = None
         self._selectedNodes.clear()
+        self.selectedNodeChanged.emit()
         self.selectedNodesChanged.emit()
 
     def clearNodeHover(self):

--- a/meshroom/ui/qml/GraphEditor/GraphEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/GraphEditor.qml
@@ -62,15 +62,15 @@ Item {
     }
 
     /// Duplicate a node and optionnally all the following ones
-    function duplicateNode(node, duplicateFollowingNodes) {
+    function duplicateNode(duplicateFollowingNodes) {
         if (duplicateFollowingNodes) {
-            var nodes = uigraph.duplicateNodesFrom(node)
+            var nodes = uigraph.duplicateNodesFrom(uigraph.selectedNodes)
         } else {
             var nodes = uigraph.duplicateNodes(uigraph.selectedNodes)
         }
         uigraph.clearNodeSelection()
-        selectNode(nodes[0])
-        uigraph.selectFollowing(nodes[0])
+        uigraph.selectedNode = nodes[0]
+        uigraph.selectNodes(nodes)
     }
 
 
@@ -79,11 +79,11 @@ Item {
             fit()
         if(event.key === Qt.Key_Delete)
             if(event.modifiers == Qt.AltModifier)
-                uigraph.removeNodesFrom(uigraph.selectedNode)
+                uigraph.removeNodesFrom(uigraph.selectedNodes)
             else
                 uigraph.removeNodes(uigraph.selectedNodes)
         if(event.key === Qt.Key_D)
-            duplicateNode(uigraph.selectedNode, event.modifiers == Qt.AltModifier)
+            duplicateNode(event.modifiers == Qt.AltModifier)
     }
 
     MouseArea {
@@ -338,14 +338,14 @@ Item {
                 MenuItem {
                     text: "Duplicate Node(s)" + (duplicateFollowingButton.hovered ? " From Here" : "")
                     enabled: true
-                    onTriggered: duplicateNode(nodeMenu.currentNode, false)
+                    onTriggered: duplicateNode(false)
                     MaterialToolButton {
                         id: duplicateFollowingButton
                         height: parent.height
                         anchors { right: parent.right; rightMargin: parent.padding }
                         text: MaterialIcons.fast_forward
                         onClicked: {
-                            duplicateNode(nodeMenu.currentNode, true);
+                            duplicateNode(true);
                             nodeMenu.close();
                         }
                     }
@@ -360,7 +360,7 @@ Item {
                         anchors { right: parent.right; rightMargin: parent.padding }
                         text: MaterialIcons.fast_forward
                         onClicked: {
-                            uigraph.removeNodesFrom(nodeMenu.currentNode);
+                            uigraph.removeNodesFrom(uigraph.selectedNodes);
                             nodeMenu.close();
                         }
                     }
@@ -419,7 +419,7 @@ Item {
 
                             onAccepted: {
                                 if(deleteFollowing)
-                                    graph.clearDataFrom(node);
+                                    uigraph.clearDataFrom(uigraph.selectedNodes);
                                 else
                                     uigraph.clearData(uigraph.selectedNodes);
                             }

--- a/meshroom/ui/qml/GraphEditor/GraphEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/GraphEditor.qml
@@ -55,8 +55,8 @@ Item {
     function selectNode(node)
     {
         uigraph.selectedNode = node
-        if (!uigraph.selectedNodes.contains(node) && node !== null) {
-            uigraph.selectedNodes.append(node)
+        if (node !== null) {
+            uigraph.appendSelection(node)
             uigraph.selectedNodesChanged()
         }
     }
@@ -68,7 +68,9 @@ Item {
         } else {
             var nodes = uigraph.duplicateNodes(uigraph.selectedNodes)
         }
+        uigraph.clearNodeSelection()
         selectNode(nodes[0])
+        uigraph.selectFollowing(nodes[0])
     }
 
 
@@ -80,6 +82,8 @@ Item {
                 uigraph.removeNodesFrom(uigraph.selectedNode)
             else
                 uigraph.removeNodes(uigraph.selectedNodes)
+        if(event.key === Qt.Key_D)
+            duplicateNode(uigraph.selectedNode, event.modifiers == Qt.AltModifier)
     }
 
     MouseArea {
@@ -448,7 +452,7 @@ Item {
 
                     onPressed: {
                         if (mouse.button == Qt.LeftButton) {
-                            if (mouse.modifiers & Qt.ControlModifier) {
+                            if (mouse.modifiers & Qt.ControlModifier && !(mouse.modifiers & Qt.AltModifier)) {
                                 if (mainSelected && selected) {
                                     // left clicking a selected node twice with control will deselect it
                                     uigraph.selectedNodes.remove(node)
@@ -457,7 +461,10 @@ Item {
                                     return
                                 }
                             } else if (mouse.modifiers & Qt.AltModifier) {
-                                duplicateNode(node, true)
+                                if (!(mouse.modifiers & Qt.ControlModifier)){
+                                    uigraph.clearNodeSelection()
+                                }
+                                uigraph.selectFollowing(node)
                             } else if (!mainSelected && !selected) {
                                 uigraph.clearNodeSelection()
                             }

--- a/meshroom/ui/qml/GraphEditor/GraphEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/GraphEditor.qml
@@ -55,11 +55,19 @@ Item {
     function selectNode(node)
     {
         uigraph.selectedNode = node
+        if (!uigraph.selectedNodes.contains(node) && node !== null) {
+            uigraph.selectedNodes.append(node)
+            uigraph.selectedNodesChanged()
+        }
     }
 
     /// Duplicate a node and optionnally all the following ones
     function duplicateNode(node, duplicateFollowingNodes) {
-        var nodes = uigraph.duplicateNode(node, duplicateFollowingNodes)
+        if (duplicateFollowingNodes) {
+            var nodes = uigraph.duplicateNodesFrom(node)
+        } else {
+            var nodes = uigraph.duplicateNodes(uigraph.selectedNodes)
+        }
         selectNode(nodes[0])
     }
 
@@ -71,7 +79,7 @@ Item {
             if(event.modifiers == Qt.AltModifier)
                 uigraph.removeNodesFrom(uigraph.selectedNode)
             else
-                uigraph.removeNode(uigraph.selectedNode)
+                uigraph.removeNodes(uigraph.selectedNodes)
     }
 
     MouseArea {
@@ -288,6 +296,7 @@ Item {
                 property bool canComputeNode: currentNode != null && uigraph.graph.canCompute(currentNode)
                 //canSubmitOrCompute: return int n : 0 >= n <= 3 | n=0 cannot submit or compute | n=1 can compute | n=2 can submit | n=3 can compute & submit
                 property int canSubmitOrCompute: currentNode != null && uigraph.graph.canSubmitOrCompute(currentNode)
+                width: 220
                 onClosed: currentNode = null
 
                 MenuItem {
@@ -324,7 +333,7 @@ Item {
                 }
                 MenuSeparator {}
                 MenuItem {
-                    text: "Duplicate Node" + (duplicateFollowingButton.hovered ? "s From Here" : uigraph.nodeSelection(nodeMenu.currentNode) ? "s" : "")
+                    text: "Duplicate Node(s)" + (duplicateFollowingButton.hovered ? " From Here" : "")
                     enabled: true
                     onTriggered: duplicateNode(nodeMenu.currentNode, false)
                     MaterialToolButton {
@@ -339,9 +348,9 @@ Item {
                     }
                 }
                 MenuItem {
-                    text: "Remove Node" + (removeFollowingButton.hovered ? "s From Here" : uigraph.nodeSelection(nodeMenu.currentNode) ? "s" : "")
+                    text: "Remove Node(s)" + (removeFollowingButton.hovered ? " From Here" : "")
                     enabled: nodeMenu.currentNode ? !nodeMenu.currentNode.locked : false
-                    onTriggered: uigraph.removeNode(nodeMenu.currentNode)
+                    onTriggered: uigraph.removeNodes(uigraph.selectedNodes)
                     MaterialToolButton {
                         id: removeFollowingButton
                         height: parent.height
@@ -409,7 +418,7 @@ Item {
                                 if(deleteFollowing)
                                     graph.clearDataFrom(node);
                                 else
-                                    uigraph.clearData(node);
+                                    uigraph.clearData(uigraph.selectedNodes);
                             }
                             onClosed: destroy()
                         }
@@ -447,9 +456,6 @@ Item {
                                     uigraph.selectedNodesChanged()
                                     selectNode(null)
                                     return
-                                } else if (!selected) {
-                                    uigraph.selectedNodes.append(node)
-                                    uigraph.selectedNodesChanged()
                                 }
                             } else if (mouse.modifiers & Qt.AltModifier) {
                                 duplicateNode(node, true)
@@ -468,7 +474,7 @@ Item {
 
                     onDoubleClicked: root.nodeDoubleClicked(mouse, node)
 
-                    onMoved: uigraph.moveNode(node, position)
+                    onMoved: uigraph.moveNode(node, position, uigraph.selectedNodes)
 
                     onEntered: uigraph.hoveredNode = node
                     onExited: uigraph.hoveredNode = null

--- a/meshroom/ui/qml/GraphEditor/GraphEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/GraphEditor.qml
@@ -441,7 +441,7 @@ Item {
                     onPressed: {
                         if (mouse.button == Qt.LeftButton) {
                             if (mouse.modifiers & Qt.ControlModifier) {
-                                if (mainSelected) {
+                                if (mainSelected && selected) {
                                     // left clicking a selected node twice with control will deselect it
                                     uigraph.selectedNodes.remove(node)
                                     uigraph.selectedNodesChanged()

--- a/meshroom/ui/qml/GraphEditor/GraphEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/GraphEditor.qml
@@ -112,8 +112,7 @@ Item {
 
         onPressed: {
             if (mouse.button != Qt.MiddleButton && mouse.modifiers == Qt.NoModifier) {
-                selectNode(null)
-                uigraph.clearNodesSelections()
+                uigraph.clearNodeSelection()
             }
             if (mouse.button == Qt.LeftButton && (mouse.modifiers == Qt.NoModifier || mouse.modifiers == Qt.ControlModifier)) {
                 boxSelect.startX = mouseX
@@ -460,11 +459,11 @@ Item {
                             } else if (mouse.modifiers & Qt.AltModifier) {
                                 duplicateNode(node, true)
                             } else if (!mainSelected && !selected) {
-                                uigraph.clearNodesSelections()
+                                uigraph.clearNodeSelection()
                             }
                         } else if (mouse.button == Qt.RightButton) {
                             if (!mainSelected && !selected) {
-                                uigraph.clearNodesSelections()
+                                uigraph.clearNodeSelection()
                             }
                             nodeMenu.currentNode = node
                             nodeMenu.popup()

--- a/meshroom/ui/qml/GraphEditor/GraphEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/GraphEditor.qml
@@ -87,7 +87,7 @@ Item {
         hoverEnabled: true
         acceptedButtons: Qt.LeftButton | Qt.RightButton | Qt.MiddleButton
         drag.threshold: 0
-        cursorShape: drag.active ? Qt.ClosedHandCursor : Qt.ArrowCursor
+        cursorShape: drag.target == draggable ? Qt.ClosedHandCursor : Qt.ArrowCursor
 
         onWheel: {
             var zoomFactor = wheel.angleDelta.y > 0 ? factor : 1/factor
@@ -487,13 +487,7 @@ Item {
                     }
 
                     // allow all nodes to know if they are being dragged
-                    onDraggingChanged: {
-                        if (dragging) {
-                            nodeRepeater.dragging = true
-                        } else {
-                            nodeRepeater.dragging = false
-                        }
-                    }
+                    onDraggingChanged: nodeRepeater.dragging = dragging
 
                     // must not be enabled during drag because the other nodes will be slow to match the movement of the node being dragged
                     Behavior on x {

--- a/meshroom/ui/qml/GraphEditor/Node.qml
+++ b/meshroom/ui/qml/GraphEditor/Node.qml
@@ -20,8 +20,12 @@ Item {
     /// Whether the node is in compatibility mode
     readonly property bool isCompatibilityNode: node ? node.hasOwnProperty("compatibilityIssue") : false
     /// Mouse related states
+    property bool mainSelected: false
     property bool selected: false
     property bool hovered: false
+    property bool dragging: mouseArea.drag.active
+    /// Combined x and y
+    property point position: Qt.point(x, y)
     /// Styling
     property color shadowColor: "#cc000000"
     readonly property color defaultColor: isCompatibilityNode ? "#444" : activePalette.base
@@ -93,6 +97,7 @@ Item {
 
     // Main Layout
     MouseArea {
+        id: mouseArea
         width: parent.width
         height: body.height
         drag.target: root
@@ -117,9 +122,9 @@ Item {
         Rectangle {
             anchors.fill: nodeContent
             anchors.margins: -border.width
-            visible: root.selected || root.hovered
+            visible: root.mainSelected || root.hovered
             border.width: 2.5
-            border.color: root.selected ? activePalette.highlight : Qt.darker(activePalette.highlight, 1.5)
+            border.color: root.mainSelected ? activePalette.highlight : Qt.darker(activePalette.highlight, 1.5)
             opacity: 0.9
             radius: background.radius
             color: "transparent"
@@ -151,7 +156,7 @@ Item {
                     id: header
                     width: parent.width
                     height: headerLayout.height
-                    color: root.selected ? activePalette.highlight : root.baseColor
+                    color: root.mainSelected ? activePalette.highlight : root.selected ? Qt.darker(activePalette.highlight, 1.1): root.baseColor
                     radius: background.radius
 
                     // Fill header's bottom radius
@@ -174,7 +179,7 @@ Item {
                             Layout.fillWidth: true
                             text: node ? node.label : ""
                             padding: 4
-                            color: root.selected ? "white" : activePalette.text
+                            color: root.mainSelected ? "white" : activePalette.text
                             elide: Text.ElideMiddle
                             font.pointSize: 8
                         }

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -264,7 +264,8 @@ def test_duplicate_nodes():
     n3 = g.addNewNode('AppendFiles', input=n1.output, input2=n2.output)
 
     # duplicate from n1
-    nMap = g.duplicateNodesFromNode(fromNode=n1)
+    nodes_to_duplicate, _ = g.dfsOnDiscover(startNodes=[n1], reverse=True, dependenciesOnly=True)
+    nMap = g.duplicateNodes(srcNodes=nodes_to_duplicate)
     for s, d in nMap.items():
         assert s.nodeType == d.nodeType
 


### PR DESCRIPTION
## Description

The ability to select multiple nodes at once improves the efficiency of using the graph editor. I have tried to make the node selection behave similar to blender. The box select widget is used by dragging with the left mouse button. The main selected node is slightly brighter than the other selected nodes and has a blue border.
![Screenshot_20210115_202417](https://user-images.githubusercontent.com/32775248/104775236-ed59be00-576f-11eb-86a7-8d67343251a0.png)
![Screenshot_20210115_193313](https://user-images.githubusercontent.com/32775248/104770693-e54a5000-5768-11eb-9e90-0024d2e52b1e.png)

## Features list

- select multiple nodes at once
- use of control key modifier to select multiple nodes
- use of box select widget to select multiple nodes
- duplicate selected nodes
- remove selected nodes
- delete data of selected nodes
- move selected nodes together

(Resolves some points on #269) 
