### PR TITLE
Publish to basedir

### DIFF
--- a/meshroom/nodes/aliceVision/PublishToBaseDir.py
+++ b/meshroom/nodes/aliceVision/PublishToBaseDir.py
@@ -13,8 +13,11 @@ class PublishToBaseDir(desc.Node):
 
     category = 'Export'
     documentation = '''
-This node copies the results to the /mnt/models/<project name>_XXX directory. It also saves a copy
-of the current pipeline as src.mg.
+This node copies the results to a /<base dir>/<project name>_XXX directory. It copies all the input files.
+
+In addition, it saves a copy of the current pipeline as src.mg to that directory.
+
+If the directory already exists, a new directory is created whereby XXX is increment, i.e. it starts with _000 then _001 then _002 ....
 '''
 
     inputs = [
@@ -54,7 +57,7 @@ of the current pipeline as src.mg.
             name='output_folder',
             label='Output Folder',
             description='Folder that was created for model.',
-            value="",
+            value="{outputValue}/{inputFilesValue}/directory",
             uid=[],
             group=""
         ),
@@ -124,5 +127,7 @@ of the current pipeline as src.mg.
             chunk.logger.info('Publish end')
 
             chunk.node.output_folder.value = output_dir
+            chunk.node.output_folder.valueChanged.emit()
+
         finally:
             chunk.logManager.end()

--- a/meshroom/nodes/aliceVision/PublishToBaseDir.py
+++ b/meshroom/nodes/aliceVision/PublishToBaseDir.py
@@ -3,6 +3,8 @@ from __future__ import print_function
 __version__ = "0.1"
 
 from meshroom.core import desc
+import shutil
+import glob
 import os
 import json
 

--- a/meshroom/nodes/aliceVision/PublishToBaseDir.py
+++ b/meshroom/nodes/aliceVision/PublishToBaseDir.py
@@ -49,6 +49,17 @@ of the current pipeline as src.mg.
             ),
         ]
 
+    outputs = [
+        desc.File(
+            name='output_folder',
+            label='Output Folder',
+            description='Folder that was created for model.',
+            value="",
+            uid=[],
+            group=""
+        ),
+    ]
+
     def resolvedPaths(self, inputFiles, outDir):
         paths = {}
         for inputFile in inputFiles:
@@ -111,5 +122,7 @@ of the current pipeline as src.mg.
                 chunk.logger.info('Publish file {} into {}'.format(iFile, oFile))
                 shutil.copyfile(iFile, oFile)
             chunk.logger.info('Publish end')
+
+            chunk.node.output_folder.value = output_dir
         finally:
             chunk.logManager.end()

--- a/meshroom/nodes/aliceVision/PublishToBaseDir.py
+++ b/meshroom/nodes/aliceVision/PublishToBaseDir.py
@@ -3,8 +3,6 @@ from __future__ import print_function
 __version__ = "0.1"
 
 from meshroom.core import desc
-import shutil
-import glob
 import os
 import json
 

