### PR TITLE
Support copying/pasting a node in the Graph Editor

### DIFF
--- a/meshroom/core/graph.py
+++ b/meshroom/core/graph.py
@@ -396,11 +396,11 @@ class Graph(BaseObject):
 
         return duplicates
 
-    def pasteNode(self, nodeType, **kwargs):
+    def pasteNode(self, nodeType, position, **kwargs):
         name = self._createUniqueNodeName(nodeType)
         node = None
         with GraphModification(self):
-            node = Node(nodeType, **kwargs)
+            node = Node(nodeType, position=position, **kwargs)
             self._addNode(node, name)
             self._applyExpr()
         return node

--- a/meshroom/core/graph.py
+++ b/meshroom/core/graph.py
@@ -396,6 +396,15 @@ class Graph(BaseObject):
 
         return duplicates
 
+    def pasteNode(self, nodeType, **kwargs):
+        name = self._createUniqueNodeName(nodeType)
+        node = None
+        with GraphModification(self):
+            node = Node(nodeType, **kwargs)
+            self._addNode(node, name)
+            self._applyExpr()
+        return node
+
     def outEdges(self, attribute):
         """ Return the list of edges starting from the given attribute """
         # type: (Attribute,) -> [Edge]

--- a/meshroom/ui/commands.py
+++ b/meshroom/ui/commands.py
@@ -199,14 +199,15 @@ class PasteNodeCommand(GraphCommand):
     """
     Handle node pasting in a Graph.
     """
-    def __init__(self, graph, nodeType, parent=None, **kwargs):
+    def __init__(self, graph, nodeType, position=None, parent=None, **kwargs):
         super(PasteNodeCommand, self).__init__(graph, parent)
         self.nodeType = nodeType
+        self.position = position
         self.nodeName = None
         self.kwargs = kwargs
 
     def redoImpl(self):
-        node = self.graph.pasteNode(self.nodeType, **self.kwargs)
+        node = self.graph.pasteNode(self.nodeType, self.position, **self.kwargs)
         self.nodeName = node.name
         self.setText("Paste Node {}".format(self.nodeName))
         return node

--- a/meshroom/ui/commands.py
+++ b/meshroom/ui/commands.py
@@ -195,6 +195,26 @@ class DuplicateNodesCommand(GraphCommand):
             self.graph.removeNode(duplicate)
 
 
+class PasteNodeCommand(GraphCommand):
+    """
+    Handle node pasting in a Graph.
+    """
+    def __init__(self, graph, nodeType, parent=None, **kwargs):
+        super(PasteNodeCommand, self).__init__(graph, parent)
+        self.nodeType = nodeType
+        self.nodeName = None
+        self.kwargs = kwargs
+
+    def redoImpl(self):
+        node = self.graph.pasteNode(self.nodeType, **self.kwargs)
+        self.nodeName = node.name
+        self.setText("Paste Node {}".format(self.nodeName))
+        return node
+
+    def undoImpl(self):
+        self.graph.removeNode(self.nodeName)
+
+
 class SetAttributeCommand(GraphCommand):
     def __init__(self, graph, attribute, value, parent=None):
         super(SetAttributeCommand, self).__init__(graph, parent)

--- a/meshroom/ui/components/clipboard.py
+++ b/meshroom/ui/components/clipboard.py
@@ -11,6 +11,13 @@ class ClipboardHelper(QObject):
         super(ClipboardHelper, self).__init__(parent)
         self._clipboard = QClipboard(parent=self)
 
+    def __del__(self):
+        # Workaround to avoid the "QXcbClipboard: Unable to receive an event from the clipboard manager
+        # in a reasonable time" that will hold up the application when exiting if the clipboard has been
+        # used at least once and its content exceeds a certain size (on X11/XCB).
+        # The bug occurs in QClipboard and is present on all Qt5 versions.
+        self.clear()
+
     @Slot(str)
     def setText(self, value):
         self._clipboard.setText(value)

--- a/meshroom/ui/components/clipboard.py
+++ b/meshroom/ui/components/clipboard.py
@@ -15,6 +15,10 @@ class ClipboardHelper(QObject):
     def setText(self, value):
         self._clipboard.setText(value)
 
+    @Slot(result=str)
+    def getText(self):
+        return self._clipboard.text()
+
     @Slot()
     def clear(self):
         self._clipboard.clear()

--- a/meshroom/ui/graph.py
+++ b/meshroom/ui/graph.py
@@ -3,6 +3,7 @@
 import logging
 import os
 import time
+import json
 from enum import Enum
 from threading import Thread, Event, Lock
 from multiprocessing.pool import ThreadPool
@@ -752,6 +753,18 @@ class UIGraph(QObject):
     def clearNodeHover(self):
         """ Reset currently hovered node to None. """
         self.hoveredNode = None
+
+    @Slot(result=str)
+    def getSelectedNodeContent(self):
+        """
+        Return the content of the currently selected node in a string, formatted to JSON.
+        If no node is currently selected, an empty string is returned.
+        """
+        if self._selectedNode:
+            d = self._graph.toDict()
+            node = d[self._selectedNode.name]
+            return json.dumps(node, indent=4)
+        return ''
 
     undoStack = Property(QObject, lambda self: self._undoStack, constant=True)
     graphChanged = Signal()

