### PR TITLE
Fix incompatibility with recent cx_Freeze

### DIFF
--- a/setupInitScriptUnix.py
+++ b/setupInitScriptUnix.py
@@ -30,11 +30,14 @@ sys.frozen = True
 sys.path = sys.path[:4]
 
 
-def run():
+def run(*args):
     m = __import__("__main__")
     importer = zipimport.zipimporter(os.path.dirname(os.__file__))
-    name, ext = os.path.splitext(os.path.basename(os.path.normcase(FILE_NAME)))
-    moduleName = "%s__main__" % name
+    if len(args) == 0:
+        name, ext = os.path.splitext(os.path.basename(os.path.normcase(FILE_NAME)))
+        moduleName = "%s__main__" % name
+    else:
+        moduleName = args[0]
     code = importer.get_code(moduleName)
     exec(code, m.__dict__)
 


### PR DESCRIPTION
In cx_Freeze 6.7, released last week, the startup code was changed so the run() function in the startup module is given the name of the main module as an argument.  This causes meshroom to fail to start on Linux (and presumably also on macOS, which uses the same startup script) with a confusing error:
```
Traceback (most recent call last):
  File ".../cx_Freeze/initscripts/__startup__.py", line 104, in run
    module_init.run(name + "__main__")
TypeError: run() takes 0 positional arguments but 1 was given
```

This change makes meshroom compatible with new cx_Freeze, while retaining the old behaviour if run() received no arguments.