### PR TITLE
[UI] StatViewer: fix displayed unit

### DIFF
--- a/meshroom/ui/qml/GraphEditor/StatViewer.qml
+++ b/meshroom/ui/qml/GraphEditor/StatViewer.qml
@@ -398,7 +398,7 @@ Item {
                     titleColor: textColor
 
                     visible: (root.fileVersion > 0.0)  // only visible if we have valid information
-                    title: "CPU: " + root.nbCores + " cores, " + root.cpuFrequency + "Hz"
+                    title: "CPU: " + root.nbCores + " cores, " + root.cpuFrequency + "MHz"
 
                     ValueAxis {
                         id: valueCpuY


### PR DESCRIPTION
## Description
Changed/fixed frequency unit in CPU stat view.



## Implementation remarks
Frequency is read in MHz but the current version uses Hz as unit; ie a 3600MHz cpu is displayed as 3600Hz.

