### PR TITLE
Migration to Qt 6 / PySide 6

### DIFF
--- a/meshroom/common/qt.py
+++ b/meshroom/common/qt.py
@@ -1,5 +1,5 @@
-from PySide2 import QtCore, QtQml
-import shiboken2
+from PySide6 import QtCore, QtQml
+import shiboken6
 
 class QObjectListModel(QtCore.QAbstractListModel):
     """
@@ -272,7 +272,7 @@ class QObjectListModel(QtCore.QAbstractListModel):
 
     def _dereferenceItem(self, item):
         # Ask for object deletion if parented to the model
-        if shiboken2.isValid(item) and item.parent() == self:
+        if shiboken6.isValid(item) and item.parent() == self:
             # delay deletion until the next event loop
             # This avoids warnings when the QML engine tries to evaluate (but should not)
             # an object that has already been deleted

--- a/meshroom/ui/app.py
+++ b/meshroom/ui/app.py
@@ -2,9 +2,9 @@ import logging
 import os
 import argparse
 
-from PySide2.QtCore import Qt, QUrl, Slot, QJsonValue, Property, Signal, qInstallMessageHandler, QtMsgType, QSettings
-from PySide2.QtGui import QIcon
-from PySide2.QtWidgets import QApplication
+from PySide6.QtCore import Qt, QUrl, Slot, QJsonValue, Property, Signal, qInstallMessageHandler, QtMsgType, QSettings
+from PySide6.QtGui import QIcon
+from PySide6.QtWidgets import QApplication
 
 import meshroom
 from meshroom.core import nodesDesc

--- a/meshroom/ui/commands.py
+++ b/meshroom/ui/commands.py
@@ -2,8 +2,8 @@ import logging
 import traceback
 from contextlib import contextmanager
 
-from PySide2.QtWidgets import QUndoCommand, QUndoStack
-from PySide2.QtCore import Property, Signal
+from PySide6.QtGui import QUndoCommand, QUndoStack
+from PySide6.QtCore import Property, Signal
 
 from meshroom.core.attribute import ListAttribute, Attribute
 from meshroom.core.graph import GraphModification

--- a/meshroom/ui/components/__init__.py
+++ b/meshroom/ui/components/__init__.py
@@ -1,6 +1,6 @@
 
 def registerTypes():
-    from PySide2.QtQml import qmlRegisterType
+    from PySide6.QtQml import qmlRegisterType
     from meshroom.ui.components.clipboard import ClipboardHelper
     from meshroom.ui.components.edge import EdgeMouseArea
     from meshroom.ui.components.filepath import FilepathHelper

--- a/meshroom/ui/components/clipboard.py
+++ b/meshroom/ui/components/clipboard.py
@@ -1,5 +1,5 @@
-from PySide2.QtCore import Slot, QObject
-from PySide2.QtGui import QClipboard
+from PySide6.QtCore import Slot, QObject
+from PySide6.QtGui import QClipboard
 
 
 class ClipboardHelper(QObject):

--- a/meshroom/ui/components/csvData.py
+++ b/meshroom/ui/components/csvData.py
@@ -1,7 +1,7 @@
 from meshroom.common.qt import QObjectListModel
 
-from PySide2.QtCore import QObject, Slot, Signal, Property
-from PySide2.QtCharts import QtCharts
+from PySide6.QtCore import QObject, Slot, Signal, Property
+from PySide6.QtCharts import QtCharts
 
 import csv
 import os

--- a/meshroom/ui/components/edge.py
+++ b/meshroom/ui/components/edge.py
@@ -1,6 +1,6 @@
-from PySide2.QtCore import Signal, Property, QPointF, Qt, QObject
-from PySide2.QtGui import QPainterPath, QVector2D
-from PySide2.QtQuick import QQuickItem
+from PySide6.QtCore import Signal, Property, QPointF, Qt, QObject
+from PySide6.QtGui import QPainterPath, QVector2D
+from PySide6.QtQuick import QQuickItem
 
 
 class MouseEvent(QObject):

--- a/meshroom/ui/components/filepath.py
+++ b/meshroom/ui/components/filepath.py
@@ -2,8 +2,8 @@
 # coding:utf-8
 from meshroom.core import pyCompatibility
 
-from PySide2.QtCore import QUrl, QFileInfo
-from PySide2.QtCore import QObject, Slot
+from PySide6.QtCore import QUrl, QFileInfo
+from PySide6.QtCore import QObject, Slot
 
 import os
 

--- a/meshroom/ui/components/scene3D.py
+++ b/meshroom/ui/components/scene3D.py
@@ -1,9 +1,9 @@
 from math import acos, pi, sqrt
 
-from PySide2.QtCore import QObject, Slot, QSize, Signal, QPointF
-from PySide2.Qt3DCore import Qt3DCore
-from PySide2.Qt3DRender import Qt3DRender
-from PySide2.QtGui import QVector3D, QQuaternion, QVector2D, QVector4D, QMatrix4x4
+from PySide6.QtCore import QObject, Slot, QSize, Signal, QPointF
+from PySide6.Qt3DCore import Qt3DCore
+from PySide6.Qt3DRender import Qt3DRender
+from PySide6.QtGui import QVector3D, QQuaternion, QVector2D, QVector4D, QMatrix4x4
 
 from meshroom.ui.utils import makeProperty
 

--- a/meshroom/ui/graph.py
+++ b/meshroom/ui/graph.py
@@ -7,7 +7,7 @@ from enum import Enum
 from threading import Thread, Event, Lock
 from multiprocessing.pool import ThreadPool
 
-from PySide2.QtCore import Slot, QJsonValue, QObject, QUrl, Property, Signal, QPoint
+from PySide6.QtCore import Slot, QJsonValue, QObject, QUrl, Property, Signal, QPoint
 
 from meshroom import multiview
 from meshroom.common.qt import QObjectListModel

--- a/meshroom/ui/palette.py
+++ b/meshroom/ui/palette.py
@@ -1,6 +1,6 @@
-from PySide2.QtCore import QObject, Qt, Slot, Property, Signal
-from PySide2.QtGui import QPalette, QColor
-from PySide2.QtWidgets import QApplication
+from PySide6.QtCore import QObject, Qt, Slot, Property, Signal
+from PySide6.QtGui import QPalette, QColor
+from PySide6.QtWidgets import QApplication
 
 
 class PaletteManager(QObject):

--- a/meshroom/ui/qml/AboutDialog.qml
+++ b/meshroom/ui/qml/AboutDialog.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.9
-import QtQuick.Controls 2.3
+import QtQuick 2.15
+import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.3
 import Utils 1.0
 import MaterialIcons 2.2

--- a/meshroom/ui/qml/Charts/ChartViewCheckBox.qml
+++ b/meshroom/ui/qml/Charts/ChartViewCheckBox.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.9
-import QtQuick.Controls 2.3
+import QtQuick 2.15
+import QtQuick.Controls 2.15
 
 
 /**

--- a/meshroom/ui/qml/Charts/ChartViewLegend.qml
+++ b/meshroom/ui/qml/Charts/ChartViewLegend.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.9
-import QtQuick.Controls 2.9
+import QtQuick 2.15
+import QtQuick.Controls 2.15
 import QtCharts 2.3
 
 

--- a/meshroom/ui/qml/Charts/ChartViewLegend.qml
+++ b/meshroom/ui/qml/Charts/ChartViewLegend.qml
@@ -29,8 +29,8 @@ Flow {
     // Update internal ListModel when ChartView's series change
     Connections {
         target: chartView
-        onSeriesAdded: seriesModel.append({"series": series})
-        onSeriesRemoved: {
+        function onSeriesAdded() { seriesModel.append({"series": series}) }
+        function onSeriesRemoved() {
             for(var i = 0; i < seriesModel.count; ++i)
             {
                 if(seriesModel.get(i)["series"] === series)

--- a/meshroom/ui/qml/Charts/InteractiveChartView.qml
+++ b/meshroom/ui/qml/Charts/InteractiveChartView.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.9
-import QtQuick.Controls 2.3
+import QtQuick 2.15
+import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.3
 import MaterialIcons 2.2
 import QtPositioning 5.8

--- a/meshroom/ui/qml/Controls/ColorChart.qml
+++ b/meshroom/ui/qml/Controls/ColorChart.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.10
-import QtQuick.Controls 2.10
+import QtQuick 2.15
+import QtQuick.Controls 2.15
 
 import Utils 1.0
 

--- a/meshroom/ui/qml/Controls/FloatingPane.qml
+++ b/meshroom/ui/qml/Controls/FloatingPane.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.9
-import QtQuick.Controls 2.3
+import QtQuick 2.15
+import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.3
 
 /**

--- a/meshroom/ui/qml/Controls/Group.qml
+++ b/meshroom/ui/qml/Controls/Group.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.7
-import QtQuick.Controls 2.3
+import QtQuick 2.15
+import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.3
 import MaterialIcons 2.2
 

--- a/meshroom/ui/qml/Controls/KeyValue.qml
+++ b/meshroom/ui/qml/Controls/KeyValue.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.7
-import QtQuick.Controls 2.3
+import QtQuick 2.15
+import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.3
 import MaterialIcons 2.2
 

--- a/meshroom/ui/qml/Controls/MessageDialog.qml
+++ b/meshroom/ui/qml/Controls/MessageDialog.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.9
-import QtQuick.Controls 2.3
+import QtQuick 2.15
+import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.3
 import MaterialIcons 2.2
 

--- a/meshroom/ui/qml/Controls/Panel.qml
+++ b/meshroom/ui/qml/Controls/Panel.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.9
-import QtQuick.Controls 2.3
+import QtQuick 2.15
+import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.3
 
 

--- a/meshroom/ui/qml/Controls/SearchBar.qml
+++ b/meshroom/ui/qml/Controls/SearchBar.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.9
-import QtQuick.Controls 2.3
+import QtQuick 2.15
+import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.3
 import MaterialIcons 2.2
 

--- a/meshroom/ui/qml/Controls/TabPanel.qml
+++ b/meshroom/ui/qml/Controls/TabPanel.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.9
-import QtQuick.Controls 2.3
+import QtQuick 2.15
+import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.3
 
 Page {

--- a/meshroom/ui/qml/Controls/TextFileViewer.qml
+++ b/meshroom/ui/qml/Controls/TextFileViewer.qml
@@ -314,10 +314,8 @@ Item {
             return;
 
         loading = true;
-        var xhr = new XMLHttpRequest;
 
-        xhr.open("GET", root.source);
-        xhr.onreadystatechange = function() {
+        Request.get(root.source, function(xhr){
             // - can't rely on 'Last-Modified' header response to verify
             //   that file has changed on disk (not always up-to-date)
             // - instead, let QML engine evaluate whether 'text' property value has changed
@@ -328,7 +326,6 @@ Item {
                 if(autoReload)
                     reloadTimer.restart();
             }
-        };
-        xhr.send();
+        })
     }
 }

--- a/meshroom/ui/qml/Controls/TextFileViewer.qml
+++ b/meshroom/ui/qml/Controls/TextFileViewer.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.11
-import QtQuick.Controls 2.4
+import QtQuick 2.15
+import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.11
 import MaterialIcons 2.2
 

--- a/meshroom/ui/qml/DialogsFactory.qml
+++ b/meshroom/ui/qml/DialogsFactory.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.9
+import QtQuick 2.15
 import MaterialIcons 2.2
 import Controls 1.0
 

--- a/meshroom/ui/qml/GraphEditor/AttributeEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/AttributeEditor.qml
@@ -1,6 +1,6 @@
-import QtQuick 2.9
+import QtQuick 2.15
 import QtQuick.Layouts 1.3
-import QtQuick.Controls 2.2
+import QtQuick.Controls 2.15
 import MaterialIcons 2.2
 import Utils 1.0
 

--- a/meshroom/ui/qml/GraphEditor/AttributeItemDelegate.qml
+++ b/meshroom/ui/qml/GraphEditor/AttributeItemDelegate.qml
@@ -191,7 +191,7 @@ RowLayout {
                 onActivated: _reconstruction.setAttribute(attribute, currentText)
                 Connections {
                     target: attribute
-                    onValueChanged: combo.currentIndex = combo.find(attribute.value)
+                    function onValueChanged() {combo.currentIndex = combo.find(attribute.value)}
                 }
             }
         }

--- a/meshroom/ui/qml/GraphEditor/AttributeItemDelegate.qml
+++ b/meshroom/ui/qml/GraphEditor/AttributeItemDelegate.qml
@@ -1,6 +1,6 @@
-import QtQuick 2.9
+import QtQuick 2.15
 import QtQuick.Layouts 1.3
-import QtQuick.Controls 2.2
+import QtQuick.Controls 2.15
 import MaterialIcons 2.2
 import Utils 1.0
 

--- a/meshroom/ui/qml/GraphEditor/AttributePin.qml
+++ b/meshroom/ui/qml/GraphEditor/AttributePin.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.9
-import QtQuick.Controls 2.3
+import QtQuick 2.15
+import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.3
 import MaterialIcons 2.2
 import Utils 1.0

--- a/meshroom/ui/qml/GraphEditor/ChunksListView.qml
+++ b/meshroom/ui/qml/GraphEditor/ChunksListView.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.11
-import QtQuick.Controls 2.3
+import QtQuick 2.15
+import QtQuick.Controls 2.15
 import QtQuick.Controls 1.4 as Controls1 // SplitView
 import QtQuick.Layouts 1.3
 import MaterialIcons 2.2

--- a/meshroom/ui/qml/GraphEditor/ChunksListView.qml
+++ b/meshroom/ui/qml/GraphEditor/ChunksListView.qml
@@ -1,6 +1,5 @@
 import QtQuick 2.15
 import QtQuick.Controls 2.15
-import QtQuick.Controls 1.4 as Controls1 // SplitView
 import QtQuick.Layouts 1.3
 import MaterialIcons 2.2
 import Controls 1.0

--- a/meshroom/ui/qml/GraphEditor/CompatibilityBadge.qml
+++ b/meshroom/ui/qml/GraphEditor/CompatibilityBadge.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.9
-import QtQuick.Controls 2.3
+import QtQuick 2.15
+import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.3
 import MaterialIcons 2.2
 

--- a/meshroom/ui/qml/GraphEditor/CompatibilityManager.qml
+++ b/meshroom/ui/qml/GraphEditor/CompatibilityManager.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.9
-import QtQuick.Controls 2.3
+import QtQuick 2.15
+import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.3
 import MaterialIcons 2.2
 import Controls 1.0

--- a/meshroom/ui/qml/GraphEditor/Edge.qml
+++ b/meshroom/ui/qml/GraphEditor/Edge.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.9
+import QtQuick 2.15
 import GraphEditor 1.0
 import QtQuick.Shapes 1.0
 

--- a/meshroom/ui/qml/GraphEditor/GraphEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/GraphEditor.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.7
-import QtQuick.Controls 2.3
+import QtQuick 2.15
+import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.3
 import Controls 1.0
 import Utils 1.0

--- a/meshroom/ui/qml/GraphEditor/Node.qml
+++ b/meshroom/ui/qml/GraphEditor/Node.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.9
-import QtQuick.Controls 2.3
+import QtQuick 2.15
+import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.3
 import QtGraphicalEffects 1.0
 

--- a/meshroom/ui/qml/GraphEditor/Node.qml
+++ b/meshroom/ui/qml/GraphEditor/Node.qml
@@ -58,7 +58,7 @@ Item {
     Connections {
         target: root.node
         // update x,y when node position changes
-        onPositionChanged: {
+        function onPositionChanged() {
             root.x = root.node.x
             root.y = root.node.y
         }

--- a/meshroom/ui/qml/GraphEditor/Node.qml
+++ b/meshroom/ui/qml/GraphEditor/Node.qml
@@ -1,7 +1,7 @@
 import QtQuick 2.15
 import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.3
-import QtGraphicalEffects 1.0
+// import QtGraphicalEffects 1.0 // TODO: Porting to Qt6, QtGraphicalEffects is unavailable
 
 import Utils 1.0
 import MaterialIcons 2.2
@@ -130,7 +130,7 @@ Item {
             anchors.fill: nodeContent
             color: Qt.lighter(activePalette.base, 1.4)
             layer.enabled: true
-            layer.effect: DropShadow { radius: 3; color: shadowColor }
+            // layer.effect: DropShadow { radius: 3; color: shadowColor } // TODO: Porting to Qt6, QtGraphicalEffects is unavailable
             radius: 3
             opacity: 0.7
         }

--- a/meshroom/ui/qml/GraphEditor/NodeChunks.qml
+++ b/meshroom/ui/qml/GraphEditor/NodeChunks.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.7
+import QtQuick 2.15
 import Utils 1.0
 
 //import "common.js" as Common

--- a/meshroom/ui/qml/GraphEditor/NodeDocumentation.qml
+++ b/meshroom/ui/qml/GraphEditor/NodeDocumentation.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.11
-import QtQuick.Controls 2.3
+import QtQuick 2.15
+import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.3
 import Controls 1.0
 

--- a/meshroom/ui/qml/GraphEditor/NodeEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/NodeEditor.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.9
-import QtQuick.Controls 2.4
+import QtQuick 2.15
+import QtQuick.Controls 2.15
 import QtQuick.Controls 1.4 as Controls1 // SplitView
 import QtQuick.Layouts 1.3
 import MaterialIcons 2.2

--- a/meshroom/ui/qml/GraphEditor/NodeEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/NodeEditor.qml
@@ -1,6 +1,5 @@
 import QtQuick 2.15
 import QtQuick.Controls 2.15
-import QtQuick.Controls 1.4 as Controls1 // SplitView
 import QtQuick.Layouts 1.3
 import MaterialIcons 2.2
 import Controls 1.0
@@ -106,7 +105,7 @@ Panel {
             Component {
                 id: editor_component
 
-                Controls1.SplitView {
+                SplitView {
                     anchors.fill: parent
 
                     // The list of chunks
@@ -117,8 +116,8 @@ Panel {
                     }
 
                     StackLayout {
-                        Layout.fillHeight: true
-                        Layout.fillWidth: true
+                        SplitView.fillHeight: true
+                        SplitView.fillWidth: true
 
                         currentIndex: tabBar.currentIndex
 

--- a/meshroom/ui/qml/GraphEditor/NodeLog.qml
+++ b/meshroom/ui/qml/GraphEditor/NodeLog.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.11
-import QtQuick.Controls 2.3
+import QtQuick 2.15
+import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.3
 import MaterialIcons 2.2
 import Controls 1.0

--- a/meshroom/ui/qml/GraphEditor/NodeStatistics.qml
+++ b/meshroom/ui/qml/GraphEditor/NodeStatistics.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.11
-import QtQuick.Controls 2.3
+import QtQuick 2.15
+import QtQuick.Controls 2.15
 import QtQuick.Controls 1.4 as Controls1 // SplitView
 import QtQuick.Layouts 1.3
 import MaterialIcons 2.2

--- a/meshroom/ui/qml/GraphEditor/NodeStatistics.qml
+++ b/meshroom/ui/qml/GraphEditor/NodeStatistics.qml
@@ -1,6 +1,5 @@
 import QtQuick 2.15
 import QtQuick.Controls 2.15
-import QtQuick.Controls 1.4 as Controls1 // SplitView
 import QtQuick.Layouts 1.3
 import MaterialIcons 2.2
 import Controls 1.0

--- a/meshroom/ui/qml/GraphEditor/NodeStatus.qml
+++ b/meshroom/ui/qml/GraphEditor/NodeStatus.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.11
-import QtQuick.Controls 2.3
+import QtQuick 2.15
+import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.3
 import MaterialIcons 2.2
 import Controls 1.0

--- a/meshroom/ui/qml/GraphEditor/NodeStatus.qml
+++ b/meshroom/ui/qml/GraphEditor/NodeStatus.qml
@@ -50,10 +50,7 @@ FocusScope {
                     if(!Filepath.urlToString(source).endsWith("status"))
                         return;
 
-                    var xhr = new XMLHttpRequest;
-                    xhr.open("GET", source);
-
-                    xhr.onreadystatechange = function() {
+                    Request.get(source, function(xhr) {
                         if (xhr.readyState === XMLHttpRequest.DONE && xhr.status === 200) {
                             // console.warn("StatusListModel: read valid file")
                             if(lastModified === undefined || lastModified !== xhr.getResponseHeader('Last-Modified')) {
@@ -88,8 +85,7 @@ FocusScope {
                             lastModified = undefined;
                             statusListModel.clear();
                         }
-                    };
-                    xhr.send();
+                    })
                 }
             }
 

--- a/meshroom/ui/qml/GraphEditor/StatViewer.qml
+++ b/meshroom/ui/qml/GraphEditor/StatViewer.qml
@@ -97,12 +97,8 @@ Item {
         if(!Filepath.urlToString(source).endsWith("statistics"))
             return;
 
-        var xhr = new XMLHttpRequest;
-        xhr.open("GET", source);
-
-        xhr.onreadystatechange = function() {
+        Request.get(source, function(xhr){
             if (xhr.readyState === XMLHttpRequest.DONE && xhr.status == 200) {
-
                 if(sourceModified === undefined || sourceModified < xhr.getResponseHeader('Last-Modified')) {
                     try {
                         root.jsonObject = JSON.parse(xhr.responseText);
@@ -119,8 +115,7 @@ Item {
                     reloadTimer.restart();
                 }
             }
-        };
-        xhr.send();
+        })
     }
 
     function resetCharts() {

--- a/meshroom/ui/qml/GraphEditor/StatViewer.qml
+++ b/meshroom/ui/qml/GraphEditor/StatViewer.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.7
-import QtQuick.Controls 2.3
+import QtQuick 2.15
+import QtQuick.Controls 2.15
 import QtCharts 2.2
 import QtQuick.Layouts 1.11
 import Utils 1.0

--- a/meshroom/ui/qml/GraphEditor/TaskManager.qml
+++ b/meshroom/ui/qml/GraphEditor/TaskManager.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.7
-import QtQuick.Controls 2.3
+import QtQuick 2.15
+import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.3
 import Controls 1.0
 import Utils 1.0

--- a/meshroom/ui/qml/ImageGallery/ImageBadge.qml
+++ b/meshroom/ui/qml/ImageGallery/ImageBadge.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.9
+import QtQuick 2.15
 import MaterialIcons 2.2
 import Utils 1.0
 

--- a/meshroom/ui/qml/ImageGallery/ImageDelegate.qml
+++ b/meshroom/ui/qml/ImageGallery/ImageDelegate.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.9
-import QtQuick.Controls 2.3
+import QtQuick 2.15
+import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.3
 import Utils 1.0
 

--- a/meshroom/ui/qml/ImageGallery/ImageGallery.qml
+++ b/meshroom/ui/qml/ImageGallery/ImageGallery.qml
@@ -103,7 +103,7 @@ Panel {
             // Update grid current item when selected view changes
             Connections {
                 target: _reconstruction
-                onSelectedViewIdChanged: {
+                function onSelectedViewIdChanged() {
                     var idx = grid.model.find(_reconstruction.selectedViewId, "viewId")
                     if(idx >= 0)
                         grid.currentIndex = idx

--- a/meshroom/ui/qml/ImageGallery/ImageGallery.qml
+++ b/meshroom/ui/qml/ImageGallery/ImageGallery.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.7
-import QtQuick.Controls 2.3
+import QtQuick 2.15
+import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.3
 import MaterialIcons 2.2
 import QtQml.Models 2.2

--- a/meshroom/ui/qml/ImageGallery/IntrinsicsIndicator.qml
+++ b/meshroom/ui/qml/ImageGallery/IntrinsicsIndicator.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.9
-import QtQuick.Controls 2.4
+import QtQuick 2.15
+import QtQuick.Controls 2.15
 import MaterialIcons 2.2
 import Utils 1.0
 

--- a/meshroom/ui/qml/ImageGallery/SensorDBDialog.qml
+++ b/meshroom/ui/qml/ImageGallery/SensorDBDialog.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.9
-import QtQuick.Controls 2.3
+import QtQuick 2.15
+import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.3
 
 import MaterialIcons 2.2

--- a/meshroom/ui/qml/LiveSfmView.qml
+++ b/meshroom/ui/qml/LiveSfmView.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.9
-import QtQuick.Controls 2.3
+import QtQuick 2.15
+import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.3
 import MaterialIcons 2.2
 import Qt.labs.platform 1.0 as Platform // for FileDialog

--- a/meshroom/ui/qml/MaterialIcons/MLabel.qml
+++ b/meshroom/ui/qml/MaterialIcons/MLabel.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.9
-import QtQuick.Controls 2.4
+import QtQuick 2.15
+import QtQuick.Controls 2.15
 
 
 /**

--- a/meshroom/ui/qml/MaterialIcons/MaterialIcons.qml
+++ b/meshroom/ui/qml/MaterialIcons/MaterialIcons.qml
@@ -1,5 +1,5 @@
 pragma Singleton
-import QtQuick 2.0
+import QtQuick 2.15
 
 QtObject {
     property FontLoader fl: FontLoader {

--- a/meshroom/ui/qml/MaterialIcons/MaterialLabel.qml
+++ b/meshroom/ui/qml/MaterialIcons/MaterialLabel.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.9
-import QtQuick.Controls 2.4
+import QtQuick 2.15
+import QtQuick.Controls 2.15
 
 
 /**

--- a/meshroom/ui/qml/MaterialIcons/MaterialToolButton.qml
+++ b/meshroom/ui/qml/MaterialIcons/MaterialToolButton.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.9
-import QtQuick.Controls 2.3
+import QtQuick 2.15
+import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.3
 
 

--- a/meshroom/ui/qml/MaterialIcons/MaterialToolLabel.qml
+++ b/meshroom/ui/qml/MaterialIcons/MaterialToolLabel.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.9
-import QtQuick.Controls 2.3
+import QtQuick 2.15
+import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.3
 
 

--- a/meshroom/ui/qml/MaterialIcons/MaterialToolLabelButton.qml
+++ b/meshroom/ui/qml/MaterialIcons/MaterialToolLabelButton.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.9
-import QtQuick.Controls 2.3
+import QtQuick 2.15
+import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.3
 
 

--- a/meshroom/ui/qml/Utils/Colors.qml
+++ b/meshroom/ui/qml/Utils/Colors.qml
@@ -1,6 +1,6 @@
 pragma Singleton
-import QtQuick 2.9
-import QtQuick.Controls 2.4
+import QtQuick 2.15
+import QtQuick.Controls 2.15
 
 /**
  * Singleton that gathers useful colors, shades and system palettes.

--- a/meshroom/ui/qml/Utils/SortFilterDelegateModel.qml
+++ b/meshroom/ui/qml/Utils/SortFilterDelegateModel.qml
@@ -1,6 +1,6 @@
-import QtQuick 2.9
+import QtQuick 2.15
 import QtQml.Models 2.2
-import QtQuick.Controls 2.3
+import QtQuick.Controls 2.15
 
 /**
  * SortFilderDelegateModel adds sorting and filtering capabilities on a source model.

--- a/meshroom/ui/qml/Utils/request.js
+++ b/meshroom/ui/qml/Utils/request.js
@@ -2,6 +2,11 @@
 
 /**
  * Perform 'GET' request on url, and bind 'callback' to onreadystatechange (with XHR objet as parameter).
+ *
+ * TODO: Porting to Qt6
+ * TODO: This function needs to be rewritten in Python.
+ * Using GET on a local file with XMLHttpRequest is disabled by default in Qt6.
+ * For now, environmental variable QML_XHR_ALLOW_FILE_READ must be set to 1 to enable this feature.
  */
 function get(url, callback) {
     var xhr = new XMLHttpRequest();

--- a/meshroom/ui/qml/Viewer/CameraResponseGraph.qml
+++ b/meshroom/ui/qml/Viewer/CameraResponseGraph.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.9
-import QtQuick.Controls 2.3
+import QtQuick 2.15
+import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.3
 import MaterialIcons 2.2
 import QtPositioning 5.8

--- a/meshroom/ui/qml/Viewer/CircleGizmo.qml
+++ b/meshroom/ui/qml/Viewer/CircleGizmo.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.11
+import QtQuick 2.15
 
 Rectangle {
     id: root

--- a/meshroom/ui/qml/Viewer/ColorCheckerEntity.qml
+++ b/meshroom/ui/qml/Viewer/ColorCheckerEntity.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.11
+import QtQuick 2.15
 
 Item {
     id: root

--- a/meshroom/ui/qml/Viewer/ColorCheckerPane.qml
+++ b/meshroom/ui/qml/Viewer/ColorCheckerPane.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.11
+import QtQuick 2.15
 import QtQuick.Layouts 1.3
 
 import Controls 1.0

--- a/meshroom/ui/qml/Viewer/ColorCheckerViewer.qml
+++ b/meshroom/ui/qml/Viewer/ColorCheckerViewer.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.11
+import QtQuick 2.15
 
 Item {
     id: root

--- a/meshroom/ui/qml/Viewer/ColorCheckerViewer.qml
+++ b/meshroom/ui/qml/Viewer/ColorCheckerViewer.qml
@@ -39,11 +39,7 @@ Item {
     }
 
     function readSourceFile() {
-        var xhr = new XMLHttpRequest;
-        // console.warn("readSourceFile: " + root.source)
-        xhr.open("GET", root.source);
-
-        xhr.onreadystatechange = function() {
+        Request.get(root.source, function(xhr){
             if (xhr.readyState === XMLHttpRequest.DONE && xhr.status == 200) {
                 try {
                     root.json = null;
@@ -58,8 +54,7 @@ Item {
                 }
             }
             loadCCheckers();
-        };
-        xhr.send();
+        })
     }
 
     function loadCCheckers() {

--- a/meshroom/ui/qml/Viewer/FeaturesInfoOverlay.qml
+++ b/meshroom/ui/qml/Viewer/FeaturesInfoOverlay.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.9
-import QtQuick.Controls 2.3
+import QtQuick 2.15
+import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.3
 import MaterialIcons 2.2
 

--- a/meshroom/ui/qml/Viewer/FeaturesViewer.qml
+++ b/meshroom/ui/qml/Viewer/FeaturesViewer.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.11
+import QtQuick 2.15
 import AliceVision 1.0 as AliceVision
 
 import Utils 1.0

--- a/meshroom/ui/qml/Viewer/FloatImage.qml
+++ b/meshroom/ui/qml/Viewer/FloatImage.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.11
+import QtQuick 2.15
 import Utils 1.0
 
 import AliceVision 1.0 as AliceVision

--- a/meshroom/ui/qml/Viewer/HdrImageToolbar.qml
+++ b/meshroom/ui/qml/Viewer/HdrImageToolbar.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.11
-import QtQuick.Controls 2.0
+import QtQuick 2.15
+import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.3
 import MaterialIcons 2.2
 import Controls 1.0

--- a/meshroom/ui/qml/Viewer/ImageMetadataView.qml
+++ b/meshroom/ui/qml/Viewer/ImageMetadataView.qml
@@ -268,7 +268,7 @@ FloatingPane {
 
                 Connections {
                     target: root
-                    onCoordinatesChanged: recenter()
+                    function onCoordinatesChanged() { recenter() }
                 }
 
                 zoomLevel: 16

--- a/meshroom/ui/qml/Viewer/ImageMetadataView.qml
+++ b/meshroom/ui/qml/Viewer/ImageMetadataView.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.9
-import QtQuick.Controls 2.3
+import QtQuick 2.15
+import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.3
 import MaterialIcons 2.2
 import QtPositioning 5.8

--- a/meshroom/ui/qml/Viewer/MSfMData.qml
+++ b/meshroom/ui/qml/Viewer/MSfMData.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.11
+import QtQuick 2.15
 import AliceVision 1.0 as AliceVision
 
 // Data from the SfM 

--- a/meshroom/ui/qml/Viewer/MTracks.qml
+++ b/meshroom/ui/qml/Viewer/MTracks.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.11
+import QtQuick 2.15
 import AliceVision 1.0 as AliceVision
 
 AliceVision.MTracks {

--- a/meshroom/ui/qml/Viewer/SfmGlobalStats.qml
+++ b/meshroom/ui/qml/Viewer/SfmGlobalStats.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.9
-import QtQuick.Controls 2.3
+import QtQuick 2.15
+import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.3
 import MaterialIcons 2.2
 import QtPositioning 5.8

--- a/meshroom/ui/qml/Viewer/SfmStatsView.qml
+++ b/meshroom/ui/qml/Viewer/SfmStatsView.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.9
-import QtQuick.Controls 2.3
+import QtQuick 2.15
+import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.3
 import MaterialIcons 2.2
 import QtPositioning 5.8

--- a/meshroom/ui/qml/Viewer/TestAliceVisionPlugin.qml
+++ b/meshroom/ui/qml/Viewer/TestAliceVisionPlugin.qml
@@ -1,5 +1,5 @@
 import AliceVision 1.0
-import QtQuick 2.7
+import QtQuick 2.15
 
 /**
  * To evaluate if the QtAliceVision plugin is available.

--- a/meshroom/ui/qml/Viewer/TestOIIOPlugin.qml
+++ b/meshroom/ui/qml/Viewer/TestOIIOPlugin.qml
@@ -1,5 +1,5 @@
 import DepthMapEntity 2.1
-import QtQuick 2.7
+import QtQuick 2.15
 
 /**
  * To evaluate if the QtOIIO plugin is available.

--- a/meshroom/ui/qml/Viewer/Viewer2D.qml
+++ b/meshroom/ui/qml/Viewer/Viewer2D.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.7
-import QtQuick.Controls 2.0
+import QtQuick 2.15
+import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.3
 import MaterialIcons 2.2
 import Controls 1.0

--- a/meshroom/ui/qml/Viewer3D/AlembicLoader.qml
+++ b/meshroom/ui/qml/Viewer3D/AlembicLoader.qml
@@ -1,8 +1,8 @@
 import AlembicEntity 2.0
 import QtQuick 2.15
 import Qt3D.Core 2.15
-import Qt3D.Render 2.1
-import Qt3D.Extras 2.1
+import Qt3D.Render 2.15
+import Qt3D.Extras 2.15
 
 /**
  * Support for Alembic files in Qt3d.

--- a/meshroom/ui/qml/Viewer3D/AlembicLoader.qml
+++ b/meshroom/ui/qml/Viewer3D/AlembicLoader.qml
@@ -1,6 +1,6 @@
 import AlembicEntity 2.0
-import QtQuick 2.9
-import Qt3D.Core 2.1
+import QtQuick 2.15
+import Qt3D.Core 2.15
 import Qt3D.Render 2.1
 import Qt3D.Extras 2.1
 

--- a/meshroom/ui/qml/Viewer3D/BoundingBox.qml
+++ b/meshroom/ui/qml/Viewer3D/BoundingBox.qml
@@ -1,7 +1,7 @@
-import Qt3D.Core 2.0
-import Qt3D.Render 2.9
-import Qt3D.Input 2.0
-import Qt3D.Extras 2.10
+import Qt3D.Core 2.15
+import Qt3D.Render 2.15
+import Qt3D.Input 2.15
+import Qt3D.Extras 2.15
 import QtQuick 2.15
 
 Entity {

--- a/meshroom/ui/qml/Viewer3D/BoundingBox.qml
+++ b/meshroom/ui/qml/Viewer3D/BoundingBox.qml
@@ -2,7 +2,7 @@ import Qt3D.Core 2.0
 import Qt3D.Render 2.9
 import Qt3D.Input 2.0
 import Qt3D.Extras 2.10
-import QtQuick 2.9
+import QtQuick 2.15
 
 Entity {
     id: root

--- a/meshroom/ui/qml/Viewer3D/DefaultCameraController.qml
+++ b/meshroom/ui/qml/Viewer3D/DefaultCameraController.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.7
+import QtQuick 2.15
 import Qt3D.Core 2.1
 import Qt3D.Render 2.1
 import Qt3D.Input 2.1

--- a/meshroom/ui/qml/Viewer3D/DefaultCameraController.qml
+++ b/meshroom/ui/qml/Viewer3D/DefaultCameraController.qml
@@ -1,8 +1,8 @@
 import QtQuick 2.15
-import Qt3D.Core 2.1
-import Qt3D.Render 2.1
-import Qt3D.Input 2.1
-import Qt3D.Logic 2.0
+import Qt3D.Core 2.15
+import Qt3D.Render 2.15
+import Qt3D.Input 2.15
+import Qt3D.Logic 2.15
 import QtQml 2.2
 
 import Meshroom.Helpers 1.0

--- a/meshroom/ui/qml/Viewer3D/EntityWithGizmo.qml
+++ b/meshroom/ui/qml/Viewer3D/EntityWithGizmo.qml
@@ -2,7 +2,7 @@ import Qt3D.Core 2.0
 import Qt3D.Render 2.9
 import Qt3D.Input 2.0
 import Qt3D.Extras 2.10
-import QtQuick 2.9
+import QtQuick 2.15
 import Qt3D.Logic 2.0
 
 /**

--- a/meshroom/ui/qml/Viewer3D/EntityWithGizmo.qml
+++ b/meshroom/ui/qml/Viewer3D/EntityWithGizmo.qml
@@ -1,9 +1,9 @@
-import Qt3D.Core 2.0
-import Qt3D.Render 2.9
-import Qt3D.Input 2.0
-import Qt3D.Extras 2.10
+import Qt3D.Core 2.15
+import Qt3D.Render 2.15
+import Qt3D.Input 2.15
+import Qt3D.Extras 2.15
 import QtQuick 2.15
-import Qt3D.Logic 2.0
+import Qt3D.Logic 2.15
 
 /**
  * Wrapper for TransformGizmo.

--- a/meshroom/ui/qml/Viewer3D/EnvironmentMapEntity.qml
+++ b/meshroom/ui/qml/Viewer3D/EnvironmentMapEntity.qml
@@ -1,7 +1,7 @@
 import QtQuick 2.15
-import Qt3D.Core 2.1
-import Qt3D.Render 2.1
-import Qt3D.Extras 2.10
+import Qt3D.Core 2.15
+import Qt3D.Render 2.15
+import Qt3D.Extras 2.15
 
 
 /**

--- a/meshroom/ui/qml/Viewer3D/EnvironmentMapEntity.qml
+++ b/meshroom/ui/qml/Viewer3D/EnvironmentMapEntity.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.9
+import QtQuick 2.15
 import Qt3D.Core 2.1
 import Qt3D.Render 2.1
 import Qt3D.Extras 2.10

--- a/meshroom/ui/qml/Viewer3D/Grid3D.qml
+++ b/meshroom/ui/qml/Viewer3D/Grid3D.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.7
+import QtQuick 2.15
 import Qt3D.Core 2.0
 import Qt3D.Render 2.0
 import Qt3D.Extras 2.0

--- a/meshroom/ui/qml/Viewer3D/Grid3D.qml
+++ b/meshroom/ui/qml/Viewer3D/Grid3D.qml
@@ -1,7 +1,7 @@
 import QtQuick 2.15
-import Qt3D.Core 2.0
-import Qt3D.Render 2.0
-import Qt3D.Extras 2.0
+import Qt3D.Core 2.15
+import Qt3D.Render 2.15
+import Qt3D.Extras 2.15
 
 // Grid
 Entity {

--- a/meshroom/ui/qml/Viewer3D/ImageOverlay.qml
+++ b/meshroom/ui/qml/Viewer3D/ImageOverlay.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.12
+import QtQuick 2.15
 import QtQuick.Layouts 1.12
 
 /**

--- a/meshroom/ui/qml/Viewer3D/Inspector3D.qml
+++ b/meshroom/ui/qml/Viewer3D/Inspector3D.qml
@@ -185,12 +185,14 @@ FloatingPane {
 
                 Connections {
                     target: uigraph
-                    onSelectedNodeChanged: mediaListView.currentIndex = -1
+                    function onSelectedNodeChanged() {
+                        mediaListView.currentIndex = -1
+                    }
                 }
 
                 Connections {
                     target: mediaLibrary
-                    onLoadRequest: {
+                    function onLoadRequest() {
                         mediaListView.positionViewAtIndex(idx, ListView.Visible);
                     }
                 }

--- a/meshroom/ui/qml/Viewer3D/Inspector3D.qml
+++ b/meshroom/ui/qml/Viewer3D/Inspector3D.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.7
-import QtQuick.Controls 2.3
+import QtQuick 2.15
+import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.3
 import MaterialIcons 2.2
 import Qt3D.Core 2.0

--- a/meshroom/ui/qml/Viewer3D/Inspector3D.qml
+++ b/meshroom/ui/qml/Viewer3D/Inspector3D.qml
@@ -2,8 +2,8 @@ import QtQuick 2.15
 import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.3
 import MaterialIcons 2.2
-import Qt3D.Core 2.0
-import Qt3D.Render 2.1
+import Qt3D.Core 2.15
+import Qt3D.Render 2.15
 import QtQuick.Controls.Material 2.4
 import Controls 1.0
 import Utils 1.0

--- a/meshroom/ui/qml/Viewer3D/Inspector3D.qml
+++ b/meshroom/ui/qml/Viewer3D/Inspector3D.qml
@@ -240,7 +240,7 @@ FloatingPane {
 
                         Connections {
                             target: mediaListView
-                            onCountChanged: mediaDelegate.updateCurrentIndex()
+                            function onCountChanged() { mediaDelegate.updateCurrentIndex() }
                         }
 
                         // Current/selected element indicator
@@ -342,7 +342,7 @@ FloatingPane {
                                     background: Rectangle {
                                         Connections {
                                             target: mediaLibrary
-                                            onLoadRequest: if(idx == index) focusAnim.restart()
+                                            function onLoadRequest() { if(idx == index) focusAnim.restart() }
                                         }
                                         ColorAnimation on color {
                                             id: focusAnim

--- a/meshroom/ui/qml/Viewer3D/Locator3D.qml
+++ b/meshroom/ui/qml/Viewer3D/Locator3D.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.7
+import QtQuick 2.15
 import Qt3D.Core 2.0
 import Qt3D.Render 2.0
 import Qt3D.Extras 2.0

--- a/meshroom/ui/qml/Viewer3D/Locator3D.qml
+++ b/meshroom/ui/qml/Viewer3D/Locator3D.qml
@@ -1,7 +1,7 @@
 import QtQuick 2.15
-import Qt3D.Core 2.0
-import Qt3D.Render 2.0
-import Qt3D.Extras 2.0
+import Qt3D.Core 2.15
+import Qt3D.Render 2.15
+import Qt3D.Extras 2.15
 import Utils 1.0
 
 // Locator

--- a/meshroom/ui/qml/Viewer3D/MaterialSwitcher.qml
+++ b/meshroom/ui/qml/Viewer3D/MaterialSwitcher.qml
@@ -2,7 +2,7 @@ import Qt3D.Core 2.0
 import Qt3D.Render 2.9
 import Qt3D.Input 2.0
 import Qt3D.Extras 2.10
-import QtQuick 2.0
+import QtQuick 2.15
 import Utils 1.0
 import "Materials"
 

--- a/meshroom/ui/qml/Viewer3D/MaterialSwitcher.qml
+++ b/meshroom/ui/qml/Viewer3D/MaterialSwitcher.qml
@@ -1,7 +1,7 @@
-import Qt3D.Core 2.0
-import Qt3D.Render 2.9
-import Qt3D.Input 2.0
-import Qt3D.Extras 2.10
+import Qt3D.Core 2.15
+import Qt3D.Render 2.15
+import Qt3D.Input 2.15
+import Qt3D.Extras 2.15
 import QtQuick 2.15
 import Utils 1.0
 import "Materials"

--- a/meshroom/ui/qml/Viewer3D/Materials/SphericalHarmonicsEffect.qml
+++ b/meshroom/ui/qml/Viewer3D/Materials/SphericalHarmonicsEffect.qml
@@ -1,5 +1,5 @@
-import Qt3D.Core 2.0
-import Qt3D.Render 2.0
+import Qt3D.Core 2.15
+import Qt3D.Render 2.15
 
 Effect {
     id: root

--- a/meshroom/ui/qml/Viewer3D/Materials/SphericalHarmonicsMaterial.qml
+++ b/meshroom/ui/qml/Viewer3D/Materials/SphericalHarmonicsMaterial.qml
@@ -1,5 +1,5 @@
-import Qt3D.Core 2.0
-import Qt3D.Render 2.0
+import Qt3D.Core 2.15
+import Qt3D.Render 2.15
 import Utils 1.0
 
 Material {

--- a/meshroom/ui/qml/Viewer3D/Materials/WireframeEffect.qml
+++ b/meshroom/ui/qml/Viewer3D/Materials/WireframeEffect.qml
@@ -1,5 +1,5 @@
-import Qt3D.Core 2.0
-import Qt3D.Render 2.0
+import Qt3D.Core 2.15
+import Qt3D.Render 2.15
 
 Effect {
     id: root

--- a/meshroom/ui/qml/Viewer3D/Materials/WireframeMaterial.qml
+++ b/meshroom/ui/qml/Viewer3D/Materials/WireframeMaterial.qml
@@ -1,5 +1,5 @@
-import Qt3D.Core 2.0
-import Qt3D.Render 2.0
+import Qt3D.Core 2.15
+import Qt3D.Render 2.15
 
 Material {
     id: root

--- a/meshroom/ui/qml/Viewer3D/MediaCache.qml
+++ b/meshroom/ui/qml/Viewer3D/MediaCache.qml
@@ -1,6 +1,6 @@
 import QtQuick 2.15
-import Qt3D.Core 2.1
-import Qt3D.Render 2.1
+import Qt3D.Core 2.15
+import Qt3D.Render 2.15
 
 import Utils 1.0
 

--- a/meshroom/ui/qml/Viewer3D/MediaCache.qml
+++ b/meshroom/ui/qml/Viewer3D/MediaCache.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.9
+import QtQuick 2.15
 import Qt3D.Core 2.1
 import Qt3D.Render 2.1
 

--- a/meshroom/ui/qml/Viewer3D/MediaLibrary.qml
+++ b/meshroom/ui/qml/Viewer3D/MediaLibrary.qml
@@ -1,6 +1,6 @@
 import QtQuick 2.15
-import Qt3D.Core 2.1
-import Qt3D.Render 2.1
+import Qt3D.Core 2.15
+import Qt3D.Render 2.15
 import Utils 1.0
 
 

--- a/meshroom/ui/qml/Viewer3D/MediaLibrary.qml
+++ b/meshroom/ui/qml/Viewer3D/MediaLibrary.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.9
+import QtQuick 2.15
 import Qt3D.Core 2.1
 import Qt3D.Render 2.1
 import Utils 1.0

--- a/meshroom/ui/qml/Viewer3D/MediaLoader.qml
+++ b/meshroom/ui/qml/Viewer3D/MediaLoader.qml
@@ -1,7 +1,7 @@
 import QtQuick 2.15
-import Qt3D.Core 2.1
-import Qt3D.Render 2.1
-import Qt3D.Extras 2.10
+import Qt3D.Core 2.15
+import Qt3D.Render 2.15
+import Qt3D.Extras 2.15
 import QtQuick.Scene3D 2.0
 import "Materials"
 import Utils 1.0

--- a/meshroom/ui/qml/Viewer3D/MediaLoader.qml
+++ b/meshroom/ui/qml/Viewer3D/MediaLoader.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.9
+import QtQuick 2.15
 import Qt3D.Core 2.1
 import Qt3D.Render 2.1
 import Qt3D.Extras 2.10

--- a/meshroom/ui/qml/Viewer3D/MediaLoaderEntity.qml
+++ b/meshroom/ui/qml/Viewer3D/MediaLoaderEntity.qml
@@ -1,5 +1,5 @@
 import QtQuick 2.15
-import Qt3D.Core 2.1
+import Qt3D.Core 2.15
 
 
 /**

--- a/meshroom/ui/qml/Viewer3D/MediaLoaderEntity.qml
+++ b/meshroom/ui/qml/Viewer3D/MediaLoaderEntity.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.9
+import QtQuick 2.15
 import Qt3D.Core 2.1
 
 

--- a/meshroom/ui/qml/Viewer3D/MeshingBoundingBox.qml
+++ b/meshroom/ui/qml/Viewer3D/MeshingBoundingBox.qml
@@ -2,7 +2,7 @@ import Qt3D.Core 2.0
 import Qt3D.Render 2.9
 import Qt3D.Input 2.0
 import Qt3D.Extras 2.10
-import QtQuick 2.9
+import QtQuick 2.15
 
 /**
  * BoundingBox entity for Meshing node. Used to define the area to reconstruct.

--- a/meshroom/ui/qml/Viewer3D/MeshingBoundingBox.qml
+++ b/meshroom/ui/qml/Viewer3D/MeshingBoundingBox.qml
@@ -1,7 +1,7 @@
-import Qt3D.Core 2.0
-import Qt3D.Render 2.9
-import Qt3D.Input 2.0
-import Qt3D.Extras 2.10
+import Qt3D.Core 2.15
+import Qt3D.Render 2.15
+import Qt3D.Input 2.15
+import Qt3D.Extras 2.15
 import QtQuick 2.15
 
 /**

--- a/meshroom/ui/qml/Viewer3D/SfMTransformGizmo.qml
+++ b/meshroom/ui/qml/Viewer3D/SfMTransformGizmo.qml
@@ -2,7 +2,7 @@ import Qt3D.Core 2.0
 import Qt3D.Render 2.9
 import Qt3D.Input 2.0
 import Qt3D.Extras 2.10
-import QtQuick 2.9
+import QtQuick 2.15
 
 /**
  * Gizmo for SfMTransform node.

--- a/meshroom/ui/qml/Viewer3D/SfMTransformGizmo.qml
+++ b/meshroom/ui/qml/Viewer3D/SfMTransformGizmo.qml
@@ -1,7 +1,7 @@
-import Qt3D.Core 2.0
-import Qt3D.Render 2.9
-import Qt3D.Input 2.0
-import Qt3D.Extras 2.10
+import Qt3D.Core 2.15
+import Qt3D.Render 2.15
+import Qt3D.Input 2.15
+import Qt3D.Extras 2.15
 import QtQuick 2.15
 
 /**

--- a/meshroom/ui/qml/Viewer3D/TrackballGizmo.qml
+++ b/meshroom/ui/qml/Viewer3D/TrackballGizmo.qml
@@ -1,7 +1,7 @@
-import Qt3D.Core 2.0
-import Qt3D.Render 2.9
-import Qt3D.Input 2.0
-import Qt3D.Extras 2.10
+import Qt3D.Core 2.15
+import Qt3D.Render 2.15
+import Qt3D.Input 2.15
+import Qt3D.Extras 2.15
 import QtQuick 2.15
 
 Entity {

--- a/meshroom/ui/qml/Viewer3D/TrackballGizmo.qml
+++ b/meshroom/ui/qml/Viewer3D/TrackballGizmo.qml
@@ -2,7 +2,7 @@ import Qt3D.Core 2.0
 import Qt3D.Render 2.9
 import Qt3D.Input 2.0
 import Qt3D.Extras 2.10
-import QtQuick 2.9
+import QtQuick 2.15
 
 Entity {
     id: root

--- a/meshroom/ui/qml/Viewer3D/TransformGizmo.qml
+++ b/meshroom/ui/qml/Viewer3D/TransformGizmo.qml
@@ -1,9 +1,9 @@
-import Qt3D.Core 2.0
-import Qt3D.Render 2.9
-import Qt3D.Input 2.0
-import Qt3D.Extras 2.10
+import Qt3D.Core 2.15
+import Qt3D.Render 2.15
+import Qt3D.Input 2.15
+import Qt3D.Extras 2.15
 import QtQuick 2.15
-import Qt3D.Logic 2.0
+import Qt3D.Logic 2.15
 import QtQuick.Controls 2.15
 import Utils 1.0
 

--- a/meshroom/ui/qml/Viewer3D/TransformGizmo.qml
+++ b/meshroom/ui/qml/Viewer3D/TransformGizmo.qml
@@ -2,9 +2,9 @@ import Qt3D.Core 2.0
 import Qt3D.Render 2.9
 import Qt3D.Input 2.0
 import Qt3D.Extras 2.10
-import QtQuick 2.9
+import QtQuick 2.15
 import Qt3D.Logic 2.0
-import QtQuick.Controls 2.3
+import QtQuick.Controls 2.15
 import Utils 1.0
 
 

--- a/meshroom/ui/qml/Viewer3D/TransformGizmoPicker.qml
+++ b/meshroom/ui/qml/Viewer3D/TransformGizmoPicker.qml
@@ -1,9 +1,9 @@
-import Qt3D.Core 2.0
-import Qt3D.Render 2.9
-import Qt3D.Input 2.0
-import Qt3D.Extras 2.10
+import Qt3D.Core 2.15
+import Qt3D.Render 2.15
+import Qt3D.Input 2.15
+import Qt3D.Extras 2.15
 import QtQuick 2.15
-import Qt3D.Logic 2.0
+import Qt3D.Logic 2.15
 
 ObjectPicker {
     id: root

--- a/meshroom/ui/qml/Viewer3D/TransformGizmoPicker.qml
+++ b/meshroom/ui/qml/Viewer3D/TransformGizmoPicker.qml
@@ -2,7 +2,7 @@ import Qt3D.Core 2.0
 import Qt3D.Render 2.9
 import Qt3D.Input 2.0
 import Qt3D.Extras 2.10
-import QtQuick 2.9
+import QtQuick 2.15
 import Qt3D.Logic 2.0
 
 ObjectPicker {

--- a/meshroom/ui/qml/Viewer3D/Viewer3D.qml
+++ b/meshroom/ui/qml/Viewer3D/Viewer3D.qml
@@ -1,6 +1,5 @@
 import QtQuick 2.15
 import QtQuick.Controls 2.15
-import QtQuick.Controls 1.4 as Controls1
 import QtQuick.Layouts 1.3
 import QtQml.Models 2.2
 import QtQuick.Scene3D 2.0

--- a/meshroom/ui/qml/Viewer3D/Viewer3D.qml
+++ b/meshroom/ui/qml/Viewer3D/Viewer3D.qml
@@ -5,9 +5,9 @@ import QtQuick.Layouts 1.3
 import QtQml.Models 2.2
 import QtQuick.Scene3D 2.0
 import Qt3D.Core 2.15
-import Qt3D.Render 2.1
-import Qt3D.Extras 2.10
-import Qt3D.Input 2.1 as Qt3DInput // to avoid clash with Controls2 Action
+import Qt3D.Render 2.15
+import Qt3D.Extras 2.15
+import Qt3D.Input 2.15 as Qt3DInput // to avoid clash with Controls2 Action
 
 import MaterialIcons 2.2
 

--- a/meshroom/ui/qml/Viewer3D/Viewer3D.qml
+++ b/meshroom/ui/qml/Viewer3D/Viewer3D.qml
@@ -1,10 +1,10 @@
-import QtQuick 2.7
-import QtQuick.Controls 2.3
+import QtQuick 2.15
+import QtQuick.Controls 2.15
 import QtQuick.Controls 1.4 as Controls1
 import QtQuick.Layouts 1.3
 import QtQml.Models 2.2
 import QtQuick.Scene3D 2.0
-import Qt3D.Core 2.1
+import Qt3D.Core 2.15
 import Qt3D.Render 2.1
 import Qt3D.Extras 2.10
 import Qt3D.Input 2.1 as Qt3DInput // to avoid clash with Controls2 Action

--- a/meshroom/ui/qml/Viewer3D/Viewer3DSettings.qml
+++ b/meshroom/ui/qml/Viewer3D/Viewer3DSettings.qml
@@ -1,5 +1,5 @@
 pragma Singleton
-import QtQuick 2.9
+import QtQuick 2.15
 import MaterialIcons 2.2
 
 /**

--- a/meshroom/ui/qml/Viewer3D/ViewpointCamera.qml
+++ b/meshroom/ui/qml/Viewer3D/ViewpointCamera.qml
@@ -1,6 +1,6 @@
 import QtQuick 2.15
 import Qt3D.Core 2.15
-import Qt3D.Render 2.12
+import Qt3D.Render 2.15
 
 
 /**

--- a/meshroom/ui/qml/Viewer3D/ViewpointCamera.qml
+++ b/meshroom/ui/qml/Viewer3D/ViewpointCamera.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.12
-import Qt3D.Core 2.12
+import QtQuick 2.15
+import Qt3D.Core 2.15
 import Qt3D.Render 2.12
 
 

--- a/meshroom/ui/qml/WorkspaceView.qml
+++ b/meshroom/ui/qml/WorkspaceView.qml
@@ -1,6 +1,5 @@
 import QtQuick 2.15
 import QtQuick.Controls 2.15
-import QtQuick.Controls 1.4 as Controls1 // For SplitView
 import QtQuick.Layouts 1.3
 import Qt.labs.platform 1.0 as Platform
 import ImageGallery 1.0
@@ -52,17 +51,18 @@ Item {
 
     SystemPalette { id: activePalette }
 
-    Controls1.SplitView {
+    SplitView {
         anchors.fill: parent
 
-        Controls1.SplitView {
+        SplitView {
             orientation: Qt.Vertical
-            Layout.fillHeight: true
-            Layout.minimumWidth: imageGallery.defaultCellSize
+            SplitView.fillHeight: true
+            SplitView.preferredWidth : Math.round(parent.width * 0.17)
+            SplitView.minimumWidth: imageGallery.defaultCellSize
 
             ImageGallery {
                 id: imageGallery
-                Layout.fillHeight: true
+                SplitView.fillHeight: true
                 readOnly: root.readOnly
                 cameraInits: root.cameraInits
                 cameraInit: reconstruction.cameraInit
@@ -74,15 +74,14 @@ Item {
             LiveSfmView {
                 visible: settings_UILayout.showLiveReconstruction
                 reconstruction: root.reconstruction
-                Layout.fillWidth: true
-                Layout.preferredHeight: childrenRect.height
+                SplitView.fillWidth: true
+                SplitView.preferredHeight: childrenRect.height
             }
         }
         Panel {
             title: "Image Viewer"
-            Layout.fillHeight: true
-            Layout.fillWidth: true
-            Layout.minimumWidth: 50
+            SplitView.fillWidth: true
+            SplitView.minimumWidth: 50
             loading: viewer2D.loadingModules.length > 0
             loadingText: loading ? "Loading " + viewer2D.loadingModules : ""
 
@@ -148,10 +147,10 @@ Item {
         Panel {
             title: "3D Viewer"
             implicitWidth: Math.round(parent.width * 0.45)
-            Layout.minimumWidth: 20
-            Layout.minimumHeight: 80
+            SplitView.minimumWidth: 20
+            SplitView.minimumHeight: 80
 
-            Controls1.SplitView {
+            SplitView {
                 anchors.fill: parent
                 Viewer3D {
                     id: viewer3D

--- a/meshroom/ui/qml/WorkspaceView.qml
+++ b/meshroom/ui/qml/WorkspaceView.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.7
-import QtQuick.Controls 2.3
+import QtQuick 2.15
+import QtQuick.Controls 2.15
 import QtQuick.Controls 1.4 as Controls1 // For SplitView
 import QtQuick.Layouts 1.3
 import Qt.labs.platform 1.0 as Platform

--- a/meshroom/ui/qml/WorkspaceView.qml
+++ b/meshroom/ui/qml/WorkspaceView.qml
@@ -36,9 +36,9 @@ Item {
 
     Connections {
         target: reconstruction
-        onGraphChanged: viewer3D.clear()
-        onSfmChanged: viewSfM()
-        onSfmReportChanged: viewSfM()
+        function onGraphChanged() { viewer3D.clear() }
+        function onSfmChanged() { viewSfM() }
+        function onSfmReportChanged() { viewSfM() }
     }
     Component.onCompleted: viewSfM()
 
@@ -123,7 +123,7 @@ Item {
 
                 Connections {
                     target: imageGallery
-                    onCurrentItemChanged: {
+                    function onCurrentItemChanged() {
                         viewer2D.source = imageGallery.currentItemSource
                         viewer2D.metadata = imageGallery.currentItemMetadata
                     }

--- a/meshroom/ui/qml/main.qml
+++ b/meshroom/ui/qml/main.qml
@@ -602,7 +602,7 @@ ApplicationWindow {
             dialog.detailedText = message.detailedText
         }
 
-        onGraphChanged: {
+        function onGraphChanged() {
             // open CompatibilityManager after file loading if any issue is detected
             if(compatibilityManager.issueCount)
                 compatibilityManager.open()
@@ -610,9 +610,9 @@ ApplicationWindow {
             graphEditor.fit()
         }
 
-        onInfo: createDialog(dialogsFactory.info, arguments[0])
-        onWarning: createDialog(dialogsFactory.warning, arguments[0])
-        onError: createDialog(dialogsFactory.error, arguments[0])
+        function onInfo() { createDialog(dialogsFactory.info, arguments[0]) }
+        function onWarning() { createDialog(dialogsFactory.warning, arguments[0]) }
+        function onError() { createDialog(dialogsFactory.error, arguments[0]) }
     }
 
 

--- a/meshroom/ui/qml/main.qml
+++ b/meshroom/ui/qml/main.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.7
-import QtQuick.Controls 2.3
+import QtQuick 2.15
+import QtQuick.Controls 2.15
 import QtQuick.Controls 1.4 as Controls1 // For SplitView
 import QtQuick.Layouts 1.1
 import QtQuick.Window 2.3

--- a/meshroom/ui/qml/main.qml
+++ b/meshroom/ui/qml/main.qml
@@ -6,7 +6,6 @@ import QtQuick.Window 2.3
 import QtQml.Models 2.2
 
 import Qt.labs.platform 1.0 as Platform
-import QtQuick.Dialogs 1.3
 
 import Qt.labs.settings 1.0
 import GraphEditor 1.0
@@ -293,8 +292,7 @@ ApplicationWindow {
     FileDialog {
         id: importFilesDialog
         title: "Import Images"
-        selectExisting: true
-        selectMultiple: true
+        fileMode: FileDialog.OpenFiles
         nameFilters: []
         onAccepted: {
             console.warn("importFilesDialog fileUrls: " + importFilesDialog.fileUrls)

--- a/meshroom/ui/qml/main.qml
+++ b/meshroom/ui/qml/main.qml
@@ -1,6 +1,5 @@
 import QtQuick 2.15
 import QtQuick.Controls 2.15
-import QtQuick.Controls 1.4 as Controls1 // For SplitView
 import QtQuick.Layouts 1.1
 import QtQuick.Window 2.3
 import QtQml.Models 2.2
@@ -614,7 +613,7 @@ ApplicationWindow {
     }
 
 
-    Controls1.SplitView {
+    SplitView {
         anchors.fill: parent
         orientation: Qt.Vertical
 
@@ -622,8 +621,8 @@ ApplicationWindow {
         ToolTip.toolTip.background: Rectangle { color: activePalette.base; border.color: activePalette.mid }
 
         ColumnLayout {
-            Layout.fillWidth: true
-            Layout.fillHeight: true
+            SplitView.fillWidth: true
+            SplitView.fillHeight: true
             Layout.topMargin: 2
             implicitHeight: Math.round(parent.height * 0.7)
             spacing: 4
@@ -728,15 +727,16 @@ ApplicationWindow {
             }
         }
 
-        Controls1.SplitView {
+        SplitView {
             orientation: Qt.Horizontal
-            width: parent.width
-            height: Math.round(parent.height * 0.3)
+            SplitView.preferredWidth: parent.width
+            SplitView.preferredHeight: Math.round(parent.height * 0.3)
             visible: settings_UILayout.showGraphEditor
 
             TabPanel {
                 id: graphEditorPanel
-                Layout.fillWidth: true
+                SplitView.fillWidth: true
+                width: Math.round(parent.width * 0.7)
                 padding: 4
                 tabs: ["Graph Editor", "Task Manager"]
 
@@ -818,7 +818,7 @@ ApplicationWindow {
 
             NodeEditor {
                 id: nodeEditor
-                width: Math.round(parent.width * 0.3)
+                SplitView.preferredWidth: Math.round(parent.width * 0.3)
                 node: _reconstruction.selectedNode
                 property bool computing: _reconstruction.computing
                 // Make NodeEditor readOnly when computing

--- a/meshroom/ui/reconstruction.py
+++ b/meshroom/ui/reconstruction.py
@@ -5,8 +5,8 @@ import os
 from threading import Thread
 from collections import Iterable
 
-from PySide2.QtCore import QObject, Slot, Property, Signal, QUrl, QSizeF
-from PySide2.QtGui import QMatrix4x4, QMatrix3x3, QQuaternion, QVector3D, QVector2D
+from PySide6.QtCore import QObject, Slot, Property, Signal, QUrl, QSizeF
+from PySide6.QtGui import QMatrix4x4, QMatrix3x3, QQuaternion, QVector3D, QVector2D
 
 import meshroom.core
 import meshroom.common

--- a/meshroom/ui/utils.py
+++ b/meshroom/ui/utils.py
@@ -1,12 +1,12 @@
 import os
 import time
 
-from PySide2.QtCore import QFileSystemWatcher, QUrl, Slot, QTimer, Property, QObject
-from PySide2.QtQml import QQmlApplicationEngine
+from PySide6.QtCore import QFileSystemWatcher, QUrl, Slot, QTimer, Property, QObject
+from PySide6.QtQml import QQmlApplicationEngine
 try:
-    from PySide2 import shiboken2
+    from PySide6 import shiboken6
 except:
-    import shiboken2
+    import shiboken6
 
 
 class QmlInstantEngine(QQmlApplicationEngine):
@@ -237,7 +237,7 @@ def makeProperty(T, attributeName, notify=None, resetOnDestroy=False):
             setattr(instance, resetCallbackName, lambda self=instance, *args: setter(self, None))
         resetCallback = getattr(instance, resetCallbackName, None)
 
-        if resetCallback and currentValue and shiboken2.isValid(currentValue):
+        if resetCallback and currentValue and shiboken6.isValid(currentValue):
             currentValue.destroyed.disconnect(resetCallback)
         setattr(instance, attributeName, value)
         if resetCallback and value:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # runtime
 psutil>=5.6.3
 enum34;python_version<"3.4"
-PySide2==5.15.0
+PySide6==6.0.3
 markdown==2.6.11
 requests==2.22.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # runtime
 psutil>=5.6.3
 enum34;python_version<"3.4"
-PySide2==5.14.1
+PySide2==5.15.0
 markdown==2.6.11
 requests==2.22.0

--- a/setup.py
+++ b/setup.py
@@ -130,7 +130,7 @@ meshroomCompute = PlatformExecutable(
 setup(
     name="Meshroom",
     description="Meshroom",
-    install_requires=['psutil', 'pytest', 'PySide2', 'markdown'],
+    install_requires=['psutil', 'pytest', 'PySide6', 'markdown'],
     extras_require={
         ':python_version < "3.4"': [
             'enum34',

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,6 +1,6 @@
 import pytest
 
-from PySide2.QtCore import QObject, Property
+from PySide6.QtCore import QObject, Property
 
 from meshroom.common.core import CoreDictModel
 from meshroom.common.qt import QObjectListModel, QTypedObjectListModel


### PR DESCRIPTION
## Description
Meshroom migration to Qt 6 / PySide 6.

## Features list
- [x] Update QML Connections functions syntax (https://doc.qt.io/qt-6/qml-qtqml-connections.html)
- [x] Use PySide 6
- [x] Remove QtGraphicalEffects dependency (https://doc.qt.io/qt-6/whatsnew60.html#removed-modules-in-qt-6-0)
- [x] Remove QtQuick.Dialogs dependency (https://codereview.qt-project.org/c/qt/qtdoc/+/322469)
- [x] Remove QtQuick.Controls 1.x dependencies (https://doc-snapshots.qt.io/qt6-dev/qtquickcontrols-changes-qt6.html)
- [x] Use QtQuick.Controls 2 for QML SplitView. (SplitView previously used QtQuick.Controls 1.x)
- [x] Use js function Request.get for all calls to XMLHttpRequest (see : Implementation remarks)
- [ ] Remove QML import module version
- [ ] Update UI QML Style
- [ ] Update 3D Graphics backend
- [ ] Update Shader Management in QML (https://www.qt.io/blog/graphics-in-qt-6.0-qrhi-qt-quick-qt-quick-3d)
- [ ] ...

## Missing modules for migration
- [x] QtCharts &rarr; *Wait for Qt 6.1*, [now released](https://wiki.qt.io/Qt_6.1_Release)
- [x] QtPositioning &rarr; *Wait for Qt 6.2* [now released](https://wiki.qt.io/Qt_6.2_Release), [qt6 changes](https://doc-snapshots.qt.io/qt6-dev/qtpositioning-changes-qt6.html)
- [ ] QtLocation  &rarr; *Wait for Qt 6.5* [blog post](https://www.qt.io/blog/the-road-to-qt-location), [wip 6.5 release](https://wiki.qt.io/Qt_6.5_Release), [qt6 changes](https://doc-snapshots.qt.io/qt6-dev/qtlocation-changes-qt6.html)
- [x] QtQuick.Dialogs &rarr; *Remove dependencies (Use Qt.labs.platform)*
- [x] QtQuick.Controls 1.x &rarr; *Remove dependencies (Use QtQuick.Controls 2.x)*
- [x] QtGraphicalEffects (QML) &rarr; *Remove usage*

## Missing features of the current branch
- [ ] 3D Viewer (3D Graphics backend, Shader Management)
- [ ] Node Statistics
- [ ] Image Metadata (2D Viewer)
- [ ] Meshroom Plugins migration

## Implementation remarks
#### XMLHttpRequest
Using GET on a local file with XMLHttpRequest is disabled by default in Qt6.
For now, environmental variable **QML_XHR_ALLOW_FILE_READ** must be set to 1 to enable this feature.
Local files access might need to be rewritten in Python.

## Qt Issues
- [x] Missing assimpsceneimport: https://bugreports.qt.io/browse/QTBUG-93500
- [x] Qt 6.2 planned release date: 30.09.2021, see https://wiki.qt.io/Qt_6.2_Release
- [x] Qt 6.3 planned release date: 12.04.2022, see https://wiki.qt.io/Qt_6.3_Release
- [x] Qt 6.4 planned release date: 29.09.2022, see https://wiki.qt.io/Qt_6.4_Release
- [ ] Qt 6.5 planned release date: 30.03.2023, see https://wiki.qt.io/Qt_6.5_Release

https://doc-snapshots.qt.io/qt6-dev/whatsnew60.html
https://doc-snapshots.qt.io/qt6-dev/whatsnew61.html
https://doc-snapshots.qt.io/qt6-dev/whatsnew62.html
https://doc-snapshots.qt.io/qt6-dev/whatsnew63.html
https://doc-snapshots.qt.io/qt6-dev/whatsnew64.html
https://doc-snapshots.qt.io/qt6-dev/whatsnew65.html

https://doc.qt.io/qt-6/modulechanges.html
