### PR TITLE
removed duplicated call to findnodes

### DIFF
--- a/bin/meshroom_batch
+++ b/bin/meshroom_batch
@@ -193,8 +193,10 @@ if args.submit:
     if not args.save:
         raise ValueError('Need to save the project to file to submit on renderfarm.')
     # submit on renderfarm
-    meshroom.core.graph.submit(args.save, args.submitter, toNode=toNodes)
+    meshroom.core.graph.submit(args.save, args.submitter, toNode=args.toNode)
 elif args.compute:
+    # find end nodes (None will compute all graph)
+    toNodes = graph.findNodes(args.toNode) if args.toNode else None
     # start computation
     meshroom.core.graph.executeGraph(graph, toNodes=toNodes, forceCompute=args.forceCompute, forceStatus=args.forceStatus)
 

--- a/meshroom/core/graph.py
+++ b/meshroom/core/graph.py
@@ -1315,6 +1315,6 @@ def submit(graphFile, submitter, toNode=None):
     Submit the given graph via the given submitter.
     """
     graph = loadGraph(graphFile)
-    toNodes = graph.findNodes([toNode]) if toNode else None
+    toNodes = graph.findNodes(toNode) if toNode else None
     submitGraph(graph, submitter, toNodes)
 


### PR DESCRIPTION
## Description
meshroom_batch was not working because of a duplicated call to findNodes.


## Features list
Removed the duplicated call and modified the submit function.


