### PR TITLE
Add abstract InitNode

### DIFF
--- a/bin/meshroom_batch
+++ b/bin/meshroom_batch
@@ -9,7 +9,9 @@ meshroom.setupEnvironment()
 
 import meshroom.core.graph
 from meshroom import multiview
+from meshroom.core.desc import InitNode
 import logging
+
 
 parser = argparse.ArgumentParser(description='Launch the full photogrammetry or Panorama HDR pipeline.')
 parser.add_argument('-i', '--input', metavar='SFM/FOLDERS/IMAGES', type=str, nargs='*',
@@ -94,32 +96,23 @@ def getOnlyNodeOfType(g, nodeType):
     return nodes[0]
 
 
+def getInitNode(g):
+    """
+    Helper function to get the Init node in the graph 'g' and raise an exception if there is no or
+    multiple candidates.
+    """
+    nodes = g.findInitNodes()
+    if len(nodes) == 0:
+        raise RuntimeError("meshroom_batch requires an Init node in the pipeline.")
+    elif len(nodes) > 1:
+        raise RuntimeError("meshroom_batch requires exactly one Init node in the pipeline, {} found: {}"
+                           .format(len(nodes), str(nodes)))
+    return nodes[0]
+
+
 if not args.input and not args.inputRecursive:
     print('Nothing to compute. You need to set --input or --inputRecursive.')
     sys.exit(1)
-
-views, intrinsics = [], []
-# Build image files list from inputImages arguments
-filesByType = multiview.FilesByType()
-
-hasSearchedForImages = False
-
-if args.input:
-    if len(args.input) == 1 and os.path.isfile(args.input[0]) and os.path.splitext(args.input[0])[-1] in ('.json', '.sfm'):
-        # args.input is a sfmData file: setup pre-calibrated views and intrinsics
-        from meshroom.nodes.aliceVision.CameraInit import readSfMData
-        views, intrinsics = readSfMData(args.input[0])
-    else:
-        filesByType.extend(multiview.findFilesByTypeInFolder(args.input, recursive=False))
-        hasSearchedForImages = True
-
-if args.inputRecursive:
-    filesByType.extend(multiview.findFilesByTypeInFolder(args.inputRecursive, recursive=True))
-    hasSearchedForImages = True
-
-if hasSearchedForImages and not filesByType.images:
-    print("No image found")
-    sys.exit(-1)
 
 graph = multiview.Graph(name=args.pipeline)
 
@@ -131,15 +124,10 @@ with multiview.GraphModification(graph):
     else:
         # custom pipeline
         graph.load(args.pipeline, setupProjectFile=False)
-        # graph.update()
 
-    cameraInit = getOnlyNodeOfType(graph, 'CameraInit')
-    # reset graph inputs
-    cameraInit.viewpoints.resetValue()
-    cameraInit.intrinsics.resetValue()
-    # add views and intrinsics (if any) read from args.input
-    cameraInit.viewpoints.extend(views)
-    cameraInit.intrinsics.extend(intrinsics)
+    # get init node and initialize it
+    initNode = getInitNode(graph)
+    initNode.nodeDesc.initialize(initNode, args.input, args.inputRecursive)
 
     if not graph.canComputeLeaves:
         raise RuntimeError("Graph cannot be computed. Check for compatibility issues.")
@@ -150,11 +138,6 @@ with multiview.GraphModification(graph):
     if args.output:
         publish = getOnlyNodeOfType(graph, 'Publish')
         publish.output.value = args.output
-
-    if filesByType.images:
-        views, intrinsics = cameraInit.nodeDesc.buildIntrinsics(cameraInit, filesByType.images)
-        cameraInit.viewpoints.value = views
-        cameraInit.intrinsics.value = intrinsics
 
     if args.overrides:
         import io

--- a/meshroom/core/desc.py
+++ b/meshroom/core/desc.py
@@ -527,3 +527,55 @@ class CommandLineNode(Node):
         finally:
             chunk.subprocess = None
 
+
+# Test abstract node
+class InitNode:
+    def __init__(self):
+        pass
+
+    def initialize(self, node, inputs, recursiveInputs):
+        """
+        Initialize the attributes that are needed for a node to start running.
+
+        Args:
+            node (Node): the node whose attributes must be initialized
+            inputs (list): the user-provided list of input files/directories
+            recursiveInputs (list): the user-provided list of input directories to search recursively for images
+        """
+        pass
+
+    def resetAttributes(self, node, attributeNames):
+        """
+        Reset the values of the provided attributes for a node.
+
+        Args:
+            node (Node): the node whose attributes are to be reset
+            attributeNames (list): the list containing the names of the attributes to reset
+        """
+        for attrName in attributeNames:
+            if node.hasAttribute(attrName):
+                node.attribute(attrName).resetValue()
+
+    def extendAttributes(self, node, attributesDict):
+        """
+        Extend the values of the provided attributes for a node.
+
+        Args:
+            node (Node): the node whose attributes are to be extended
+            attributesDict (dict): the dictionary containing the attributes' names (as keys) and the values to extend with
+        """
+        for attr in attributesDict.keys():
+            if node.hasAttribute(attr):
+                node.attribute(attr).extend(attributesDict[attr])
+
+    def setAttributes(self, node, attributesDict):
+        """
+        Set the values of the provided attributes for a node.
+
+        Args:
+            node (Node): the node whose attributes are to be extended
+            attributesDict (dict): the dictionary containing the attributes' names (as keys) and the values to set
+        """
+        for attr in attributesDict:
+            if node.hasAttribute(attr):
+                node.attribute(attr).value = attributesDict[attr]

--- a/meshroom/core/graph.py
+++ b/meshroom/core/graph.py
@@ -547,6 +547,14 @@ class Graph(BaseObject):
         nodes = [n for n in self._nodes.values() if n.nodeType == nodeType]
         return self.sortNodesByIndex(nodes) if sortedByIndex else nodes
 
+    def findInitNodes(self):
+        """
+        Returns:
+            list[Node]: the list of Init nodes (nodes inheriting from InitNode)
+        """
+        nodes = [n for n in self._nodes.values() if isinstance(n.nodeDesc, meshroom.core.desc.InitNode)]
+        return nodes
+
     def findNodeCandidates(self, nodeNameExpr):
         pattern = re.compile(nodeNameExpr)
         return [v for k, v in self._nodes.objects.items() if pattern.match(k)]


### PR DESCRIPTION
## Description

This PR adds the abstract class "InitNode" which is meant to be inherited by all the initialization nodes (such as CameraInit), included those that might be created by the user. InitNode contains methods that can be reimplemented by the children classes if necessary.

This abstract class allows to keep on using scripts (such as meshroom_batch) without being limited to the use a specific initialization node (like it used to be with CameraInit in the case of meshroom_batch, for example), needing to have the knowledge of the used initialization node and/or having to modify the scripts as a workaround. 