### PR TITLE
[ui] Update intrinsics table when switching between groups

### DIFF
--- a/meshroom/ui/qml/ImageGallery/ImageGallery.qml
+++ b/meshroom/ui/qml/ImageGallery/ImageGallery.qml
@@ -48,6 +48,10 @@ Panel {
         parseIntr()
     }
 
+    onCameraInitIndexChanged: {
+        parseIntr()
+    }
+
     function changeCurrentIndex(newIndex) {
         _reconstruction.cameraInitIndex = newIndex
     }


### PR DESCRIPTION
## Description

This PR fixes a UI bug that would cause the displayed intrinsics table to always be the first CameraInit node's, no matter which group the user wanted to display. The intrinsics table was loaded once on the first CameraInit node and never reloaded after that, so if there was more than a single CameraInit node in the graph, the corresponding tables could not be displayed.

The intrinsics table is now correctly reloaded when the group index is changed. 
