### PR TITLE
[ui] Restrain the "copy/paste nodes" shortcuts to the GraphEditor

### DIFF
--- a/meshroom/ui/qml/GraphEditor/GraphEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/GraphEditor.qml
@@ -114,6 +114,10 @@ Item {
                 uigraph.removeNodes(uigraph.selectedNodes)
         if (event.key === Qt.Key_D)
             duplicateNode(event.modifiers == Qt.AltModifier)
+        if (event.key === Qt.Key_C && event.modifiers == Qt.ControlModifier)
+            copyNodes()
+        if (event.key === Qt.Key_V && event.modifiers == Qt.ControlModifier)
+            pasteNodes()
     }
 
     MouseArea {

--- a/meshroom/ui/qml/main.qml
+++ b/meshroom/ui/qml/main.qml
@@ -430,7 +430,6 @@ ApplicationWindow {
             return s
         }
         text: "Copy Node" + (_reconstruction.selectedNodes.count > 1 ? "s " : " ")
-        shortcut: "Ctrl+C"
         enabled: _reconstruction.selectedNodes.count > 0
         onTriggered: graphEditor.copyNodes()
 
@@ -453,7 +452,6 @@ ApplicationWindow {
 
         property string tooltip: "Paste the clipboard content to the scene if it contains valid nodes"
         text: "Paste Node(s)"
-        shortcut: "Ctrl+V"
         onTriggered: graphEditor.pasteNodes()
     }
 


### PR DESCRIPTION
## Description

This PR fixes an issue introduced with #1758 which overrides any Ctrl+C / Ctrl+V shortcut with a "Copy node(s)" / "Paste node(s)", no matter which part of Meshroom has the focus or which element is currently selected.

If a Ctrl+C or Ctrl+V shortcut is performed outside the GraphEditor, the performed action should not be a copy or a paste of the nodes, but the own copy/paste of the current element. For example, if the currently selected element is a text field in the NodeEditor, then using Ctrl+C shoud trigger that text field's own copy function and copy its content to the clipboard; "Copy node(s)" and "Paste node(s)" should only be called when Ctrl+C and Ctrl+V are performed within the GraphEditor.
