### PR TITLE
[ui] add link to online documentation in 'Help' menu

### DIFF
--- a/meshroom/ui/qml/main.qml
+++ b/meshroom/ui/qml/main.qml
@@ -549,6 +549,10 @@ ApplicationWindow {
         Menu {
             title: "Help"
             Action {
+                text: "Online Documentation"
+                onTriggered: Qt.openUrlExternally("https://meshroom-manual.readthedocs.io")
+            }
+            Action {
                 text: "About Meshroom"
                 onTriggered: aboutDialog.open()
                 // shoud be StandardKey.HelpContents, but for some reason it's not stable


### PR DESCRIPTION
Small change to get a quick link to https://meshroom-manual.readthedocs.io within Meshroom. This makes it very easy to find the documentation.