### PR TITLE
meshroom/multiview.py: Add .heic, .heif and .avif as supported formats

### DIFF
--- a/meshroom/multiview.py
+++ b/meshroom/multiview.py
@@ -19,6 +19,8 @@ imageExtensions = (
     '.gif',
     # hdr:
     '.hdr', '.rgbe',
+    # heif
+    '.heic', '.heif', '.avif',
     # ico:
     '.ico',
     # iff:


### PR DESCRIPTION
On most platforms Meshroom and Alicevision are already build with libheif enabled, this commit enables Meshroom to also accept the files as known image formats.

## Features list
- [x] Support HEIF and AVIF images on platforms that already build with libheif. Part of #1193.

## Implementation remarks
Could be a bit buggy on platforms that don't build with libheif by default.
