### PR TITLE
[ui] Display computation time for "running" or "finished" nodes

### DIFF
--- a/meshroom/core/node.py
+++ b/meshroom/core/node.py
@@ -387,6 +387,9 @@ class NodeChunk(BaseObject):
     def isFinishedOrRunning(self):
         return self._status.status in (Status.SUCCESS, Status.RUNNING)
 
+    def isRunning(self):
+        return self._status.status == Status.RUNNING
+
     def isStopped(self):
         return self._status.status == Status.STOPPED
 
@@ -443,6 +446,8 @@ class NodeChunk(BaseObject):
 
     nodeName = Property(str, lambda self: self.node.name, constant=True)
     statusNodeName = Property(str, lambda self: self._status.nodeName, constant=True)
+
+    elapsedTime = Property(float, lambda self: self._status.elapsedTime, notify=statusChanged)
 
 
 # simple structure for storing node position
@@ -732,6 +737,17 @@ class BaseNode(BaseObject):
                 return False
         return True
 
+    @Slot(result=bool)
+    def isSubmittedOrRunning(self):
+        """ Return True if all chunks are at least submitted and there is one running chunk, False otherwise. """
+        if not self.isAlreadySubmittedOrFinished():
+            return False
+        for chunk in self._chunks:
+            if chunk.isRunning():
+                return True
+        return False
+
+    @Slot(result=bool)
     def isFinishedOrRunning(self):
         """ Return True if all chunks of this Node is either finished or running, False otherwise. """
         return all(chunk.isFinishedOrRunning() for chunk in self._chunks)


### PR DESCRIPTION
## Description

This PR displays, for a node whose status is either "FINISHED" or "RUNNING", the computation time in the title bar of the node. For nodes with several chunks, the displayed time corresponds to the cumulated computation time of every chunk; in that case, the computation time for the longest chunk is also displayed in a tooltip. 