--- a/meshroom/ui/graph.py
+++ b/meshroom/ui/graph.py
@@ -766,8 +766,8 @@ class UIGraph(QObject):
             return json.dumps(node, indent=4)
         return ''
 
-    @Slot(str)
-    def pasteNode(self, clipboardContent):
+    @Slot(str, QPoint)
+    def pasteNode(self, clipboardContent, position=None):
         """
         Parse the content of the clipboard to see whether it contains
         a valid node description. If that is the case, the node described
@@ -802,7 +802,10 @@ class UIGraph(QObject):
         attributes.update(d.get("inputs", {}))
         attributes.update(d.get("outputs", {}))
 
-        self.push(commands.PasteNodeCommand(self._graph, nodeType, **attributes))
+        if isinstance(position, QPoint):
+            position = Position(position.x(), position.y())
+
+        self.push(commands.PasteNodeCommand(self._graph, nodeType, position=position, **attributes))
 
     undoStack = Property(QObject, lambda self: self._undoStack, constant=True)
     graphChanged = Signal()

--- a/meshroom/ui/qml/GraphEditor/GraphEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/GraphEditor.qml
@@ -75,17 +75,31 @@ Item {
         uigraph.selectNodes(nodes)
     }
 
+    /// Copy node content to clipboard
+    function copyNode()
+    {
+        var nodeContent = uigraph.getSelectedNodeContent()
+        if (nodeContent !== '') {
+            Clipboard.clear()
+            Clipboard.setText(nodeContent)
+        }
+    }
+
 
     Keys.onPressed: {
-        if(event.key === Qt.Key_F)
+        if (event.key === Qt.Key_F)
             fit()
-        if(event.key === Qt.Key_Delete)
-            if(event.modifiers == Qt.AltModifier)
+        if (event.key === Qt.Key_Delete)
+            if (event.modifiers == Qt.AltModifier)
                 uigraph.removeNodesFrom(uigraph.selectedNodes)
             else
                 uigraph.removeNodes(uigraph.selectedNodes)
-        if(event.key === Qt.Key_D)
+        if (event.key === Qt.Key_D)
             duplicateNode(event.modifiers == Qt.AltModifier)
+
+        if (event.key === Qt.Key_C)
+            if (event.modifiers == Qt.ControlModifier)
+                copyNode()
     }
 
     MouseArea {

--- a/meshroom/ui/qml/GraphEditor/GraphEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/GraphEditor.qml
@@ -41,6 +41,7 @@ Item {
     clip: true
 
     SystemPalette { id: activePalette }
+    property point pastePosition
 
     /// Get node delegate for the given node object
     function nodeDelegate(node)
@@ -88,8 +89,9 @@ Item {
     /// Paste content of clipboard to graph editor and create new node if valid
     function pasteNode()
     {
+        root.pastePosition = mapToItem(draggable, mouseArea.mouseX, mouseArea.mouseY)
         var copiedContent = Clipboard.getText()
-        uigraph.pasteNode(copiedContent)
+        uigraph.pasteNode(copiedContent, root.pastePosition)
     }
 
     Keys.onPressed: {

--- a/meshroom/ui/qml/GraphEditor/GraphEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/GraphEditor.qml
@@ -85,6 +85,12 @@ Item {
         }
     }
 
+    /// Paste content of clipboard to graph editor and create new node if valid
+    function pasteNode()
+    {
+        var copiedContent = Clipboard.getText()
+        uigraph.pasteNode(copiedContent)
+    }
 
     Keys.onPressed: {
         if (event.key === Qt.Key_F)
@@ -100,6 +106,9 @@ Item {
         if (event.key === Qt.Key_C)
             if (event.modifiers == Qt.ControlModifier)
                 copyNode()
+        if (event.key === Qt.Key_V)
+            if (event.modifiers == Qt.ControlModifier)
+                pasteNode()
     }
 
     MouseArea {


### PR DESCRIPTION
## Description

This PR adds support for copying (Ctrl+C) and pasting (Ctrl+V) a node.
- Copy: if a node is currently selected, its content will be formatted to JSON (in the same manner as when a graph is saved to an .mg file) and copied to the system's clipboard. It can then be pasted anywhere.
- Paste: if the system's clipboard contains a correctly formatted node description, even if it does not contain any attribute, a node corresponding to that description will be created and added to the graph. If the clipboard does not contain a valid node description and there still is an attempt to paste its content in the Graph Editor, nothing will happen. The clipboard's content must be formatted to JSON to be considered valid. For example, `{
"nodeType": "CameraInit"
}` is a valid description of a default CameraInit node (with all its attributes set to their default values). 


## Features list

- [X] Format to JSON and copy a selected node to the system's clipboard when Ctrl+C is pressed in the Graph Editor
- [X] Parse the clipboard's content and, if it contains a valid and correctly formatted node description, create and add a node to the graph with that description when Ctrl+V is pressed in the Graph Editor

## Implementation remarks

- The clipboard must be cleared when exiting Meshroom because of an issue in the QClipboard object that occurs on Unix systems with X11/XCB. See https://bugreports.qt.io/browse/QTBUG-56456. 
- If the node description in the clipboard contains a position, it is ignored when pasting it into the Graph Editor. The node will be created and placed where the mouse is placed (the top left corner of the node will be placed right under the mouse).