### PR TITLE
Add dedicated "minimal" mode for templates

### DIFF
--- a/meshroom/core/attribute.py
+++ b/meshroom/core/attribute.py
@@ -283,7 +283,7 @@ class Attribute(BaseObject):
         return copy.copy(self.desc.value)
 
     def _isDefault(self):
-        return self._value == self.defaultValue()
+        return self.value == self.defaultValue()
 
     def getPrimitiveValue(self, exportDefault=True):
         return self._value

--- a/meshroom/pipelines/cameraTracking.mg
+++ b/meshroom/pipelines/cameraTracking.mg
@@ -3,6 +3,7 @@
         "pipelineVersion": "2.2", 
         "releaseVersion": "2021.1.0", 
         "fileVersion": "1.1", 
+        "template": true, 
         "nodesVersions": {
             "ExportAnimatedCamera": "2.0", 
             "FeatureMatching": "2.0", 
@@ -16,9 +17,7 @@
     "graph": {
         "DistortionCalibration_1": {
             "inputs": {
-                "verboseLevel": "info", 
-                "input": "{CameraInit_1.output}", 
-                "lensGrid": []
+                "input": "{CameraInit_1.output}"
             }, 
             "nodeType": "DistortionCalibration", 
             "uids": {
@@ -40,15 +39,9 @@
         }, 
         "ImageMatching_1": {
             "inputs": {
-                "minNbImages": 200, 
                 "nbNeighbors": 10, 
-                "tree": "${ALICEVISION_VOCTREE}", 
-                "maxDescriptors": 500, 
-                "verboseLevel": "info", 
-                "weights": "", 
                 "nbMatches": 5, 
                 "input": "{FeatureExtraction_1.input}", 
-                "method": "SequentialAndVocabularyTree", 
                 "featuresFolders": [
                     "{FeatureExtraction_1.output}"
                 ]
@@ -73,20 +66,7 @@
         }, 
         "FeatureExtraction_1": {
             "inputs": {
-                "verboseLevel": "info", 
-                "maxThreads": 0, 
-                "describerTypes": [
-                    "dspsift"
-                ], 
-                "maxNbFeatures": 0, 
-                "relativePeakThreshold": 0.01, 
-                "forceCpuExtraction": true, 
-                "masksFolder": "", 
-                "contrastFiltering": "GridSort", 
-                "describerQuality": "normal", 
-                "gridFiltering": true, 
-                "input": "{CameraInit_1.output}", 
-                "describerPreset": "normal"
+                "input": "{CameraInit_1.output}"
             }, 
             "nodeType": "FeatureExtraction", 
             "uids": {
@@ -108,39 +88,16 @@
         }, 
         "StructureFromMotion_1": {
             "inputs": {
-                "localizerEstimatorMaxIterations": 4096, 
                 "minAngleForLandmark": 0.5, 
-                "filterTrackForks": false, 
                 "minNumberOfObservationsForTriangulation": 3, 
-                "maxAngleInitialPair": 40.0, 
-                "observationConstraint": "Scale", 
-                "maxNumberOfMatches": 0, 
-                "localizerEstimator": "acransac", 
                 "describerTypes": "{FeatureMatching_1.describerTypes}", 
-                "lockScenePreviouslyReconstructed": false, 
-                "localBAGraphDistance": 1, 
-                "minNbCamerasToRefinePrincipalPoint": 3, 
-                "lockAllIntrinsics": false, 
                 "input": "{FeatureMatching_1.input}", 
                 "featuresFolders": "{FeatureMatching_1.featuresFolders}", 
-                "useRigConstraint": true, 
-                "rigMinNbCamerasForCalibration": 20, 
-                "initialPairA": "", 
-                "initialPairB": "", 
-                "interFileExtension": ".abc", 
-                "useLocalBA": true, 
-                "computeStructureColor": true, 
                 "matchesFolders": [
                     "{FeatureMatching_1.output}"
                 ], 
                 "minInputTrackLength": 5, 
-                "useOnlyMatchesFromInputFolder": false, 
-                "verboseLevel": "info", 
-                "minAngleForTriangulation": 1.0, 
-                "maxReprojectionError": 4.0, 
-                "minAngleInitialPair": 5.0, 
-                "minNumberOfMatches": 0, 
-                "localizerEstimatorError": 0.0
+                "minAngleForTriangulation": 1.0
             }, 
             "nodeType": "StructureFromMotion", 
             "uids": {
@@ -164,15 +121,7 @@
         }, 
         "ExportAnimatedCamera_1": {
             "inputs": {
-                "exportFullROD": false, 
-                "undistortedImageType": "exr", 
-                "exportUVMaps": true, 
-                "verboseLevel": "info", 
-                "sfmDataFilter": "", 
-                "exportUndistortedImages": false, 
-                "input": "{StructureFromMotion_1.output}", 
-                "viewFilter": "", 
-                "correctPrincipalPoint": true
+                "input": "{StructureFromMotion_1.output}"
             }, 
             "nodeType": "ExportAnimatedCamera", 
             "uids": {
@@ -195,28 +144,7 @@
             "internalFolder": "{cache}/{nodeType}/{uid0}/"
         }, 
         "CameraInit_1": {
-            "inputs": {
-                "groupCameraFallback": "folder", 
-                "intrinsics": [], 
-                "viewIdRegex": ".*?(\\d+)", 
-                "defaultFieldOfView": 45.0, 
-                "allowedCameraModels": [
-                    "pinhole", 
-                    "radial1", 
-                    "radial3", 
-                    "brown", 
-                    "fisheye4", 
-                    "fisheye1", 
-                    "3deanamorphic4", 
-                    "3deradial4", 
-                    "3declassicld"
-                ], 
-                "verboseLevel": "info", 
-                "viewIdMethod": "metadata", 
-                "viewpoints": [], 
-                "useInternalWhiteBalance": true, 
-                "sensorDatabase": "${ALICEVISION_SENSOR_DB}"
-            }, 
+            "inputs": {}, 
             "nodeType": "CameraInit", 
             "uids": {
                 "0": "f9436e97e444fa71a05aa5cf7639b206df8ba282"
@@ -237,23 +165,9 @@
         }, 
         "FeatureMatching_1": {
             "inputs": {
-                "verboseLevel": "info", 
                 "describerTypes": "{FeatureExtraction_1.describerTypes}", 
-                "exportDebugFiles": false, 
-                "crossMatching": false, 
-                "geometricError": 0.0, 
-                "maxMatches": 0, 
-                "matchFromKnownCameraPoses": false, 
-                "savePutativeMatches": false, 
-                "guidedMatching": false, 
                 "imagePairsList": "{ImageMatching_1.output}", 
-                "geometricEstimator": "acransac", 
-                "geometricFilterType": "fundamental_matrix", 
-                "maxIteration": 2048, 
-                "distanceRatio": 0.8, 
                 "input": "{DistortionCalibration_1.outSfMData}", 
-                "photometricMatchingMethod": "ANN_L2", 
-                "knownPosesGeometricErrorMax": 5.0, 
                 "featuresFolders": "{ImageMatching_1.featuresFolders}"
             }, 
             "nodeType": "FeatureMatching", 

--- a/meshroom/pipelines/panoramaFisheyeHdr.mg
+++ b/meshroom/pipelines/panoramaFisheyeHdr.mg
@@ -6,34 +6,27 @@
             "ImageProcessing": "3.0", 
             "PanoramaCompositing": "2.0", 
             "LdrToHdrMerge": "4.0", 
-            "LdrToHdrSampling": "4.0", 
-            "LdrToHdrCalibration": "3.0", 
             "PanoramaEstimation": "1.0", 
+            "LdrToHdrCalibration": "3.0", 
+            "LdrToHdrSampling": "4.0", 
             "PanoramaInit": "2.0", 
-            "PanoramaMerging": "1.0", 
-            "SfMTransform": "3.0", 
             "CameraInit": "7.0", 
+            "SfMTransform": "3.0", 
+            "PanoramaMerging": "1.0", 
             "ImageMatching": "2.0", 
             "FeatureExtraction": "1.1", 
             "PanoramaPrepareImages": "1.1", 
             "PanoramaWarping": "1.0"
         }, 
         "releaseVersion": "2021.1.0", 
-        "fileVersion": "1.1"
+        "fileVersion": "1.1", 
+        "template": true
     }, 
     "graph": {
         "LdrToHdrMerge_1": {
             "inputs": {
-                "verboseLevel": "info", 
-                "fusionWeight": "gaussian", 
                 "channelQuantizationPower": "{LdrToHdrCalibration_1.channelQuantizationPower}", 
-                "nbBrackets": 0, 
-                "enableHighlight": false, 
-                "offsetRefBracketIndex": 1, 
-                "storageDataType": "float", 
-                "highlightTargetLux": 120000.0, 
                 "byPass": "{LdrToHdrCalibration_1.byPass}", 
-                "highlightCorrectionFactor": 1.0, 
                 "input": "{LdrToHdrCalibration_1.input}", 
                 "userNbBrackets": "{LdrToHdrCalibration_1.userNbBrackets}", 
                 "response": "{LdrToHdrCalibration_1.response}"
@@ -58,48 +51,14 @@
         }, 
         "ImageProcessing_1": {
             "inputs": {
-                "outputFormat": "rgba", 
-                "sharpenFilter": {
-                    "threshold": 0.0, 
-                    "width": 3, 
-                    "sharpenFilterEnabled": false, 
-                    "contrast": 1.0
-                }, 
                 "extension": "exr", 
-                "exposureCompensation": false, 
-                "storageDataType": "float", 
-                "inputFolders": [], 
-                "verboseLevel": "info", 
-                "metadataFolders": [], 
-                "claheFilter": {
-                    "claheClipLimit": 4.0, 
-                    "claheTileGridSize": 8, 
-                    "claheEnabled": false
-                }, 
-                "medianFilter": 0, 
                 "fillHoles": true, 
-                "reconstructedViewsOnly": false, 
                 "input": "{PanoramaMerging_1.outputPanorama}", 
-                "noiseFilter": {
-                    "noiseEnabled": false, 
-                    "noiseMethod": "uniform", 
-                    "noiseB": 1.0, 
-                    "noiseMono": true, 
-                    "noiseA": 0.0
-                }, 
-                "scaleFactor": 1.0, 
-                "bilateralFilter": {
-                    "bilateralFilterDistance": 0, 
-                    "bilateralFilterSigmaColor": 0.0, 
-                    "bilateralFilterSigmaSpace": 0.0, 
-                    "bilateralFilterEnabled": false
-                }, 
-                "contrast": 1.0, 
                 "fixNonFinite": true
             }, 
             "nodeType": "ImageProcessing", 
             "uids": {
-                "0": "494b97af203ddbe4767c922a6c5795297cf53eef"
+                "0": "3b8b39e478a30aa0ef1871576665b2914204a919"
             }, 
             "parallelization": {
                 "blockSize": 0, 
@@ -108,8 +67,7 @@
             }, 
             "outputs": {
                 "output": "{cache}/{nodeType}/{uid0}/", 
-                "outputImages": "{cache}/{nodeType}/{uid0}/panorama.exr", 
-                "outSfMData": ""
+                "outputImages": "{cache}/{nodeType}/{uid0}/panorama.exr"
             }, 
             "position": [
                 3000, 
@@ -119,13 +77,7 @@
         }, 
         "PanoramaWarping_1": {
             "inputs": {
-                "panoramaWidth": 10000, 
-                "maxPanoramaWidth": 70000, 
-                "verboseLevel": "info", 
-                "percentUpscale": 50, 
-                "input": "{SfMTransform_1.output}", 
-                "storageDataType": "float", 
-                "estimateResolution": true
+                "input": "{SfMTransform_1.output}"
             }, 
             "nodeType": "PanoramaWarping", 
             "uids": {
@@ -149,11 +101,6 @@
             "inputs": {
                 "samples": "{LdrToHdrSampling_1.output}", 
                 "channelQuantizationPower": "{LdrToHdrSampling_1.channelQuantizationPower}", 
-                "maxTotalPoints": 1000000, 
-                "nbBrackets": 0, 
-                "calibrationMethod": "debevec", 
-                "calibrationWeight": "default", 
-                "verboseLevel": "info", 
                 "byPass": "{LdrToHdrSampling_1.byPass}", 
                 "input": "{LdrToHdrSampling_1.input}", 
                 "userNbBrackets": "{LdrToHdrSampling_1.userNbBrackets}"
@@ -178,16 +125,7 @@
         }, 
         "LdrToHdrSampling_1": {
             "inputs": {
-                "blockSize": 256, 
-                "nbBrackets": 0, 
-                "verboseLevel": "info", 
-                "radius": 5, 
-                "byPass": false, 
-                "channelQuantizationPower": 10, 
-                "debug": false, 
-                "input": "{PanoramaPrepareImages_1.output}", 
-                "maxCountSample": 200, 
-                "userNbBrackets": 0
+                "input": "{PanoramaPrepareImages_1.output}"
             }, 
             "nodeType": "LdrToHdrSampling", 
             "uids": {
@@ -209,13 +147,6 @@
         }, 
         "ImageMatching_1": {
             "inputs": {
-                "minNbImages": 200, 
-                "nbNeighbors": 5, 
-                "tree": "${ALICEVISION_VOCTREE}", 
-                "maxDescriptors": 500, 
-                "verboseLevel": "info", 
-                "weights": "", 
-                "nbMatches": 40, 
                 "input": "{PanoramaInit_1.outSfMData}", 
                 "method": "FrustumOrVocabularyTree", 
                 "featuresFolders": [
@@ -242,18 +173,10 @@
         }, 
         "FeatureExtraction_1": {
             "inputs": {
-                "verboseLevel": "info", 
-                "maxThreads": 0, 
                 "describerTypes": [
                     "sift"
                 ], 
-                "maxNbFeatures": 0, 
-                "relativePeakThreshold": 0.01, 
-                "forceCpuExtraction": true, 
-                "masksFolder": "", 
-                "contrastFiltering": "GridSort", 
                 "describerQuality": "high", 
-                "gridFiltering": true, 
                 "input": "{LdrToHdrMerge_1.outSfMData}", 
                 "describerPreset": "high"
             }, 
@@ -275,17 +198,14 @@
             ], 
             "internalFolder": "{cache}/{nodeType}/{uid0}/"
         }, 
-        "PanoramaSeams_1": {
+        "PanoramaMerging_1": {
             "inputs": {
-                "verboseLevel": "info", 
-                "input": "{PanoramaWarping_1.input}", 
-                "warpingFolder": "{PanoramaWarping_1.output}", 
-                "maxWidth": 5000, 
-                "useGraphCut": true
+                "compositingFolder": "{PanoramaCompositing_1.output}", 
+                "input": "{PanoramaCompositing_1.input}"
             }, 
-            "nodeType": "PanoramaSeams", 
+            "nodeType": "PanoramaMerging", 
             "uids": {
-                "0": "dd02562c5c3b1e18e42561d99590cbf4ff5ba35a"
+                "0": "70edd7fe8194bf35dcb0b221141cd4abd2354547"
             }, 
             "parallelization": {
                 "blockSize": 0, 
@@ -293,10 +213,10 @@
                 "size": 0
             }, 
             "outputs": {
-                "output": "{cache}/{nodeType}/{uid0}/labels.exr"
+                "outputPanorama": "{cache}/{nodeType}/{uid0}/panorama.{outputFileTypeValue}"
             }, 
             "position": [
-                2400, 
+                2800, 
                 0
             ], 
             "internalFolder": "{cache}/{nodeType}/{uid0}/"
@@ -304,13 +224,8 @@
         "PanoramaCompositing_1": {
             "inputs": {
                 "warpingFolder": "{PanoramaSeams_1.warpingFolder}", 
-                "maxThreads": 4, 
                 "labels": "{PanoramaSeams_1.output}", 
-                "verboseLevel": "info", 
-                "overlayType": "none", 
-                "compositerType": "multiband", 
-                "input": "{PanoramaSeams_1.input}", 
-                "storageDataType": "float"
+                "input": "{PanoramaSeams_1.input}"
             }, 
             "nodeType": "PanoramaCompositing", 
             "uids": {
@@ -332,10 +247,6 @@
         }, 
         "CameraInit_1": {
             "inputs": {
-                "groupCameraFallback": "folder", 
-                "intrinsics": [], 
-                "viewIdRegex": ".*?(\\d+)", 
-                "defaultFieldOfView": 45.0, 
                 "allowedCameraModels": [
                     "pinhole", 
                     "radial1", 
@@ -345,12 +256,7 @@
                     "3deanamorphic4", 
                     "3deradial4", 
                     "3declassicld"
-                ], 
-                "verboseLevel": "info", 
-                "viewIdMethod": "metadata", 
-                "viewpoints": [], 
-                "useInternalWhiteBalance": true, 
-                "sensorDatabase": "${ALICEVISION_SENSOR_DB}"
+                ]
             }, 
             "nodeType": "CameraInit", 
             "uids": {
@@ -372,7 +278,6 @@
         }, 
         "PanoramaPrepareImages_1": {
             "inputs": {
-                "verboseLevel": "info", 
                 "input": "{CameraInit_1.output}"
             }, 
             "nodeType": "PanoramaPrepareImages", 
@@ -395,33 +300,8 @@
         }, 
         "SfMTransform_1": {
             "inputs": {
-                "applyScale": true, 
-                "scale": 1.0, 
-                "applyTranslation": true, 
-                "landmarksDescriberTypes": [
-                    "sift", 
-                    "dspsift", 
-                    "akaze"
-                ], 
-                "markers": [], 
                 "method": "manual", 
-                "verboseLevel": "info", 
-                "input": "{PanoramaEstimation_1.output}", 
-                "applyRotation": true, 
-                "manualTransform": {
-                    "manualTranslation": {
-                        "y": 0.0, 
-                        "x": 0.0, 
-                        "z": 0.0
-                    }, 
-                    "manualRotation": {
-                        "y": 0.0, 
-                        "x": 0.0, 
-                        "z": 0.0
-                    }, 
-                    "manualScale": 1.0
-                }, 
-                "transformation": ""
+                "input": "{PanoramaEstimation_1.output}"
             }, 
             "nodeType": "SfMTransform", 
             "uids": {
@@ -442,17 +322,14 @@
             ], 
             "internalFolder": "{cache}/{nodeType}/{uid0}/"
         }, 
-        "PanoramaMerging_1": {
+        "PanoramaSeams_1": {
             "inputs": {
-                "verboseLevel": "info", 
-                "compositingFolder": "{PanoramaCompositing_1.output}", 
-                "outputFileType": "exr", 
-                "storageDataType": "float", 
-                "input": "{PanoramaCompositing_1.input}"
+                "input": "{PanoramaWarping_1.input}", 
+                "warpingFolder": "{PanoramaWarping_1.output}"
             }, 
-            "nodeType": "PanoramaMerging", 
+            "nodeType": "PanoramaSeams", 
             "uids": {
-                "0": "70edd7fe8194bf35dcb0b221141cd4abd2354547"
+                "0": "dd02562c5c3b1e18e42561d99590cbf4ff5ba35a"
             }, 
             "parallelization": {
                 "blockSize": 0, 
@@ -460,34 +337,21 @@
                 "size": 0
             }, 
             "outputs": {
-                "outputPanorama": "{cache}/{nodeType}/{uid0}/panorama.{outputFileTypeValue}"
+                "output": "{cache}/{nodeType}/{uid0}/labels.exr"
             }, 
             "position": [
-                2800, 
+                2400, 
                 0
             ], 
             "internalFolder": "{cache}/{nodeType}/{uid0}/"
         }, 
         "PanoramaEstimation_1": {
             "inputs": {
-                "intermediateRefineWithFocalDist": false, 
-                "offsetLongitude": 0.0, 
                 "matchesFolders": [
                     "{FeatureMatching_1.output}"
                 ], 
-                "filterMatches": false, 
-                "rotationAveragingWeighting": true, 
-                "offsetLatitude": 0.0, 
-                "verboseLevel": "info", 
-                "maxAngularError": 100.0, 
-                "lockAllIntrinsics": false, 
-                "refine": true, 
                 "input": "{FeatureMatching_1.input}", 
-                "intermediateRefineWithFocal": false, 
                 "describerTypes": "{FeatureMatching_1.describerTypes}", 
-                "relativeRotation": "rotation_matrix", 
-                "maxAngleToPrior": 20.0, 
-                "rotationAveraging": "L2_minimization", 
                 "featuresFolders": "{FeatureMatching_1.featuresFolders}"
             }, 
             "nodeType": "PanoramaEstimation", 
@@ -512,23 +376,10 @@
         "PanoramaInit_1": {
             "inputs": {
                 "useFisheye": true, 
-                "fisheyeCenterOffset": {
-                    "fisheyeCenterOffset_y": 0.0, 
-                    "fisheyeCenterOffset_x": 0.0
-                }, 
-                "initializeCameras": "No", 
-                "nbViewsPerLine": [], 
-                "debugFisheyeCircleEstimation": false, 
-                "verboseLevel": "info", 
                 "dependency": [
                     "{FeatureExtraction_1.output}"
                 ], 
-                "estimateFisheyeCircle": true, 
-                "input": "{FeatureExtraction_1.input}", 
-                "yawCW": 1, 
-                "config": "", 
-                "fisheyeRadius": 96.0, 
-                "inputAngle": "None"
+                "input": "{FeatureExtraction_1.input}"
             }, 
             "nodeType": "PanoramaInit", 
             "uids": {
@@ -550,23 +401,9 @@
         }, 
         "FeatureMatching_1": {
             "inputs": {
-                "verboseLevel": "info", 
                 "describerTypes": "{FeatureExtraction_1.describerTypes}", 
-                "exportDebugFiles": false, 
-                "crossMatching": false, 
-                "geometricError": 0.0, 
-                "maxMatches": 0, 
-                "matchFromKnownCameraPoses": false, 
-                "savePutativeMatches": false, 
-                "guidedMatching": false, 
                 "imagePairsList": "{ImageMatching_1.output}", 
-                "geometricEstimator": "acransac", 
-                "geometricFilterType": "fundamental_matrix", 
-                "maxIteration": 2048, 
-                "distanceRatio": 0.8, 
                 "input": "{ImageMatching_1.input}", 
-                "photometricMatchingMethod": "ANN_L2", 
-                "knownPosesGeometricErrorMax": 5.0, 
                 "featuresFolders": "{ImageMatching_1.featuresFolders}"
             }, 
             "nodeType": "FeatureMatching", 

--- a/meshroom/pipelines/panoramaHdr.mg
+++ b/meshroom/pipelines/panoramaHdr.mg
@@ -6,34 +6,27 @@
             "ImageProcessing": "3.0", 
             "PanoramaCompositing": "2.0", 
             "LdrToHdrMerge": "4.0", 
-            "LdrToHdrSampling": "4.0", 
-            "LdrToHdrCalibration": "3.0", 
             "PanoramaEstimation": "1.0", 
+            "LdrToHdrCalibration": "3.0", 
+            "LdrToHdrSampling": "4.0", 
             "PanoramaInit": "2.0", 
-            "PanoramaMerging": "1.0", 
-            "SfMTransform": "3.0", 
             "CameraInit": "7.0", 
+            "SfMTransform": "3.0", 
+            "PanoramaMerging": "1.0", 
             "ImageMatching": "2.0", 
             "FeatureExtraction": "1.1", 
             "PanoramaPrepareImages": "1.1", 
             "PanoramaWarping": "1.0"
         }, 
         "releaseVersion": "2021.1.0", 
-        "fileVersion": "1.1"
+        "fileVersion": "1.1", 
+        "template": true
     }, 
     "graph": {
         "LdrToHdrMerge_1": {
             "inputs": {
-                "verboseLevel": "info", 
-                "fusionWeight": "gaussian", 
                 "channelQuantizationPower": "{LdrToHdrCalibration_1.channelQuantizationPower}", 
-                "nbBrackets": 0, 
-                "enableHighlight": false, 
-                "offsetRefBracketIndex": 1, 
-                "storageDataType": "float", 
-                "highlightTargetLux": 120000.0, 
                 "byPass": "{LdrToHdrCalibration_1.byPass}", 
-                "highlightCorrectionFactor": 1.0, 
                 "input": "{LdrToHdrCalibration_1.input}", 
                 "userNbBrackets": "{LdrToHdrCalibration_1.userNbBrackets}", 
                 "response": "{LdrToHdrCalibration_1.response}"
@@ -58,48 +51,14 @@
         }, 
         "ImageProcessing_1": {
             "inputs": {
-                "outputFormat": "rgba", 
-                "sharpenFilter": {
-                    "threshold": 0.0, 
-                    "width": 3, 
-                    "sharpenFilterEnabled": false, 
-                    "contrast": 1.0
-                }, 
                 "extension": "exr", 
-                "exposureCompensation": false, 
-                "storageDataType": "float", 
-                "inputFolders": [], 
-                "verboseLevel": "info", 
-                "metadataFolders": [], 
-                "claheFilter": {
-                    "claheClipLimit": 4.0, 
-                    "claheTileGridSize": 8, 
-                    "claheEnabled": false
-                }, 
-                "medianFilter": 0, 
                 "fillHoles": true, 
-                "reconstructedViewsOnly": false, 
                 "input": "{PanoramaMerging_1.outputPanorama}", 
-                "noiseFilter": {
-                    "noiseEnabled": false, 
-                    "noiseMethod": "uniform", 
-                    "noiseB": 1.0, 
-                    "noiseMono": true, 
-                    "noiseA": 0.0
-                }, 
-                "scaleFactor": 1.0, 
-                "bilateralFilter": {
-                    "bilateralFilterDistance": 0, 
-                    "bilateralFilterSigmaColor": 0.0, 
-                    "bilateralFilterSigmaSpace": 0.0, 
-                    "bilateralFilterEnabled": false
-                }, 
-                "contrast": 1.0, 
                 "fixNonFinite": true
             }, 
             "nodeType": "ImageProcessing", 
             "uids": {
-                "0": "d7845b276d97c3489223cce16a1e9d581d98a832"
+                "0": "a6d1b7d35fd36828f678e4547e9e267d84586f20"
             }, 
             "parallelization": {
                 "blockSize": 0, 
@@ -108,8 +67,7 @@
             }, 
             "outputs": {
                 "output": "{cache}/{nodeType}/{uid0}/", 
-                "outputImages": "{cache}/{nodeType}/{uid0}/panorama.exr", 
-                "outSfMData": ""
+                "outputImages": "{cache}/{nodeType}/{uid0}/panorama.exr"
             }, 
             "position": [
                 3000, 
@@ -119,13 +77,7 @@
         }, 
         "PanoramaWarping_1": {
             "inputs": {
-                "panoramaWidth": 10000, 
-                "maxPanoramaWidth": 70000, 
-                "verboseLevel": "info", 
-                "percentUpscale": 50, 
-                "input": "{SfMTransform_1.output}", 
-                "storageDataType": "float", 
-                "estimateResolution": true
+                "input": "{SfMTransform_1.output}"
             }, 
             "nodeType": "PanoramaWarping", 
             "uids": {
@@ -149,11 +101,6 @@
             "inputs": {
                 "samples": "{LdrToHdrSampling_1.output}", 
                 "channelQuantizationPower": "{LdrToHdrSampling_1.channelQuantizationPower}", 
-                "maxTotalPoints": 1000000, 
-                "nbBrackets": 0, 
-                "calibrationMethod": "debevec", 
-                "calibrationWeight": "default", 
-                "verboseLevel": "info", 
                 "byPass": "{LdrToHdrSampling_1.byPass}", 
                 "input": "{LdrToHdrSampling_1.input}", 
                 "userNbBrackets": "{LdrToHdrSampling_1.userNbBrackets}"
@@ -178,16 +125,7 @@
         }, 
         "LdrToHdrSampling_1": {
             "inputs": {
-                "blockSize": 256, 
-                "nbBrackets": 0, 
-                "verboseLevel": "info", 
-                "radius": 5, 
-                "byPass": false, 
-                "channelQuantizationPower": 10, 
-                "debug": false, 
-                "input": "{PanoramaPrepareImages_1.output}", 
-                "maxCountSample": 200, 
-                "userNbBrackets": 0
+                "input": "{PanoramaPrepareImages_1.output}"
             }, 
             "nodeType": "LdrToHdrSampling", 
             "uids": {
@@ -209,13 +147,6 @@
         }, 
         "ImageMatching_1": {
             "inputs": {
-                "minNbImages": 200, 
-                "nbNeighbors": 5, 
-                "tree": "${ALICEVISION_VOCTREE}", 
-                "maxDescriptors": 500, 
-                "verboseLevel": "info", 
-                "weights": "", 
-                "nbMatches": 40, 
                 "input": "{PanoramaInit_1.outSfMData}", 
                 "method": "FrustumOrVocabularyTree", 
                 "featuresFolders": [
@@ -242,20 +173,8 @@
         }, 
         "FeatureExtraction_1": {
             "inputs": {
-                "verboseLevel": "info", 
-                "maxThreads": 0, 
-                "describerTypes": [
-                    "dspsift"
-                ], 
-                "maxNbFeatures": 0, 
-                "relativePeakThreshold": 0.01, 
-                "forceCpuExtraction": true, 
-                "masksFolder": "", 
-                "contrastFiltering": "GridSort", 
                 "describerQuality": "high", 
-                "gridFiltering": true, 
-                "input": "{LdrToHdrMerge_1.outSfMData}", 
-                "describerPreset": "normal"
+                "input": "{LdrToHdrMerge_1.outSfMData}"
             }, 
             "nodeType": "FeatureExtraction", 
             "uids": {
@@ -275,17 +194,14 @@
             ], 
             "internalFolder": "{cache}/{nodeType}/{uid0}/"
         }, 
-        "PanoramaSeams_1": {
+        "PanoramaMerging_1": {
             "inputs": {
-                "verboseLevel": "info", 
-                "input": "{PanoramaWarping_1.input}", 
-                "warpingFolder": "{PanoramaWarping_1.output}", 
-                "maxWidth": 5000, 
-                "useGraphCut": true
+                "compositingFolder": "{PanoramaCompositing_1.output}", 
+                "input": "{PanoramaCompositing_1.input}"
             }, 
-            "nodeType": "PanoramaSeams", 
+            "nodeType": "PanoramaMerging", 
             "uids": {
-                "0": "0ee6da171bd684358b7c64dcc631f81ba743e1fa"
+                "0": "e007a4eb5fc5937b320638eba667cea183c0c642"
             }, 
             "parallelization": {
                 "blockSize": 0, 
@@ -293,10 +209,10 @@
                 "size": 0
             }, 
             "outputs": {
-                "output": "{cache}/{nodeType}/{uid0}/labels.exr"
+                "outputPanorama": "{cache}/{nodeType}/{uid0}/panorama.{outputFileTypeValue}"
             }, 
             "position": [
-                2400, 
+                2800, 
                 0
             ], 
             "internalFolder": "{cache}/{nodeType}/{uid0}/"
@@ -304,13 +220,8 @@
         "PanoramaCompositing_1": {
             "inputs": {
                 "warpingFolder": "{PanoramaSeams_1.warpingFolder}", 
-                "maxThreads": 4, 
                 "labels": "{PanoramaSeams_1.output}", 
-                "verboseLevel": "info", 
-                "overlayType": "none", 
-                "compositerType": "multiband", 
-                "input": "{PanoramaSeams_1.input}", 
-                "storageDataType": "float"
+                "input": "{PanoramaSeams_1.input}"
             }, 
             "nodeType": "PanoramaCompositing", 
             "uids": {
@@ -332,10 +243,6 @@
         }, 
         "CameraInit_1": {
             "inputs": {
-                "groupCameraFallback": "folder", 
-                "intrinsics": [], 
-                "viewIdRegex": ".*?(\\d+)", 
-                "defaultFieldOfView": 45.0, 
                 "allowedCameraModels": [
                     "pinhole", 
                     "radial1", 
@@ -345,12 +252,7 @@
                     "3deanamorphic4", 
                     "3deradial4", 
                     "3declassicld"
-                ], 
-                "verboseLevel": "info", 
-                "viewIdMethod": "metadata", 
-                "viewpoints": [], 
-                "useInternalWhiteBalance": true, 
-                "sensorDatabase": "${ALICEVISION_SENSOR_DB}"
+                ]
             }, 
             "nodeType": "CameraInit", 
             "uids": {
@@ -372,7 +274,6 @@
         }, 
         "PanoramaPrepareImages_1": {
             "inputs": {
-                "verboseLevel": "info", 
                 "input": "{CameraInit_1.output}"
             }, 
             "nodeType": "PanoramaPrepareImages", 
@@ -395,33 +296,8 @@
         }, 
         "SfMTransform_1": {
             "inputs": {
-                "applyScale": true, 
-                "scale": 1.0, 
-                "applyTranslation": true, 
-                "landmarksDescriberTypes": [
-                    "sift", 
-                    "dspsift", 
-                    "akaze"
-                ], 
-                "markers": [], 
                 "method": "manual", 
-                "verboseLevel": "info", 
-                "input": "{PanoramaEstimation_1.output}", 
-                "applyRotation": true, 
-                "manualTransform": {
-                    "manualTranslation": {
-                        "y": 0.0, 
-                        "x": 0.0, 
-                        "z": 0.0
-                    }, 
-                    "manualRotation": {
-                        "y": 0.0, 
-                        "x": 0.0, 
-                        "z": 0.0
-                    }, 
-                    "manualScale": 1.0
-                }, 
-                "transformation": ""
+                "input": "{PanoramaEstimation_1.output}"
             }, 
             "nodeType": "SfMTransform", 
             "uids": {
@@ -442,17 +318,14 @@
             ], 
             "internalFolder": "{cache}/{nodeType}/{uid0}/"
         }, 
-        "PanoramaMerging_1": {
+        "PanoramaSeams_1": {
             "inputs": {
-                "verboseLevel": "info", 
-                "compositingFolder": "{PanoramaCompositing_1.output}", 
-                "outputFileType": "exr", 
-                "storageDataType": "float", 
-                "input": "{PanoramaCompositing_1.input}"
+                "input": "{PanoramaWarping_1.input}", 
+                "warpingFolder": "{PanoramaWarping_1.output}"
             }, 
-            "nodeType": "PanoramaMerging", 
+            "nodeType": "PanoramaSeams", 
             "uids": {
-                "0": "e007a4eb5fc5937b320638eba667cea183c0c642"
+                "0": "0ee6da171bd684358b7c64dcc631f81ba743e1fa"
             }, 
             "parallelization": {
                 "blockSize": 0, 
@@ -460,34 +333,21 @@
                 "size": 0
             }, 
             "outputs": {
-                "outputPanorama": "{cache}/{nodeType}/{uid0}/panorama.{outputFileTypeValue}"
+                "output": "{cache}/{nodeType}/{uid0}/labels.exr"
             }, 
             "position": [
-                2800, 
+                2400, 
                 0
             ], 
             "internalFolder": "{cache}/{nodeType}/{uid0}/"
         }, 
         "PanoramaEstimation_1": {
             "inputs": {
-                "intermediateRefineWithFocalDist": false, 
-                "offsetLongitude": 0.0, 
                 "matchesFolders": [
                     "{FeatureMatching_1.output}"
                 ], 
-                "filterMatches": false, 
-                "rotationAveragingWeighting": true, 
-                "offsetLatitude": 0.0, 
-                "verboseLevel": "info", 
-                "maxAngularError": 100.0, 
-                "lockAllIntrinsics": false, 
-                "refine": true, 
                 "input": "{FeatureMatching_1.input}", 
-                "intermediateRefineWithFocal": false, 
                 "describerTypes": "{FeatureMatching_1.describerTypes}", 
-                "relativeRotation": "rotation_matrix", 
-                "maxAngleToPrior": 20.0, 
-                "rotationAveraging": "L2_minimization", 
                 "featuresFolders": "{FeatureMatching_1.featuresFolders}"
             }, 
             "nodeType": "PanoramaEstimation", 
@@ -511,24 +371,10 @@
         }, 
         "PanoramaInit_1": {
             "inputs": {
-                "useFisheye": false, 
-                "fisheyeCenterOffset": {
-                    "fisheyeCenterOffset_y": 0.0, 
-                    "fisheyeCenterOffset_x": 0.0
-                }, 
-                "initializeCameras": "No", 
-                "nbViewsPerLine": [], 
-                "debugFisheyeCircleEstimation": false, 
-                "verboseLevel": "info", 
                 "dependency": [
                     "{FeatureExtraction_1.output}"
                 ], 
-                "estimateFisheyeCircle": true, 
-                "input": "{FeatureExtraction_1.input}", 
-                "yawCW": 1, 
-                "config": "", 
-                "fisheyeRadius": 96.0, 
-                "inputAngle": "None"
+                "input": "{FeatureExtraction_1.input}"
             }, 
             "nodeType": "PanoramaInit", 
             "uids": {
@@ -550,23 +396,9 @@
         }, 
         "FeatureMatching_1": {
             "inputs": {
-                "verboseLevel": "info", 
                 "describerTypes": "{FeatureExtraction_1.describerTypes}", 
-                "exportDebugFiles": false, 
-                "crossMatching": false, 
-                "geometricError": 0.0, 
-                "maxMatches": 0, 
-                "matchFromKnownCameraPoses": false, 
-                "savePutativeMatches": false, 
-                "guidedMatching": false, 
                 "imagePairsList": "{ImageMatching_1.output}", 
-                "geometricEstimator": "acransac", 
-                "geometricFilterType": "fundamental_matrix", 
-                "maxIteration": 2048, 
-                "distanceRatio": 0.8, 
                 "input": "{ImageMatching_1.input}", 
-                "photometricMatchingMethod": "ANN_L2", 
-                "knownPosesGeometricErrorMax": 5.0, 
                 "featuresFolders": "{ImageMatching_1.featuresFolders}"
             }, 
             "nodeType": "FeatureMatching", 

--- a/meshroom/pipelines/photogrammetry.mg
+++ b/meshroom/pipelines/photogrammetry.mg
@@ -3,17 +3,18 @@
         "pipelineVersion": "2.2", 
         "releaseVersion": "2021.1.0", 
         "fileVersion": "1.1", 
+        "template": true, 
         "nodesVersions": {
             "FeatureMatching": "2.0", 
             "MeshFiltering": "3.0", 
             "Texturing": "6.0", 
             "PrepareDenseScene": "3.0", 
             "DepthMap": "2.0", 
-            "Meshing": "7.0", 
+            "StructureFromMotion": "2.0", 
             "CameraInit": "7.0", 
             "ImageMatching": "2.0", 
             "FeatureExtraction": "1.1", 
-            "StructureFromMotion": "2.0", 
+            "Meshing": "7.0", 
             "DepthMapFilter": "3.0"
         }
     }, 
@@ -21,47 +22,8 @@
         "Texturing_1": {
             "inputs": {
                 "imagesFolder": "{DepthMap_1.imagesFolder}", 
-                "downscale": 2, 
-                "bumpMapping": {
-                    "normalFileType": "exr", 
-                    "enable": true, 
-                    "bumpType": "Normal", 
-                    "heightFileType": "exr"
-                }, 
-                "forceVisibleByAllVertices": false, 
-                "fillHoles": false, 
-                "multiBandDownscale": 4, 
-                "useScore": true, 
-                "displacementMapping": {
-                    "displacementMappingFileType": "exr", 
-                    "enable": true
-                }, 
-                "outputMeshFileType": "obj", 
-                "angleHardThreshold": 90.0, 
-                "textureSide": 8192, 
-                "processColorspace": "sRGB", 
                 "input": "{Meshing_1.output}", 
-                "useUDIM": true, 
-                "subdivisionTargetRatio": 0.8, 
-                "padding": 5, 
-                "inputRefMesh": "", 
-                "correctEV": false, 
-                "visibilityRemappingMethod": "PullPush", 
-                "inputMesh": "{MeshFiltering_1.outputMesh}", 
-                "verboseLevel": "info", 
-                "colorMapping": {
-                    "enable": true, 
-                    "colorMappingFileType": "exr"
-                }, 
-                "bestScoreThreshold": 0.1, 
-                "unwrapMethod": "Basic", 
-                "multiBandNbContrib": {
-                    "high": 1, 
-                    "midHigh": 5, 
-                    "low": 0, 
-                    "midLow": 10
-                }, 
-                "flipNormals": false
+                "inputMesh": "{MeshFiltering_1.outputMesh}"
             }, 
             "nodeType": "Texturing", 
             "uids": {
@@ -86,67 +48,8 @@
         }, 
         "Meshing_1": {
             "inputs": {
-                "exportDebugTetrahedralization": false, 
-                "useBoundingBox": false, 
-                "maxInputPoints": 50000000, 
-                "repartition": "multiResolution", 
-                "helperPointsGridSize": 10, 
-                "seed": 0, 
-                "voteFilteringForWeaklySupportedSurfaces": true, 
-                "verboseLevel": "info", 
-                "outputMeshFileType": "obj", 
-                "simGaussianSizeInit": 10.0, 
-                "nPixelSizeBehind": 4.0, 
-                "fullWeight": 1.0, 
                 "depthMapsFolder": "{DepthMapFilter_1.output}", 
-                "densify": false, 
-                "simFactor": 15.0, 
-                "maskHelperPointsWeight": 1.0, 
-                "densifyScale": 20.0, 
-                "input": "{DepthMapFilter_1.input}", 
-                "addLandmarksToTheDensePointCloud": false, 
-                "voteMarginFactor": 4.0, 
-                "saveRawDensePointCloud": false, 
-                "contributeMarginFactor": 2.0, 
-                "estimateSpaceMinObservationAngle": 10, 
-                "nbSolidAngleFilteringIterations": 2, 
-                "minStep": 2, 
-                "colorizeOutput": false, 
-                "pixSizeMarginFinalCoef": 4.0, 
-                "densifyNbFront": 1, 
-                "boundingBox": {
-                    "bboxScale": {
-                        "y": 1.0, 
-                        "x": 1.0, 
-                        "z": 1.0
-                    }, 
-                    "bboxTranslation": {
-                        "y": 0.0, 
-                        "x": 0.0, 
-                        "z": 0.0
-                    }, 
-                    "bboxRotation": {
-                        "y": 0.0, 
-                        "x": 0.0, 
-                        "z": 0.0
-                    }
-                }, 
-                "minSolidAngleRatio": 0.2, 
-                "maxPoints": 5000000, 
-                "addMaskHelperPoints": false, 
-                "maxPointsPerVoxel": 1000000, 
-                "angleFactor": 15.0, 
-                "partitioning": "singleBlock", 
-                "estimateSpaceFromSfM": true, 
-                "minAngleThreshold": 1.0, 
-                "pixSizeMarginInitCoef": 2.0, 
-                "refineFuse": true, 
-                "maxNbConnectedHelperPoints": 50, 
-                "estimateSpaceMinObservations": 3, 
-                "invertTetrahedronBasedOnNeighborsNbIterations": 10, 
-                "maskBorderSize": 4, 
-                "simGaussianSize": 10.0, 
-                "densifyNbBack": 1
+                "input": "{DepthMapFilter_1.input}"
             }, 
             "nodeType": "Meshing", 
             "uids": {
@@ -169,17 +72,7 @@
         }, 
         "DepthMapFilter_1": {
             "inputs": {
-                "minNumOfConsistentCamsWithLowSimilarity": 4, 
-                "computeNormalMaps": false, 
-                "minNumOfConsistentCams": 3, 
                 "depthMapsFolder": "{DepthMap_1.output}", 
-                "verboseLevel": "info", 
-                "nNearestCams": 10, 
-                "pixSizeBallWithLowSimilarity": 0, 
-                "pixToleranceFactor": 2.0, 
-                "pixSizeBall": 0, 
-                "minViewAngle": 2.0, 
-                "maxViewAngle": 70.0, 
                 "input": "{DepthMap_1.input}"
             }, 
             "nodeType": "DepthMapFilter", 
@@ -202,15 +95,7 @@
         }, 
         "ImageMatching_1": {
             "inputs": {
-                "minNbImages": 200, 
-                "nbNeighbors": 5, 
-                "tree": "${ALICEVISION_VOCTREE}", 
-                "maxDescriptors": 500, 
-                "verboseLevel": "info", 
-                "weights": "", 
-                "nbMatches": 40, 
                 "input": "{FeatureExtraction_1.input}", 
-                "method": "SequentialAndVocabularyTree", 
                 "featuresFolders": [
                     "{FeatureExtraction_1.output}"
                 ]
@@ -235,20 +120,7 @@
         }, 
         "FeatureExtraction_1": {
             "inputs": {
-                "verboseLevel": "info", 
-                "maxThreads": 0, 
-                "describerTypes": [
-                    "dspsift"
-                ], 
-                "maxNbFeatures": 0, 
-                "relativePeakThreshold": 0.01, 
-                "forceCpuExtraction": true, 
-                "masksFolder": "", 
-                "contrastFiltering": "GridSort", 
-                "describerQuality": "normal", 
-                "gridFiltering": true, 
-                "input": "{CameraInit_1.output}", 
-                "describerPreset": "normal"
+                "input": "{CameraInit_1.output}"
             }, 
             "nodeType": "FeatureExtraction", 
             "uids": {
@@ -270,39 +142,12 @@
         }, 
         "StructureFromMotion_1": {
             "inputs": {
-                "localizerEstimatorMaxIterations": 4096, 
-                "minAngleForLandmark": 2.0, 
-                "filterTrackForks": false, 
-                "minNumberOfObservationsForTriangulation": 2, 
-                "maxAngleInitialPair": 40.0, 
-                "observationConstraint": "Scale", 
-                "maxNumberOfMatches": 0, 
-                "localizerEstimator": "acransac", 
                 "describerTypes": "{FeatureMatching_1.describerTypes}", 
-                "lockScenePreviouslyReconstructed": false, 
-                "localBAGraphDistance": 1, 
-                "minNbCamerasToRefinePrincipalPoint": 3, 
-                "lockAllIntrinsics": false, 
                 "input": "{FeatureMatching_1.input}", 
                 "featuresFolders": "{FeatureMatching_1.featuresFolders}", 
-                "useRigConstraint": true, 
-                "rigMinNbCamerasForCalibration": 20, 
-                "initialPairA": "", 
-                "initialPairB": "", 
-                "interFileExtension": ".abc", 
-                "useLocalBA": true, 
-                "computeStructureColor": true, 
                 "matchesFolders": [
                     "{FeatureMatching_1.output}"
-                ], 
-                "minInputTrackLength": 2, 
-                "useOnlyMatchesFromInputFolder": false, 
-                "verboseLevel": "info", 
-                "minAngleForTriangulation": 3.0, 
-                "maxReprojectionError": 4.0, 
-                "minAngleInitialPair": 5.0, 
-                "minNumberOfMatches": 0, 
-                "localizerEstimatorError": 0.0
+                ]
             }, 
             "nodeType": "StructureFromMotion", 
             "uids": {
@@ -326,14 +171,7 @@
         }, 
         "PrepareDenseScene_1": {
             "inputs": {
-                "imagesFolders": [], 
-                "masksFolders": [], 
-                "outputFileType": "exr", 
-                "verboseLevel": "info", 
-                "saveMatricesTxtFiles": false, 
-                "saveMetadata": true, 
-                "input": "{StructureFromMotion_1.output}", 
-                "evCorrection": false
+                "input": "{StructureFromMotion_1.output}"
             }, 
             "nodeType": "PrepareDenseScene", 
             "uids": {
@@ -355,28 +193,7 @@
             "internalFolder": "{cache}/{nodeType}/{uid0}/"
         }, 
         "CameraInit_1": {
-            "inputs": {
-                "groupCameraFallback": "folder", 
-                "intrinsics": [], 
-                "viewIdRegex": ".*?(\\d+)", 
-                "defaultFieldOfView": 45.0, 
-                "allowedCameraModels": [
-                    "pinhole", 
-                    "radial1", 
-                    "radial3", 
-                    "brown", 
-                    "fisheye4", 
-                    "fisheye1", 
-                    "3deanamorphic4", 
-                    "3deradial4", 
-                    "3declassicld"
-                ], 
-                "verboseLevel": "info", 
-                "viewIdMethod": "metadata", 
-                "viewpoints": [], 
-                "useInternalWhiteBalance": true, 
-                "sensorDatabase": "${ALICEVISION_SENSOR_DB}"
-            }, 
+            "inputs": {}, 
             "nodeType": "CameraInit", 
             "uids": {
                 "0": "f9436e97e444fa71a05aa5cf7639b206df8ba282"
@@ -397,37 +214,8 @@
         }, 
         "DepthMap_1": {
             "inputs": {
-                "sgmMaxDepthsPerTc": 1500, 
-                "sgmP2": 100.0, 
                 "imagesFolder": "{PrepareDenseScene_1.output}", 
-                "downscale": 2, 
-                "refineMaxTCams": 6, 
-                "exportIntermediateResults": false, 
-                "nbGPUs": 0, 
-                "refineNiters": 100, 
-                "refineGammaP": 8.0, 
-                "refineGammaC": 15.5, 
-                "sgmMaxDepths": 3000, 
-                "sgmUseSfmSeeds": true, 
-                "input": "{PrepareDenseScene_1.input}", 
-                "refineWSH": 3, 
-                "sgmP1": 10.0, 
-                "sgmFilteringAxes": "YX", 
-                "sgmMaxTCams": 10, 
-                "refineSigma": 15, 
-                "sgmScale": -1, 
-                "minViewAngle": 2.0, 
-                "maxViewAngle": 70.0, 
-                "sgmGammaC": 5.5, 
-                "sgmWSH": 4, 
-                "refineNSamplesHalf": 150, 
-                "sgmMaxSideXY": 700, 
-                "refineUseTcOrRcPixSize": false, 
-                "verboseLevel": "info", 
-                "sgmGammaP": 8.0, 
-                "sgmStepXY": -1, 
-                "refineNDepthsToRefine": 31, 
-                "sgmStepZ": -1
+                "input": "{PrepareDenseScene_1.input}"
             }, 
             "nodeType": "DepthMap", 
             "uids": {
@@ -449,18 +237,7 @@
         }, 
         "MeshFiltering_1": {
             "inputs": {
-                "filteringSubset": "all", 
-                "outputMeshFileType": "obj", 
-                "inputMesh": "{Meshing_1.outputMesh}", 
-                "filterTrianglesRatio": 0.0, 
-                "smoothingSubset": "all", 
-                "verboseLevel": "info", 
-                "smoothingIterations": 5, 
-                "filterLargeTrianglesFactor": 60.0, 
-                "keepLargestMeshOnly": false, 
-                "smoothingBoundariesNeighbours": 0, 
-                "smoothingLambda": 1.0, 
-                "filteringIterations": 1
+                "inputMesh": "{Meshing_1.outputMesh}"
             }, 
             "nodeType": "MeshFiltering", 
             "uids": {
@@ -482,23 +259,9 @@
         }, 
         "FeatureMatching_1": {
             "inputs": {
-                "verboseLevel": "info", 
                 "describerTypes": "{FeatureExtraction_1.describerTypes}", 
-                "exportDebugFiles": false, 
-                "crossMatching": false, 
-                "geometricError": 0.0, 
-                "maxMatches": 0, 
-                "matchFromKnownCameraPoses": false, 
-                "savePutativeMatches": false, 
-                "guidedMatching": false, 
                 "imagePairsList": "{ImageMatching_1.output}", 
-                "geometricEstimator": "acransac", 
-                "geometricFilterType": "fundamental_matrix", 
-                "maxIteration": 2048, 
-                "distanceRatio": 0.8, 
                 "input": "{ImageMatching_1.input}", 
-                "photometricMatchingMethod": "ANN_L2", 
-                "knownPosesGeometricErrorMax": 5.0, 
                 "featuresFolders": "{ImageMatching_1.featuresFolders}"
             }, 
             "nodeType": "FeatureMatching", 

--- a/meshroom/pipelines/photogrammetryAndCameraTracking.mg
+++ b/meshroom/pipelines/photogrammetryAndCameraTracking.mg
@@ -3,6 +3,7 @@
         "pipelineVersion": "2.2", 
         "releaseVersion": "2021.1.0", 
         "fileVersion": "1.1", 
+        "template": true, 
         "nodesVersions": {
             "ExportAnimatedCamera": "2.0", 
             "FeatureMatching": "2.0", 
@@ -17,9 +18,7 @@
     "graph": {
         "DistortionCalibration_1": {
             "inputs": {
-                "verboseLevel": "info", 
-                "input": "{CameraInit_2.output}", 
-                "lensGrid": []
+                "input": "{CameraInit_2.output}"
             }, 
             "nodeType": "DistortionCalibration", 
             "uids": {
@@ -41,15 +40,7 @@
         }, 
         "ImageMatching_1": {
             "inputs": {
-                "minNbImages": 200, 
-                "nbNeighbors": 5, 
-                "tree": "${ALICEVISION_VOCTREE}", 
-                "maxDescriptors": 500, 
-                "verboseLevel": "info", 
-                "weights": "", 
-                "nbMatches": 40, 
                 "input": "{FeatureExtraction_1.input}", 
-                "method": "SequentialAndVocabularyTree", 
                 "featuresFolders": [
                     "{FeatureExtraction_1.output}"
                 ]
@@ -74,20 +65,7 @@
         }, 
         "FeatureExtraction_1": {
             "inputs": {
-                "verboseLevel": "info", 
-                "maxThreads": 0, 
-                "describerTypes": [
-                    "dspsift"
-                ], 
-                "maxNbFeatures": 0, 
-                "relativePeakThreshold": 0.01, 
-                "forceCpuExtraction": true, 
-                "masksFolder": "", 
-                "contrastFiltering": "GridSort", 
-                "describerQuality": "normal", 
-                "gridFiltering": true, 
-                "input": "{CameraInit_1.output}", 
-                "describerPreset": "normal"
+                "input": "{CameraInit_1.output}"
             }, 
             "nodeType": "FeatureExtraction", 
             "uids": {
@@ -109,39 +87,12 @@
         }, 
         "StructureFromMotion_1": {
             "inputs": {
-                "localizerEstimatorMaxIterations": 4096, 
-                "minAngleForLandmark": 2.0, 
-                "filterTrackForks": false, 
-                "minNumberOfObservationsForTriangulation": 2, 
-                "maxAngleInitialPair": 40.0, 
-                "observationConstraint": "Scale", 
-                "maxNumberOfMatches": 0, 
-                "localizerEstimator": "acransac", 
                 "describerTypes": "{FeatureMatching_1.describerTypes}", 
-                "lockScenePreviouslyReconstructed": false, 
-                "localBAGraphDistance": 1, 
-                "minNbCamerasToRefinePrincipalPoint": 3, 
-                "lockAllIntrinsics": false, 
                 "input": "{FeatureMatching_1.input}", 
                 "featuresFolders": "{FeatureMatching_1.featuresFolders}", 
-                "useRigConstraint": true, 
-                "rigMinNbCamerasForCalibration": 20, 
-                "initialPairA": "", 
-                "initialPairB": "", 
-                "interFileExtension": ".abc", 
-                "useLocalBA": true, 
-                "computeStructureColor": true, 
                 "matchesFolders": [
                     "{FeatureMatching_1.output}"
-                ], 
-                "minInputTrackLength": 2, 
-                "useOnlyMatchesFromInputFolder": false, 
-                "verboseLevel": "info", 
-                "minAngleForTriangulation": 3.0, 
-                "maxReprojectionError": 4.0, 
-                "minAngleInitialPair": 5.0, 
-                "minNumberOfMatches": 0, 
-                "localizerEstimatorError": 0.0
+                ]
             }, 
             "nodeType": "StructureFromMotion", 
             "uids": {
@@ -165,15 +116,8 @@
         }, 
         "ExportAnimatedCamera_1": {
             "inputs": {
-                "exportFullROD": false, 
-                "undistortedImageType": "exr", 
-                "exportUVMaps": true, 
-                "verboseLevel": "info", 
                 "sfmDataFilter": "{StructureFromMotion_1.output}", 
-                "exportUndistortedImages": false, 
-                "input": "{StructureFromMotion_2.output}", 
-                "viewFilter": "", 
-                "correctPrincipalPoint": true
+                "input": "{StructureFromMotion_2.output}"
             }, 
             "nodeType": "ExportAnimatedCamera", 
             "uids": {
@@ -196,28 +140,7 @@
             "internalFolder": "{cache}/{nodeType}/{uid0}/"
         }, 
         "CameraInit_1": {
-            "inputs": {
-                "groupCameraFallback": "folder", 
-                "intrinsics": [], 
-                "viewIdRegex": ".*?(\\d+)", 
-                "defaultFieldOfView": 45.0, 
-                "allowedCameraModels": [
-                    "pinhole", 
-                    "radial1", 
-                    "radial3", 
-                    "brown", 
-                    "fisheye4", 
-                    "fisheye1", 
-                    "3deanamorphic4", 
-                    "3deradial4", 
-                    "3declassicld"
-                ], 
-                "verboseLevel": "info", 
-                "viewIdMethod": "metadata", 
-                "viewpoints": [], 
-                "useInternalWhiteBalance": true, 
-                "sensorDatabase": "${ALICEVISION_SENSOR_DB}"
-            }, 
+            "inputs": {}, 
             "nodeType": "CameraInit", 
             "uids": {
                 "0": "f9436e97e444fa71a05aa5cf7639b206df8ba282"
@@ -238,17 +161,10 @@
         }, 
         "ImageMatchingMultiSfM_1": {
             "inputs": {
-                "minNbImages": 200, 
-                "matchingMode": "a/a+a/b", 
                 "nbNeighbors": 10, 
-                "tree": "${ALICEVISION_VOCTREE}", 
                 "nbMatches": 5, 
-                "verboseLevel": "info", 
-                "weights": "", 
-                "maxDescriptors": 500, 
                 "input": "{FeatureExtraction_2.input}", 
                 "inputB": "{StructureFromMotion_1.output}", 
-                "method": "SequentialAndVocabularyTree", 
                 "featuresFolders": [
                     "{FeatureExtraction_2.output}"
                 ]
@@ -273,28 +189,7 @@
             "internalFolder": "{cache}/{nodeType}/{uid0}/"
         }, 
         "CameraInit_2": {
-            "inputs": {
-                "groupCameraFallback": "folder", 
-                "intrinsics": [], 
-                "viewIdRegex": ".*?(\\d+)", 
-                "defaultFieldOfView": 45.0, 
-                "allowedCameraModels": [
-                    "pinhole", 
-                    "radial1", 
-                    "radial3", 
-                    "brown", 
-                    "fisheye4", 
-                    "fisheye1", 
-                    "3deanamorphic4", 
-                    "3deradial4", 
-                    "3declassicld"
-                ], 
-                "verboseLevel": "info", 
-                "viewIdMethod": "metadata", 
-                "viewpoints": [], 
-                "useInternalWhiteBalance": true, 
-                "sensorDatabase": "${ALICEVISION_SENSOR_DB}"
-            }, 
+            "inputs": {}, 
             "nodeType": "CameraInit", 
             "uids": {
                 "0": "f9436e97e444fa71a05aa5cf7639b206df8ba282"
@@ -315,20 +210,7 @@
         }, 
         "FeatureExtraction_2": {
             "inputs": {
-                "verboseLevel": "info", 
-                "maxThreads": 0, 
-                "describerTypes": [
-                    "dspsift"
-                ], 
-                "maxNbFeatures": 0, 
-                "relativePeakThreshold": 0.01, 
-                "forceCpuExtraction": true, 
-                "masksFolder": "", 
-                "contrastFiltering": "GridSort", 
-                "describerQuality": "normal", 
-                "gridFiltering": true, 
-                "input": "{CameraInit_2.output}", 
-                "describerPreset": "normal"
+                "input": "{CameraInit_2.output}"
             }, 
             "nodeType": "FeatureExtraction", 
             "uids": {
@@ -350,23 +232,9 @@
         }, 
         "FeatureMatching_2": {
             "inputs": {
-                "verboseLevel": "info", 
                 "describerTypes": "{FeatureExtraction_2.describerTypes}", 
-                "exportDebugFiles": false, 
-                "crossMatching": false, 
-                "geometricError": 0.0, 
-                "maxMatches": 0, 
-                "matchFromKnownCameraPoses": false, 
-                "savePutativeMatches": false, 
-                "guidedMatching": false, 
                 "imagePairsList": "{ImageMatchingMultiSfM_1.output}", 
-                "geometricEstimator": "acransac", 
-                "geometricFilterType": "fundamental_matrix", 
-                "maxIteration": 2048, 
-                "distanceRatio": 0.8, 
                 "input": "{DistortionCalibration_1.outSfMData}", 
-                "photometricMatchingMethod": "ANN_L2", 
-                "knownPosesGeometricErrorMax": 5.0, 
                 "featuresFolders": "{ImageMatchingMultiSfM_1.featuresFolders}"
             }, 
             "nodeType": "FeatureMatching", 
@@ -389,23 +257,9 @@
         }, 
         "FeatureMatching_1": {
             "inputs": {
-                "verboseLevel": "info", 
                 "describerTypes": "{FeatureExtraction_1.describerTypes}", 
-                "exportDebugFiles": false, 
-                "crossMatching": false, 
-                "geometricError": 0.0, 
-                "maxMatches": 0, 
-                "matchFromKnownCameraPoses": false, 
-                "savePutativeMatches": false, 
-                "guidedMatching": false, 
                 "imagePairsList": "{ImageMatching_1.output}", 
-                "geometricEstimator": "acransac", 
-                "geometricFilterType": "fundamental_matrix", 
-                "maxIteration": 2048, 
-                "distanceRatio": 0.8, 
                 "input": "{ImageMatching_1.input}", 
-                "photometricMatchingMethod": "ANN_L2", 
-                "knownPosesGeometricErrorMax": 5.0, 
                 "featuresFolders": "{ImageMatching_1.featuresFolders}"
             }, 
             "nodeType": "FeatureMatching", 
@@ -428,39 +282,16 @@
         }, 
         "StructureFromMotion_2": {
             "inputs": {
-                "localizerEstimatorMaxIterations": 4096, 
                 "minAngleForLandmark": 0.5, 
-                "filterTrackForks": false, 
                 "minNumberOfObservationsForTriangulation": 3, 
-                "maxAngleInitialPair": 40.0, 
-                "observationConstraint": "Scale", 
-                "maxNumberOfMatches": 0, 
-                "localizerEstimator": "acransac", 
                 "describerTypes": "{FeatureMatching_2.describerTypes}", 
-                "lockScenePreviouslyReconstructed": false, 
-                "localBAGraphDistance": 1, 
-                "minNbCamerasToRefinePrincipalPoint": 3, 
-                "lockAllIntrinsics": false, 
                 "input": "{FeatureMatching_2.input}", 
                 "featuresFolders": "{FeatureMatching_2.featuresFolders}", 
-                "useRigConstraint": true, 
-                "rigMinNbCamerasForCalibration": 20, 
-                "initialPairA": "", 
-                "initialPairB": "", 
-                "interFileExtension": ".abc", 
-                "useLocalBA": true, 
-                "computeStructureColor": true, 
                 "matchesFolders": [
                     "{FeatureMatching_2.output}"
                 ], 
                 "minInputTrackLength": 5, 
-                "useOnlyMatchesFromInputFolder": false, 
-                "verboseLevel": "info", 
-                "minAngleForTriangulation": 1.0, 
-                "maxReprojectionError": 4.0, 
-                "minAngleInitialPair": 5.0, 
-                "minNumberOfMatches": 0, 
-                "localizerEstimatorError": 0.0
+                "minAngleForTriangulation": 1.0
             }, 
             "nodeType": "StructureFromMotion", 
             "uids": {

--- a/meshroom/pipelines/photogrammetryDraft.mg
+++ b/meshroom/pipelines/photogrammetryDraft.mg
@@ -4,60 +4,21 @@
             "FeatureMatching": "2.0", 
             "MeshFiltering": "3.0", 
             "Texturing": "6.0", 
-            "Meshing": "7.0", 
+            "StructureFromMotion": "2.0", 
             "CameraInit": "7.0", 
             "ImageMatching": "2.0", 
             "FeatureExtraction": "1.1", 
-            "StructureFromMotion": "2.0"
+            "Meshing": "7.0"
         }, 
         "releaseVersion": "2021.1.0", 
-        "fileVersion": "1.1"
+        "fileVersion": "1.1", 
+        "template": true
     }, 
     "graph": {
         "Texturing_1": {
             "inputs": {
-                "imagesFolder": "", 
-                "downscale": 2, 
-                "bumpMapping": {
-                    "normalFileType": "exr", 
-                    "enable": true, 
-                    "bumpType": "Normal", 
-                    "heightFileType": "exr"
-                }, 
-                "forceVisibleByAllVertices": false, 
-                "fillHoles": false, 
-                "multiBandDownscale": 4, 
-                "useScore": true, 
-                "displacementMapping": {
-                    "displacementMappingFileType": "exr", 
-                    "enable": true
-                }, 
-                "outputMeshFileType": "obj", 
-                "angleHardThreshold": 90.0, 
-                "textureSide": 8192, 
-                "processColorspace": "sRGB", 
                 "input": "{Meshing_1.output}", 
-                "useUDIM": true, 
-                "subdivisionTargetRatio": 0.8, 
-                "padding": 5, 
-                "inputRefMesh": "", 
-                "correctEV": false, 
-                "visibilityRemappingMethod": "PullPush", 
-                "inputMesh": "{MeshFiltering_1.outputMesh}", 
-                "verboseLevel": "info", 
-                "colorMapping": {
-                    "enable": true, 
-                    "colorMappingFileType": "exr"
-                }, 
-                "bestScoreThreshold": 0.1, 
-                "unwrapMethod": "Basic", 
-                "multiBandNbContrib": {
-                    "high": 1, 
-                    "midHigh": 5, 
-                    "low": 0, 
-                    "midLow": 10
-                }, 
-                "flipNormals": false
+                "inputMesh": "{MeshFiltering_1.outputMesh}"
             }, 
             "nodeType": "Texturing", 
             "uids": {
@@ -82,67 +43,7 @@
         }, 
         "Meshing_1": {
             "inputs": {
-                "exportDebugTetrahedralization": false, 
-                "useBoundingBox": false, 
-                "maxInputPoints": 50000000, 
-                "repartition": "multiResolution", 
-                "helperPointsGridSize": 10, 
-                "seed": 0, 
-                "voteFilteringForWeaklySupportedSurfaces": true, 
-                "verboseLevel": "info", 
-                "outputMeshFileType": "obj", 
-                "simGaussianSizeInit": 10.0, 
-                "nPixelSizeBehind": 4.0, 
-                "fullWeight": 1.0, 
-                "depthMapsFolder": "", 
-                "densify": false, 
-                "simFactor": 15.0, 
-                "maskHelperPointsWeight": 1.0, 
-                "densifyScale": 20.0, 
-                "input": "{StructureFromMotion_1.output}", 
-                "addLandmarksToTheDensePointCloud": false, 
-                "voteMarginFactor": 4.0, 
-                "saveRawDensePointCloud": false, 
-                "contributeMarginFactor": 2.0, 
-                "estimateSpaceMinObservationAngle": 10, 
-                "nbSolidAngleFilteringIterations": 2, 
-                "minStep": 2, 
-                "colorizeOutput": false, 
-                "pixSizeMarginFinalCoef": 4.0, 
-                "densifyNbFront": 1, 
-                "boundingBox": {
-                    "bboxScale": {
-                        "y": 1.0, 
-                        "x": 1.0, 
-                        "z": 1.0
-                    }, 
-                    "bboxTranslation": {
-                        "y": 0.0, 
-                        "x": 0.0, 
-                        "z": 0.0
-                    }, 
-                    "bboxRotation": {
-                        "y": 0.0, 
-                        "x": 0.0, 
-                        "z": 0.0
-                    }
-                }, 
-                "minSolidAngleRatio": 0.2, 
-                "maxPoints": 5000000, 
-                "addMaskHelperPoints": false, 
-                "maxPointsPerVoxel": 1000000, 
-                "angleFactor": 15.0, 
-                "partitioning": "singleBlock", 
-                "estimateSpaceFromSfM": true, 
-                "minAngleThreshold": 1.0, 
-                "pixSizeMarginInitCoef": 2.0, 
-                "refineFuse": true, 
-                "maxNbConnectedHelperPoints": 50, 
-                "estimateSpaceMinObservations": 3, 
-                "invertTetrahedronBasedOnNeighborsNbIterations": 10, 
-                "maskBorderSize": 4, 
-                "simGaussianSize": 10.0, 
-                "densifyNbBack": 1
+                "input": "{StructureFromMotion_1.output}"
             }, 
             "nodeType": "Meshing", 
             "uids": {
@@ -165,15 +66,7 @@
         }, 
         "ImageMatching_1": {
             "inputs": {
-                "minNbImages": 200, 
-                "nbNeighbors": 5, 
-                "tree": "${ALICEVISION_VOCTREE}", 
-                "maxDescriptors": 500, 
-                "verboseLevel": "info", 
-                "weights": "", 
-                "nbMatches": 40, 
                 "input": "{FeatureExtraction_1.input}", 
-                "method": "SequentialAndVocabularyTree", 
                 "featuresFolders": [
                     "{FeatureExtraction_1.output}"
                 ]
@@ -198,20 +91,7 @@
         }, 
         "FeatureExtraction_1": {
             "inputs": {
-                "verboseLevel": "info", 
-                "maxThreads": 0, 
-                "describerTypes": [
-                    "dspsift"
-                ], 
-                "maxNbFeatures": 0, 
-                "relativePeakThreshold": 0.01, 
-                "forceCpuExtraction": true, 
-                "masksFolder": "", 
-                "contrastFiltering": "GridSort", 
-                "describerQuality": "normal", 
-                "gridFiltering": true, 
-                "input": "{CameraInit_1.output}", 
-                "describerPreset": "normal"
+                "input": "{CameraInit_1.output}"
             }, 
             "nodeType": "FeatureExtraction", 
             "uids": {
@@ -233,39 +113,12 @@
         }, 
         "StructureFromMotion_1": {
             "inputs": {
-                "localizerEstimatorMaxIterations": 4096, 
-                "minAngleForLandmark": 2.0, 
-                "filterTrackForks": false, 
-                "minNumberOfObservationsForTriangulation": 2, 
-                "maxAngleInitialPair": 40.0, 
-                "observationConstraint": "Scale", 
-                "maxNumberOfMatches": 0, 
-                "localizerEstimator": "acransac", 
                 "describerTypes": "{FeatureMatching_1.describerTypes}", 
-                "lockScenePreviouslyReconstructed": false, 
-                "localBAGraphDistance": 1, 
-                "minNbCamerasToRefinePrincipalPoint": 3, 
-                "lockAllIntrinsics": false, 
                 "input": "{FeatureMatching_1.input}", 
                 "featuresFolders": "{FeatureMatching_1.featuresFolders}", 
-                "useRigConstraint": true, 
-                "rigMinNbCamerasForCalibration": 20, 
-                "initialPairA": "", 
-                "initialPairB": "", 
-                "interFileExtension": ".abc", 
-                "useLocalBA": true, 
-                "computeStructureColor": true, 
                 "matchesFolders": [
                     "{FeatureMatching_1.output}"
-                ], 
-                "minInputTrackLength": 2, 
-                "useOnlyMatchesFromInputFolder": false, 
-                "verboseLevel": "info", 
-                "minAngleForTriangulation": 3.0, 
-                "maxReprojectionError": 4.0, 
-                "minAngleInitialPair": 5.0, 
-                "minNumberOfMatches": 0, 
-                "localizerEstimatorError": 0.0
+                ]
             }, 
             "nodeType": "StructureFromMotion", 
             "uids": {
@@ -288,28 +141,7 @@
             "internalFolder": "{cache}/{nodeType}/{uid0}/"
         }, 
         "CameraInit_1": {
-            "inputs": {
-                "groupCameraFallback": "folder", 
-                "intrinsics": [], 
-                "viewIdRegex": ".*?(\\d+)", 
-                "defaultFieldOfView": 45.0, 
-                "allowedCameraModels": [
-                    "pinhole", 
-                    "radial1", 
-                    "radial3", 
-                    "brown", 
-                    "fisheye4", 
-                    "fisheye1", 
-                    "3deanamorphic4", 
-                    "3deradial4", 
-                    "3declassicld"
-                ], 
-                "verboseLevel": "info", 
-                "viewIdMethod": "metadata", 
-                "viewpoints": [], 
-                "useInternalWhiteBalance": true, 
-                "sensorDatabase": "${ALICEVISION_SENSOR_DB}"
-            }, 
+            "inputs": {}, 
             "nodeType": "CameraInit", 
             "uids": {
                 "0": "f9436e97e444fa71a05aa5cf7639b206df8ba282"
@@ -330,18 +162,7 @@
         }, 
         "MeshFiltering_1": {
             "inputs": {
-                "filteringSubset": "all", 
-                "outputMeshFileType": "obj", 
-                "inputMesh": "{Meshing_1.outputMesh}", 
-                "filterTrianglesRatio": 0.0, 
-                "smoothingSubset": "all", 
-                "verboseLevel": "info", 
-                "smoothingIterations": 5, 
-                "filterLargeTrianglesFactor": 60.0, 
-                "keepLargestMeshOnly": false, 
-                "smoothingBoundariesNeighbours": 0, 
-                "smoothingLambda": 1.0, 
-                "filteringIterations": 1
+                "inputMesh": "{Meshing_1.outputMesh}"
             }, 
             "nodeType": "MeshFiltering", 
             "uids": {
@@ -363,23 +184,9 @@
         }, 
         "FeatureMatching_1": {
             "inputs": {
-                "verboseLevel": "info", 
                 "describerTypes": "{FeatureExtraction_1.describerTypes}", 
-                "exportDebugFiles": false, 
-                "crossMatching": false, 
-                "geometricError": 0.0, 
-                "maxMatches": 0, 
-                "matchFromKnownCameraPoses": false, 
-                "savePutativeMatches": false, 
-                "guidedMatching": false, 
                 "imagePairsList": "{ImageMatching_1.output}", 
-                "geometricEstimator": "acransac", 
-                "geometricFilterType": "fundamental_matrix", 
-                "maxIteration": 2048, 
-                "distanceRatio": 0.8, 
                 "input": "{ImageMatching_1.input}", 
-                "photometricMatchingMethod": "ANN_L2", 
-                "knownPosesGeometricErrorMax": 5.0, 
                 "featuresFolders": "{ImageMatching_1.featuresFolders}"
             }, 
             "nodeType": "FeatureMatching", 

--- a/meshroom/ui/app.py
+++ b/meshroom/ui/app.py
@@ -188,6 +188,12 @@ class MeshroomApp(QApplication):
             templates.append(variant)
         return templates
 
+    @Slot()
+    def reloadTemplateList(self):
+        for f in meshroom.core.pipelineTemplatesFolders:
+            meshroom.core.loadPipelineTemplates(f)
+        self.pipelineTemplateFilesChanged.emit()
+
     def _recentProjectFiles(self):
         projects = []
         settings = QSettings()

--- a/meshroom/ui/graph.py
+++ b/meshroom/ui/graph.py
@@ -354,6 +354,14 @@ class UIGraph(QObject):
 
     @Slot(QUrl)
     def saveAs(self, url):
+        self._saveAs(url)
+
+    @Slot(QUrl)
+    def saveAsTemplate(self, url):
+        self._saveAs(url, setupProjectFile=False, template=True)
+
+    def _saveAs(self, url, setupProjectFile=True, template=False):
+        """ Helper function for 'save as' features. """
         if isinstance(url, (str)):
             localFile = url
         else:
@@ -361,7 +369,7 @@ class UIGraph(QObject):
         # ensure file is saved with ".mg" extension
         if os.path.splitext(localFile)[-1] != ".mg":
             localFile += ".mg"
-        self._graph.save(localFile)
+        self._graph.save(localFile, setupProjectFile=setupProjectFile, template=template)
         self._undoStack.setClean()
         # saving file on disk impacts cache folder location
         # => force re-evaluation of monitored status files paths

--- a/meshroom/ui/qml/main.qml
+++ b/meshroom/ui/qml/main.qml
@@ -154,6 +154,7 @@ ApplicationWindow {
         onAccepted: {
             _reconstruction.saveAsTemplate(file)
             closed(Platform.Dialog.Accepted)
+            MeshroomApp.reloadTemplateList()
         }
         onRejected: closed(Platform.Dialog.Rejected)
     }

--- a/meshroom/ui/qml/main.qml
+++ b/meshroom/ui/qml/main.qml
@@ -142,6 +142,22 @@ ApplicationWindow {
         onRejected: closed(Platform.Dialog.Rejected)
     }
 
+    Platform.FileDialog {
+        id: saveTemplateDialog
+
+        signal closed(var result)
+
+        title: "Save Template"
+        nameFilters: ["Meshroom Graphs (*.mg)"]
+        defaultSuffix: ".mg"
+        fileMode: Platform.FileDialog.SaveFile
+        onAccepted: {
+            _reconstruction.saveAsTemplate(file)
+            closed(Platform.Dialog.Accepted)
+        }
+        onRejected: closed(Platform.Dialog.Rejected)
+    }
+
     Item {
         id: computeManager
 
@@ -548,6 +564,17 @@ ApplicationWindow {
                         saveFileDialog.folder = Filepath.stringToUrl(Filepath.dirname(_reconstruction.graph.filepath))
                     }
                     saveFileDialog.open()
+                }
+            }
+            Action {
+                id: saveAsTemplateAction
+                text: "Save As Template..."
+                shortcut: "Ctrl+Shift+T"
+                onTriggered: {
+                    if(_reconstruction.graph && _reconstruction.graph.filepath) {
+                        saveTemplateDialog.folder = Filepath.stringToUrl(Filepath.dirname(_reconstruction.graph.filepath))
+                    }
+                    saveTemplateDialog.open()
                 }
             }
             MenuSeparator { }


### PR DESCRIPTION
## Description

Following #1727, project files can be used as templates, with the .mg files containing the entire description of the graph. This implies that if there is a single node whose description is modified (parameters added, parameters removed, etc.), description conflicts will arise when opening a template containing such a node. For these conflicts to be resolved, the template would need to be saved again with the upgraded version of the node every single time there is a change, which defeats the purpose of having templates.

This PR adds a "minimal" mode to save and load templates. Instead of saving the entire graph description, the minimal mode only saves the modified input/output parameters. When that template is opened, conflicts are detected only on the saved parameters (with non-default values) and automatically solved. This makes templates robust to changes in node descriptions.

## Features list

- [x] Support saving only modified input/output parameters of a graph in an .mg file
- [x] Support reading an .mg file containing only modified input/output parameters
- [x] Add a "Save As Template" option that saves a graph in minimal mode
- [x] Update all the existing templates with minimal mode
- [x] Reload the list of available templates after saving a graph as a template 

## Implementation remarks

- Files written in minimal mode can be identified with the flag "template: True" in the header. If that flag is not detected in an .mg file, it is loaded as a regular file and not a template.
- .mg files written normally (with all the parameters saved) can still be opened as templates, but they will not be robust to any node description changes.
- test_multiviewPipeline now tests both "minimal" and "regular" modes: the first part of the test opens the default Photogrammetry template (which has been updated to minimal mode) while the second part of the test saves the graph obtained after reading the template into a normal .mg file (in which all the input/output parameters are written).