### PR TITLE
[Feature Matching] Add an option to remove matches without enough motion

### DIFF
--- a/meshroom/nodes/aliceVision/FeatureMatching.py
+++ b/meshroom/nodes/aliceVision/FeatureMatching.py
@@ -152,8 +152,8 @@ then it checks the number of features that validates this model and iterate thro
         ),
         desc.FloatParam(
             name='minRequired2DMotion',
-            label='required 2d motion',
-            description='A match is invalid if the 2d motion between the 2 points is less than a threshold (or -1 to disable this filter).',
+            label='Minimal 2D Motion',
+            description='Filter out matches without enough 2D motion (threshold in pixels). Use -1 to disable this filter. Useful for filtering the background during acquisition with a turntable and a static camera.',
             value=-1.0,
             range=(0.0, 10.0, 1.0),
             uid=[0],

--- a/meshroom/nodes/aliceVision/FeatureMatching.py
+++ b/meshroom/nodes/aliceVision/FeatureMatching.py
@@ -157,7 +157,6 @@ then it checks the number of features that validates this model and iterate thro
             value=-1.0,
             range=(0.0, 10.0, 1.0),
             uid=[0],
-            advanced=True,
         ),
         desc.IntParam(
             name='maxMatches',

--- a/meshroom/nodes/aliceVision/FeatureMatching.py
+++ b/meshroom/nodes/aliceVision/FeatureMatching.py
@@ -150,6 +150,15 @@ then it checks the number of features that validates this model and iterate thro
             uid=[0],
             advanced=True,
         ),
+        desc.FloatParam(
+            name='minRequired2DMotion',
+            label='required 2d motion',
+            description='A match is invalid if the 2d motion between the 2 points is less than a threshold (or -1 to disable this filter).',
+            value=-1.0,
+            range=(0.0, 10.0, 1.0),
+            uid=[0],
+            advanced=True,
+        ),
         desc.IntParam(
             name='maxMatches',
             label='Max Matches',


### PR DESCRIPTION
Option to remove matches without enough motion between the two observations

May be useful to remove matches caused by dirt/dust on sensor
May be useful to remove background features on turning tables

See AliceVision PR :  https://github.com/alicevision/AliceVision/pull/1198