### PR TITLE
Context manager for python node logging

### DIFF
--- a/meshroom/core/desc.py
+++ b/meshroom/core/desc.py
@@ -520,14 +520,15 @@ class CommandLineNode(Node):
 
 
 class Logger(logging.Logger):
-    """A subclass of `logging.Logger` that:
+    """
+    A subclass of `logging.Logger` that:
 
-    * provides a context manager
-    * logs any exception raised in the context manager
-    * sets the verbose level from the node option
-    * handles formatting
-    * handles the log file (clearing, adding handler)
-    * provides methods to handle a progress bar
+    - provides a context manager
+    - logs any exception raised in the statement body
+    - sets the verbose level from the node option
+    - handles formatting
+    - handles the log file (clearing, adding handler)
+    - provides methods to handle a progress bar
     """
     class Formatter(logging.Formatter):
         """For internal use only."""
@@ -562,13 +563,15 @@ class Logger(logging.Logger):
             handler.close()
 
     def makeProgressBar(self, end, message=''):
-        """Make a new progress bar.
+        """
+        Make a new progress bar.
 
         Args:
             end: the highest possible value
             message (optional): title of the progress bar
         """
-        assert end > 0
+        if end <= 0:
+            raise ValueError('Progress end {} must be more than 0'.format(end))
 
         self.progressEnd = end
         self.currentProgressTics = 0
@@ -585,7 +588,8 @@ class Logger(logging.Logger):
             self.progressBarPosition = content.rfind('\n')
 
     def updateProgressBar(self, value):
-        """Update the current progress bar with the latest value.
+        """
+        Update the current progress bar with the latest value.
 
         Args:
             value: can be equal to or greater than the current value

--- a/meshroom/core/desc.py
+++ b/meshroom/core/desc.py
@@ -1,6 +1,7 @@
 from meshroom.common import BaseObject, Property, Variant, VariantList, JSValue
 from meshroom.core import pyCompatibility
 from enum import Enum  # available by default in python3. For python2: "pip install enum34"
+import logging
 import math
 import os
 import psutil
@@ -517,3 +518,87 @@ class CommandLineNode(Node):
         finally:
             chunk.subprocess = None
 
+
+class Logger(logging.Logger):
+    """A subclass of `logging.Logger` that:
+
+    * provides a context manager
+    * logs any exception raised in the context manager
+    * sets the verbose level from the node option
+    * handles formatting
+    * handles the log file (clearing, adding handler)
+    * provides methods to handle a progress bar
+    """
+    class Formatter(logging.Formatter):
+        """For internal use only."""
+        def format(self, record):
+            # Make level name lower case
+            record.levelname = record.levelname.lower()
+            return logging.Formatter.format(self, record)
+
+    def __init__(self, chunk):
+        super(Logger, self).__init__(
+            '',
+            chunk.node.verboseLevel.value.upper() if hasattr(chunk.node, 'verboseLevel') else logging.NOTSET,
+        )
+        self.chunk = chunk
+
+        open(chunk.logFile, 'w').close() # Clear log file
+        handler = logging.FileHandler(chunk.logFile)
+        formatter = self.Formatter('[%(asctime)s.%(msecs)03d][%(levelname)s] %(message)s', '%H:%M:%S')
+        handler.setFormatter(formatter)
+        self.addHandler(handler)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        if exc_type:
+            # log exception
+            self.critical('{}: {}'.format(exc_type.__name__, exc_value))
+
+        for handler in self.handlers[:]:
+            # Stops the file being locked
+            handler.close()
+
+    def makeProgressBar(self, end, message=''):
+        """Make a new progress bar.
+
+        Args:
+            end: the highest possible value
+            message (optional): title of the progress bar
+        """
+        assert end > 0
+
+        self.progressEnd = end
+        self.currentProgressTics = 0
+
+        with open(self.chunk.logFile, 'a') as f:
+            if message:
+                f.write(message+'\n')
+            f.write('0%   10   20   30   40   50   60   70   80   90   100%\n')
+            f.write('|----|----|----|----|----|----|----|----|----|----|\n\n')
+
+        with open(self.chunk.logFile, 'r') as f:
+            content = f.read()
+            # adding to the progress bar in the same place means normal logging can be used at the same time
+            self.progressBarPosition = content.rfind('\n')
+
+    def updateProgressBar(self, value):
+        """Update the current progress bar with the latest value.
+
+        Args:
+            value: can be equal to or greater than the current value
+        """
+        tics = round((value/self.progressEnd)*51)
+        nTicsToAdd = tics-self.currentProgressTics
+        if nTicsToAdd < 1:
+            return
+
+        with open(self.chunk.logFile, 'r+') as f:
+            text = f.read()
+            text = text[:self.progressBarPosition]+('*'*nTicsToAdd)+text[self.progressBarPosition:]
+            f.seek(0)
+            f.write(text)
+
+        self.currentProgressTics = tics

