### PR TITLE
[ui] Viewer 2D: enable the HDR viewer by default

### DIFF
--- a/meshroom/ui/app.py
+++ b/meshroom/ui/app.py
@@ -344,8 +344,13 @@ class MeshroomApp(QApplication):
             }
         ]
 
+    def _default8bitViewerEnabled(self):
+        return bool(os.environ.get("MESHROOM_USE_8BIT_VIEWER", False))
+
+
     licensesModel = Property("QVariantList", _licensesModel, constant=True)
     pipelineTemplateFilesChanged = Signal()
     recentProjectFilesChanged = Signal()
     pipelineTemplateFiles = Property("QVariantList", _pipelineTemplateFiles, notify=pipelineTemplateFilesChanged)
     recentProjectFiles = Property("QVariantList", _recentProjectFiles, notify=recentProjectFilesChanged)
+    default8bitViewerEnabled = Property(bool, _default8bitViewerEnabled, constant=True)

--- a/meshroom/ui/qml/Viewer/Viewer2D.qml
+++ b/meshroom/ui/qml/Viewer/Viewer2D.qml
@@ -94,7 +94,7 @@ FocusScope {
         }
         if(msfmDataLoader.status === Loader.Ready)
         {
-            if(msfmDataLoader.item.status === MSfMData.Loading)
+            if(msfmDataLoader.item != null && msfmDataLoader.item.status === MSfMData.Loading)
             {
                 res += " SfMData";
             }
@@ -309,7 +309,7 @@ FocusScope {
                                 'surface.subdivisions' : Qt.binding(function(){ return root.useFloatImageViewer ? 1 : lensDistortionImageToolbar.subdivisionsValue;}),
                                 'viewerTypeString': Qt.binding(function(){ return displayLensDistortionViewer.checked ? "distortion" : "hdr";}),
                                 'sfmRequired': Qt.binding(function(){ return displayLensDistortionViewer.checked ? true : false;}),
-                                'surface.msfmData': Qt.binding(function() { return (msfmDataLoader.status === Loader.Ready && msfmDataLoader.item.status === 2) ? msfmDataLoader.item : null; }),
+                                'surface.msfmData': Qt.binding(function() { return (msfmDataLoader.status === Loader.Ready && msfmDataLoader.item != null && msfmDataLoader.item.status === 2) ? msfmDataLoader.item : null; }),
                                 'canBeHovered': false,
                                 'idView': Qt.binding(function() { return _reconstruction.selectedViewId; }),
                                 'cropFisheye': false


### PR DESCRIPTION
## Description

This PR enables the HDR viewer (float image viewer) by default in the 2D Viewer instead of the 8-bit image viewer. 

The 8-bit image viewer becomes unavaible unless the QtAliceVision plugin (which provides the HDR viewer) is unavailable or Meshroom is started with a specific environment variable, `MESHROOM_USE_8BIT_VIEWER`:
- If the HDR viewer is available and the environment variable is provided, the 8-bit viewer can be used by disabling the HDR viewer through the interface;
- If the QtAliceVision plugin is unavailable for any reason, the 8-bit image viewer is necessarily used

The behaviours of the other viewers (i.e. lens distortion, feature display, panorama viewers) remain unchanged. 