### PR TITLE
Add internal attributes in "Notes" tab

### DIFF
--- a/meshroom/core/attribute.py
+++ b/meshroom/core/attribute.py
@@ -143,6 +143,10 @@ class Attribute(BaseObject):
         self._enabled = v
         self.enabledChanged.emit()
 
+    def getUidIgnoreValue(self):
+        """ Value for which the attribute should be ignored during the UID computation. """
+        return self.attributeDesc.uidIgnoreValue
+
     def _get_value(self):
         if self.isLink:
             return self.getLinkParam().value
@@ -333,6 +337,7 @@ class Attribute(BaseObject):
     node = Property(BaseObject, node.fget, constant=True)
     enabledChanged = Signal()
     enabled = Property(bool, getEnabled, setEnabled, notify=enabledChanged)
+    uidIgnoreValue = Property(Variant, getUidIgnoreValue, constant=True)
 
 
 def raiseIfLink(func):

--- a/meshroom/core/attribute.py
+++ b/meshroom/core/attribute.py
@@ -168,6 +168,10 @@ class Attribute(BaseObject):
         # TODO: only update the graph if this attribute participates to a UID
         if self.isInput:
             self.requestGraphUpdate()
+            # TODO: only call update of the node if the attribute is internal
+            # Internal attributes are set as inputs
+            self.requestNodeUpdate()
+
         self.valueChanged.emit()
 
     def upgradeValue(self, exportedValue):
@@ -180,6 +184,12 @@ class Attribute(BaseObject):
         if self.node.graph:
             self.node.graph.markNodesDirty(self.node)
             self.node.graph.update()
+
+    def requestNodeUpdate(self):
+        # Update specific node information that do not affect the rest of the graph
+        # (like internal attributes)
+        if self.node:
+            self.node.updateInternalAttributes()
 
     @property
     def isOutput(self):

--- a/meshroom/core/desc.py
+++ b/meshroom/core/desc.py
@@ -14,7 +14,7 @@ class Attribute(BaseObject):
     """
     """
 
-    def __init__(self, name, label, description, value, advanced, semantic, uid, group, enabled):
+    def __init__(self, name, label, description, value, advanced, semantic, uid, group, enabled, uidIgnoreValue=None):
         super(Attribute, self).__init__()
         self._name = name
         self._label = label
@@ -25,6 +25,7 @@ class Attribute(BaseObject):
         self._advanced = advanced
         self._enabled = enabled
         self._semantic = semantic
+        self._uidIgnoreValue = uidIgnoreValue
 
     name = Property(str, lambda self: self._name, constant=True)
     label = Property(str, lambda self: self._label, constant=True)
@@ -35,6 +36,7 @@ class Attribute(BaseObject):
     advanced = Property(bool, lambda self: self._advanced, constant=True)
     enabled = Property(Variant, lambda self: self._enabled, constant=True)
     semantic = Property(str, lambda self: self._semantic, constant=True)
+    uidIgnoreValue = Property(Variant, lambda self: self._uidIgnoreValue, constant=True)
     type = Property(str, lambda self: self.__class__.__name__, constant=True)
 
     def validateValue(self, value):
@@ -201,8 +203,9 @@ class GroupAttribute(Attribute):
 class Param(Attribute):
     """
     """
-    def __init__(self, name, label, description, value, uid, group, advanced, semantic, enabled):
-        super(Param, self).__init__(name=name, label=label, description=description, value=value, uid=uid, group=group, advanced=advanced, semantic=semantic, enabled=enabled)
+    def __init__(self, name, label, description, value, uid, group, advanced, semantic, enabled, uidIgnoreValue=None):
+        super(Param, self).__init__(name=name, label=label, description=description, value=value, uid=uid, group=group, advanced=advanced, semantic=semantic, enabled=enabled,
+            uidIgnoreValue=uidIgnoreValue)
 
 
 class File(Attribute):
@@ -329,8 +332,9 @@ class ChoiceParam(Param):
 class StringParam(Param):
     """
     """
-    def __init__(self, name, label, description, value, uid, group='allParams', advanced=False, semantic='', enabled=True):
-        super(StringParam, self).__init__(name=name, label=label, description=description, value=value, uid=uid, group=group, advanced=advanced, semantic=semantic, enabled=enabled)
+    def __init__(self, name, label, description, value, uid, group='allParams', advanced=False, semantic='', enabled=True, uidIgnoreValue=None):
+        super(StringParam, self).__init__(name=name, label=label, description=description, value=value, uid=uid, group=group, advanced=advanced, semantic=semantic, enabled=enabled,
+            uidIgnoreValue=uidIgnoreValue)
 
     def validateValue(self, value):
         if not isinstance(value, str):
@@ -509,6 +513,7 @@ class Node(object):
             semantic="multiline",
             uid=[0],
             advanced=True,
+            uidIgnoreValue="",  # If the invalidation string is empty, it does not participate to the node's UID
         ),
         StringParam(
             name="comment",

--- a/meshroom/core/desc.py
+++ b/meshroom/core/desc.py
@@ -501,6 +501,13 @@ class Node(object):
             value="",
             semantic="multiline",
             uid=[0],
+        ),
+        StringParam(
+            name="label",
+            label="Label",
+            description="Custom label to replace the node's default label.",
+            value="",
+            uid=[],
         )
     ]
     inputs = []