--- a/meshroom/core/node.py
+++ b/meshroom/core/node.py
@@ -139,98 +139,6 @@ class StatusData(BaseObject):
         self.sessionUid = d.get('sessionUid', '')
 
 
-class LogManager:
-    dateTimeFormatting = '%H:%M:%S'
-
-    def __init__(self, chunk):
-        self.chunk = chunk
-        self.logger = logging.getLogger(chunk.node.getName())
-
-    class Formatter(logging.Formatter):
-        def format(self, record):
-            # Make level name lower case
-            record.levelname = record.levelname.lower()
-            return logging.Formatter.format(self, record)
-
-    def configureLogger(self):
-        for handler in self.logger.handlers[:]:
-            self.logger.removeHandler(handler)
-        handler = logging.FileHandler(self.chunk.logFile)
-        formatter = self.Formatter('[%(asctime)s.%(msecs)03d][%(levelname)s] %(message)s', self.dateTimeFormatting)
-        handler.setFormatter(formatter)
-        self.logger.addHandler(handler)
-
-    def start(self, level):
-        # Clear log file
-        open(self.chunk.logFile, 'w').close()
-
-        self.configureLogger()
-        self.logger.setLevel(self.textToLevel(level))
-        self.progressBar = False
-
-    def end(self):
-        for handler in self.logger.handlers[:]:
-            # Stops the file being locked
-            handler.close()
-
-    def makeProgressBar(self, end, message=''):
-        assert end > 0
-        assert not self.progressBar
-
-        self.progressEnd = end
-        self.currentProgressTics = 0
-        self.progressBar = True
-
-        with open(self.chunk.logFile, 'a') as f:
-            if message:
-                f.write(message+'\n')
-            f.write('0%   10   20   30   40   50   60   70   80   90   100%\n')
-            f.write('|----|----|----|----|----|----|----|----|----|----|\n\n')
-
-            f.close()
-
-        with open(self.chunk.logFile, 'r') as f:
-            content = f.read()
-            self.progressBarPosition = content.rfind('\n')
-
-            f.close()
-
-    def updateProgressBar(self, value):
-        assert self.progressBar
-        assert value <= self.progressEnd
-
-        tics = round((value/self.progressEnd)*51)
-
-        with open(self.chunk.logFile, 'r+') as f:
-            text = f.read()
-            for i in range(tics-self.currentProgressTics):
-                text = text[:self.progressBarPosition]+'*'+text[self.progressBarPosition:]
-            f.seek(0)
-            f.write(text)
-            f.close()
-
-        self.currentProgressTics = tics
-
-    def completeProgressBar(self):
-        assert self.progressBar
-
-        self.progressBar = False
-
-    def textToLevel(self, text):
-        if text == 'critical':
-            return logging.CRITICAL
-        elif text == 'error':
-            return logging.ERROR
-        elif text == 'warning':
-            return logging.WARNING
-        elif text == 'info':
-            return logging.INFO
-        elif text == 'debug':
-            return logging.DEBUG
-        else:
-            return logging.NOTSET
-
-
 runningProcesses = {}
 
 
@@ -246,7 +154,6 @@ class NodeChunk(BaseObject):
         super(NodeChunk, self).__init__(parent)
         self.node = node
         self.range = range
-        self.logManager = LogManager(self)
         self._status = StatusData(node.name, node.nodeType, node.packageName, node.packageVersion)
         self.statistics = stats.Statistics()
         self.statusFileLastModTime = -1
@@ -270,10 +177,6 @@ class NodeChunk(BaseObject):
     @property
     def statusName(self):
         return self._status.status.name
-
-    @property
-    def logger(self):
-        return self.logManager.logger
 
     @property
     def execModeName(self):

--- a/meshroom/nodes/aliceVision/SketchfabUpload.py
+++ b/meshroom/nodes/aliceVision/SketchfabUpload.py
@@ -1,6 +1,5 @@
 __version__ = "1.0"
 
-from meshroom.core import desc
 import glob
 import os
 import json
@@ -8,46 +7,32 @@ import zipfile
 import requests
 import io
 
+from meshroom.core import desc
 
-class BufferReader(io.BytesIO): # object to call the callback while the file is being uploaded
-    def __init__(self, buf=b'',
-                 callback=None,
-                 cb_args=(),
-                 cb_kwargs={},
-                 stopped=None):
-        self._callback = callback
-        self._cb_args = cb_args
-        self._cb_kwargs = cb_kwargs
+
+class BufferReader(io.BytesIO):
+    """
+    I/O wrapper to update progress bar while the file is being uploaded.
+    """
+    def __init__(self, buffer, logger, stopped):
+        self._logger = logger
         self._stopped = stopped
         self._progress = 0
