### PR TITLE
Fix node duplication/removal behaviour

### DIFF
--- a/meshroom/core/graph.py
+++ b/meshroom/core/graph.py
@@ -382,7 +382,7 @@ class Graph(BaseObject):
                 node, edges = self.copyNode(srcNode, withEdges=False)
                 duplicate = self.addNode(node)
                 duplicateEdges.update(edges)
-                duplicates[srcNode] = duplicate  # original node to duplicate map
+                duplicates.setdefault(srcNode, []).append(duplicate)
 
             # re-create edges taking into account what has been duplicated
             for attr, linkExpression in duplicateEdges.items():
@@ -390,8 +390,10 @@ class Graph(BaseObject):
                 # get source node and attribute name
                 edgeSrcNodeName, edgeSrcAttrName = link.split(".", 1)
                 edgeSrcNode = self.node(edgeSrcNodeName)
-                # if the edge's source node has been duplicated, use the duplicate; otherwise use the original node
-                edgeSrcNode = duplicates.get(edgeSrcNode, edgeSrcNode)
+                # if the edge's source node has been duplicated (the key exists in the dictionary),
+                # use the duplicate; otherwise use the original node
+                if edgeSrcNode in duplicates:
+                    edgeSrcNode = duplicates.get(edgeSrcNode)[0]
                 self.addEdge(edgeSrcNode.attribute(edgeSrcAttrName), attr)
 
         return duplicates

--- a/meshroom/ui/commands.py
+++ b/meshroom/ui/commands.py
@@ -184,7 +184,8 @@ class DuplicateNodesCommand(GraphCommand):
 
     def redoImpl(self):
         srcNodes = [ self.graph.node(i) for i in self.srcNodeNames ]
-        duplicates = list(self.graph.duplicateNodes(srcNodes).values())
+        # flatten the list of duplicated nodes to avoid lists within the list
+        duplicates = [ n for nodes in list(self.graph.duplicateNodes(srcNodes).values()) for n in nodes ]
         self.duplicates = [ n.name for n in duplicates ]
         return duplicates
 

--- a/meshroom/ui/graph.py
+++ b/meshroom/ui/graph.py
@@ -559,9 +559,11 @@ class UIGraph(QObject):
         """
         with self.groupedGraphModification("Remove Nodes From Selected Nodes"):
             nodesToRemove, _ = self._graph.dfsOnDiscover(startNodes=nodes, reverse=True, dependenciesOnly=True)
+            # filter out nodes that will be removed more than once
+            uniqueNodesToRemove = list(dict.fromkeys(nodesToRemove))
             # Perform nodes removal from leaves to start node so that edges
             # can be re-created in correct order on redo.
-            self.removeNodes(list(reversed(nodesToRemove)))
+            self.removeNodes(list(reversed(uniqueNodesToRemove)))
 
     @Slot(QObject, result="QVariantList")
     def duplicateNodes(self, nodes):
@@ -609,7 +611,9 @@ class UIGraph(QObject):
         """
         with self.groupedGraphModification("Duplicate Nodes From Selected Nodes"):
             nodesToDuplicate, _ = self._graph.dfsOnDiscover(startNodes=nodes, reverse=True, dependenciesOnly=True)
-            duplicates = self.duplicateNodes(nodesToDuplicate)
+            # filter out nodes that will be duplicated more than once
+            uniqueNodesToDuplicate = list(dict.fromkeys(nodesToDuplicate))
+            duplicates = self.duplicateNodes(uniqueNodesToDuplicate)
         return duplicates
 
     @Slot(QObject)

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -266,14 +266,16 @@ def test_duplicate_nodes():
     # duplicate from n1
     nodes_to_duplicate, _ = g.dfsOnDiscover(startNodes=[n1], reverse=True, dependenciesOnly=True)
     nMap = g.duplicateNodes(srcNodes=nodes_to_duplicate)
-    for s, d in nMap.items():
-        assert s.nodeType == d.nodeType
+    for s, duplicated in nMap.items():
+        for d in duplicated:
+            assert s.nodeType == d.nodeType
 
-    # check number of duplicated nodes
-    assert len(nMap) == 3
+    # check number of duplicated nodes and that every parent node has been duplicated once
+    assert len(nMap) == 3 and all([len(nMap[i]) == 1 for i in nMap.keys()])
 
     # check connections
-    assert nMap[n1].input.getLinkParam() == n0.output
-    assert nMap[n2].input.getLinkParam() == nMap[n1].output
-    assert nMap[n3].input.getLinkParam() == nMap[n1].output
-    assert nMap[n3].input2.getLinkParam() == nMap[n2].output
+    # access directly index 0 because we know there is a single duplicate for each parent node
+    assert nMap[n1][0].input.getLinkParam() == n0.output
+    assert nMap[n2][0].input.getLinkParam() == nMap[n1][0].output
+    assert nMap[n3][0].input.getLinkParam() == nMap[n1][0].output
+    assert nMap[n3][0].input2.getLinkParam() == nMap[n2][0].output


### PR DESCRIPTION
## Description

Fix corner cases that could lead to some errors when duplicating or removing nodes: 
- a node could be duplicated several times at once but only the first duplicate was stored, causing the "undo" operation to not remove any of the duplicates for that specific node beyond the first one; additionally, duplicated nodes could get stacked on top of other nodes, "hiding" them.
- there could be attempts to remove a single nodes several times at once, causing errors.

Change the ambiguous behaviour of the "duplicate node(s) from here" action that could lead to duplicating several times the same node unwillingly.

## Features list

- [X] Store correctly all the duplicated nodes: ensures that a duplication operation can be undone/redone properly, with all the duplicated nodes removed/re-duplicated.
- [X] Vertically align the duplicated nodes correctly: make sure there cannot be any duplicated node stacked on top of another.
- [X] Prevent the duplication/removal of a node more than once in the same action: ensures a node cannot be duplicated more. than once during a duplication operation, and fixes the cases where a same node was attempted to be removed several times during the same operation (thus raising errors).