### PR TITLE
[pipelines] Update CameraInit version from 7.0 to 8.0 in templates

### DIFF
--- a/meshroom/pipelines/cameraTracking.mg
+++ b/meshroom/pipelines/cameraTracking.mg
@@ -8,7 +8,7 @@
             "ExportAnimatedCamera": "2.0", 
             "FeatureMatching": "2.0", 
             "DistortionCalibration": "2.0", 
-            "CameraInit": "7.0", 
+            "CameraInit": "8.0", 
             "ImageMatching": "2.0", 
             "FeatureExtraction": "1.1", 
             "StructureFromMotion": "2.0"
@@ -101,7 +101,7 @@
             }, 
             "nodeType": "StructureFromMotion", 
             "uids": {
-                "0": "4d198974784fd71f5a1c189e10c2914e56523585"
+                "0": "28715b8d4a51e5a90fbfee17d9eb193262116845"
             }, 
             "parallelization": {
                 "blockSize": 0, 
@@ -125,7 +125,7 @@
             }, 
             "nodeType": "ExportAnimatedCamera", 
             "uids": {
-                "0": "31413f19e51b239874733f13f9628286fd185c18"
+                "0": "65b4d273f9b9c6a177a8f586b1f9a085f3430133"
             }, 
             "parallelization": {
                 "blockSize": 0, 
@@ -172,7 +172,7 @@
             }, 
             "nodeType": "FeatureMatching", 
             "uids": {
-                "0": "8386c096445d6988ea7d14f1ae3192978a4dd2e8"
+                "0": "d6266b2126948174744b0ff6c33d96440e7596de"
             }, 
             "parallelization": {
                 "blockSize": 20, 

--- a/meshroom/pipelines/panoramaFisheyeHdr.mg
+++ b/meshroom/pipelines/panoramaFisheyeHdr.mg
@@ -10,7 +10,7 @@
             "LdrToHdrCalibration": "3.0", 
             "LdrToHdrSampling": "4.0", 
             "PanoramaInit": "2.0", 
-            "CameraInit": "7.0", 
+            "CameraInit": "8.0", 
             "SfMTransform": "3.0", 
             "PanoramaMerging": "1.0", 
             "ImageMatching": "2.0", 
@@ -58,7 +58,7 @@
             }, 
             "nodeType": "ImageProcessing", 
             "uids": {
-                "0": "3b8b39e478a30aa0ef1871576665b2914204a919"
+                "0": "51d41208c0c929fa50d88c183713958e9a407fd3"
             }, 
             "parallelization": {
                 "blockSize": 0, 
@@ -81,7 +81,7 @@
             }, 
             "nodeType": "PanoramaWarping", 
             "uids": {
-                "0": "45cca14aba2a8c4f68c79a15d3fbc48f30ae9d66"
+                "0": "2def8d004a44dcb3bbaa35da318d38bbb076b6ee"
             }, 
             "parallelization": {
                 "blockSize": 5, 
@@ -205,7 +205,7 @@
             }, 
             "nodeType": "PanoramaMerging", 
             "uids": {
-                "0": "70edd7fe8194bf35dcb0b221141cd4abd2354547"
+                "0": "6895704a5fcd5fd070562190b3747cb3ca08121c"
             }, 
             "parallelization": {
                 "blockSize": 0, 
@@ -229,7 +229,7 @@
             }, 
             "nodeType": "PanoramaCompositing", 
             "uids": {
-                "0": "1f1e629021e2280291046226e009a52dbb7809c1"
+                "0": "29f97e3a8c4d4989fae0ab4c1f3831a92dfbae5c"
             }, 
             "parallelization": {
                 "blockSize": 5, 
@@ -305,7 +305,7 @@
             }, 
             "nodeType": "SfMTransform", 
             "uids": {
-                "0": "b8568fb40b68b42ac80c18df2dcdf600744fe3e1"
+                "0": "d9ff08700916f4e9e3ace1048c2c2621c9541272"
             }, 
             "parallelization": {
                 "blockSize": 0, 
@@ -329,7 +329,7 @@
             }, 
             "nodeType": "PanoramaSeams", 
             "uids": {
-                "0": "dd02562c5c3b1e18e42561d99590cbf4ff5ba35a"
+                "0": "52cbb0d53e0ef49cefe9848394023cf3e7f30572"
             }, 
             "parallelization": {
                 "blockSize": 0, 
@@ -356,7 +356,7 @@
             }, 
             "nodeType": "PanoramaEstimation", 
             "uids": {
-                "0": "47b0976fc98eefcbc0342bbb63e7d27ef3e0d4de"
+                "0": "350636ae916682708019397a10592596e8ef7e84"
             }, 
             "parallelization": {
                 "blockSize": 0, 
@@ -408,7 +408,7 @@
             }, 
             "nodeType": "FeatureMatching", 
             "uids": {
-                "0": "c0fbe0b12fe47ada6a1ca8f74d266e99c1cc548c"
+                "0": "cb919baf3a96df73f0ef07a23357f3d8a7f380e8"
             }, 
             "parallelization": {
                 "blockSize": 20, 

--- a/meshroom/pipelines/panoramaHdr.mg
+++ b/meshroom/pipelines/panoramaHdr.mg
@@ -10,7 +10,7 @@
             "LdrToHdrCalibration": "3.0", 
             "LdrToHdrSampling": "4.0", 
             "PanoramaInit": "2.0", 
-            "CameraInit": "7.0", 
+            "CameraInit": "8.0", 
             "SfMTransform": "3.0", 
             "PanoramaMerging": "1.0", 
             "ImageMatching": "2.0", 
@@ -58,7 +58,7 @@
             }, 
             "nodeType": "ImageProcessing", 
             "uids": {
-                "0": "a6d1b7d35fd36828f678e4547e9e267d84586f20"
+                "0": "db79f52d50b71d5f8a0b398109bb8ff4c4506e75"
             }, 
             "parallelization": {
                 "blockSize": 0, 
@@ -81,7 +81,7 @@
             }, 
             "nodeType": "PanoramaWarping", 
             "uids": {
-                "0": "f2971d0c73b15fa99cbccbc9515de346ca141a1e"
+                "0": "2b35fc7d314e510119ba9c40e2870fee75c0f145"
             }, 
             "parallelization": {
                 "blockSize": 5, 
@@ -201,7 +201,7 @@
             }, 
             "nodeType": "PanoramaMerging", 
             "uids": {
-                "0": "e007a4eb5fc5937b320638eba667cea183c0c642"
+                "0": "ebc83e08ec420c2451e6e667feed11fad346acd7"
             }, 
             "parallelization": {
                 "blockSize": 0, 
@@ -225,7 +225,7 @@
             }, 
             "nodeType": "PanoramaCompositing", 
             "uids": {
-                "0": "8aba78572808d012e0bb376503c2016df943b3f0"
+                "0": "7c118e7273f8f93818fbf82fe272c6d6553c650f"
             }, 
             "parallelization": {
                 "blockSize": 5, 
@@ -301,7 +301,7 @@
             }, 
             "nodeType": "SfMTransform", 
             "uids": {
-                "0": "c72641a2cca50759bcf5283ae6e0b6f7abc3fe4a"
+                "0": "634e1a4143def636efac5c0f9cd64e0dcb99c20c"
             }, 
             "parallelization": {
                 "blockSize": 0, 
@@ -325,7 +325,7 @@
             }, 
             "nodeType": "PanoramaSeams", 
             "uids": {
-                "0": "0ee6da171bd684358b7c64dcc631f81ba743e1fa"
+                "0": "89eb43d21b7fa9fcd438ed92109f4d736dafcdfb"
             }, 
             "parallelization": {
                 "blockSize": 0, 
@@ -352,7 +352,7 @@
             }, 
             "nodeType": "PanoramaEstimation", 
             "uids": {
-                "0": "de946a7c1080873d15c9eb8a0523b544cf548719"
+                "0": "dc44122c2490f220a4e5f62aeec0745bfa44a8e3"
             }, 
             "parallelization": {
                 "blockSize": 0, 
@@ -403,7 +403,7 @@
             }, 
             "nodeType": "FeatureMatching", 
             "uids": {
-                "0": "cec6da6e894230ab66683c2e959bc9581ea5430e"
+                "0": "f818137ea50d2e41fb541690adeb842db7cecc43"
             }, 
             "parallelization": {
                 "blockSize": 20, 

--- a/meshroom/pipelines/photogrammetry.mg
+++ b/meshroom/pipelines/photogrammetry.mg
@@ -11,7 +11,7 @@
             "PrepareDenseScene": "3.0", 
             "DepthMap": "2.0", 
             "StructureFromMotion": "2.0", 
-            "CameraInit": "7.0", 
+            "CameraInit": "8.0", 
             "ImageMatching": "2.0", 
             "FeatureExtraction": "1.1", 
             "Meshing": "7.0", 
@@ -27,7 +27,7 @@
             }, 
             "nodeType": "Texturing", 
             "uids": {
-                "0": "09f72f6745c6b13aae56fc3876e6541fbeaa557d"
+                "0": "a7508a27971a36b86401f0476f64287476069faa"
             }, 
             "parallelization": {
                 "blockSize": 0, 
@@ -53,7 +53,7 @@
             }, 
             "nodeType": "Meshing", 
             "uids": {
-                "0": "aeb66fceaacd37ecd5bae8364bd9e87ccff2a84c"
+                "0": "a520c188f5e02d00b841b1a376de78a252c79c24"
             }, 
             "parallelization": {
                 "blockSize": 0, 
@@ -77,7 +77,7 @@
             }, 
             "nodeType": "DepthMapFilter", 
             "uids": {
-                "0": "4de4649a857d7bd4f7fdfb27470a5087625ff8c9"
+                "0": "9d7527658e450be51a2fffb3923fd3d24b2b928c"
             }, 
             "parallelization": {
                 "blockSize": 10, 
@@ -151,7 +151,7 @@
             }, 
             "nodeType": "StructureFromMotion", 
             "uids": {
-                "0": "89c3db0849ba07dfac5e97ca9e27dd690dc476ce"
+                "0": "5af4f4052aa22b0450708941b40928d46170f364"
             }, 
             "parallelization": {
                 "blockSize": 0, 
@@ -175,7 +175,7 @@
             }, 
             "nodeType": "PrepareDenseScene", 
             "uids": {
-                "0": "894725f62ffeead1307d9d91852b07d7c8453625"
+                "0": "489beb05de9e2d5cdfac149936b8c30c691f4b67"
             }, 
             "parallelization": {
                 "blockSize": 40, 
@@ -219,7 +219,7 @@
             }, 
             "nodeType": "DepthMap", 
             "uids": {
-                "0": "f5ef2fd13dad8f48fcb87e2364e1e821a9db7d2d"
+                "0": "279cdf5aa186d06aa81d952999991df43f3299f8"
             }, 
             "parallelization": {
                 "blockSize": 3, 
@@ -241,7 +241,7 @@
             }, 
             "nodeType": "MeshFiltering", 
             "uids": {
-                "0": "febb162c4fbce195f6d312bbb80697720a2f52b9"
+                "0": "590f12b2789757dcbe3bfd3e5b50e28d73a4e060"
             }, 
             "parallelization": {
                 "blockSize": 0, 
@@ -266,7 +266,7 @@
             }, 
             "nodeType": "FeatureMatching", 
             "uids": {
-                "0": "3b1f2c3fcfe0b94c65627c397a2671ba7594827d"
+                "0": "534c5224ba51c770ae3793cc085ae3aaa8c2c415"
             }, 
             "parallelization": {
                 "blockSize": 20, 

--- a/meshroom/pipelines/photogrammetryAndCameraTracking.mg
+++ b/meshroom/pipelines/photogrammetryAndCameraTracking.mg
@@ -8,7 +8,7 @@
             "ExportAnimatedCamera": "2.0", 
             "FeatureMatching": "2.0", 
             "DistortionCalibration": "2.0", 
-            "CameraInit": "7.0", 
+            "CameraInit": "8.0", 
             "ImageMatchingMultiSfM": "1.0", 
             "ImageMatching": "2.0", 
             "FeatureExtraction": "1.1", 
@@ -96,7 +96,7 @@
             }, 
             "nodeType": "StructureFromMotion", 
             "uids": {
-                "0": "89c3db0849ba07dfac5e97ca9e27dd690dc476ce"
+                "0": "5af4f4052aa22b0450708941b40928d46170f364"
             }, 
             "parallelization": {
                 "blockSize": 0, 
@@ -121,7 +121,7 @@
             }, 
             "nodeType": "ExportAnimatedCamera", 
             "uids": {
-                "0": "6f482ab9e161bd79341c5cd4a43ab9f8e39aec1f"
+                "0": "c28dfbc702edbecf8bf6721224cf6b10799a6a5d"
             }, 
             "parallelization": {
                 "blockSize": 0, 
@@ -171,7 +171,7 @@
             }, 
             "nodeType": "ImageMatchingMultiSfM", 
             "uids": {
-                "0": "ef147c1bc069c7689863c7e14cdbbaca86af4006"
+                "0": "a789cef752e327c0f2ee58012ca4792e9ab6a70e"
             }, 
             "parallelization": {
                 "blockSize": 0, 
@@ -239,7 +239,7 @@
             }, 
             "nodeType": "FeatureMatching", 
             "uids": {
-                "0": "7bb42f40b3f607da7e9f5f432409ddf6ef9c5951"
+                "0": "142e98e3637aedcd3ebc1e19a03878690896a35b"
             }, 
             "parallelization": {
                 "blockSize": 20, 
@@ -264,7 +264,7 @@
             }, 
             "nodeType": "FeatureMatching", 
             "uids": {
-                "0": "3b1f2c3fcfe0b94c65627c397a2671ba7594827d"
+                "0": "534c5224ba51c770ae3793cc085ae3aaa8c2c415"
             }, 
             "parallelization": {
                 "blockSize": 20, 
@@ -295,7 +295,7 @@
             }, 
             "nodeType": "StructureFromMotion", 
             "uids": {
-                "0": "4bc466c45bc7b430553752d1eb1640c581c43e36"
+                "0": "eddc0ed596eb15943d6acd74a7d64753344b40dd"
             }, 
             "parallelization": {
                 "blockSize": 0, 

--- a/meshroom/pipelines/photogrammetryDraft.mg
+++ b/meshroom/pipelines/photogrammetryDraft.mg
@@ -5,7 +5,7 @@
             "MeshFiltering": "3.0", 
             "Texturing": "6.0", 
             "StructureFromMotion": "2.0", 
-            "CameraInit": "7.0", 
+            "CameraInit": "8.0", 
             "ImageMatching": "2.0", 
             "FeatureExtraction": "1.1", 
             "Meshing": "7.0"
@@ -22,7 +22,7 @@
             }, 
             "nodeType": "Texturing", 
             "uids": {
-                "0": "1ed1516bf83493071547e69146be3f1218012e25"
+                "0": "32a36e3e637609b4d5a6971606728b59f3e7e62c"
             }, 
             "parallelization": {
                 "blockSize": 0, 
@@ -47,7 +47,7 @@
             }, 
             "nodeType": "Meshing", 
             "uids": {
-                "0": "dc3d06f150a2601334a44174aa8e5523d3055468"
+                "0": "d2499e39c1dd2e30c366e3e912254fce9cd0ed59"
             }, 
             "parallelization": {
                 "blockSize": 0, 
@@ -122,7 +122,7 @@
             }, 
             "nodeType": "StructureFromMotion", 
             "uids": {
-                "0": "89c3db0849ba07dfac5e97ca9e27dd690dc476ce"
+                "0": "5af4f4052aa22b0450708941b40928d46170f364"
             }, 
             "parallelization": {
                 "blockSize": 0, 
@@ -166,7 +166,7 @@
             }, 
             "nodeType": "MeshFiltering", 
             "uids": {
-                "0": "057d1647de39a617f79aad02a721938e5625ff64"
+                "0": "a5f72b9e67b26be5a4974c21b9d0bc0b3c34bea5"
             }, 
             "parallelization": {
                 "blockSize": 0, 
@@ -191,7 +191,7 @@
             }, 
             "nodeType": "FeatureMatching", 
             "uids": {
-                "0": "3b1f2c3fcfe0b94c65627c397a2671ba7594827d"
+                "0": "534c5224ba51c770ae3793cc085ae3aaa8c2c415"
             }, 
             "parallelization": {
                 "blockSize": 20, 


### PR DESCRIPTION
## Description

This PR upgrades the version of the CameraInit nodes in the templates. 

The CameraInit node's version was last updated with #1747.
