### PR TITLE
[ui] Elapsed time indicators in log

### DIFF
--- a/meshroom/ui/qml/Controls/TextFileViewer.qml
+++ b/meshroom/ui/qml/Controls/TextFileViewer.qml
@@ -197,7 +197,7 @@ Item {
                     width: textView.width
                     spacing: 6
 
-                    property var duration: textView.model.get(index).duration
+                    property var logLine: textView.model.get(index) ? textView.model.get(index) : {"line": "", "duration": -1}
 
                     Item {
                         Layout.minimumWidth: childrenRect.width
@@ -208,7 +208,7 @@ Item {
                             Rectangle {
                                 width: 4
                                 Layout.fillHeight: true
-                                color: Colors.interpolate(Colors.grey, Colors.red, duration/180)
+                                color: Colors.interpolate(Colors.grey, Colors.red, logLine.duration/180)
                             }
                             // Line number
                             Label {
@@ -226,8 +226,8 @@ Item {
                             hoverEnabled: true
                             anchors.fill: parent
                         }
-                        enabled: duration > 0
-                        ToolTip.text: "Elapsed time: " + Format.getTimeStr(duration)
+                        enabled: logLine.duration > 0
+                        ToolTip.text: "Elapsed time: " + Format.getTimeStr(logLine.duration)
                         ToolTip.visible: mouseArea.containsMouse
                     }
 
@@ -243,8 +243,8 @@ Item {
                                 State {
                                     name: "progressBar"
                                     // detect textual progressbar (non empty line with only progressbar character)
-                                    when: textView.model.get(index).line.trim().length
-                                          && textView.model.get(index).line.split(progressMetrics.character).length - 1 === textView.model.get(index).line.trim().length
+                                    when: logLine.line.trim().length
+                                          && logLine.line.split(progressMetrics.character).length - 1 === logLine.line.trim().length
                                     PropertyChanges {
                                         target: delegateLoader
                                         sourceComponent: progressBar_component
@@ -265,7 +265,7 @@ Item {
                                     anchors.verticalCenter: parent.verticalCenter
                                     from: 0
                                     to: progressMetrics.count
-                                    value: textView.model.get(index).line.length
+                                    value: logLine.line.length
                                 }
                             }
                         }
@@ -275,7 +275,7 @@ Item {
                             id: line_component
                             TextInput {
                                 wrapMode: Text.WrapAnywhere
-                                text: textView.model.get(index).line
+                                text: logLine.line
                                 font.family: "Monospace, Consolas, Monaco"
                                 padding: 0
                                 selectByMouse: true

--- a/meshroom/ui/qml/Controls/TextFileViewer.qml
+++ b/meshroom/ui/qml/Controls/TextFileViewer.qml
@@ -231,11 +231,14 @@ Item {
                     width: textView.width
                     spacing: 6
 
+                    property var duration: textView.model.get(index).duration
+
                     // Duration color
                     Rectangle {
                         width: 4
                         height: lineMetrics.height
-                        color: Colors.durationColorScale(textView.model.get(index).duration)
+                        Layout.alignment: Qt.AlignTop
+                        color: duration > 0 ? Colors.durationColorScale(duration) : "transparent"
                     }
 
                     // Line number
@@ -243,9 +246,17 @@ Item {
                         text: index + 1
                         Layout.minimumWidth: lineMetrics.width
                         rightPadding: 2
-                        enabled: false
                         Layout.fillHeight: true
                         horizontalAlignment: Text.AlignRight
+                        color: "#CCCCCC"
+                        enabled: duration > 0
+                        ToolTip.text: "elapsed time: " + String(duration) + "s"
+                        ToolTip.visible: mouseArea.containsMouse
+                        MouseArea {
+                            id: mouseArea
+                            anchors.fill: parent
+                            hoverEnabled: true
+                        }
                     }
 
                     Loader {

--- a/meshroom/ui/qml/Controls/TextFileViewer.qml
+++ b/meshroom/ui/qml/Controls/TextFileViewer.qml
@@ -199,30 +199,36 @@ Item {
 
                     property var duration: textView.model.get(index).duration
 
-                    // Colored marker to quickly indicate duration
-                    Rectangle {
-                        width: 4
+                    Item {
+                        Layout.minimumWidth: childrenRect.width
                         Layout.fillHeight: true
-                        color: Colors.interpolate(Colors.grey, Colors.red, duration/180)
-                    }
-
-                    // Line number
-                    // displays a tooltip with the duration when hovered
-                    Label {
-                        text: index + 1
-                        Layout.minimumWidth: lineMetrics.width
-                        rightPadding: 2
-                        Layout.fillHeight: true
-                        horizontalAlignment: Text.AlignRight
-                        color: "#CCCCCC"
+                        RowLayout {
+                            height: parent.height
+                            // Colored marker to quickly indicate duration
+                            Rectangle {
+                                width: 4
+                                Layout.fillHeight: true
+                                color: Colors.interpolate(Colors.grey, Colors.red, duration/180)
+                            }
+                            // Line number
+                            Label {
+                                text: index + 1
+                                Layout.minimumWidth: lineMetrics.width
+                                rightPadding: 6
+                                Layout.fillHeight: true
+                                horizontalAlignment: Text.AlignRight
+                                color: "#CCCCCC"
+                            }
+                        }
+                        // Display a tooltip with the duration when hovered
+                        MouseArea {
+                            id: mouseArea
+                            hoverEnabled: true
+                            anchors.fill: parent
+                        }
                         enabled: duration > 0
                         ToolTip.text: "Elapsed time: " + Format.getTimeStr(duration)
                         ToolTip.visible: mouseArea.containsMouse
-                        MouseArea {
-                            id: mouseArea
-                            anchors.fill: parent
-                            hoverEnabled: true
-                        }
                     }
 
                     Loader {

--- a/meshroom/ui/qml/Controls/TextFileViewer.qml
+++ b/meshroom/ui/qml/Controls/TextFileViewer.qml
@@ -203,7 +203,7 @@ Item {
                     Rectangle {
                         width: 4
                         Layout.fillHeight: true
-                        color: duration > 0 ? Colors.durationColorScale(duration) : "transparent"
+                        color: Colors.interpolate(Colors.grey, Colors.red, duration/180)
                     }
 
                     // Line number

--- a/meshroom/ui/qml/Controls/TextFileViewer.qml
+++ b/meshroom/ui/qml/Controls/TextFileViewer.qml
@@ -202,8 +202,7 @@ Item {
                     // Colored marker to quickly indicate duration
                     Rectangle {
                         width: 4
-                        height: lineMetrics.height
-                        Layout.alignment: Qt.AlignTop
+                        Layout.fillHeight: true
                         color: duration > 0 ? Colors.durationColorScale(duration) : "transparent"
                     }
 

--- a/meshroom/ui/qml/Controls/TextFileViewer.qml
+++ b/meshroom/ui/qml/Controls/TextFileViewer.qml
@@ -208,7 +208,7 @@ Item {
                             Rectangle {
                                 width: 4
                                 Layout.fillHeight: true
-                                color: Colors.interpolate(Colors.grey, Colors.red, logLine.duration/180)
+                                color: Colors.durationColor(logLine.duration)
                             }
                             // Line number
                             Label {

--- a/meshroom/ui/qml/Controls/TextFileViewer.qml
+++ b/meshroom/ui/qml/Controls/TextFileViewer.qml
@@ -216,7 +216,7 @@ Item {
                         horizontalAlignment: Text.AlignRight
                         color: "#CCCCCC"
                         enabled: duration > 0
-                        ToolTip.text: "elapsed time: " + String(duration) + "s"
+                        ToolTip.text: "Elapsed time: " + Format.getTimeStr(duration)
                         ToolTip.visible: mouseArea.containsMouse
                         MouseArea {
                             id: mouseArea

--- a/meshroom/ui/qml/GraphEditor/NodeEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/NodeEditor.qml
@@ -4,6 +4,7 @@ import QtQuick.Controls 1.4 as Controls1 // SplitView
 import QtQuick.Layouts 1.3
 import MaterialIcons 2.2
 import Controls 1.0
+import Utils 1.0
 
 
 /**
@@ -29,7 +30,7 @@ Panel {
                 if (node !== null && node.isSubmittedOrRunning()) {
                     // Some chunks might be submitted but they'll all run eventually
                     if (node.elapsedTime > 0) { // At least a chunk is done running
-                        return "Running for: " + getTimeStr(node.elapsedTime)
+                        return "Running for: " + Format.getTimeStr(node.elapsedTime)
                     } else {
                         return (node.chunks.count > 1) ? "First chunk running" : "Node running"
                     }
@@ -37,7 +38,7 @@ Panel {
                     /* Either all chunks finished running or the last one is running
                         * Placed inside an "else if" instead of "else" to avoid entering the functions
                         * when there is no real use */
-                    return getTimeStr(node.elapsedTime)
+                    return Format.getTimeStr(node.elapsedTime)
                 } else {
                     return ""
                 }
@@ -57,7 +58,7 @@ Panel {
                 if (node !== null && (node.isFinishedOrRunning() || (node.isSubmittedOrRunning() && node.elapsedTime > 0))) {
                     var longestChunkTime = getLongestChunkTime(node.chunks)
                     if (longestChunkTime > 0)
-                        return "Longest chunk: " + getTimeStr(longestChunkTime) + " (" + node.chunks.count + " chunks)"
+                        return "Longest chunk: " + Format.getTimeStr(longestChunkTime) + " (" + node.chunks.count + " chunks)"
                     else
                         return ""
                 } else {
@@ -69,35 +70,6 @@ Panel {
                 id: runningTimeMa
                 anchors.fill: parent
                 hoverEnabled: true
-            }
-
-            function getTimeStr(elapsed)
-            {
-                if (elapsed <= 0)
-                    return ""
-
-                var hours = 0
-                var min = 0
-                var finalTime = ""
-
-                if (elapsed > 3600) {
-                    hours = Math.floor(elapsed / 3600)
-                    elapsed = elapsed - (hours * 3600)
-                    finalTime += hours + "h"
-                }
-                if (elapsed > 60) {
-                    min = Math.floor(elapsed / 60)
-                    elapsed = elapsed - (min * 60)
-                    finalTime += min + "m"
-                }
-                if (hours == 0 && min == 0) {
-                    // Millisecond precision for execution times below 1 min
-                    finalTime += Number(elapsed.toLocaleString(Qt.locale('en-US'))) + "s"
-                } else {
-                    finalTime += Math.round(elapsed) + "s"
-                }
-
-                return finalTime
             }
 
             function getLongestChunkTime(chunks)

--- a/meshroom/ui/qml/Utils/Colors.qml
+++ b/meshroom/ui/qml/Utils/Colors.qml
@@ -62,9 +62,7 @@ QtObject {
     }
 
     function durationColorScale(t) {
-        if (t < 0) {
-            return "transparent";
-        } else if (t < 10) {
+        if (t < 10) {
             return cyan;
         } else if (t < 30) {
             return green;

--- a/meshroom/ui/qml/Utils/Colors.qml
+++ b/meshroom/ui/qml/Utils/Colors.qml
@@ -60,4 +60,20 @@ QtObject {
         console.warn("Unknown status : " + chunk.status)
         return "magenta"
     }
+
+    function durationColorScale(t) {
+        if (t < 0) {
+            return "transparent";
+        } else if (t < 10) {
+            return cyan;
+        } else if (t < 30) {
+            return green;
+        } else if (t < 60) {
+            return yellow;
+        } else if (t < 180) {
+            return orange;
+        } else {
+            return red;
+        }
+    }
 }

--- a/meshroom/ui/qml/Utils/Colors.qml
+++ b/meshroom/ui/qml/Utils/Colors.qml
@@ -39,6 +39,13 @@ QtObject {
         "SUBMITTED": "#2196F3"
     }
 
+    readonly property var durationColorScale: [
+        {"time": 0, "color": grey}, 
+        {"time": 60, "color": green}, 
+        {"time": 180, "color": yellow}, 
+        {"time": 600, "color": red}
+    ]
+
     function getChunkColor(chunk, overrides)
     {
         if(overrides && chunk.statusName in overrides)
@@ -69,13 +76,28 @@ QtObject {
         ];
     }
 
-    function interpolate(c1, c2, t) {
+    function interpolate(c1, c2, u) {
         let rgb1 = toRgb(c1);
         let rgb2 = toRgb(c2);
         return Qt.rgba(
-            rgb1[0] * (1-t) + rgb2[0] * t, 
-            rgb1[1] * (1-t) + rgb2[1] * t, 
-            rgb1[2] * (1-t) + rgb2[2] * t
+            rgb1[0] * (1-u) + rgb2[0] * u, 
+            rgb1[1] * (1-u) + rgb2[1] * u, 
+            rgb1[2] * (1-u) + rgb2[2] * u
         );
+    }
+
+    function durationColor(t) {
+        if (t < durationColorScale[0].time) {
+            return durationColorScale[0].color;
+        }
+        if (t > durationColorScale[durationColorScale.length-1].time) {
+            return durationColorScale[durationColorScale.length-1].color;
+        }
+        for (let idx = 1; idx < durationColorScale.length; idx++) {
+            if (t < durationColorScale[idx].time) {
+                let u = (t - durationColorScale[idx-1].time) / (durationColorScale[idx].time - durationColorScale[idx-1].time);
+                return interpolate(durationColorScale[idx-1].color, durationColorScale[idx].color, u);
+            }
+        }
     }
 }

--- a/meshroom/ui/qml/Utils/Colors.qml
+++ b/meshroom/ui/qml/Utils/Colors.qml
@@ -40,10 +40,10 @@ QtObject {
     }
 
     readonly property var durationColorScale: [
-        {"time": 0, "color": grey}, 
-        {"time": 60, "color": green}, 
-        {"time": 180, "color": yellow}, 
-        {"time": 600, "color": red}
+        {"time": 0, "color": grey},
+        {"time": 5, "color": green},
+        {"time": 20, "color": yellow},
+        {"time": 90, "color": red}
     ]
 
     function getChunkColor(chunk, overrides)

--- a/meshroom/ui/qml/Utils/Colors.qml
+++ b/meshroom/ui/qml/Utils/Colors.qml
@@ -61,17 +61,21 @@ QtObject {
         return "magenta"
     }
 
-    function durationColorScale(t) {
-        if (t < 10) {
-            return cyan;
-        } else if (t < 30) {
-            return green;
-        } else if (t < 60) {
-            return yellow;
-        } else if (t < 180) {
-            return orange;
-        } else {
-            return red;
-        }
+    function toRgb(color) {
+        return [
+            parseInt(color.toString().substr(1, 2), 16) / 255, 
+            parseInt(color.toString().substr(3, 2), 16) / 255, 
+            parseInt(color.toString().substr(5, 2), 16) / 255
+        ];
+    }
+
+    function interpolate(c1, c2, t) {
+        let rgb1 = toRgb(c1);
+        let rgb2 = toRgb(c2);
+        return Qt.rgba(
+            rgb1[0] * (1-t) + rgb2[0] * t, 
+            rgb1[1] * (1-t) + rgb2[1] * t, 
+            rgb1[2] * (1-t) + rgb2[2] * t
+        );
     }
 }

--- a/meshroom/ui/qml/Utils/format.js
+++ b/meshroom/ui/qml/Utils/format.js
@@ -22,3 +22,32 @@ function sec2time(time) {
 
     return pad(hours, 2) + ':' + pad(minutes, 2) + ':' + pad(seconds, 2)
 }
+
+function getTimeStr(elapsed)
+{
+    if (elapsed <= 0)
+        return ""
+
+    var hours = 0
+    var min = 0
+    var finalTime = ""
+
+    if (elapsed > 3600) {
+        hours = Math.floor(elapsed / 3600)
+        elapsed = elapsed - (hours * 3600)
+        finalTime += hours + "h"
+    }
+    if (elapsed > 60) {
+        min = Math.floor(elapsed / 60)
+        elapsed = elapsed - (min * 60)
+        finalTime += min + "m"
+    }
+    if (hours == 0 && min == 0) {
+        // Millisecond precision for execution times below 1 min
+        finalTime += Number(elapsed.toLocaleString(Qt.locale('en-US'))) + "s"
+    } else {
+        finalTime += Math.round(elapsed) + "s"
+    }
+
+    return finalTime
+}

--- a/meshroom/ui/qml/Utils/format.js
+++ b/meshroom/ui/qml/Utils/format.js
@@ -42,7 +42,7 @@ function getTimeStr(elapsed)
         elapsed = elapsed - (min * 60)
         finalTime += min + "m"
     }
-    if (hours == 0 && min == 0) {
+    if (hours === 0 && min === 0) {
         // Millisecond precision for execution times below 1 min
         finalTime += Number(elapsed.toLocaleString(Qt.locale('en-US'))) + "s"
     } else {


### PR DESCRIPTION
## Description

The goal of this PR is to enrich the node log viewer so that finding the steps that require long calculations is easier for users. To achieve that, we retrieve the time value of each log-line (when it exists) and we display the elapsed time between consecutive time values.

We add 2 visual indicators: 
- a colored marker next to the line number
- a tooltip when hovering over the line number cell displaying the elapsed time.
