### PR TITLE
Node highlight radius

### DIFF
--- a/meshroom/ui/qml/GraphEditor/Node.qml
+++ b/meshroom/ui/qml/GraphEditor/Node.qml
@@ -121,7 +121,7 @@ Item {
             border.width: 2.5
             border.color: root.selected ? activePalette.highlight : Qt.darker(activePalette.highlight, 1.5)
             opacity: 0.9
-            radius: background.radius
+            radius: background.radius + border.width
             color: "transparent"
         }
 


### PR DESCRIPTION
This change increases the radius of the node highlight so that the inner radius of the highlight is the same as the node. This makes it so that there is no longer a gap between the highlight and the node at the corners. 

Before:
![Screenshot_20210329_163149](https://user-images.githubusercontent.com/32775248/112863109-69487e80-90ae-11eb-8b12-79002b3585a6.png)

After:
![Screenshot_20210329_164455](https://user-images.githubusercontent.com/32775248/112863147-749baa00-90ae-11eb-8751-07818eff15c5.png)
