### PR TITLE
Fix compatibility with Python 3

### DIFF
--- a/meshroom/core/attribute.py
+++ b/meshroom/core/attribute.py
@@ -37,7 +37,7 @@ def attributeFactory(description, value, isOutput, node, root=None, parent=None)
 class Attribute(BaseObject):
     """
     """
-    stringIsLinkRe = re.compile('^\{[A-Za-z]+[A-Za-z0-9_.]*\}$')
+    stringIsLinkRe = re.compile(r'^\{[A-Za-z]+[A-Za-z0-9_.]*\}$')
 
     def __init__(self, node, attributeDesc, isOutput, root=None, parent=None):
         """

--- a/meshroom/ui/reconstruction.py
+++ b/meshroom/ui/reconstruction.py
@@ -3,7 +3,6 @@ import logging
 import math
 import os
 from threading import Thread
-from collections import Iterable
 
 from PySide2.QtCore import QObject, Slot, Property, Signal, QUrl, QSizeF
 from PySide2.QtGui import QMatrix4x4, QMatrix3x3, QQuaternion, QVector3D, QVector2D
@@ -14,6 +13,7 @@ from meshroom import multiview
 from meshroom.common.qt import QObjectListModel
 from meshroom.core import Version
 from meshroom.core.node import Node, CompatibilityNode, Status, Position
+from meshroom.core.pyCompatibility import Iterable
 from meshroom.ui.graph import UIGraph
 from meshroom.ui.utils import makeProperty
 


### PR DESCRIPTION
## Description

This PR fixes a couple of deprecation warnings with Python 3:
- import "collections" correctly depending on the used version of Python (fixes `DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3,and in 3.9 it will stop working`)
- use a raw string for a regex compilation (fixes `DeprecationWarning: invalid escape sequence \{`)