--- a/meshroom/core/desc.py
+++ b/meshroom/core/desc.py
@@ -504,6 +504,7 @@ class Node(object):
             label="Invalidation Message",
             description="A message that will invalidate the node's output folder.\n"
                         "This is useful for development, we can invalidate the output of the node when we modify the code.\n"
+                        "It is displayed in bold font in the invalidation/comment messages tooltip.",
             value="",
             semantic="multiline",
             uid=[0],
@@ -513,6 +514,7 @@ class Node(object):
             name="comment",
             label="Comments",
             description="User comments describing this specific node instance.\n"
+                        "It is displayed in regular font in the invalidation/comment messages tooltip.",
             value="",
             semantic="multiline",
             uid=[],

--- a/meshroom/core/desc.py
+++ b/meshroom/core/desc.py
@@ -343,6 +343,19 @@ class StringParam(Param):
         return ""
 
 
+class ColorParam(Param):
+    """
+    """
+    def __init__(self, name, label, description, value, uid, group='allParams', advanced=False, semantic='', enabled=True):
+        super(ColorParam, self).__init__(name=name, label=label, description=description, value=value, uid=uid, group=group, advanced=advanced, semantic=semantic, enabled=enabled)
+
+    def validateValue(self, value):
+        if not isinstance(value, pyCompatibility.basestring) or len(value.split(" ")) > 1:
+            raise ValueError('ColorParam value should be a string containing either an SVG name or an hexadecimal '
+                             'color code (param: {}, value: {}, type: {})'.format(self.name, value, type(value)))
+        return value
+
+
 class Level(Enum):
     NONE = 0
     NORMAL = 1
@@ -506,6 +519,13 @@ class Node(object):
             name="label",
             label="Label",
             description="Custom label to replace the node's default label.",
+            value="",
+            uid=[],
+        ),
+        ColorParam(
+            name="color",
+            label="Color",
+            description="Custom color for the node (SVG name or hexadecimal code).",
             value="",
             uid=[],
         )

--- a/meshroom/core/desc.py
+++ b/meshroom/core/desc.py
@@ -485,6 +485,24 @@ class Node(object):
     ram = Level.NORMAL
     packageName = ''
     packageVersion = ''
+    internalInputs = [
+        StringParam(
+            name="comment",
+            label="Comments",
+            description="Comments on the node.",
+            value="",
+            semantic="multiline",
+            uid=[],
+        ),
+        StringParam(
+            name="invalid",
+            label="Invalid Comments",
+            description="Invalid comments on the node.",
+            value="",
+            semantic="multiline",
+            uid=[0],
+        )
+    ]
     inputs = []
     outputs = []
     size = StaticNodeSize(1)

