### PR TITLE
[ui] Add a clear images button 

### DIFF
--- a/meshroom/ui/qml/main.qml
+++ b/meshroom/ui/qml/main.qml
@@ -494,6 +494,30 @@ ApplicationWindow {
                 shortcut: "Ctrl+I"
                 onTriggered: importFilesDialog.open()
             }
+
+            Action {
+                id: clearActionItem
+                text: "Clear Images"
+                onTriggered: {
+                    //Loop through all the camera inits
+                    for(var i = 0 ; i < _reconstruction.cameraInits.count; i++){
+                        var cameraInit = _reconstruction.cameraInits.at(i)
+
+                        //Delete all viewpoints
+                        var viewpoints = cameraInit.attribute('viewpoints')
+                        for(var y = viewpoints.value.count - 1 ; y >= 0 ; y--){
+                              _reconstruction.removeAttribute(viewpoints.value.at(y))
+                        }
+
+                        //Delete all intrinsics
+                        var intrinsics = cameraInit.attribute('intrinsics')
+                        for(var z = intrinsics.value.count - 1 ; z >= 0 ; z--){
+                              _reconstruction.removeAttribute(intrinsics.value.at(z))
+                        }
+                    }
+                }
+            }
+
             Action {
                 id: saveAction
                 text: "Save"


### PR DESCRIPTION
## Description

New button in the file menu to clear all images from the scene.
This means it deletes all the viewpoints and intrinsics from all the camera inits present in the scene.

![clearimage](https://user-images.githubusercontent.com/44846959/124886064-30387800-dfd4-11eb-8533-0cc8e02539db.jpg)

## Features list

- [x] Button _"Clear Images"_ inside the _"File"_ dropdown menu


