### PR TITLE
Documentation update : how to use Meshroom without building AliceVision

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,9 +58,9 @@ The project is released under MPLv2, see [**COPYING.md**](COPYING.md).
 
 ## Get the project
 
-If you don't want to built it yourself, you can directly download the released version in [releases](https://github.com/alicevision/meshroom/releases).  
+You can [download pre-compiled binaries for the latest release](https://github.com/alicevision/meshroom/releases).  
 
-[**INSTALL.md**](INSTALL.md) to setup the project and pre-requisites.
+If you want to build it yourself, see [**INSTALL.md**](INSTALL.md) to setup the project and pre-requisites.
 
 Get the source code and install runtime requirements:
 ```bash

--- a/README.md
+++ b/README.md
@@ -97,10 +97,13 @@ python bin/meshroom_batch --input INPUT_IMAGES_FOLDER --output OUTPUT_FOLDER
 
 ## Start Meshroom without building AliceVision
 
-If you want to use Meshroom (ui) without building AliceVision, download [released](https://github.com/alicevision/meshroom/releases) and checkout corresponding Meshroom (ui) version/tag to avoid versions incompatibilities:
-```bash
-LD_LIBRARY_PATH=~/foo/Meshroom-2021.1.0/aliceVision/lib/ PATH=$PATH:~/foo/Meshroom-2021.1.0/aliceVision/bin/ PYTHONPATH=$PWD python3 meshroom/ui
-```
+To use Meshroom (ui) without building AliceVision  
+  - Download a [release](https://github.com/alicevision/meshroom/releases)
+  - Checkout corresponding Meshroom (ui) version/tag to avoid versions incompatibilities  
+  - 
+    ```bash
+    LD_LIBRARY_PATH=~/foo/Meshroom-2021.1.0/aliceVision/lib/ PATH=$PATH:~/foo/Meshroom-2021.1.0/aliceVision/bin/ PYTHONPATH=$PWD python3 meshroom/ui
+    ```
 
 ## FAQ
 

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ python bin/meshroom_batch --input INPUT_IMAGES_FOLDER --output OUTPUT_FOLDER
 ## Start Meshroom without building AliceVision
 
 To use Meshroom (ui) without building AliceVision
-*  Download a [release](https://github.com/alicevision/meshroom/releases)
+*   Download a [release](https://github.com/alicevision/meshroom/releases)
 *   Checkout corresponding Meshroom (ui) version/tag to avoid versions incompatibilities
 *   `LD_LIBRARY_PATH=~/foo/Meshroom-2021.1.0/aliceVision/lib/ PATH=$PATH:~/foo/Meshroom-2021.1.0/aliceVision/bin/ PYTHONPATH=$PWD python3 meshroom/ui`
 

--- a/README.md
+++ b/README.md
@@ -97,13 +97,10 @@ python bin/meshroom_batch --input INPUT_IMAGES_FOLDER --output OUTPUT_FOLDER
 
 ## Start Meshroom without building AliceVision
 
-To use Meshroom (ui) without building AliceVision  
-  - Download a [release](https://github.com/alicevision/meshroom/releases)
-  - Checkout corresponding Meshroom (ui) version/tag to avoid versions incompatibilities  
-  - 
-    ```bash
-    LD_LIBRARY_PATH=~/foo/Meshroom-2021.1.0/aliceVision/lib/ PATH=$PATH:~/foo/Meshroom-2021.1.0/aliceVision/bin/ PYTHONPATH=$PWD python3 meshroom/ui
-    ```
+To use Meshroom (ui) without building AliceVision
+* Download a [release](https://github.com/alicevision/meshroom/releases)
+* Checkout corresponding Meshroom (ui) version/tag to avoid versions incompatibilities
+* `LD_LIBRARY_PATH=~/foo/Meshroom-2021.1.0/aliceVision/lib/ PATH=$PATH:~/foo/Meshroom-2021.1.0/aliceVision/bin/ PYTHONPATH=$PWD python3 meshroom/ui`
 
 ## FAQ
 

--- a/README.md
+++ b/README.md
@@ -98,9 +98,9 @@ python bin/meshroom_batch --input INPUT_IMAGES_FOLDER --output OUTPUT_FOLDER
 ## Start Meshroom without building AliceVision
 
 To use Meshroom (ui) without building AliceVision
-* Download a [release](https://github.com/alicevision/meshroom/releases)
-* Checkout corresponding Meshroom (ui) version/tag to avoid versions incompatibilities
-* `LD_LIBRARY_PATH=~/foo/Meshroom-2021.1.0/aliceVision/lib/ PATH=$PATH:~/foo/Meshroom-2021.1.0/aliceVision/bin/ PYTHONPATH=$PWD python3 meshroom/ui`
+*  Download a [release](https://github.com/alicevision/meshroom/releases)
+*   Checkout corresponding Meshroom (ui) version/tag to avoid versions incompatibilities
+*   `LD_LIBRARY_PATH=~/foo/Meshroom-2021.1.0/aliceVision/lib/ PATH=$PATH:~/foo/Meshroom-2021.1.0/aliceVision/bin/ PYTHONPATH=$PWD python3 meshroom/ui`
 
 ## FAQ
 

--- a/README.md
+++ b/README.md
@@ -102,6 +102,16 @@ To use Meshroom (ui) without building AliceVision
 *   Checkout corresponding Meshroom (ui) version/tag to avoid versions incompatibilities
 *   `LD_LIBRARY_PATH=~/foo/Meshroom-2021.1.0/aliceVision/lib/ PATH=$PATH:~/foo/Meshroom-2021.1.0/aliceVision/bin/ PYTHONPATH=$PWD python3 meshroom/ui`
 
+## Start and Debug Meshroom in an IDE
+
+PyCharm Community is free IDE which can be used. To start and debug a project with that IDE,
+right-click on `Meshroom/ui/__main__.py` > `Debug`, then `Edit Configuration`, in `Environment variables` : 
+*   If you want to use aliceVision built by yourself add: `PATH=$PATH:/foo/build/Linux-x86_64/`
+*   If you want to use aliceVision release add: `LD_LIBRARY_PATH=/foo/Meshroom-2021.1.0/aliceVision/lib/;PATH=$PATH:/foo/Meshroom-2021.1.0/aliceVision/bin/` (Make sure that you are on the branch matching the right version)
+
+![image](https://user-images.githubusercontent.com/937836/127321375-3bf78e73-569d-414a-8649-de0307adf794.png)
+
+
 ## FAQ
 
 See the [Meshroom wiki](https://github.com/alicevision/meshroom/wiki) for more information.

--- a/README.md
+++ b/README.md
@@ -58,7 +58,9 @@ The project is released under MPLv2, see [**COPYING.md**](COPYING.md).
 
 ## Get the project
 
-See [**INSTALL.md**](INSTALL.md) to setup the project and pre-requisites.
+If you don't want to built it yourself, you can directly download the released version in [releases](https://github.com/alicevision/meshroom/releases).  
+
+[**INSTALL.md**](INSTALL.md) to setup the project and pre-requisites.
 
 Get the source code and install runtime requirements:
 ```bash
@@ -93,6 +95,12 @@ You may need to adjust the folder `/usr/lib/nvidia-340` with the correct driver 
 python bin/meshroom_batch --input INPUT_IMAGES_FOLDER --output OUTPUT_FOLDER
 ```
 
+## Start Meshroom without building AliceVision
+
+If you want to use Meshroom (ui) without building AliceVision, download [released](https://github.com/alicevision/meshroom/releases) and checkout corresponding Meshroom (ui) version/tag to avoid versions incompatibilities:
+```bash
+LD_LIBRARY_PATH=~/foo/Meshroom-2021.1.0/aliceVision/lib/ PATH=$PATH:~/foo/Meshroom-2021.1.0/aliceVision/bin/ PYTHONPATH=$PWD python3 meshroom/ui
+```
 
 ## FAQ
 

--- a/start.sh
+++ b/start.sh
@@ -9,4 +9,4 @@ export PYTHONPATH=$MESHROOM_ROOT:$PYTHONPATH
 # using alicevision built source
 #export PATH=$PATH:/foo/build/Linux-x86_64/
 
-python3 $MESHROOM_ROOT/meshroom/ui
+python3 "$MESHROOM_ROOT/meshroom/ui"

--- a/start.sh
+++ b/start.sh
@@ -1,3 +1,12 @@
-#!/bin/sh
-export PYTHONPATH="$(dirname "$(readlink -f "${BASH_SOURCE[0]}" )" )"
-python meshroom/ui
+#!/bin/bash
+export MESHROOM_ROOT="$(dirname "$(readlink -f "${BASH_SOURCE[0]}" )" )"
+export PYTHONPATH=$MESHROOM_ROOT:$PYTHONPATH
+
+# using existing alicevision release
+#export LD_LIBRARY_PATH=/foo/Meshroom-2021.1.0/aliceVision/lib/
+#export PATH=$PATH:/foo/Meshroom-2021.1.0/aliceVision/bin/
+
+# using alicevision built source
+#export PATH=$PATH:/foo/build/Linux-x86_64/
+
+python3 $MESHROOM_ROOT/meshroom/ui

--- a/start.sh
+++ b/start.sh
@@ -9,4 +9,4 @@ export PYTHONPATH=$MESHROOM_ROOT:$PYTHONPATH
 # using alicevision built source
 #export PATH=$PATH:/foo/build/Linux-x86_64/
 
-python3 "$MESHROOM_ROOT/meshroom/ui"
+python "$MESHROOM_ROOT/meshroom/ui"


### PR DESCRIPTION
## Description
Improve the documentation to be able to run Meshroom without building UI (tested only on Ubuntu 20.04 LTS)
How to run and debug with PyCharm
Add information about downloading meshroom release directly, as I've seen users on reddit not aware about the existence of the built version

## Features list
No feature

## Implementation remarks
This is an complex workflow just a small change in the documentation. Not sure if this is the right way to do.

