### PR TITLE
Avoid install errors with Python 3.9

### DIFF
--- a/meshroom/ui/app.py
+++ b/meshroom/ui/app.py
@@ -284,7 +284,6 @@ class MeshroomApp(QApplication):
             return md
         return markdown(md)
 
-    @Property(QJsonValue, constant=True)
     def systemInfo(self):
         import platform
         import sys
@@ -292,8 +291,8 @@ class MeshroomApp(QApplication):
             'platform': '{} {}'.format(platform.system(), platform.release()),
             'python': 'Python {}'.format(sys.version.split(" ")[0])
         }
+    systemInfo = Property(QJsonValue, fget=systemInfo, constant=True)
 
-    @Property("QVariantList", constant=True)
     def licensesModel(self):
         """
         Get info about open-source licenses for the application.
@@ -315,6 +314,7 @@ class MeshroomApp(QApplication):
                 "onlineUrl": "https://raw.githubusercontent.com/alicevision/AliceVision/develop/COPYING.md"
             }
         ]
+    licensesModel = Property("QVariantList", fget=licensesModel, constant=True)
 
     recentProjectFilesChanged = Signal()
     recentProjectFiles = Property("QVariantList", _recentProjectFiles, notify=recentProjectFilesChanged)

--- a/meshroom/ui/reconstruction.py
+++ b/meshroom/ui/reconstruction.py
@@ -249,10 +249,10 @@ class ViewpointWrapper(QObject):
             self._undistortedImagePath = os.path.join(self._activeNode_PrepareDenseScene.node.output.value, filename)
         self.denseSceneParamsChanged.emit()
 
-    @Property(type=QObject, constant=True)
     def attribute(self):
         """ Get the underlying Viewpoint attribute wrapped by this Viewpoint. """
         return self._viewpoint
+    attribute = Property(QObject, fget=attribute, constant=True)
 
     @Property(type="QVariant", notify=initialParamsChanged)
     def initialIntrinsics(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # runtime
 psutil>=5.6.3
 enum34;python_version<"3.4"
-PySide2==5.14.1
+PySide2>=5.14.1
 markdown==2.6.11
 requests==2.22.0


### PR DESCRIPTION
## Description

I'm currently using macOS and the state of meshroom is *bad*.

Documentation from https://meshroom-manual.readthedocs.io/en/latest/install/osx/osx.html does not work because alicevision fails to build and meshroom/ui will crash at startup.
This fixes the meshroom/ui problems I experienced:.

##### Unavailability of PySide2==5.14.1 on macOS

`PySide2==5.14.1` is not available on macOS Big Sur 11.2.1 with Python 3.9 installed using homebrew.

```
$ pip install -r requirements.txt
[...]
ERROR: Could not find a version that satisfies the requirement PySide2==5.14.1
ERROR: No matching distribution found for PySide2==5.14.1
```

##### Crash of meshroom/ui during startup

In addition, I'd get errors like this:

```
$ python3 ./meshroom/ui/
[2021-02-28 19:26:43,377][WARNING] == The following "submitters" plugins could not be loaded ==
  * simpleFarmSubmitter: No module named 'simpleFarm'

Traceback (most recent call last):
  File "/usr/local/Cellar/python@3.9/3.9.2_1/Frameworks/Python.framework/Versions/3.9/lib/python3.9/runpy.py", line 197, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/local/Cellar/python@3.9/3.9.2_1/Frameworks/Python.framework/Versions/3.9/lib/python3.9/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "meshroom/./meshroom/ui/__main__.py", line 10, in <module>
    from meshroom.ui.app import MeshroomApp
  File "meshroom/meshroom/ui/app.py", line 19, in <module>
    from meshroom.ui.reconstruction import Reconstruction
  File "/usr/local/lib/python3.9/site-packages/shiboken2/files.dir/shibokensupport/__feature__.py", line 142, in _import
    return original_import(name, *args, **kwargs)
  File "meshroom/meshroom/ui/reconstruction.py", line 169, in <module>
    class ViewpointWrapper(QObject):
  File "meshroom/meshroom/ui/reconstruction.py", line 253, in ViewpointWrapper
    def attribute(self):
TypeError: A constant property cannot have a WRITE method or a NOTIFY signal.
```

This problem also affects versions as far back as the 2019.2.0 release.
I wasn't able to find a way to work around this issue locally, without touching the source-code of meshroom.


## Features list

- Allows higher PySide2, which, at the time of writing, picks 5.15.2 for me.
- Avoids errors, by moving problematic properties into class scope as suggested here https://stackoverflow.com/a/66280981.


## Implementation remarks

This PR seems to fix macOS support of meshroom for me.

I'm also in the process of sending more patches to https://github.com/ryanfb/homebrew-alicevision/pull/14 and reported outdated underlying tools in https://github.com/ryanfb/homebrew-alicevision/issues/12

With both of these changes, people should be able to follow https://meshroom-manual.readthedocs.io/en/latest/install/osx/osx.html again (when we bump version numbers, so builds include this fix).