### PR TITLE
[core] TaskManager: fix compute after submit

### DIFF
--- a/meshroom/core/taskManager.py
+++ b/meshroom/core/taskManager.py
@@ -173,13 +173,7 @@ class TaskManager(BaseObject):
         """
         self._graph = graph
 
-        if self._thread._state != State.RUNNING:
-            self._nodes.clear()
-            externEmpty = any(node.isAlreadySubmitted() for node in self._nodesExtern)
-            if not externEmpty:
-                self._nodes.update(self._nodesExtern)
-            else:
-                self._nodesExtern = []
+        self.updateNodes()
 
         if forceCompute:
             nodes, edges = graph.dfsOnFinish(startNodes=toNodes)
@@ -283,6 +277,16 @@ class TaskManager(BaseObject):
         self._nodes.clear()
         self._nodesExtern = []
         self._nodesToProcess = []
+
+    def updateNodes(self):
+        """
+        Update task manager nodes lists by checking the nodes status.
+        """
+        self._nodesExtern = [node for node in self._nodesExtern if node.isExtern() and node.isAlreadySubmitted()]
+        newNodes = [node for node in self._nodes if node.isAlreadySubmitted()]
+        if len(newNodes) != len(self._nodes):
+            self._nodes.clear()
+            self._nodes.update(newNodes)
 
     def update(self, graph):
         """
@@ -390,19 +394,7 @@ class TaskManager(BaseObject):
                                 ))
 
         # Update task manager's lists
-        if self._thread._state != State.RUNNING:
-            self._nodes.clear()
-
-            externEmpty = True
-            for node in self._nodesExtern:
-                if node.isAlreadySubmitted():
-                    externEmpty = False
-                    break
-
-            if not externEmpty:
-                self._nodes.update(self._nodesExtern)
-            else:
-                self._nodesExtern = []
+        self.updateNodes()
 
         # Check dependencies of toNodes
         if not toNodes:


### PR DESCRIPTION
After a renderfarm submit, it was not possible to compute the same node locally anymore.
