### PR TITLE
Allow replacing edges

### DIFF
--- a/meshroom/ui/graph.py
+++ b/meshroom/ui/graph.py
@@ -535,8 +535,14 @@ class UIGraph(QObject):
         if isinstance(dst, ListAttribute) and not isinstance(src, ListAttribute):
             with self.groupedGraphModification("Insert and Add Edge on {}".format(dst.getFullName())):
                 self.appendAttribute(dst)
-                self.push(commands.AddEdgeCommand(self._graph, src, dst.at(-1)))
+                self._addEdge(src, dst.at(-1))
         else:
+            self._addEdge(src, dst)
+
+    def _addEdge(self, src, dst):
+        with self.groupedGraphModification("Connect '{}'->'{}'".format(src.getFullName(), dst.getFullName())):
+            if dst in self._graph.edges.keys():
+                self.removeEdge(self._graph.edge(dst))
             self.push(commands.AddEdgeCommand(self._graph, src, dst))
 
     @Slot(Edge)

--- a/meshroom/ui/qml/GraphEditor/AttributePin.qml
+++ b/meshroom/ui/qml/GraphEditor/AttributePin.qml
@@ -87,7 +87,6 @@ RowLayout {
                   || drag.source.objectName != inputDragTarget.objectName // not an edge connector
                   || drag.source.baseType != inputDragTarget.baseType     // not the same base type
                   || drag.source.nodeItem == inputDragTarget.nodeItem     // connection between attributes of the same node
-                  || inputDragTarget.attribute.isLink                     // already connected attribute
                   || (drag.source.isList && !inputDragTarget.isList)      // connection between a list and a simple attribute
                   || (drag.source.isList && childrenRepeater.count)       // source/target are lists but target already has children
                   || drag.source.connectorType == "input"                 // refuse to connect an "input pin" on another one (input attr can be connected to input attr, but not the graphical pin)
@@ -131,7 +130,7 @@ RowLayout {
         MouseArea {
             id: inputConnectMA
             // If an input attribute is connected (isLink), we disable drag&drop
-            drag.target: (attribute.isLink || attribute.isReadOnly) ? undefined : inputDragTarget
+            drag.target: (attribute.isReadOnly) ? undefined : inputDragTarget
             drag.threshold: 0
             enabled: !root.readOnly
             anchors.fill: parent
@@ -227,7 +226,6 @@ RowLayout {
                 if( drag.source.objectName != outputDragTarget.objectName // not an edge connector
                   || drag.source.baseType != outputDragTarget.baseType    // not the same base type
                   || drag.source.nodeItem == outputDragTarget.nodeItem    // connection between attributes of the same node
-                  || drag.source.attribute.isLink                         // already connected attribute
                   || (!drag.source.isList && outputDragTarget.isList)     // connection between a list and a simple attribute
                   || (drag.source.isList && childrenRepeater.count)       // source/target are lists but target already has children
                   || drag.source.connectorType == "output"                // refuse to connect an output pin on another one
@@ -295,7 +293,7 @@ RowLayout {
         }
     }
 
-    state: (inputConnectMA.pressed && !attribute.isLink) ? "DraggingInput" : outputConnectMA.pressed ? "DraggingOutput" : ""
+    state: (inputConnectMA.pressed) ? "DraggingInput" : outputConnectMA.pressed ? "DraggingOutput" : ""
 
     states: [
         State {


### PR DESCRIPTION
## Description

This makes using the graph editor more efficient because if I have node A connected to node C but then I want to connect node B to node C instead then I would have to first delete the edge from node A to node C before it was possible to drag the edge from node B to node C. With these changes it is possible to do this without having to explicitly delete the previous edge.