### PR TITLE
[nodes] StructureFromMotion: add option computeStructureColor

### DIFF
--- a/meshroom/nodes/aliceVision/StructureFromMotion.py
+++ b/meshroom/nodes/aliceVision/StructureFromMotion.py
@@ -308,6 +308,13 @@ It iterates like that, adding cameras and triangulating new 2D features into 3D 
             value=False,
             uid=[0],
         ),
+        desc.BoolParam(
+            name='computeStructureColor',
+            label='Compute Structure Color',
+            description='Enable/Disable color computation of each 3D point.',
+            value=True,
+            uid=[0],
+        ),
         desc.File(
             name='initialPairA',
             label='Initial Pair A',


### PR DESCRIPTION
## Description

Add `computeStructureColor` option to `StructureFromMotion` node to enable/disable color computation of each 3D point.
See https://github.com/alicevision/AliceVision/pull/1151