### PR TITLE
Draft Reconstruction pipeline

### DIFF
--- a/bin/meshroom_batch
+++ b/bin/meshroom_batch
@@ -20,8 +20,8 @@ parser.add_argument('-I', '--inputRecursive', metavar='FOLDERS/IMAGES', type=str
                     default=[],
                     help='Input folders containing all images recursively.')
 
-parser.add_argument('-p', '--pipeline', metavar='photogrammetry/panoramaHdr/panoramaFisheyeHdr/MG_FILE', type=str, default='photogrammetry',
-                    help='"photogrammetry", "panoramaHdr", "panoramaFisheyeHdr", "cameraTracking" pipeline or a Meshroom file containing a custom pipeline to run on input images. '
+parser.add_argument('-p', '--pipeline', metavar='photogrammetry/panoramaHdr/panoramaFisheyeHdr/cameraTracking/photogrammetryDraft/MG_FILE', type=str, default='photogrammetry',
+                    help='"photogrammetry", "panoramaHdr", "panoramaFisheyeHdr", "cameraTracking", "photogrammetryDraft" pipeline or a Meshroom file containing a custom pipeline to run on input images. '
                          'Requirements: the graph must contain one CameraInit node, '
                          'and one Publish node if --output is set.')
 

--- a/meshroom/ui/qml/main.qml
+++ b/meshroom/ui/qml/main.qml
@@ -436,6 +436,10 @@ ApplicationWindow {
                     text: "Camera Tracking (experimental)"
                     onTriggered: ensureSaved(function() { _reconstruction.new("cameratracking") })
                 }
+                Action {
+                    text: "Photogrammetry Draft (No CUDA)"
+                    onTriggered: ensureSaved(function() { _reconstruction.new("photogrammetrydraft") })
+                }
             }
             Action {
                 id: openActionItem

--- a/meshroom/ui/reconstruction.py
+++ b/meshroom/ui/reconstruction.py
@@ -496,6 +496,9 @@ class Reconstruction(UIGraph):
         elif p.lower() == "cameratracking":
             # default camera tracking pipeline
             self.setGraph(multiview.cameraTracking())
+        elif p.lower() == "photogrammetrydraft":
+            # photogrammetry pipeline in draft mode (no cuda)
+            self.setGraph(multiview.photogrammetryDraft())
         else:
             # use the user-provided default photogrammetry project file
             self.load(p, setupProjectFile=False)


### PR DESCRIPTION
## Description

In order to easier the use of Meshroom for user who don't have an NVIDIA CUDA card, I think that it is important to be able to start a project with the appropriate pipeline without customing it manually.
Related with wiki page https://github.com/alicevision/meshroom/wiki/Draft-Meshing

## Features list

Add File > New Pipeline > Photogrammetry (No CUDA)
![image](https://user-images.githubusercontent.com/937836/127017080-ee77e5da-0cb8-4c25-9a11-459148b49b20.png)

## Remarks
Use the same parameters than others pipelines
An alternative would be to https://github.com/alicevision/AliceVision/issues/439 or to make it compatible with OpenMVS which doesn't need CUDA
