### PR TITLE
[ui] ImageGallery: fix some minor issues

### DIFF
--- a/meshroom/ui/qml/ImageGallery/ImageGallery.qml
+++ b/meshroom/ui/qml/ImageGallery/ImageGallery.qml
@@ -457,6 +457,7 @@ Panel {
             Layout.fillWidth: true
             Layout.fillHeight: true
             visible: intrinsicsFilterButton.checked
+            clip: true
 
             TableView {
                 id : intrinsicTable

--- a/meshroom/ui/qml/ImageGallery/ImageGallery.qml
+++ b/meshroom/ui/qml/ImageGallery/ImageGallery.qml
@@ -536,12 +536,21 @@ Panel {
             Label { id: groupLabel; text: "Group " }
             ComboBox {
                 id: nodesCB
-                model: root.cameraInits.count
+                model: {
+                    // Create an array from 1 to cameraInits.count for the
+                    // display of group indices (real indices still are from
+                    // 0 to cameraInits.count - 1)
+                    var l = [];
+                    for (var i = 1; i <= root.cameraInits.count; i++) {
+                        l.push(i);
+                    }
+                    return l;
+                }
                 implicitWidth: 40
                 currentIndex: root.cameraInitIndex
                 onActivated: root.changeCurrentIndex(currentIndex)
             }
-            Label { text: "/ " + (root.cameraInits.count - 1) }
+            Label { text: "/ " + (root.cameraInits.count) }
             ToolButton {
                 text: MaterialIcons.navigate_next
                 font.family: MaterialIcons.fontFamily

--- a/meshroom/ui/reconstruction.py
+++ b/meshroom/ui/reconstruction.py
@@ -950,6 +950,10 @@ class Reconstruction(UIGraph):
                 self.activeNodes.get(category).node = node
                 if category == 'sfm':
                     self.setSfm(node)
+
+                # if the active node is a CameraInit node, update the camera init index
+                if node.nodeType == "CameraInit":
+                    self.setCameraInitIndex(self._cameraInits.indexOf(node))
         self.activeNodes.get(node.nodeType).node = node
 
     @Slot(QObject)


### PR DESCRIPTION
## Description

This PR fixes a couple minor UI issues with the Image Gallery:
- the indexing of the groups that was displayed as starting at 0 instead of 1
- the intrinsics table that was overlapping with the group label when there were enough intrinsics entries in the table

Additionally, it adds the automatic switch to the correct group when a user double-clicks on a CameraInit node in the graph. 

## Features list

- [X] Start the group indexing at 1 instead of 0
- [X] Prevent the intrinsics table from ever overlapping with the group label
- [X] When the user double-clicks on a CameraInit node, automatically switch to the corresponding group
