### PR TITLE
Removing `io_counters` from the ProcStatatistics

### DIFF
--- a/meshroom/core/stats.py
+++ b/meshroom/core/stats.py
@@ -163,7 +163,7 @@ class ProcStatistics:
         # 'memory_maps',
         'status',
         # 'num_fds', # The number of file descriptors currently opened by this process (non cumulative) - N/A on Windows
-        'io_counters',
+        # 'io_counters', # The number and bytes read/write by the process - N/A on some platforms
         'num_ctx_switches',
         ]
 


### PR DESCRIPTION
`io_counters` is not always available (e.g. under Ubunutu 20 run in WSL), resulting in an exception being throw.

See #1373 for a complete explanation of the issue.