--- a/meshroom/nodes/aliceVision/PublishToBaseDir.py
+++ b/meshroom/nodes/aliceVision/PublishToBaseDir.py
@@ -1,0 +1,115 @@
+from __future__ import print_function
+
+__version__ = "0.1"
+
+from meshroom.core import desc
+import shutil
+import glob
+import os
+import json
+
+class PublishToBaseDir(desc.Node):
+    size = desc.DynamicNodeSize('inputFiles')
+
+    category = 'Export'
+    documentation = '''
+This node copies the results to the /mnt/models/<project name>_XXX directory. It also saves a copy
+of the current pipeline as src.mg.
+'''
+
+    inputs = [
+        desc.ListAttribute(
+            elementDesc=desc.File(
+                name="input",
+                label="Input",
+                description="",
+                value="",
+                uid=[0],
+            ),
+            name="inputFiles",
+            label="Input Files",
+            description="Input Files to publish.",
+            group="",
+        ),
+        desc.File(
+            name="output",
+            label="Base Output Folder",
+            description="",
+            value="/mnt/models",
+            uid=[0],
+        ),
+        desc.ChoiceParam(
+            name='verboseLevel',
+            label='Verbose Level',
+            description='''verbosity level (critical, error, warning, info, debug).''',
+            value='info',
+            values=['critical', 'error', 'warning', 'info', 'debug'],
+            exclusive=True,
+            uid=[],
+            ),
+        ]
+
+    def resolvedPaths(self, inputFiles, outDir):
+        paths = {}
+        for inputFile in inputFiles:
+            for f in glob.glob(inputFile.value):
+                paths[f] = os.path.join(outDir, os.path.basename(f))
+        return paths
+
+    def get_output_directory(self, prjname, base_dir):
+        cnt = 0
+        path = os.path.join(base_dir, prjname)
+
+        while os.path.isdir(path):
+            path = os.path.join(base_dir,"{}_{}".format(prjname, "%03d"%cnt))
+            cnt += 1
+
+        return path
+
+    def processChunk(self, chunk):
+        try:
+            if not chunk.node.output.value:
+                chunk.logger.warning('No Base Output Folder')
+                return
+
+            graph = chunk.node._attributes.parent().parent().parent()
+            prjname = graph.name
+
+            output_dir = self.get_output_directory(prjname, chunk.node.output.value)
+            chunk.logManager.start(chunk.node.verboseLevel.value)
+
+            chunk.logger.info('Output Directory: {}'.format(output_dir))
+
+            if not os.path.exists(output_dir):
+                os.mkdir(output_dir)
+
+            #
+            # The .mg format was taken from:
+            #   https://github.com/alicevision/meshroom/blob/18be350e6f7a410941d2d609722b9459469ea2a2/meshroom/core/graph.py#L1008-L1014
+            #
+            data = {
+                graph.IO.Keys.Header: graph.header,
+                graph.IO.Keys.Graph: graph.toDict(),
+            }
+
+            with open(os.path.join(output_dir, "src.mg"), 'w') as jsonFile:
+                json.dump(data, jsonFile, indent=4)
+
+            if not chunk.node.inputFiles:
+                chunk.logger.warning('Nothing to publish')
+                return
+
+            outFiles = self.resolvedPaths(chunk.node.inputFiles.value, output_dir)
+
+            if not outFiles:
+                error = 'Publish: input files listed, but nothing to publish'
+                chunk.logger.error(error)
+                chunk.logger.info('Listed input files: {}'.format([i.value for i in chunk.node.inputFiles.value]))
+                raise RuntimeError(error)
+
+            for iFile, oFile in outFiles.items():
+                chunk.logger.info('Publish file {} into {}'.format(iFile, oFile))
+                shutil.copyfile(iFile, oFile)
+            chunk.logger.info('Publish end')
+        finally:
+            chunk.logManager.end()


### PR DESCRIPTION
<!-- Checklist before submission:

 - I have read the [contribution guidelines](../CONTRIBUTING.md).
 - I have updated the documentation, if applicable.
 - I have ensured that the change is tested somewhere.
 - I have followed the prevailing code style (for history readability and limit conflicts for maintainance).

-->
## Description

This is a suggestion for a new publish node that creates a sub-directory for each compute of the Node. It also creates a `src.mg` file that is a copy of the current pipeline, i.e. the pipeline that generated the meshes and textures.

So for example, the file structure becomes:

```
/<basedir>/<project_name>/...
    src.mg
    <textures>
    <meshes>
/<basedir>/<project_name>_000/...
    src.mg
    <textures>
    <meshes>
/<basedir>/<project_name>_001/...
    src.mg
    <textures>
    <meshes>
```

This allows me to experiment with different settings without overwriting existing models.

## Features list

<!--
- [ ] Feature one. Fix #XXX
- [ ] Improve something else
- [ ] Connect to #3 (to declare link to issues without closing it when the PR is merged).
- [X] Add "X" when it is done.
-->


## Implementation remarks

I made the assumption that this [line](https://github.com/gorenje/meshroom/blob/publish_to_basedir/meshroom/nodes/aliceVision/PublishToBaseDir.py#L75):

```
graph = chunk.node._attributes.parent().parent().parent()
```

will give me the top-level node, i.e. the project details. I don't know whether this is the correct
way to access the toplevel node ... 

A [second assumption](https://github.com/gorenje/meshroom/blob/publish_to_basedir/meshroom/nodes/aliceVision/PublishToBaseDir.py#L90-L96) I make in the node is the file format of `.mg` files. 
I found that over in the [Graph class](https://github.com/alicevision/meshroom/blob/18be350e6f7a410941d2d609722b9459469ea2a2/meshroom/core/graph.py#L1008-L1014).

<!--
Explain main implementation choices.
It is also the right place to ask for feedback and help when you hesitate on the implementation.
-->