--- a/meshroom/core/desc.py
+++ b/meshroom/core/desc.py
@@ -500,23 +500,22 @@ class Node(object):
     packageVersion = ''
     internalInputs = [
         StringParam(
-            name="comment",
-            label="Comments",
-            description="User comments describing this specific node instance.",
-            value="",
-            semantic="multiline",
-            uid=[],
-        ),
-        StringParam(
             name="invalidation",
             label="Invalidation Message",
             description="A message that will invalidate the node's output folder.\n"
-                        "This is useful for development, we can invalidate\n"
-                        "the output of the node when we modify the code.",
+                        "This is useful for development, we can invalidate the output of the node when we modify the code.\n"
             value="",
             semantic="multiline",
             uid=[0],
             advanced=True,
+        ),
+        StringParam(
+            name="comment",
+            label="Comments",
+            description="User comments describing this specific node instance.\n"
+            value="",
+            semantic="multiline",
+            uid=[],
         ),
         StringParam(
             name="label",

--- a/meshroom/core/desc.py
+++ b/meshroom/core/desc.py
@@ -350,7 +350,7 @@ class ColorParam(Param):
         super(ColorParam, self).__init__(name=name, label=label, description=description, value=value, uid=uid, group=group, advanced=advanced, semantic=semantic, enabled=enabled)
 
     def validateValue(self, value):
-        if not isinstance(value, pyCompatibility.basestring) or len(value.split(" ")) > 1:
+        if not isinstance(value, str) or len(value.split(" ")) > 1:
             raise ValueError('ColorParam value should be a string containing either an SVG name or an hexadecimal '
                              'color code (param: {}, value: {}, type: {})'.format(self.name, value, type(value)))
         return value

--- a/meshroom/core/desc.py
+++ b/meshroom/core/desc.py
@@ -502,23 +502,26 @@ class Node(object):
         StringParam(
             name="comment",
             label="Comments",
-            description="Comments on the node.",
+            description="User comments describing this specific node instance.",
             value="",
             semantic="multiline",
             uid=[],
         ),
         StringParam(
-            name="invalid",
-            label="Invalid Comments",
-            description="Invalid comments on the node.",
+            name="invalidation",
+            label="Invalidation Message",
+            description="A message that will invalidate the node's output folder.\n"
+                        "This is useful for development, we can invalidate\n"
+                        "the output of the node when we modify the code.",
             value="",
             semantic="multiline",
             uid=[0],
+            advanced=True,
         ),
         StringParam(
             name="label",
-            label="Label",
-            description="Custom label to replace the node's default label.",
+            label="Node's Label",
+            description="Customize the default label (to replace the technical name of the node instance).",
             value="",
             uid=[],
         ),

--- a/meshroom/core/graph.py
+++ b/meshroom/core/graph.py
@@ -687,9 +687,24 @@ class Graph(BaseObject):
         # type: (str) -> Attribute
         """
         Return the attribute identified by the unique name 'fullName'.
+        If it does not exist, return None.
         """
         node, attribute = fullName.split('.', 1)
-        return self.node(node).attribute(attribute)
+        if self.node(node).hasAttribute(attribute):
+            return self.node(node).attribute(attribute)
+        return None
+
+    @Slot(str, result=Attribute)
+    def internalAttribute(self, fullName):
+        # type: (str) -> Attribute
+        """
+        Return the internal attribute identified by the unique name 'fullName'.
+        If it does not exist, return None.
+        """
+        node, attribute = fullName.split('.', 1)
+        if self.node(node).hasInternalAttribute(attribute):
+            return self.node(node).internalAttribute(attribute)
+        return None
 
     @staticmethod
     def getNodeIndexFromName(name):

--- a/meshroom/core/graph.py
+++ b/meshroom/core/graph.py
@@ -1236,14 +1236,14 @@ class Graph(BaseObject):
 
     def getNonDefaultInputAttributes(self):
         """
-        Instead of getting all the inputs attribute keys, only get the keys of
+        Instead of getting all the inputs and internal attribute keys, only get the keys of
         the attributes whose value is not the default one.
         The output attributes, UIDs, parallelization parameters and internal folder are
         not relevant for templates, so they are explicitly removed from the returned dictionary.
 
         Returns:
             dict: self.toDict() with the output attributes, UIDs, parallelization parameters, internal folder
-            and input attributes with default values removed
+            and input/internal attributes with default values removed
         """
         graph = self.toDict()
         for nodeName in graph.keys():
@@ -1251,11 +1251,23 @@ class Graph(BaseObject):
 
             inputKeys = list(graph[nodeName]["inputs"].keys())
 
+            internalInputKeys = []
+
+            internalInputs = graph[nodeName].get("internalInputs", None)
+            if internalInputs:
+                internalInputKeys = list(internalInputs.keys())
+
             for attrName in inputKeys:
                 attribute = node.attribute(attrName)
                 # check that attribute is not a link for choice attributes
                 if attribute.isDefault and not attribute.isLink:
                     del graph[nodeName]["inputs"][attrName]
+
+            for attrName in internalInputKeys:
+                attribute = node.internalAttribute(attrName)
+                # check that internal attribute is not a link for choice attributes
+                if attribute.isDefault and not attribute.isLink:
+                    del graph[nodeName]["internalInputs"][attrName]
 
             del graph[nodeName]["outputs"]
             del graph[nodeName]["uids"]

--- a/meshroom/core/graph.py
+++ b/meshroom/core/graph.py
@@ -1252,7 +1252,6 @@ class Graph(BaseObject):
             inputKeys = list(graph[nodeName]["inputs"].keys())
 
             internalInputKeys = []
-
             internalInputs = graph[nodeName].get("internalInputs", None)
             if internalInputs:
                 internalInputKeys = list(internalInputs.keys())
@@ -1268,6 +1267,10 @@ class Graph(BaseObject):
                 # check that internal attribute is not a link for choice attributes
                 if attribute.isDefault and not attribute.isLink:
                     del graph[nodeName]["internalInputs"][attrName]
+
+            # If all the internal attributes are set to their default values, remove the entry
+            if len(graph[nodeName]["internalInputs"]) == 0:
+                del graph[nodeName]["internalInputs"]
 
             del graph[nodeName]["outputs"]
             del graph[nodeName]["uids"]

--- a/meshroom/core/node.py
+++ b/meshroom/core/node.py
@@ -524,8 +524,12 @@ class BaseNode(BaseObject):
     def getLabel(self):
         """
         Returns:
-            str: the high-level label of this node
+            str: the user-provided label if it exists, the high-level label of this node otherwise
         """
+        if self.hasInternalAttribute("label"):
+            label = self.internalAttribute("label").value.strip()
+            if label:
+                return label
         return self.nameToLabel(self._name)
 
     @Slot(str, result=str)
@@ -856,6 +860,9 @@ class BaseNode(BaseObject):
         if self.internalFolder != folder:
             self.internalFolderChanged.emit()
 
+    def updateInternalAttributes(self):
+        self.internalAttributesChanged.emit()
+
     @property
     def internalFolder(self):
         return self._internalFolder.format(**self._cmdVars)
@@ -1089,6 +1096,7 @@ class BaseNode(BaseObject):
     y = Property(float, lambda self: self._position.y, notify=positionChanged)
     attributes = Property(BaseObject, getAttributes, constant=True)
     internalAttributes = Property(BaseObject, getInternalAttributes, constant=True)
+    internalAttributesChanged = Signal()
     internalFolderChanged = Signal()
     internalFolder = Property(str, internalFolder.fget, notify=internalFolderChanged)
     depthChanged = Signal()

--- a/meshroom/core/node.py
+++ b/meshroom/core/node.py
@@ -541,6 +541,15 @@ class BaseNode(BaseObject):
             return self.internalAttribute("color").value.strip()
         return ""
 
+    def getInvalidationMessage(self):
+        """
+        Returns:
+            str: the invalidation message on the node if it exists, empty string otherwise
+        """
+        if self.hasInternalAttribute("invalidation"):
+            return self.internalAttribute("invalidation").value
+        return ""
+
     def getComment(self):
         """
         Returns:
@@ -1131,6 +1140,7 @@ class BaseNode(BaseObject):
     attributes = Property(BaseObject, getAttributes, constant=True)
     internalAttributes = Property(BaseObject, getInternalAttributes, constant=True)
     internalAttributesChanged = Signal()
+    invalidation = Property(str, getInvalidationMessage, notify=internalAttributesChanged)
     internalFolderChanged = Signal()
     internalFolder = Property(str, internalFolder.fget, notify=internalFolderChanged)
     depthChanged = Signal()

--- a/meshroom/core/node.py
+++ b/meshroom/core/node.py
@@ -1128,9 +1128,6 @@ class BaseNode(BaseObject):
 
 
     name = Property(str, getName, constant=True)
-    label = Property(str, getLabel, constant=True)
-    color = Property(str, getColor, constant=True)
-    comment = Property(str, getComment, constant=True)
     nodeType = Property(str, nodeType.fget, constant=True)
     documentation = Property(str, getDocumentation, constant=True)
     positionChanged = Signal()
@@ -1140,7 +1137,10 @@ class BaseNode(BaseObject):
     attributes = Property(BaseObject, getAttributes, constant=True)
     internalAttributes = Property(BaseObject, getInternalAttributes, constant=True)
     internalAttributesChanged = Signal()
+    label = Property(str, getLabel, notify=internalAttributesChanged)
+    color = Property(str, getColor, notify=internalAttributesChanged)
     invalidation = Property(str, getInvalidationMessage, notify=internalAttributesChanged)
+    comment = Property(str, getComment, notify=internalAttributesChanged)
     internalFolderChanged = Signal()
     internalFolder = Property(str, internalFolder.fget, notify=internalFolderChanged)
     depthChanged = Signal()

--- a/meshroom/core/node.py
+++ b/meshroom/core/node.py
@@ -541,6 +541,15 @@ class BaseNode(BaseObject):
             return self.internalAttribute("color").value.strip()
         return ""
 
+    def getComment(self):
+        """
+        Returns:
+            str: the comments on the node if they exist, empty string otherwise
+        """
+        if self.hasInternalAttribute("comment"):
+            return self.internalAttribute("comment").value
+        return ""
+
     @Slot(str, result=str)
     def nameToLabel(self, name):
         """
@@ -1104,6 +1113,7 @@ class BaseNode(BaseObject):
     name = Property(str, getName, constant=True)
     label = Property(str, getLabel, constant=True)
     color = Property(str, getColor, constant=True)
+    comment = Property(str, getComment, constant=True)
     nodeType = Property(str, nodeType.fget, constant=True)
     documentation = Property(str, getDocumentation, constant=True)
     positionChanged = Signal()

--- a/meshroom/core/node.py
+++ b/meshroom/core/node.py
@@ -691,7 +691,7 @@ class BaseNode(BaseObject):
         """ Compute node uids by combining associated attributes' uids. """
         for uidIndex, associatedAttributes in self.attributesPerUid.items():
             # uid is computed by hashing the sorted list of tuple (name, value) of all attributes impacting this uid
-            uidAttributes = [(a.getName(), a.uid(uidIndex)) for a in associatedAttributes if a.enabled]
+            uidAttributes = [(a.getName(), a.uid(uidIndex)) for a in associatedAttributes if a.enabled and a.value != a.uidIgnoreValue]
             uidAttributes.sort()
             self._uids[uidIndex] = hashValue(uidAttributes)
 

--- a/meshroom/core/node.py
+++ b/meshroom/core/node.py
@@ -611,10 +611,18 @@ class BaseNode(BaseObject):
 
     @Slot(str, result=bool)
     def hasAttribute(self, name):
+        # Complex name indicating group or list attribute: parse it and get the
+        # first output element to check for the attribute's existence
+        if "[" in name or "." in name:
+            p = self.attributeRE.findall(name)
+            return p[0][0] in self._attributes.keys() or p[0][1] in self._attributes.keys()
         return name in self._attributes.keys()
 
     @Slot(str, result=bool)
     def hasInternalAttribute(self, name):
+        if "[" in name or "." in name:
+            p = self.attributeRE.findall(name)
+            return p[0][0] in self._internalAttributes.keys() or p[0][1] in self._internalAttributes.keys()
         return name in self._internalAttributes.keys()
 
     def _applyExpr(self):

--- a/meshroom/core/node.py
+++ b/meshroom/core/node.py
@@ -1597,6 +1597,19 @@ def nodeFactory(nodeDict, name=None, template=False):
                     sorted([attr.name for attr in nodeDesc.outputs]) != sorted(outputs.keys())):
                 compatibilityIssue = CompatibilityIssue.DescriptionConflict
 
+            # check whether there are any internal attributes that are invalidating in the node description: if there
+            # are, then check that these internal attributes are part of nodeDict; if they are not, a compatibility
+            # issue must be raised to warn the user, as this will automatically change the node's UID
+            if not template:
+                invalidatingIntInputs = []
+                for attr in nodeDesc.internalInputs:
+                    if attr.uid == [0]:
+                        invalidatingIntInputs.append(attr.name)
+                for attr in invalidatingIntInputs:
+                    if attr not in internalInputs.keys():
+                        compatibilityIssue = CompatibilityIssue.DescriptionConflict
+                        break
+
             # verify that all inputs match their descriptions
             for attrName, value in inputs.items():
                 if not CompatibilityNode.attributeDescFromName(nodeDesc.inputs, attrName, value):

--- a/meshroom/core/node.py
+++ b/meshroom/core/node.py
@@ -532,6 +532,15 @@ class BaseNode(BaseObject):
                 return label
         return self.nameToLabel(self._name)
 
+    def getColor(self):
+        """
+        Returns:
+            str: the user-provided custom color of the node if it exists, empty string otherwise
+        """
+        if self.hasInternalAttribute("color"):
+            return self.internalAttribute("color").value.strip()
+        return ""
+
     @Slot(str, result=str)
     def nameToLabel(self, name):
         """
@@ -1088,6 +1097,7 @@ class BaseNode(BaseObject):
 
     name = Property(str, getName, constant=True)
     label = Property(str, getLabel, constant=True)
+    color = Property(str, getColor, constant=True)
     nodeType = Property(str, nodeType.fget, constant=True)
     documentation = Property(str, getDocumentation, constant=True)
     positionChanged = Signal()

--- a/meshroom/core/node.py
+++ b/meshroom/core/node.py
@@ -1170,6 +1170,11 @@ class Node(BaseNode):
             for uidIndex in attr.attributeDesc.uid:
                 self.attributesPerUid[uidIndex].add(attr)
 
+        # Add internal attributes with a UID to the list
+        for attr in self._internalAttributes:
+            for uidIndex in attr.attributeDesc.uid:
+                self.attributesPerUid[uidIndex].add(attr)
+
         self.setAttributeValues(kwargs)
 
     def setAttributeValues(self, values):

--- a/meshroom/core/node.py
+++ b/meshroom/core/node.py
@@ -629,9 +629,6 @@ class BaseNode(BaseObject):
 
     @Slot(str, result=bool)
     def hasInternalAttribute(self, name):
-        if "[" in name or "." in name:
-            p = self.attributeRE.findall(name)
-            return p[0][0] in self._internalAttributes.keys() or p[0][1] in self._internalAttributes.keys()
         return name in self._internalAttributes.keys()
 
     def _applyExpr(self):

--- a/meshroom/ui/commands.py
+++ b/meshroom/ui/commands.py
@@ -264,11 +264,17 @@ class SetAttributeCommand(GraphCommand):
     def redoImpl(self):
         if self.value == self.oldValue:
             return False
-        self.graph.attribute(self.attrName).value = self.value
+        if self.graph.attribute(self.attrName) is not None:
+            self.graph.attribute(self.attrName).value = self.value
+        else:
+            self.graph.internalAttribute(self.attrName).value = self.value
         return True
 
     def undoImpl(self):
-        self.graph.attribute(self.attrName).value = self.oldValue
+        if self.graph.attribute(self.attrName) is not None:
+            self.graph.attribute(self.attrName).value = self.oldValue
+        else:
+            self.graph.internalAttribute(self.attrName).value = self.oldValue
 
 
 class AddEdgeCommand(GraphCommand):

--- a/meshroom/ui/graph.py
+++ b/meshroom/ui/graph.py
@@ -710,7 +710,8 @@ class UIGraph(QObject):
         """ Upgrade all upgradable CompatibilityNode instances in the graph. """
         with self.groupedGraphModification("Upgrade all Nodes"):
             nodes = [n for n in self._graph._compatibilityNodes.values() if n.canUpgrade]
-            for node in nodes:
+            sortedNodes = sorted(nodes, key=lambda x: x.name)
+            for node in sortedNodes:
                 self.upgradeNode(node)
 
     @Slot()

--- a/meshroom/ui/qml/GraphEditor/AttributeItemDelegate.qml
+++ b/meshroom/ui/qml/GraphEditor/AttributeItemDelegate.qml
@@ -157,6 +157,8 @@ RowLayout {
                 if (attribute.desc.semantic === 'multiline')
                     return textArea_component
                 return textField_component
+            case "ColorParam":
+                return color_component
             default: return textField_component
             }
         }
@@ -236,6 +238,70 @@ RowLayout {
                             }
                         }
                     }
+                }
+            }
+        }
+
+        Component {
+            id: color_component
+            RowLayout {
+                CheckBox {
+                    id: color_checkbox
+                    Layout.alignment: Qt.AlignLeft
+                    checked: node.color === "" ? false : true
+                    text: "Custom Color"
+                    onClicked: {
+                        if(checked) {
+                            _reconstruction.setAttribute(attribute, "#0000FF")
+                        } else {
+                            _reconstruction.setAttribute(attribute, "")
+                        }
+                    }
+                }
+                TextField {
+                    id: colorText
+                    Layout.alignment: Qt.AlignLeft
+                    implicitWidth: 100
+                    enabled: color_checkbox.checked
+                    visible: enabled
+                    text: enabled ? attribute.value : ""
+                    selectByMouse: true
+                    onEditingFinished: setTextFieldAttribute(text)
+                    onAccepted: setTextFieldAttribute(text)
+                    Component.onDestruction: {
+                        if(activeFocus)
+                            setTextFieldAttribute(text)
+                    }
+                }
+
+                Rectangle {
+                    height: colorText.height
+                    width: colorText.width / 2
+                    Layout.alignment: Qt.AlignLeft
+                    visible: color_checkbox.checked
+                    color: color_checkbox.checked ? attribute.value : ""
+
+                    MouseArea {
+                        anchors.fill: parent
+                        onClicked: colorDialog.open()
+                    }
+                }
+
+                ColorDialog {
+                    id: colorDialog
+                    title: "Please choose a color"
+                    color: attribute.value
+                    onAccepted: {
+                        colorText.text = color
+                        // Artificially trigger change of attribute value
+                        colorText.editingFinished()
+                        close()
+                    }
+                    onRejected: close()
+                }
+                Item {
+                    // Dummy item to fill out the space if needed
+                    Layout.fillWidth: true
                 }
             }
         }

--- a/meshroom/ui/qml/GraphEditor/AttributeItemDelegate.qml
+++ b/meshroom/ui/qml/GraphEditor/AttributeItemDelegate.qml
@@ -1,6 +1,7 @@
 import QtQuick 2.9
 import QtQuick.Layouts 1.3
 import QtQuick.Controls 2.2
+import QtQuick.Dialogs 1.0
 import MaterialIcons 2.2
 import Utils 1.0
 
@@ -152,6 +153,10 @@ RowLayout {
             case "BoolParam": return checkbox_component
             case "ListAttribute": return listAttribute_component
             case "GroupAttribute": return groupAttribute_component
+            case "StringParam":
+                if (attribute.desc.semantic === 'multiline')
+                    return textArea_component
+                return textField_component
             default: return textField_component
             }
         }
@@ -179,6 +184,57 @@ RowLayout {
                             setTextFieldAttribute(Filepath.urlToString(drop.urls[0]))
                         else if(drop.hasText && drop.text != '')
                             setTextFieldAttribute(drop.text)
+                    }
+                }
+            }
+        }
+
+        Component {
+            id: textArea_component
+
+            Rectangle {
+                // Fixed background for the flickable object
+                color: palette.base
+                width: parent.width
+                height: 70
+
+                Flickable {
+                    width: parent.width
+                    height: parent.height
+                    contentWidth: width
+                    contentHeight: height
+
+                    ScrollBar.vertical: ScrollBar {
+                        policy: ScrollBar.AlwaysOn
+                    }
+
+                    TextArea.flickable: TextArea {
+                        wrapMode: Text.WordWrap
+                        padding: 0
+                        rightPadding: 5
+                        bottomPadding: 2
+                        topPadding: 2
+                        readOnly: !root.editable
+                        onEditingFinished: setTextFieldAttribute(text)
+                        text: attribute.value
+                        selectByMouse: true
+                        onPressed: {
+                            root.forceActiveFocus()
+                        }
+                        Component.onDestruction: {
+                            if (activeFocus)
+                                setTextFieldAttribute(text)
+                        }
+                        DropArea {
+                            enabled: root.editable
+                            anchors.fill: parent
+                            onDropped: {
+                                if (drop.hasUrls)
+                                    setTextFieldAttribute(Filepath.urlToString(drop.urls[0]))
+                                else if (drop.hasText && drop.text != '')
+                                    setTextFieldAttribute(drop.text)
+                            }
+                        }
                     }
                 }
             }

--- a/meshroom/ui/qml/GraphEditor/AttributeItemDelegate.qml
+++ b/meshroom/ui/qml/GraphEditor/AttributeItemDelegate.qml
@@ -248,7 +248,7 @@ RowLayout {
                 CheckBox {
                     id: color_checkbox
                     Layout.alignment: Qt.AlignLeft
-                    checked: node.color === "" ? false : true
+                    checked: node && node.color === "" ? false : true
                     text: "Custom Color"
                     onClicked: {
                         if(checked) {

--- a/meshroom/ui/qml/GraphEditor/Node.qml
+++ b/meshroom/ui/qml/GraphEditor/Node.qml
@@ -75,6 +75,8 @@ Item {
         onInternalAttributesChanged: {
             nodeLabel.text = node ? node.label : ""
             background.color = (node.color === "" ? Qt.lighter(activePalette.base, 1.4) : node.color)
+            nodeCommentTooltip.text = node ? node.comment : ""
+            nodeComment.visible = node.comment != ""
         }
     }
 
@@ -257,6 +259,30 @@ Item {
                                 font.pointSize: 7
                                 palette.text: "red"
                                 ToolTip.text: "Locked"
+                            }
+
+                            MaterialLabel {
+                                id: nodeComment
+                                visible: node.comment != ""
+                                text: MaterialIcons.comment
+                                padding: 2
+                                font.pointSize: 7
+
+                                ToolTip {
+                                    id: nodeCommentTooltip
+                                    parent: header
+                                    visible: nodeCommentMA.containsMouse && nodeComment.visible
+                                    text: node.comment
+                                    implicitWidth: 400 // Forces word-wrap for long comments but the tooltip will be bigger than needed for short comments
+                                    delay: 300
+                                }
+
+                                MouseArea {
+                                    // If the node header is hovered, comments may be displayed
+                                    id: nodeCommentMA
+                                    anchors.fill: parent
+                                    hoverEnabled: true
+                                }
                             }
                         }
                     }

--- a/meshroom/ui/qml/GraphEditor/Node.qml
+++ b/meshroom/ui/qml/GraphEditor/Node.qml
@@ -71,13 +71,6 @@ Item {
             root.x = root.node.x
             root.y = root.node.y
         }
-
-        onInternalAttributesChanged: {
-            nodeLabel.text = node ? node.label : ""
-            background.color = (node.color === "" ? Qt.lighter(activePalette.base, 1.4) : node.color)
-            nodeCommentTooltip.text = node ? node.comment : ""
-            nodeComment.visible = node.comment != ""
-        }
     }
 
     // Whether an attribute can be displayed as an attribute pin on the node

--- a/meshroom/ui/qml/GraphEditor/Node.qml
+++ b/meshroom/ui/qml/GraphEditor/Node.qml
@@ -74,6 +74,7 @@ Item {
 
         onInternalAttributesChanged: {
             nodeLabel.text = node ? node.label : ""
+            background.color = (node.color === "" ? Qt.lighter(activePalette.base, 1.4) : node.color)
         }
     }
 
@@ -142,7 +143,7 @@ Item {
         Rectangle {
             id: background
             anchors.fill: nodeContent
-            color: Qt.lighter(activePalette.base, 1.4)
+            color: node.color === "" ? Qt.lighter(activePalette.base, 1.4) : node.color
             layer.enabled: true
             layer.effect: DropShadow { radius: 3; color: shadowColor }
             radius: 3

--- a/meshroom/ui/qml/GraphEditor/Node.qml
+++ b/meshroom/ui/qml/GraphEditor/Node.qml
@@ -73,6 +73,29 @@ Item {
         }
     }
 
+    function formatInternalAttributesTooltip(invalidation, comment) {
+        /*
+         * Creates a string that contains the invalidation message (if it is not empty) in bold,
+         * followed by the comment message (if it exists) in regular font, separated by an empty
+         * line.
+         * Invalidation and comment messages have their tabs or line returns in plain text format replaced
+         * by their HTML equivalents.
+         */
+        let str = ""
+        if (invalidation !== "") {
+            let replacedInvalidation = node.invalidation.replace(/\n/g, "<br/>").replace(/\t/g, "&nbsp;&nbsp;&nbsp;&nbsp;")
+            str += "<b>" + replacedInvalidation + "</b>"
+        }
+        if (invalidation !== "" && comment !== "") {
+            str += "<br/><br/>"
+        }
+        if (comment !== "") {
+            let replacedComment = node.comment.replace(/\n/g, "<br/>").replace(/\t/g, "&nbsp;&nbsp;&nbsp;&nbsp;")
+            str += replacedComment
+        }
+        return str
+    }
+
     // Whether an attribute can be displayed as an attribute pin on the node
     function isFileAttributeBaseType(attribute) {
         // ATM, only File attributes are meant to be connected
@@ -256,7 +279,7 @@ Item {
 
                             MaterialLabel {
                                 id: nodeComment
-                                visible: node.comment != ""
+                                visible: node.comment !== "" || node.invalidation !== ""
                                 text: MaterialIcons.comment
                                 padding: 2
                                 font.pointSize: 7
@@ -265,9 +288,14 @@ Item {
                                     id: nodeCommentTooltip
                                     parent: header
                                     visible: nodeCommentMA.containsMouse && nodeComment.visible
-                                    text: node.comment
+                                    text: formatInternalAttributesTooltip(node.invalidation, node.comment)
                                     implicitWidth: 400 // Forces word-wrap for long comments but the tooltip will be bigger than needed for short comments
                                     delay: 300
+
+                                    // Relative position for the tooltip to ensure we won't get stuck in a case where it starts appearing over the mouse's
+                                    // position because it's a bit long and cutting off the hovering of the mouse area (which leads to the tooltip beginning
+                                    // to appear and immediately disappearing, over and over again)
+                                    x: implicitWidth / 2.5
                                 }
 
                                 MouseArea {

--- a/meshroom/ui/qml/GraphEditor/Node.qml
+++ b/meshroom/ui/qml/GraphEditor/Node.qml
@@ -71,6 +71,10 @@ Item {
             root.x = root.node.x
             root.y = root.node.y
         }
+
+        onInternalAttributesChanged: {
+            nodeLabel.text = node ? node.label : ""
+        }
     }
 
     // Whether an attribute can be displayed as an attribute pin on the node
@@ -181,6 +185,7 @@ Item {
 
                         // Node Name
                         Label {
+                            id: nodeLabel
                             Layout.fillWidth: true
                             text: node ? node.label : ""
                             padding: 4

--- a/meshroom/ui/qml/GraphEditor/NodeEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/NodeEditor.qml
@@ -247,6 +247,15 @@ Panel {
                             Layout.fillWidth: true
                             node: root.node
                         }
+
+                        AttributeEditor {
+                            Layout.fillHeight: true
+                            Layout.fillWidth: true
+                            model: root.node.internalAttributes
+                            readOnly: root.readOnly || root.isCompatibilityNode
+                            onAttributeDoubleClicked: root.attributeDoubleClicked(mouse, attribute)
+                            onUpgradeRequest: root.upgradeRequest()
+                        }
                     }
                 }
             }
@@ -282,6 +291,12 @@ Panel {
             }
             TabButton {
                 text: "Documentation"
+                leftPadding: 8
+                rightPadding: leftPadding
+            }
+            TabButton {
+                text: "Notes"
+                padding: 4
                 leftPadding: 8
                 rightPadding: leftPadding
             }

--- a/meshroom/ui/qml/GraphEditor/NodeEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/NodeEditor.qml
@@ -185,6 +185,7 @@ Panel {
                         currentIndex: tabBar.currentIndex
 
                         AttributeEditor {
+                            id: inOutAttr
                             Layout.fillHeight: true
                             Layout.fillWidth: true
                             model: root.node.attributes
@@ -249,6 +250,7 @@ Panel {
                         }
 
                         AttributeEditor {
+                            id: nodeInternalAttr
                             Layout.fillHeight: true
                             Layout.fillWidth: true
                             model: root.node.internalAttributes

--- a/tests/test_templatesVersion.py
+++ b/tests/test_templatesVersion.py
@@ -38,6 +38,7 @@ def test_templateVersions():
             currentNodeVersion = meshroom.core.nodeVersion(nodeDesc)
 
             inputs = nodeData.get("inputs", {})
+            internalInputs = nodeData.get("internalInputs", {})
             version = nodesVersions.get(nodeType, None)
 
             compatibilityIssue = None
@@ -47,6 +48,10 @@ def test_templateVersions():
             else:
                 for attrName, value in inputs.items():
                     if not CompatibilityNode.attributeDescFromName(nodeDesc.inputs, attrName, value):
+                        compatibilityIssue = CompatibilityIssue.DescriptionConflict
+                        break
+                for attrName, value in internalInputs.items():
+                    if not CompatibilityNode.attributeDescFromName(nodeDesc.internalInputs, attrName, value):
                         compatibilityIssue = CompatibilityIssue.DescriptionConflict
                         break
 


### PR DESCRIPTION
## Description

This PR adds support for internal attributes, which are attributes that exist for all nodes independently from their type.
Internal attributes are displayed in the "Notes" tab of the graph editor (also added in this PR) and can be set for each node individually and independently. 

Four internal attributes are added with this PR: comments/invalid comments (to write some comments regarding a node), label (to rename a node), and color (to change a node's color).

Regarding the "comments" internal attribute, an icon is added to the node's header if a comment has been set, and hovering over that icon displays a tooltip containing the comment.

Internal attributes will be written to the template files if and only if they have non-default values (so they need to have been set). If no internal attribute has a non-default value, the "internalInputs" entry is not even written in the template file. The unit test checking on version/description conflicts in templates is updated accordingly. 

A new property, `uidIgnoreValue`, is added to the generic Attribute object. Its goal is to leave an attribute out of the node's UID computation if its value is set to the value it specifies. By default, it is set to `None` and any attribute that is considered for the UID computation will be taken into account. In the case of the internal attributes, `uidIgnoreValue=""` for the "invalidation" attribute: this prevents from invalidating all the existing graphs simply because this attribute has been added; instead, nodes will be invalidated because of that specific attribute if and only if its value is set to a non-empty string (when the invalidation is actually wanted). 

## Features list

- [X] Add support for internal attributes (attributes that will appear in the "Notes" tab)
- [X] Support multiline text field parameters and color selector text field parameters
- [X] Add a first set of internal parameters: "comments", "invalid comments", "label" and "color"
- [X] Add a "comment" icon in the header of nodes which have their "comment" attribute set, and a tooltip displaying that comment when the icon is hovered
- [X] Add a new attribute property, `uidIgnoreValue`, which allows to ignore an attribute during the node's UID computation depending on its value

## Implementation remarks

`uidIgnoreValue` is set to `None` by default for all types of attributes. It also is only exposed in the constructor of the `StringParam` attributes.