### PR TITLE
[ui] Paste nodes at the center of the Graph Editor when it does not contain the mouse

### DIFF
--- a/meshroom/ui/qml/GraphEditor/GraphEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/GraphEditor.qml
@@ -41,7 +41,6 @@ Item {
     clip: true
 
     SystemPalette { id: activePalette }
-    property point pastePosition
 
     /// Get node delegate for the given node object
     function nodeDelegate(node)
@@ -89,19 +88,33 @@ Item {
     /// Paste content of clipboard to graph editor and create new node if valid
     function pasteNodes()
     {
-        if (uigraph.hoveredNode != null) {
-            var node = nodeDelegate(uigraph.hoveredNode)
-            root.pastePosition = Qt.point(node.mousePosition.x + node.x, node.mousePosition.y + node.y)
+        var finalPosition = undefined
+        var centerPosition = false
+        if (mouseArea.containsMouse) {
+            if (uigraph.hoveredNode != null) {
+                var node = nodeDelegate(uigraph.hoveredNode)
+                finalPosition = Qt.point(node.mousePosition.x + node.x, node.mousePosition.y + node.y)
+            } else {
+                finalPosition = mapToItem(draggable, mouseArea.mouseX, mouseArea.mouseY)
+            }
         } else {
-            root.pastePosition = mapToItem(draggable, mouseArea.mouseX, mouseArea.mouseY)
+            finalPosition = getCenterPosition()
+            centerPosition = true
         }
+
         var copiedContent = Clipboard.getText()
-        var nodes = uigraph.pasteNodes(copiedContent, root.pastePosition)
+        var nodes = uigraph.pasteNodes(copiedContent, finalPosition, centerPosition)
         if (nodes.length > 0) {
             uigraph.clearNodeSelection()
             uigraph.selectedNode = nodes[0]
             uigraph.selectNodes(nodes)
         }
+    }
+
+    /// Get the coordinates of the point at the center of the GraphEditor
+    function getCenterPosition()
+    {
+        return mapToItem(draggable, mouseArea.width / 2, mouseArea.height / 2)
     }
 
     Keys.onPressed: {


### PR DESCRIPTION
## Description

When using the Edit > Paste action menu, or when pressing Ctrl+V while the Graph Editor has the focus but does not contain the mouse, there is no current mouse position within the GraphEditor. The position that is provided to the "pasteNodes" function is the last known mouse position within the Graph Editor, which oftentimes corresponds to its borders.

Instead of using the border of the Graph Editor as the top-left corner of the pasting zone (the zone in which all the nodes contained in the clipboard will be pasted, with their original distance to one another preserved), this PR simulates the mouse's position and sets it at the center of the Graph Editor. This position is then used as the center of the pasting zone instead of its top-left corner. Distances between the pasted nodes remain unchanged.
