### PR TITLE
[core] Set the "template" flag to "false" when saving a project as a regular file

### DIFF
--- a/meshroom/core/graph.py
+++ b/meshroom/core/graph.py
@@ -1200,9 +1200,10 @@ class Graph(BaseObject):
             for p in usedNodeTypes
         }
 
+        self.header["template"] = template
+
         data = {}
         if template:
-            self.header["template"] = True
             data = {
                 Graph.IO.Keys.Header: self.header,
                 Graph.IO.Keys.Graph: self.getNonDefaultAttributes()


### PR DESCRIPTION
## Description

When a scene is saved as a template, a flag named "template" is set to "true" in the header of the .mg file. 

Prior to this PR, and since #1754, that flag was never explicitly set to "false" when saving a scene as a regular project, meaning that any pipeline built on top of a template pipeline was necessarily saved with "template" set to "true".