-        self._len = len(buf)
-        io.BytesIO.__init__(self, buf)
+        self._len = len(buffer)
+        logger.makeProgressBar(self._len, 'Upload progress:')
+        io.BytesIO.__init__(self, buffer)
 
     def __len__(self):
         return self._len
 
     def read(self, n=-1):
-        chunk = io.BytesIO.read(self, n)
-        self._progress += int(len(chunk))
-        self._cb_kwargs.update({
-            'size'    : self._len,
-            'progress': self._progress
-        })
-        if self._callback:
-            try:
-                self._callback(*self._cb_args, **self._cb_kwargs)
-            except Exception as e: # catches exception from the callback
-                self._cb_kwargs['logManager'].logger.warning('Error at callback: {}'.format(e))
-
         if self._stopped():
             raise RuntimeError('Node stopped by user')
+        chunk = io.BytesIO.read(self, n)
+        self._progress += int(len(chunk))
+        self._logger.updateProgressBar(self._progress)
         return chunk
 
-def progressUpdate(size=None, progress=None, logManager=None):
-    if not logManager.progressBar:
-        logManager.makeProgressBar(size, 'Upload progress:')
-
-    logManager.updateProgressBar(progress)
 
 class SketchfabUpload(desc.Node):
     size = desc.DynamicNodeSize('inputFiles')
@@ -184,8 +169,8 @@ Upload a textured mesh on Sketchfab.
             uid=[],
         ),
     ]
-    
-    def upload(self, apiToken, modelFile, data, chunk):
+
+    def upload(self, apiToken, modelFile, data, logger):
         modelEndpoint = 'https://api.sketchfab.com/v3/models'
         f = open(modelFile, 'rb')
         file = {'modelFile': (os.path.basename(modelFile), f.read())}
@@ -193,18 +178,18 @@ Upload a textured mesh on Sketchfab.
         f.close()
         (files, contentType) = requests.packages.urllib3.filepost.encode_multipart_formdata(file)
         headers = {'Authorization': 'Token {}'.format(apiToken), 'Content-Type': contentType}
-        body = BufferReader(files, progressUpdate, cb_kwargs={'logManager': chunk.logManager}, stopped=self.stopped)
-        chunk.logger.info('Uploading...')
+        body = BufferReader(files, logger, self.stopped)
+        logger.info('Uploading...')
         try:
             r = requests.post(
                 modelEndpoint, **{'data': body, 'headers': headers})
-            chunk.logManager.completeProgressBar()
         except requests.exceptions.RequestException as e:
-            chunk.logger.error(u'An error occured: {}'.format(e))
-            raise RuntimeError() 
+            raise RuntimeError(u'An error occured: {}'.format(e))
+        finally:
+            os.remove(modelFile)
+            logger.debug('Deleted file: '+modelFile)
         if r.status_code != requests.codes.created:
-            chunk.logger.error(u'Upload failed with error: {}'.format(r.json()))
-            raise RuntimeError()
+            raise RuntimeError(u'Upload failed with error: {}'.format(r.json()))
 
     def resolvedPaths(self, inputFiles):
         paths = []
@@ -218,34 +203,24 @@ Upload a textured mesh on Sketchfab.
                     paths.append(f)
         return paths
 
-    def stopped(self):
-        return self._stopped
-
     def processChunk(self, chunk):
-        try:
+        with desc.Logger(chunk) as logger:
             self._stopped = False
-            chunk.logManager.start(chunk.node.verboseLevel.value)
-            uploadFile = ''
-        
+
             if not chunk.node.inputFiles:
-                chunk.logger.warning('Nothing to upload')
+                logger.warning('Nothing to upload')
                 return
             if chunk.node.apiToken.value == '':
-                chunk.logger.error('Need API token.')
-                raise RuntimeError()
+                raise RuntimeError('Need API token.')
             if len(chunk.node.title.value) > 48:
-                chunk.logger.error('Title cannot be longer than 48 characters.')
-                raise RuntimeError()
+                raise RuntimeError('Title cannot be longer than 48 characters.')
             if len(chunk.node.description.value) > 1024:
-                chunk.logger.error('Description cannot be longer than 1024 characters.')
-                raise RuntimeError()
+                raise RuntimeError('Description cannot be longer than 1024 characters.')
             tags = [ i.value.replace(' ', '-') for i in chunk.node.tags.value.values() ]
             if all(len(i) > 48 for i in tags) and len(tags) > 0:
-                chunk.logger.error('Tags cannot be longer than 48 characters.')
-                raise RuntimeError()
+                raise RuntimeError('Tags cannot be longer than 48 characters.')
             if len(tags) > 42:
-                chunk.logger.error('Maximum of 42 separate tags.')
-                raise RuntimeError()
+                raise RuntimeError('Maximum of 42 separate tags.')
 
             data = {
                 'name': chunk.node.title.value,
@@ -259,30 +234,27 @@ Upload a textured mesh on Sketchfab.
             }
             if chunk.node.category.value != 'none':
                 data.update({'categories': chunk.node.category.value})
-            chunk.logger.debug('Data to be sent: {}'.format(str(data)))
-            
+            logger.debug('Data to be sent: '+str(data))
+
             # pack files into .zip to reduce file size and simplify process
-            uploadFile = os.path.join(chunk.node.internalFolder, 'temp.zip')
+            uploadFile = os.path.join(chunk.node.internalFolder,
+                'Meshroom_{}.zip'.format("".join(x for x in chunk.node.title.value if x.isalnum()))) # use title in the file name for clarity, removing any non-alphanumeric characters
             files = self.resolvedPaths(chunk.node.inputFiles.value)
-            zf = zipfile.ZipFile(uploadFile, 'w')
-            for file in files:
-                zf.write(file, os.path.basename(file))
-            zf.close()
-            chunk.logger.debug('Files added to zip: {}'.format(str(files)))
-            chunk.logger.debug('Created {}'.format(uploadFile))
-            chunk.logger.info('File size: {}MB'.format(round(os.path.getsize(uploadFile)/(1024*1024), 3)))
+            logger.debug('Files to write: '+str(files))
+            with zipfile.ZipFile(uploadFile, 'w') as zf:
+                for file in files:
+                    if os.path.basename(file) in ('log', 'statistics', 'status'):
+                        logger.debug('File skipped: '+file)
+                    else:
+                        zf.write(file, os.path.basename(file))
+            logger.debug('Created file: '+uploadFile)
+            logger.info('File size: {}MB'.format(round(os.path.getsize(uploadFile)/(1024*1024), 3)))
 
-            self.upload(chunk.node.apiToken.value, uploadFile, data, chunk)
-            chunk.logger.info('Upload successful. Your model is being processed on Sketchfab. It may take some time to show up on your "models" page.')
-        except Exception as e:
-            chunk.logger.error(e)
-            raise RuntimeError()
-        finally:
-            if os.path.isfile(uploadFile):
-                os.remove(uploadFile)
-                chunk.logger.debug('Deleted {}'.format(uploadFile))
-
-            chunk.logManager.end()
+            self.upload(chunk.node.apiToken.value, uploadFile, data, logger)
+            logger.info('Upload successful. Your model is being processed on Sketchfab. It may take some time to show up on your "models" page.')
 
     def stopProcess(self, chunk):
         self._stopped = True
+
+    def stopped(self):
+        return self._stopped

--- a/meshroom/ui/qml/Controls/TextFileViewer.qml
+++ b/meshroom/ui/qml/Controls/TextFileViewer.qml
@@ -255,9 +255,9 @@ Item {
 
                                 color: {
                                     // color line according to log level
-                                    if(text.indexOf("[warning]") >= 0)
+                                    if(text.includes("[warning]"))
                                         return Colors.orange;
-                                    else if(text.indexOf("[error]") >= 0)
+                                    else if(text.includes("[error]") || text.includes("[fatal]") || text.includes("[critical]"))
                                         return Colors.red;
                                     return palette.text;
                                 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ psutil>=5.6.3
 enum34;python_version<"3.4"
 PySide2==5.14.1
 markdown==2.6.11
-requests==2.22.0
+requests>=2.20.1


### PR DESCRIPTION
## Description

I have revised the implementation of node python logging to make it simpler and have built-in exception handling. These changes also contain other improvements to `SketchfabUpload` and `Publish` nodes.

Example of original:
```py
def processChunk(self, chunk):
    try:
        chunk.logManager.start('debug')
        chunk.logManager.makeProgressBar(100, 'this is a progress bar')
        chunk.logManager.updateProgressBar(50)
        chunk.logger.debug('this is a debug log')
        chunk.logger.info('this is an info log')
        chunk.logger.warning('this is a warning log')
        chunk.logger.error('this is an error log')
        raise RuntimeError('something bad happened')
    except Exception as e:
        chunk.logger.critical(e)
        raise RuntimeError()
    finally:
        chunk.logManager.end()
```
Equivalent behaviour with context manager:
```py
def processChunk(self, chunk):
    with desc.Logger(chunk) as logger:
        logger.makeProgressBar(100, 'this is a progress bar')
        logger.updateProgressBar(50)
        logger.debug('this is a debug log')
        logger.info('this is an info log')
        logger.warning('this is a warning log')
        logger.error('this is an error log')
        raise RuntimeError('something bad happened')
```
## Features list

- `SketchfabUpload`: use compression (file size can usually be at least halved from my testing)
- `Publish`: added option to enable/disable overwriting files (disabled by default)
- text file viewer highlights fatal and critical levels
- context manager used for python node logging
