### PR TITLE
Add a unit test to check the node versions of templates

### DIFF
--- a/meshroom/core/graph.py
+++ b/meshroom/core/graph.py
@@ -1206,7 +1206,7 @@ class Graph(BaseObject):
         if template:
             data = {
                 Graph.IO.Keys.Header: self.header,
-                Graph.IO.Keys.Graph: self.getNonDefaultAttributes()
+                Graph.IO.Keys.Graph: self.getNonDefaultInputAttributes()
             }
         else:
             data = {
@@ -1220,20 +1220,22 @@ class Graph(BaseObject):
         if path != self._filepath and setupProjectFile:
             self._setFilepath(path)
 
-    def getNonDefaultAttributes(self):
+    def getNonDefaultInputAttributes(self):
         """
-        Instead of getting all the inputs/outputs attribute keys, only get the keys of
+        Instead of getting all the inputs attribute keys, only get the keys of
         the attributes whose value is not the default one.
+        The output attributes, UIDs, parallelization parameters and internal folder are
+        not relevant for templates, so they are explicitly removed from the returned dictionary.
 
         Returns:
-            dict: self.toDict() with all the inputs/outputs attributes with default values removed
+            dict: self.toDict() with the output attributes, UIDs, parallelization parameters, internal folder
+            and input attributes with default values removed
         """
         graph = self.toDict()
         for nodeName in graph.keys():
             node = self.node(nodeName)
 
             inputKeys = list(graph[nodeName]["inputs"].keys())
-            outputKeys = list(graph[nodeName]["outputs"].keys())
 
             for attrName in inputKeys:
                 attribute = node.attribute(attrName)
@@ -1241,13 +1243,10 @@ class Graph(BaseObject):
                 if attribute.isDefault and not attribute.isLink:
                     del graph[nodeName]["inputs"][attrName]
 
-            for attrName in outputKeys:
-                attribute = node.attribute(attrName)
-                # check that attribute is not a link for choice attributes
-                if attribute.isDefault and not attribute.isLink:
-                    del graph[nodeName]["outputs"][attrName]
-
+            del graph[nodeName]["outputs"]
             del graph[nodeName]["uids"]
+            del graph[nodeName]["internalFolder"]
+            del graph[nodeName]["parallelization"]
 
         return graph
 

--- a/meshroom/core/graph.py
+++ b/meshroom/core/graph.py
@@ -1247,6 +1247,8 @@ class Graph(BaseObject):
                 if attribute.isDefault and not attribute.isLink:
                     del graph[nodeName]["outputs"][attrName]
 
+            del graph[nodeName]["uids"]
+
         return graph
 
     def _setFilepath(self, filepath):

--- a/meshroom/pipelines/cameraTracking.mg
+++ b/meshroom/pipelines/cameraTracking.mg
@@ -20,22 +20,10 @@
                 "input": "{CameraInit_1.output}"
             }, 
             "nodeType": "DistortionCalibration", 
-            "uids": {
-                "0": "8afea9d171904cdb6ba1c0b116cb60de3ccb6fb4"
-            }, 
-            "parallelization": {
-                "blockSize": 0, 
-                "split": 1, 
-                "size": 0
-            }, 
-            "outputs": {
-                "outSfMData": "{cache}/{nodeType}/{uid0}/sfmData.sfm"
-            }, 
             "position": [
                 200, 
                 160
-            ], 
-            "internalFolder": "{cache}/{nodeType}/{uid0}/"
+            ]
         }, 
         "ImageMatching_1": {
             "inputs": {
@@ -47,44 +35,20 @@
                 ]
             }, 
             "nodeType": "ImageMatching", 
-            "uids": {
-                "0": "832b744de5fa804d7d63ea255419b1afaf24f723"
-            }, 
-            "parallelization": {
-                "blockSize": 0, 
-                "split": 1, 
-                "size": 0
-            }, 
-            "outputs": {
-                "output": "{cache}/{nodeType}/{uid0}/imageMatches.txt"
-            }, 
             "position": [
                 400, 
                 0
-            ], 
-            "internalFolder": "{cache}/{nodeType}/{uid0}/"
+            ]
         }, 
         "FeatureExtraction_1": {
             "inputs": {
                 "input": "{CameraInit_1.output}"
             }, 
             "nodeType": "FeatureExtraction", 
-            "uids": {
-                "0": "a07fb8d05b63327d05461954c2fd2a00f201275b"
-            }, 
-            "parallelization": {
-                "blockSize": 40, 
-                "split": 0, 
-                "size": 0
-            }, 
-            "outputs": {
-                "output": "{cache}/{nodeType}/{uid0}/"
-            }, 
             "position": [
                 200, 
                 0
-            ], 
-            "internalFolder": "{cache}/{nodeType}/{uid0}/"
+            ]
         }, 
         "StructureFromMotion_1": {
             "inputs": {
@@ -100,68 +64,28 @@
                 "minAngleForTriangulation": 1.0
             }, 
             "nodeType": "StructureFromMotion", 
-            "uids": {
-                "0": "28715b8d4a51e5a90fbfee17d9eb193262116845"
-            }, 
-            "parallelization": {
-                "blockSize": 0, 
-                "split": 1, 
-                "size": 0
-            }, 
-            "outputs": {
-                "output": "{cache}/{nodeType}/{uid0}/sfm.abc", 
-                "extraInfoFolder": "{cache}/{nodeType}/{uid0}/", 
-                "outputViewsAndPoses": "{cache}/{nodeType}/{uid0}/cameras.sfm"
-            }, 
             "position": [
                 800, 
                 0
-            ], 
-            "internalFolder": "{cache}/{nodeType}/{uid0}/"
+            ]
         }, 
         "ExportAnimatedCamera_1": {
             "inputs": {
                 "input": "{StructureFromMotion_1.output}"
             }, 
             "nodeType": "ExportAnimatedCamera", 
-            "uids": {
-                "0": "65b4d273f9b9c6a177a8f586b1f9a085f3430133"
-            }, 
-            "parallelization": {
-                "blockSize": 0, 
-                "split": 1, 
-                "size": 1
-            }, 
-            "outputs": {
-                "output": "{cache}/{nodeType}/{uid0}/", 
-                "outputUndistorted": "{cache}/{nodeType}/{uid0}/undistort", 
-                "outputCamera": "{cache}/{nodeType}/{uid0}/camera.abc"
-            }, 
             "position": [
                 1000, 
                 0
-            ], 
-            "internalFolder": "{cache}/{nodeType}/{uid0}/"
+            ]
         }, 
         "CameraInit_1": {
             "inputs": {}, 
             "nodeType": "CameraInit", 
-            "uids": {
-                "0": "f9436e97e444fa71a05aa5cf7639b206df8ba282"
-            }, 
-            "parallelization": {
-                "blockSize": 0, 
-                "split": 1, 
-                "size": 0
-            }, 
-            "outputs": {
-                "output": "{cache}/{nodeType}/{uid0}/cameraInit.sfm"
-            }, 
             "position": [
                 0, 
                 0
-            ], 
-            "internalFolder": "{cache}/{nodeType}/{uid0}/"
+            ]
         }, 
         "FeatureMatching_1": {
             "inputs": {
@@ -171,22 +95,10 @@
                 "featuresFolders": "{ImageMatching_1.featuresFolders}"
             }, 
             "nodeType": "FeatureMatching", 
-            "uids": {
-                "0": "d6266b2126948174744b0ff6c33d96440e7596de"
-            }, 
-            "parallelization": {
-                "blockSize": 20, 
-                "split": 0, 
-                "size": 0
-            }, 
-            "outputs": {
-                "output": "{cache}/{nodeType}/{uid0}/"
-            }, 
             "position": [
                 600, 
                 0
-            ], 
-            "internalFolder": "{cache}/{nodeType}/{uid0}/"
+            ]
         }
     }
 }

--- a/meshroom/pipelines/panoramaFisheyeHdr.mg
+++ b/meshroom/pipelines/panoramaFisheyeHdr.mg
@@ -32,9 +32,6 @@
                 "response": "{LdrToHdrCalibration_1.response}"
             }, 
             "nodeType": "LdrToHdrMerge", 
-            "uids": {
-                "0": "9b90e3b468adc487fe2905e0cc78328216966317"
-            }, 
             "parallelization": {
                 "blockSize": 2, 
                 "split": 0, 
@@ -57,9 +54,6 @@
                 "fixNonFinite": true
             }, 
             "nodeType": "ImageProcessing", 
-            "uids": {
-                "0": "51d41208c0c929fa50d88c183713958e9a407fd3"
-            }, 
             "parallelization": {
                 "blockSize": 0, 
                 "split": 1, 
@@ -80,9 +74,6 @@
                 "input": "{SfMTransform_1.output}"
             }, 
             "nodeType": "PanoramaWarping", 
-            "uids": {
-                "0": "2def8d004a44dcb3bbaa35da318d38bbb076b6ee"
-            }, 
             "parallelization": {
                 "blockSize": 5, 
                 "split": 0, 
@@ -106,9 +97,6 @@
                 "userNbBrackets": "{LdrToHdrSampling_1.userNbBrackets}"
             }, 
             "nodeType": "LdrToHdrCalibration", 
-            "uids": {
-                "0": "9225abd943d28be4387a8a8902711d0b7c604a2a"
-            }, 
             "parallelization": {
                 "blockSize": 0, 
                 "split": 1, 
@@ -128,9 +116,6 @@
                 "input": "{PanoramaPrepareImages_1.output}"
             }, 
             "nodeType": "LdrToHdrSampling", 
-            "uids": {
-                "0": "af67674ecc8524592fe2b217259c241167e28dcd"
-            }, 
             "parallelization": {
                 "blockSize": 2, 
                 "split": 0, 
@@ -154,9 +139,6 @@
                 ]
             }, 
             "nodeType": "ImageMatching", 
-            "uids": {
-                "0": "a076f9e959d62b3a6f63d3f6493527b857eab8d6"
-            }, 
             "parallelization": {
                 "blockSize": 0, 
                 "split": 1, 
@@ -181,9 +163,6 @@
                 "describerPreset": "high"
             }, 
             "nodeType": "FeatureExtraction", 
-            "uids": {
-                "0": "04f8824c2e2f206b47f05edaf76def15fa91446b"
-            }, 
             "parallelization": {
                 "blockSize": 40, 
                 "split": 0, 
@@ -204,9 +183,6 @@
                 "input": "{PanoramaCompositing_1.input}"
             }, 
             "nodeType": "PanoramaMerging", 
-            "uids": {
-                "0": "6895704a5fcd5fd070562190b3747cb3ca08121c"
-            }, 
             "parallelization": {
                 "blockSize": 0, 
                 "split": 1, 
@@ -228,9 +204,6 @@
                 "input": "{PanoramaSeams_1.input}"
             }, 
             "nodeType": "PanoramaCompositing", 
-            "uids": {
-                "0": "29f97e3a8c4d4989fae0ab4c1f3831a92dfbae5c"
-            }, 
             "parallelization": {
                 "blockSize": 5, 
                 "split": 0, 
@@ -259,9 +232,6 @@
                 ]
             }, 
             "nodeType": "CameraInit", 
-            "uids": {
-                "0": "f9436e97e444fa71a05aa5cf7639b206df8ba282"
-            }, 
             "parallelization": {
                 "blockSize": 0, 
                 "split": 1, 
@@ -281,9 +251,6 @@
                 "input": "{CameraInit_1.output}"
             }, 
             "nodeType": "PanoramaPrepareImages", 
-            "uids": {
-                "0": "6956c52a8d18cb4cdb7ceb0db68f4deb84a37aee"
-            }, 
             "parallelization": {
                 "blockSize": 0, 
                 "split": 1, 
@@ -304,9 +271,6 @@
                 "input": "{PanoramaEstimation_1.output}"
             }, 
             "nodeType": "SfMTransform", 
-            "uids": {
-                "0": "d9ff08700916f4e9e3ace1048c2c2621c9541272"
-            }, 
             "parallelization": {
                 "blockSize": 0, 
                 "split": 1, 
@@ -328,9 +292,6 @@
                 "warpingFolder": "{PanoramaWarping_1.output}"
             }, 
             "nodeType": "PanoramaSeams", 
-            "uids": {
-                "0": "52cbb0d53e0ef49cefe9848394023cf3e7f30572"
-            }, 
             "parallelization": {
                 "blockSize": 0, 
                 "split": 1, 
@@ -355,9 +316,6 @@
                 "featuresFolders": "{FeatureMatching_1.featuresFolders}"
             }, 
             "nodeType": "PanoramaEstimation", 
-            "uids": {
-                "0": "350636ae916682708019397a10592596e8ef7e84"
-            }, 
             "parallelization": {
                 "blockSize": 0, 
                 "split": 1, 
@@ -382,9 +340,6 @@
                 "input": "{FeatureExtraction_1.input}"
             }, 
             "nodeType": "PanoramaInit", 
-            "uids": {
-                "0": "2fd95a957eb42ffc8fb1c24d2666afcd859ba079"
-            }, 
             "parallelization": {
                 "blockSize": 0, 
                 "split": 1, 
@@ -407,9 +362,6 @@
                 "featuresFolders": "{ImageMatching_1.featuresFolders}"
             }, 
             "nodeType": "FeatureMatching", 
-            "uids": {
-                "0": "cb919baf3a96df73f0ef07a23357f3d8a7f380e8"
-            }, 
             "parallelization": {
                 "blockSize": 20, 
                 "split": 0, 

--- a/meshroom/pipelines/panoramaFisheyeHdr.mg
+++ b/meshroom/pipelines/panoramaFisheyeHdr.mg
@@ -32,19 +32,10 @@
                 "response": "{LdrToHdrCalibration_1.response}"
             }, 
             "nodeType": "LdrToHdrMerge", 
-            "parallelization": {
-                "blockSize": 2, 
-                "split": 0, 
-                "size": 0
-            }, 
-            "outputs": {
-                "outSfMData": "{cache}/{nodeType}/{uid0}/sfmData.sfm"
-            }, 
             "position": [
                 800, 
                 0
-            ], 
-            "internalFolder": "{cache}/{nodeType}/{uid0}/"
+            ]
         }, 
         "ImageProcessing_1": {
             "inputs": {
@@ -54,39 +45,20 @@
                 "fixNonFinite": true
             }, 
             "nodeType": "ImageProcessing", 
-            "parallelization": {
-                "blockSize": 0, 
-                "split": 1, 
-                "size": 0
-            }, 
-            "outputs": {
-                "output": "{cache}/{nodeType}/{uid0}/", 
-                "outputImages": "{cache}/{nodeType}/{uid0}/panorama.exr"
-            }, 
             "position": [
                 3000, 
                 0
-            ], 
-            "internalFolder": "{cache}/{nodeType}/{uid0}/"
+            ]
         }, 
         "PanoramaWarping_1": {
             "inputs": {
                 "input": "{SfMTransform_1.output}"
             }, 
             "nodeType": "PanoramaWarping", 
-            "parallelization": {
-                "blockSize": 5, 
-                "split": 0, 
-                "size": 0
-            }, 
-            "outputs": {
-                "output": "{cache}/{nodeType}/{uid0}/"
-            }, 
             "position": [
                 2200, 
                 0
-            ], 
-            "internalFolder": "{cache}/{nodeType}/{uid0}/"
+            ]
         }, 
         "LdrToHdrCalibration_1": {
             "inputs": {
@@ -97,38 +69,20 @@
                 "userNbBrackets": "{LdrToHdrSampling_1.userNbBrackets}"
             }, 
             "nodeType": "LdrToHdrCalibration", 
-            "parallelization": {
-                "blockSize": 0, 
-                "split": 1, 
-                "size": 0
-            }, 
-            "outputs": {
-                "response": "{cache}/{nodeType}/{uid0}/response.csv"
-            }, 
             "position": [
                 600, 
                 0
-            ], 
-            "internalFolder": "{cache}/{nodeType}/{uid0}/"
+            ]
         }, 
         "LdrToHdrSampling_1": {
             "inputs": {
                 "input": "{PanoramaPrepareImages_1.output}"
             }, 
             "nodeType": "LdrToHdrSampling", 
-            "parallelization": {
-                "blockSize": 2, 
-                "split": 0, 
-                "size": 0
-            }, 
-            "outputs": {
-                "output": "{cache}/{nodeType}/{uid0}/"
-            }, 
             "position": [
                 400, 
                 0
-            ], 
-            "internalFolder": "{cache}/{nodeType}/{uid0}/"
+            ]
         }, 
         "ImageMatching_1": {
             "inputs": {
@@ -139,19 +93,10 @@
                 ]
             }, 
             "nodeType": "ImageMatching", 
-            "parallelization": {
-                "blockSize": 0, 
-                "split": 1, 
-                "size": 0
-            }, 
-            "outputs": {
-                "output": "{cache}/{nodeType}/{uid0}/imageMatches.txt"
-            }, 
             "position": [
                 1400, 
                 0
-            ], 
-            "internalFolder": "{cache}/{nodeType}/{uid0}/"
+            ]
         }, 
         "FeatureExtraction_1": {
             "inputs": {
@@ -163,39 +108,21 @@
                 "describerPreset": "high"
             }, 
             "nodeType": "FeatureExtraction", 
-            "parallelization": {
-                "blockSize": 40, 
-                "split": 0, 
-                "size": 0
-            }, 
-            "outputs": {
-                "output": "{cache}/{nodeType}/{uid0}/"
-            }, 
             "position": [
                 1000, 
                 0
-            ], 
-            "internalFolder": "{cache}/{nodeType}/{uid0}/"
+            ]
         }, 
-        "PanoramaMerging_1": {
+        "PanoramaSeams_1": {
             "inputs": {
-                "compositingFolder": "{PanoramaCompositing_1.output}", 
-                "input": "{PanoramaCompositing_1.input}"
+                "input": "{PanoramaWarping_1.input}", 
+                "warpingFolder": "{PanoramaWarping_1.output}"
             }, 
-            "nodeType": "PanoramaMerging", 
-            "parallelization": {
-                "blockSize": 0, 
-                "split": 1, 
-                "size": 0
-            }, 
-            "outputs": {
-                "outputPanorama": "{cache}/{nodeType}/{uid0}/panorama.{outputFileTypeValue}"
-            }, 
+            "nodeType": "PanoramaSeams", 
             "position": [
-                2800, 
+                2400, 
                 0
-            ], 
-            "internalFolder": "{cache}/{nodeType}/{uid0}/"
+            ]
         }, 
         "PanoramaCompositing_1": {
             "inputs": {
@@ -204,19 +131,10 @@
                 "input": "{PanoramaSeams_1.input}"
             }, 
             "nodeType": "PanoramaCompositing", 
-            "parallelization": {
-                "blockSize": 5, 
-                "split": 0, 
-                "size": 0
-            }, 
-            "outputs": {
-                "output": "{cache}/{nodeType}/{uid0}/"
-            }, 
             "position": [
                 2600, 
                 0
-            ], 
-            "internalFolder": "{cache}/{nodeType}/{uid0}/"
+            ]
         }, 
         "CameraInit_1": {
             "inputs": {
@@ -232,38 +150,20 @@
                 ]
             }, 
             "nodeType": "CameraInit", 
-            "parallelization": {
-                "blockSize": 0, 
-                "split": 1, 
-                "size": 0
-            }, 
-            "outputs": {
-                "output": "{cache}/{nodeType}/{uid0}/cameraInit.sfm"
-            }, 
             "position": [
                 0, 
                 0
-            ], 
-            "internalFolder": "{cache}/{nodeType}/{uid0}/"
+            ]
         }, 
         "PanoramaPrepareImages_1": {
             "inputs": {
                 "input": "{CameraInit_1.output}"
             }, 
             "nodeType": "PanoramaPrepareImages", 
-            "parallelization": {
-                "blockSize": 0, 
-                "split": 1, 
-                "size": 0
-            }, 
-            "outputs": {
-                "output": "{cache}/{nodeType}/{uid0}/cameraInit.sfm"
-            }, 
             "position": [
                 200, 
                 0
-            ], 
-            "internalFolder": "{cache}/{nodeType}/{uid0}/"
+            ]
         }, 
         "SfMTransform_1": {
             "inputs": {
@@ -271,40 +171,21 @@
                 "input": "{PanoramaEstimation_1.output}"
             }, 
             "nodeType": "SfMTransform", 
-            "parallelization": {
-                "blockSize": 0, 
-                "split": 1, 
-                "size": 0
-            }, 
-            "outputs": {
-                "output": "{cache}/{nodeType}/{uid0}/panorama.abc", 
-                "outputViewsAndPoses": "{cache}/{nodeType}/{uid0}/cameras.sfm"
-            }, 
             "position": [
                 2000, 
                 0
-            ], 
-            "internalFolder": "{cache}/{nodeType}/{uid0}/"
+            ]
         }, 
-        "PanoramaSeams_1": {
+        "PanoramaMerging_1": {
             "inputs": {
-                "input": "{PanoramaWarping_1.input}", 
-                "warpingFolder": "{PanoramaWarping_1.output}"
+                "compositingFolder": "{PanoramaCompositing_1.output}", 
+                "input": "{PanoramaCompositing_1.input}"
             }, 
-            "nodeType": "PanoramaSeams", 
-            "parallelization": {
-                "blockSize": 0, 
-                "split": 1, 
-                "size": 0
-            }, 
-            "outputs": {
-                "output": "{cache}/{nodeType}/{uid0}/labels.exr"
-            }, 
+            "nodeType": "PanoramaMerging", 
             "position": [
-                2400, 
+                2800, 
                 0
-            ], 
-            "internalFolder": "{cache}/{nodeType}/{uid0}/"
+            ]
         }, 
         "PanoramaEstimation_1": {
             "inputs": {
@@ -316,20 +197,10 @@
                 "featuresFolders": "{FeatureMatching_1.featuresFolders}"
             }, 
             "nodeType": "PanoramaEstimation", 
-            "parallelization": {
-                "blockSize": 0, 
-                "split": 1, 
-                "size": 0
-            }, 
-            "outputs": {
-                "output": "{cache}/{nodeType}/{uid0}/panorama.abc", 
-                "outputViewsAndPoses": "{cache}/{nodeType}/{uid0}/cameras.sfm"
-            }, 
             "position": [
                 1800, 
                 0
-            ], 
-            "internalFolder": "{cache}/{nodeType}/{uid0}/"
+            ]
         }, 
         "PanoramaInit_1": {
             "inputs": {
@@ -340,19 +211,10 @@
                 "input": "{FeatureExtraction_1.input}"
             }, 
             "nodeType": "PanoramaInit", 
-            "parallelization": {
-                "blockSize": 0, 
-                "split": 1, 
-                "size": 0
-            }, 
-            "outputs": {
-                "outSfMData": "{cache}/{nodeType}/{uid0}/sfmData.sfm"
-            }, 
             "position": [
                 1200, 
                 0
-            ], 
-            "internalFolder": "{cache}/{nodeType}/{uid0}/"
+            ]
         }, 
         "FeatureMatching_1": {
             "inputs": {
@@ -362,19 +224,10 @@
                 "featuresFolders": "{ImageMatching_1.featuresFolders}"
             }, 
             "nodeType": "FeatureMatching", 
-            "parallelization": {
-                "blockSize": 20, 
-                "split": 0, 
-                "size": 0
-            }, 
-            "outputs": {
-                "output": "{cache}/{nodeType}/{uid0}/"
-            }, 
             "position": [
                 1600, 
                 0
-            ], 
-            "internalFolder": "{cache}/{nodeType}/{uid0}/"
+            ]
         }
     }
 }

--- a/meshroom/pipelines/panoramaHdr.mg
+++ b/meshroom/pipelines/panoramaHdr.mg
@@ -32,9 +32,6 @@
                 "response": "{LdrToHdrCalibration_1.response}"
             }, 
             "nodeType": "LdrToHdrMerge", 
-            "uids": {
-                "0": "9b90e3b468adc487fe2905e0cc78328216966317"
-            }, 
             "parallelization": {
                 "blockSize": 2, 
                 "split": 0, 
@@ -57,9 +54,6 @@
                 "fixNonFinite": true
             }, 
             "nodeType": "ImageProcessing", 
-            "uids": {
-                "0": "db79f52d50b71d5f8a0b398109bb8ff4c4506e75"
-            }, 
             "parallelization": {
                 "blockSize": 0, 
                 "split": 1, 
@@ -80,9 +74,6 @@
                 "input": "{SfMTransform_1.output}"
             }, 
             "nodeType": "PanoramaWarping", 
-            "uids": {
-                "0": "2b35fc7d314e510119ba9c40e2870fee75c0f145"
-            }, 
             "parallelization": {
                 "blockSize": 5, 
                 "split": 0, 
@@ -106,9 +97,6 @@
                 "userNbBrackets": "{LdrToHdrSampling_1.userNbBrackets}"
             }, 
             "nodeType": "LdrToHdrCalibration", 
-            "uids": {
-                "0": "9225abd943d28be4387a8a8902711d0b7c604a2a"
-            }, 
             "parallelization": {
                 "blockSize": 0, 
                 "split": 1, 
@@ -128,9 +116,6 @@
                 "input": "{PanoramaPrepareImages_1.output}"
             }, 
             "nodeType": "LdrToHdrSampling", 
-            "uids": {
-                "0": "af67674ecc8524592fe2b217259c241167e28dcd"
-            }, 
             "parallelization": {
                 "blockSize": 2, 
                 "split": 0, 
@@ -154,9 +139,6 @@
                 ]
             }, 
             "nodeType": "ImageMatching", 
-            "uids": {
-                "0": "7efc9cd43585003fc6eec0776a704e358f0a15de"
-            }, 
             "parallelization": {
                 "blockSize": 0, 
                 "split": 1, 
@@ -177,9 +159,6 @@
                 "input": "{LdrToHdrMerge_1.outSfMData}"
             }, 
             "nodeType": "FeatureExtraction", 
-            "uids": {
-                "0": "1863cc0989ab0fd910d4fe293074ff94c4e586a1"
-            }, 
             "parallelization": {
                 "blockSize": 40, 
                 "split": 0, 
@@ -200,9 +179,6 @@
                 "input": "{PanoramaCompositing_1.input}"
             }, 
             "nodeType": "PanoramaMerging", 
-            "uids": {
-                "0": "ebc83e08ec420c2451e6e667feed11fad346acd7"
-            }, 
             "parallelization": {
                 "blockSize": 0, 
                 "split": 1, 
@@ -224,9 +200,6 @@
                 "input": "{PanoramaSeams_1.input}"
             }, 
             "nodeType": "PanoramaCompositing", 
-            "uids": {
-                "0": "7c118e7273f8f93818fbf82fe272c6d6553c650f"
-            }, 
             "parallelization": {
                 "blockSize": 5, 
                 "split": 0, 
@@ -255,9 +228,6 @@
                 ]
             }, 
             "nodeType": "CameraInit", 
-            "uids": {
-                "0": "f9436e97e444fa71a05aa5cf7639b206df8ba282"
-            }, 
             "parallelization": {
                 "blockSize": 0, 
                 "split": 1, 
@@ -277,9 +247,6 @@
                 "input": "{CameraInit_1.output}"
             }, 
             "nodeType": "PanoramaPrepareImages", 
-            "uids": {
-                "0": "6956c52a8d18cb4cdb7ceb0db68f4deb84a37aee"
-            }, 
             "parallelization": {
                 "blockSize": 0, 
                 "split": 1, 
@@ -300,9 +267,6 @@
                 "input": "{PanoramaEstimation_1.output}"
             }, 
             "nodeType": "SfMTransform", 
-            "uids": {
-                "0": "634e1a4143def636efac5c0f9cd64e0dcb99c20c"
-            }, 
             "parallelization": {
                 "blockSize": 0, 
                 "split": 1, 
@@ -324,9 +288,6 @@
                 "warpingFolder": "{PanoramaWarping_1.output}"
             }, 
             "nodeType": "PanoramaSeams", 
-            "uids": {
-                "0": "89eb43d21b7fa9fcd438ed92109f4d736dafcdfb"
-            }, 
             "parallelization": {
                 "blockSize": 0, 
                 "split": 1, 
@@ -351,9 +312,6 @@
                 "featuresFolders": "{FeatureMatching_1.featuresFolders}"
             }, 
             "nodeType": "PanoramaEstimation", 
-            "uids": {
-                "0": "dc44122c2490f220a4e5f62aeec0745bfa44a8e3"
-            }, 
             "parallelization": {
                 "blockSize": 0, 
                 "split": 1, 
@@ -377,9 +335,6 @@
                 "input": "{FeatureExtraction_1.input}"
             }, 
             "nodeType": "PanoramaInit", 
-            "uids": {
-                "0": "702d6b973342e9203b50afea1470b4c01eb90174"
-            }, 
             "parallelization": {
                 "blockSize": 0, 
                 "split": 1, 
@@ -402,9 +357,6 @@
                 "featuresFolders": "{ImageMatching_1.featuresFolders}"
             }, 
             "nodeType": "FeatureMatching", 
-            "uids": {
-                "0": "f818137ea50d2e41fb541690adeb842db7cecc43"
-            }, 
             "parallelization": {
                 "blockSize": 20, 
                 "split": 0, 

--- a/meshroom/pipelines/panoramaHdr.mg
+++ b/meshroom/pipelines/panoramaHdr.mg
@@ -32,19 +32,10 @@
                 "response": "{LdrToHdrCalibration_1.response}"
             }, 
             "nodeType": "LdrToHdrMerge", 
-            "parallelization": {
-                "blockSize": 2, 
-                "split": 0, 
-                "size": 0
-            }, 
-            "outputs": {
-                "outSfMData": "{cache}/{nodeType}/{uid0}/sfmData.sfm"
-            }, 
             "position": [
                 800, 
                 0
-            ], 
-            "internalFolder": "{cache}/{nodeType}/{uid0}/"
+            ]
         }, 
         "ImageProcessing_1": {
             "inputs": {
@@ -54,39 +45,20 @@
                 "fixNonFinite": true
             }, 
             "nodeType": "ImageProcessing", 
-            "parallelization": {
-                "blockSize": 0, 
-                "split": 1, 
-                "size": 0
-            }, 
-            "outputs": {
-                "output": "{cache}/{nodeType}/{uid0}/", 
-                "outputImages": "{cache}/{nodeType}/{uid0}/panorama.exr"
-            }, 
             "position": [
                 3000, 
                 0
-            ], 
-            "internalFolder": "{cache}/{nodeType}/{uid0}/"
+            ]
         }, 
         "PanoramaWarping_1": {
             "inputs": {
                 "input": "{SfMTransform_1.output}"
             }, 
             "nodeType": "PanoramaWarping", 
-            "parallelization": {
-                "blockSize": 5, 
-                "split": 0, 
-                "size": 0
-            }, 
-            "outputs": {
-                "output": "{cache}/{nodeType}/{uid0}/"
-            }, 
             "position": [
                 2200, 
                 0
-            ], 
-            "internalFolder": "{cache}/{nodeType}/{uid0}/"
+            ]
         }, 
         "LdrToHdrCalibration_1": {
             "inputs": {
@@ -97,38 +69,20 @@
                 "userNbBrackets": "{LdrToHdrSampling_1.userNbBrackets}"
             }, 
             "nodeType": "LdrToHdrCalibration", 
-            "parallelization": {
-                "blockSize": 0, 
-                "split": 1, 
-                "size": 0
-            }, 
-            "outputs": {
-                "response": "{cache}/{nodeType}/{uid0}/response.csv"
-            }, 
             "position": [
                 600, 
                 0
-            ], 
-            "internalFolder": "{cache}/{nodeType}/{uid0}/"
+            ]
         }, 
         "LdrToHdrSampling_1": {
             "inputs": {
                 "input": "{PanoramaPrepareImages_1.output}"
             }, 
             "nodeType": "LdrToHdrSampling", 
-            "parallelization": {
-                "blockSize": 2, 
-                "split": 0, 
-                "size": 0
-            }, 
-            "outputs": {
-                "output": "{cache}/{nodeType}/{uid0}/"
-            }, 
             "position": [
                 400, 
                 0
-            ], 
-            "internalFolder": "{cache}/{nodeType}/{uid0}/"
+            ]
         }, 
         "ImageMatching_1": {
             "inputs": {
@@ -139,19 +93,10 @@
                 ]
             }, 
             "nodeType": "ImageMatching", 
-            "parallelization": {
-                "blockSize": 0, 
-                "split": 1, 
-                "size": 0
-            }, 
-            "outputs": {
-                "output": "{cache}/{nodeType}/{uid0}/imageMatches.txt"
-            }, 
             "position": [
                 1400, 
                 0
-            ], 
-            "internalFolder": "{cache}/{nodeType}/{uid0}/"
+            ]
         }, 
         "FeatureExtraction_1": {
             "inputs": {
@@ -159,39 +104,21 @@
                 "input": "{LdrToHdrMerge_1.outSfMData}"
             }, 
             "nodeType": "FeatureExtraction", 
-            "parallelization": {
-                "blockSize": 40, 
-                "split": 0, 
-                "size": 0
-            }, 
-            "outputs": {
-                "output": "{cache}/{nodeType}/{uid0}/"
-            }, 
             "position": [
                 1000, 
                 0
-            ], 
-            "internalFolder": "{cache}/{nodeType}/{uid0}/"
+            ]
         }, 
-        "PanoramaMerging_1": {
+        "PanoramaSeams_1": {
             "inputs": {
-                "compositingFolder": "{PanoramaCompositing_1.output}", 
-                "input": "{PanoramaCompositing_1.input}"
+                "input": "{PanoramaWarping_1.input}", 
+                "warpingFolder": "{PanoramaWarping_1.output}"
             }, 
-            "nodeType": "PanoramaMerging", 
-            "parallelization": {
-                "blockSize": 0, 
-                "split": 1, 
-                "size": 0
-            }, 
-            "outputs": {
-                "outputPanorama": "{cache}/{nodeType}/{uid0}/panorama.{outputFileTypeValue}"
-            }, 
+            "nodeType": "PanoramaSeams", 
             "position": [
-                2800, 
+                2400, 
                 0
-            ], 
-            "internalFolder": "{cache}/{nodeType}/{uid0}/"
+            ]
         }, 
         "PanoramaCompositing_1": {
             "inputs": {
@@ -200,19 +127,10 @@
                 "input": "{PanoramaSeams_1.input}"
             }, 
             "nodeType": "PanoramaCompositing", 
-            "parallelization": {
-                "blockSize": 5, 
-                "split": 0, 
-                "size": 0
-            }, 
-            "outputs": {
-                "output": "{cache}/{nodeType}/{uid0}/"
-            }, 
             "position": [
                 2600, 
                 0
-            ], 
-            "internalFolder": "{cache}/{nodeType}/{uid0}/"
+            ]
         }, 
         "CameraInit_1": {
             "inputs": {
@@ -228,38 +146,20 @@
                 ]
             }, 
             "nodeType": "CameraInit", 
-            "parallelization": {
-                "blockSize": 0, 
-                "split": 1, 
-                "size": 0
-            }, 
-            "outputs": {
-                "output": "{cache}/{nodeType}/{uid0}/cameraInit.sfm"
-            }, 
             "position": [
                 0, 
                 0
-            ], 
-            "internalFolder": "{cache}/{nodeType}/{uid0}/"
+            ]
         }, 
         "PanoramaPrepareImages_1": {
             "inputs": {
                 "input": "{CameraInit_1.output}"
             }, 
             "nodeType": "PanoramaPrepareImages", 
-            "parallelization": {
-                "blockSize": 0, 
-                "split": 1, 
-                "size": 0
-            }, 
-            "outputs": {
-                "output": "{cache}/{nodeType}/{uid0}/cameraInit.sfm"
-            }, 
             "position": [
                 200, 
                 0
-            ], 
-            "internalFolder": "{cache}/{nodeType}/{uid0}/"
+            ]
         }, 
         "SfMTransform_1": {
             "inputs": {
@@ -267,40 +167,21 @@
                 "input": "{PanoramaEstimation_1.output}"
             }, 
             "nodeType": "SfMTransform", 
-            "parallelization": {
-                "blockSize": 0, 
-                "split": 1, 
-                "size": 0
-            }, 
-            "outputs": {
-                "output": "{cache}/{nodeType}/{uid0}/panorama.abc", 
-                "outputViewsAndPoses": "{cache}/{nodeType}/{uid0}/cameras.sfm"
-            }, 
             "position": [
                 2000, 
                 0
-            ], 
-            "internalFolder": "{cache}/{nodeType}/{uid0}/"
+            ]
         }, 
-        "PanoramaSeams_1": {
+        "PanoramaMerging_1": {
             "inputs": {
-                "input": "{PanoramaWarping_1.input}", 
-                "warpingFolder": "{PanoramaWarping_1.output}"
+                "compositingFolder": "{PanoramaCompositing_1.output}", 
+                "input": "{PanoramaCompositing_1.input}"
             }, 
-            "nodeType": "PanoramaSeams", 
-            "parallelization": {
-                "blockSize": 0, 
-                "split": 1, 
-                "size": 0
-            }, 
-            "outputs": {
-                "output": "{cache}/{nodeType}/{uid0}/labels.exr"
-            }, 
+            "nodeType": "PanoramaMerging", 
             "position": [
-                2400, 
+                2800, 
                 0
-            ], 
-            "internalFolder": "{cache}/{nodeType}/{uid0}/"
+            ]
         }, 
         "PanoramaEstimation_1": {
             "inputs": {
@@ -312,20 +193,10 @@
                 "featuresFolders": "{FeatureMatching_1.featuresFolders}"
             }, 
             "nodeType": "PanoramaEstimation", 
-            "parallelization": {
-                "blockSize": 0, 
-                "split": 1, 
-                "size": 0
-            }, 
-            "outputs": {
-                "output": "{cache}/{nodeType}/{uid0}/panorama.abc", 
-                "outputViewsAndPoses": "{cache}/{nodeType}/{uid0}/cameras.sfm"
-            }, 
             "position": [
                 1800, 
                 0
-            ], 
-            "internalFolder": "{cache}/{nodeType}/{uid0}/"
+            ]
         }, 
         "PanoramaInit_1": {
             "inputs": {
@@ -335,19 +206,10 @@
                 "input": "{FeatureExtraction_1.input}"
             }, 
             "nodeType": "PanoramaInit", 
-            "parallelization": {
-                "blockSize": 0, 
-                "split": 1, 
-                "size": 0
-            }, 
-            "outputs": {
-                "outSfMData": "{cache}/{nodeType}/{uid0}/sfmData.sfm"
-            }, 
             "position": [
                 1200, 
                 0
-            ], 
-            "internalFolder": "{cache}/{nodeType}/{uid0}/"
+            ]
         }, 
         "FeatureMatching_1": {
             "inputs": {
@@ -357,19 +219,10 @@
                 "featuresFolders": "{ImageMatching_1.featuresFolders}"
             }, 
             "nodeType": "FeatureMatching", 
-            "parallelization": {
-                "blockSize": 20, 
-                "split": 0, 
-                "size": 0
-            }, 
-            "outputs": {
-                "output": "{cache}/{nodeType}/{uid0}/"
-            }, 
             "position": [
                 1600, 
                 0
-            ], 
-            "internalFolder": "{cache}/{nodeType}/{uid0}/"
+            ]
         }
     }
 }

--- a/meshroom/pipelines/photogrammetry.mg
+++ b/meshroom/pipelines/photogrammetry.mg
@@ -26,22 +26,10 @@
                 "inputMesh": "{MeshFiltering_1.outputMesh}"
             }, 
             "nodeType": "Texturing", 
-            "parallelization": {
-                "blockSize": 0, 
-                "split": 1, 
-                "size": 1
-            }, 
-            "outputs": {
-                "outputTextures": "{cache}/{nodeType}/{uid0}/texture_*.exr", 
-                "outputMesh": "{cache}/{nodeType}/{uid0}/texturedMesh.{outputMeshFileTypeValue}", 
-                "outputMaterial": "{cache}/{nodeType}/{uid0}/texturedMesh.mtl", 
-                "output": "{cache}/{nodeType}/{uid0}/"
-            }, 
             "position": [
                 2000, 
                 0
-            ], 
-            "internalFolder": "{cache}/{nodeType}/{uid0}/"
+            ]
         }, 
         "Meshing_1": {
             "inputs": {
@@ -49,20 +37,10 @@
                 "input": "{DepthMapFilter_1.input}"
             }, 
             "nodeType": "Meshing", 
-            "parallelization": {
-                "blockSize": 0, 
-                "split": 1, 
-                "size": 1
-            }, 
-            "outputs": {
-                "output": "{cache}/{nodeType}/{uid0}/densePointCloud.abc", 
-                "outputMesh": "{cache}/{nodeType}/{uid0}/mesh.{outputMeshFileTypeValue}"
-            }, 
             "position": [
                 1600, 
                 0
-            ], 
-            "internalFolder": "{cache}/{nodeType}/{uid0}/"
+            ]
         }, 
         "DepthMapFilter_1": {
             "inputs": {
@@ -70,21 +48,10 @@
                 "input": "{DepthMap_1.input}"
             }, 
             "nodeType": "DepthMapFilter", 
-            "parallelization": {
-                "blockSize": 10, 
-                "split": 0, 
-                "size": 0
-            }, 
-            "outputs": {
-                "output": "{cache}/{nodeType}/{uid0}/", 
-                "depth": "{cache}/{nodeType}/{uid0}/<VIEW_ID>_depthMap.exr", 
-                "sim": "{cache}/{nodeType}/{uid0}/<VIEW_ID>_simMap.exr"
-            }, 
             "position": [
                 1400, 
                 0
-            ], 
-            "internalFolder": "{cache}/{nodeType}/{uid0}/"
+            ]
         }, 
         "ImageMatching_1": {
             "inputs": {
@@ -94,38 +61,20 @@
                 ]
             }, 
             "nodeType": "ImageMatching", 
-            "parallelization": {
-                "blockSize": 0, 
-                "split": 1, 
-                "size": 0
-            }, 
-            "outputs": {
-                "output": "{cache}/{nodeType}/{uid0}/imageMatches.txt"
-            }, 
             "position": [
                 400, 
                 0
-            ], 
-            "internalFolder": "{cache}/{nodeType}/{uid0}/"
+            ]
         }, 
         "FeatureExtraction_1": {
             "inputs": {
                 "input": "{CameraInit_1.output}"
             }, 
             "nodeType": "FeatureExtraction", 
-            "parallelization": {
-                "blockSize": 40, 
-                "split": 0, 
-                "size": 0
-            }, 
-            "outputs": {
-                "output": "{cache}/{nodeType}/{uid0}/"
-            }, 
             "position": [
                 200, 
                 0
-            ], 
-            "internalFolder": "{cache}/{nodeType}/{uid0}/"
+            ]
         }, 
         "StructureFromMotion_1": {
             "inputs": {
@@ -137,58 +86,28 @@
                 ]
             }, 
             "nodeType": "StructureFromMotion", 
-            "parallelization": {
-                "blockSize": 0, 
-                "split": 1, 
-                "size": 0
-            }, 
-            "outputs": {
-                "output": "{cache}/{nodeType}/{uid0}/sfm.abc", 
-                "extraInfoFolder": "{cache}/{nodeType}/{uid0}/", 
-                "outputViewsAndPoses": "{cache}/{nodeType}/{uid0}/cameras.sfm"
-            }, 
             "position": [
                 800, 
                 0
-            ], 
-            "internalFolder": "{cache}/{nodeType}/{uid0}/"
+            ]
         }, 
         "PrepareDenseScene_1": {
             "inputs": {
                 "input": "{StructureFromMotion_1.output}"
             }, 
             "nodeType": "PrepareDenseScene", 
-            "parallelization": {
-                "blockSize": 40, 
-                "split": 0, 
-                "size": 0
-            }, 
-            "outputs": {
-                "output": "{cache}/{nodeType}/{uid0}/", 
-                "undistorted": "{cache}/{nodeType}/{uid0}/<VIEW_ID>.{outputFileTypeValue}"
-            }, 
             "position": [
                 1000, 
                 0
-            ], 
-            "internalFolder": "{cache}/{nodeType}/{uid0}/"
+            ]
         }, 
         "CameraInit_1": {
             "inputs": {}, 
             "nodeType": "CameraInit", 
-            "parallelization": {
-                "blockSize": 0, 
-                "split": 1, 
-                "size": 0
-            }, 
-            "outputs": {
-                "output": "{cache}/{nodeType}/{uid0}/cameraInit.sfm"
-            }, 
             "position": [
                 0, 
                 0
-            ], 
-            "internalFolder": "{cache}/{nodeType}/{uid0}/"
+            ]
         }, 
         "DepthMap_1": {
             "inputs": {
@@ -196,40 +115,20 @@
                 "input": "{PrepareDenseScene_1.input}"
             }, 
             "nodeType": "DepthMap", 
-            "parallelization": {
-                "blockSize": 3, 
-                "split": 0, 
-                "size": 0
-            }, 
-            "outputs": {
-                "output": "{cache}/{nodeType}/{uid0}/", 
-                "depth": "{cache}/{nodeType}/{uid0}/<VIEW_ID>_depthMap.exr", 
-                "sim": "{cache}/{nodeType}/{uid0}/<VIEW_ID>_simMap.exr"
-            }, 
             "position": [
                 1200, 
                 0
-            ], 
-            "internalFolder": "{cache}/{nodeType}/{uid0}/"
+            ]
         }, 
         "MeshFiltering_1": {
             "inputs": {
                 "inputMesh": "{Meshing_1.outputMesh}"
             }, 
             "nodeType": "MeshFiltering", 
-            "parallelization": {
-                "blockSize": 0, 
-                "split": 1, 
-                "size": 1
-            }, 
-            "outputs": {
-                "outputMesh": "{cache}/{nodeType}/{uid0}/mesh.{outputMeshFileTypeValue}"
-            }, 
             "position": [
                 1800, 
                 0
-            ], 
-            "internalFolder": "{cache}/{nodeType}/{uid0}/"
+            ]
         }, 
         "FeatureMatching_1": {
             "inputs": {
@@ -239,19 +138,10 @@
                 "featuresFolders": "{ImageMatching_1.featuresFolders}"
             }, 
             "nodeType": "FeatureMatching", 
-            "parallelization": {
-                "blockSize": 20, 
-                "split": 0, 
-                "size": 0
-            }, 
-            "outputs": {
-                "output": "{cache}/{nodeType}/{uid0}/"
-            }, 
             "position": [
                 600, 
                 0
-            ], 
-            "internalFolder": "{cache}/{nodeType}/{uid0}/"
+            ]
         }
     }
 }

--- a/meshroom/pipelines/photogrammetry.mg
+++ b/meshroom/pipelines/photogrammetry.mg
@@ -26,9 +26,6 @@
                 "inputMesh": "{MeshFiltering_1.outputMesh}"
             }, 
             "nodeType": "Texturing", 
-            "uids": {
-                "0": "a7508a27971a36b86401f0476f64287476069faa"
-            }, 
             "parallelization": {
                 "blockSize": 0, 
                 "split": 1, 
@@ -52,9 +49,6 @@
                 "input": "{DepthMapFilter_1.input}"
             }, 
             "nodeType": "Meshing", 
-            "uids": {
-                "0": "a520c188f5e02d00b841b1a376de78a252c79c24"
-            }, 
             "parallelization": {
                 "blockSize": 0, 
                 "split": 1, 
@@ -76,9 +70,6 @@
                 "input": "{DepthMap_1.input}"
             }, 
             "nodeType": "DepthMapFilter", 
-            "uids": {
-                "0": "9d7527658e450be51a2fffb3923fd3d24b2b928c"
-            }, 
             "parallelization": {
                 "blockSize": 10, 
                 "split": 0, 
@@ -101,9 +92,6 @@
                 ]
             }, 
             "nodeType": "ImageMatching", 
-            "uids": {
-                "0": "46fb9072ac753d60bec7dda9c8674b0568506ddf"
-            }, 
             "parallelization": {
                 "blockSize": 0, 
                 "split": 1, 
@@ -123,9 +111,6 @@
                 "input": "{CameraInit_1.output}"
             }, 
             "nodeType": "FeatureExtraction", 
-            "uids": {
-                "0": "a07fb8d05b63327d05461954c2fd2a00f201275b"
-            }, 
             "parallelization": {
                 "blockSize": 40, 
                 "split": 0, 
@@ -150,9 +135,6 @@
                 ]
             }, 
             "nodeType": "StructureFromMotion", 
-            "uids": {
-                "0": "5af4f4052aa22b0450708941b40928d46170f364"
-            }, 
             "parallelization": {
                 "blockSize": 0, 
                 "split": 1, 
@@ -174,9 +156,6 @@
                 "input": "{StructureFromMotion_1.output}"
             }, 
             "nodeType": "PrepareDenseScene", 
-            "uids": {
-                "0": "489beb05de9e2d5cdfac149936b8c30c691f4b67"
-            }, 
             "parallelization": {
                 "blockSize": 40, 
                 "split": 0, 
@@ -195,9 +174,6 @@
         "CameraInit_1": {
             "inputs": {}, 
             "nodeType": "CameraInit", 
-            "uids": {
-                "0": "f9436e97e444fa71a05aa5cf7639b206df8ba282"
-            }, 
             "parallelization": {
                 "blockSize": 0, 
                 "split": 1, 
@@ -218,9 +194,6 @@
                 "input": "{PrepareDenseScene_1.input}"
             }, 
             "nodeType": "DepthMap", 
-            "uids": {
-                "0": "279cdf5aa186d06aa81d952999991df43f3299f8"
-            }, 
             "parallelization": {
                 "blockSize": 3, 
                 "split": 0, 
@@ -240,9 +213,6 @@
                 "inputMesh": "{Meshing_1.outputMesh}"
             }, 
             "nodeType": "MeshFiltering", 
-            "uids": {
-                "0": "590f12b2789757dcbe3bfd3e5b50e28d73a4e060"
-            }, 
             "parallelization": {
                 "blockSize": 0, 
                 "split": 1, 
@@ -265,9 +235,6 @@
                 "featuresFolders": "{ImageMatching_1.featuresFolders}"
             }, 
             "nodeType": "FeatureMatching", 
-            "uids": {
-                "0": "534c5224ba51c770ae3793cc085ae3aaa8c2c415"
-            }, 
             "parallelization": {
                 "blockSize": 20, 
                 "split": 0, 

--- a/meshroom/pipelines/photogrammetry.mg
+++ b/meshroom/pipelines/photogrammetry.mg
@@ -76,7 +76,9 @@
                 "size": 0
             }, 
             "outputs": {
-                "output": "{cache}/{nodeType}/{uid0}/"
+                "output": "{cache}/{nodeType}/{uid0}/", 
+                "depth": "{cache}/{nodeType}/{uid0}/<VIEW_ID>_depthMap.exr", 
+                "sim": "{cache}/{nodeType}/{uid0}/<VIEW_ID>_simMap.exr"
             }, 
             "position": [
                 1400, 
@@ -163,7 +165,7 @@
             }, 
             "outputs": {
                 "output": "{cache}/{nodeType}/{uid0}/", 
-                "outputUndistorted": "{cache}/{nodeType}/{uid0}/*.{outputFileTypeValue}"
+                "undistorted": "{cache}/{nodeType}/{uid0}/<VIEW_ID>.{outputFileTypeValue}"
             }, 
             "position": [
                 1000, 
@@ -200,7 +202,9 @@
                 "size": 0
             }, 
             "outputs": {
-                "output": "{cache}/{nodeType}/{uid0}/"
+                "output": "{cache}/{nodeType}/{uid0}/", 
+                "depth": "{cache}/{nodeType}/{uid0}/<VIEW_ID>_depthMap.exr", 
+                "sim": "{cache}/{nodeType}/{uid0}/<VIEW_ID>_simMap.exr"
             }, 
             "position": [
                 1200, 

--- a/meshroom/pipelines/photogrammetryAndCameraTracking.mg
+++ b/meshroom/pipelines/photogrammetryAndCameraTracking.mg
@@ -21,19 +21,10 @@
                 "input": "{CameraInit_2.output}"
             }, 
             "nodeType": "DistortionCalibration", 
-            "parallelization": {
-                "blockSize": 0, 
-                "split": 1, 
-                "size": 0
-            }, 
-            "outputs": {
-                "outSfMData": "{cache}/{nodeType}/{uid0}/sfmData.sfm"
-            }, 
             "position": [
                 1024, 
                 393
-            ], 
-            "internalFolder": "{cache}/{nodeType}/{uid0}/"
+            ]
         }, 
         "ImageMatching_1": {
             "inputs": {
@@ -43,38 +34,20 @@
                 ]
             }, 
             "nodeType": "ImageMatching", 
-            "parallelization": {
-                "blockSize": 0, 
-                "split": 1, 
-                "size": 0
-            }, 
-            "outputs": {
-                "output": "{cache}/{nodeType}/{uid0}/imageMatches.txt"
-            }, 
             "position": [
                 400, 
                 0
-            ], 
-            "internalFolder": "{cache}/{nodeType}/{uid0}/"
+            ]
         }, 
         "FeatureExtraction_1": {
             "inputs": {
                 "input": "{CameraInit_1.output}"
             }, 
             "nodeType": "FeatureExtraction", 
-            "parallelization": {
-                "blockSize": 40, 
-                "split": 0, 
-                "size": 0
-            }, 
-            "outputs": {
-                "output": "{cache}/{nodeType}/{uid0}/"
-            }, 
             "position": [
                 200, 
                 0
-            ], 
-            "internalFolder": "{cache}/{nodeType}/{uid0}/"
+            ]
         }, 
         "StructureFromMotion_1": {
             "inputs": {
@@ -86,21 +59,10 @@
                 ]
             }, 
             "nodeType": "StructureFromMotion", 
-            "parallelization": {
-                "blockSize": 0, 
-                "split": 1, 
-                "size": 0
-            }, 
-            "outputs": {
-                "output": "{cache}/{nodeType}/{uid0}/sfm.abc", 
-                "extraInfoFolder": "{cache}/{nodeType}/{uid0}/", 
-                "outputViewsAndPoses": "{cache}/{nodeType}/{uid0}/cameras.sfm"
-            }, 
             "position": [
                 800, 
                 0
-            ], 
-            "internalFolder": "{cache}/{nodeType}/{uid0}/"
+            ]
         }, 
         "ExportAnimatedCamera_1": {
             "inputs": {
@@ -108,38 +70,18 @@
                 "input": "{StructureFromMotion_2.output}"
             }, 
             "nodeType": "ExportAnimatedCamera", 
-            "parallelization": {
-                "blockSize": 0, 
-                "split": 1, 
-                "size": 1
-            }, 
-            "outputs": {
-                "output": "{cache}/{nodeType}/{uid0}/", 
-                "outputUndistorted": "{cache}/{nodeType}/{uid0}/undistort", 
-                "outputCamera": "{cache}/{nodeType}/{uid0}/camera.abc"
-            }, 
             "position": [
                 1629, 
                 212
-            ], 
-            "internalFolder": "{cache}/{nodeType}/{uid0}/"
+            ]
         }, 
         "CameraInit_1": {
             "inputs": {}, 
             "nodeType": "CameraInit", 
-            "parallelization": {
-                "blockSize": 0, 
-                "split": 1, 
-                "size": 0
-            }, 
-            "outputs": {
-                "output": "{cache}/{nodeType}/{uid0}/cameraInit.sfm"
-            }, 
             "position": [
                 0, 
                 0
-            ], 
-            "internalFolder": "{cache}/{nodeType}/{uid0}/"
+            ]
         }, 
         "ImageMatchingMultiSfM_1": {
             "inputs": {
@@ -152,56 +94,28 @@
                 ]
             }, 
             "nodeType": "ImageMatchingMultiSfM", 
-            "parallelization": {
-                "blockSize": 0, 
-                "split": 1, 
-                "size": 0
-            }, 
-            "outputs": {
-                "output": "{cache}/{nodeType}/{uid0}/imageMatches.txt", 
-                "outputCombinedSfM": "{cache}/{nodeType}/{uid0}/combineSfM.sfm"
-            }, 
             "position": [
                 1029, 
                 212
-            ], 
-            "internalFolder": "{cache}/{nodeType}/{uid0}/"
+            ]
         }, 
         "CameraInit_2": {
             "inputs": {}, 
             "nodeType": "CameraInit", 
-            "parallelization": {
-                "blockSize": 0, 
-                "split": 1, 
-                "size": 0
-            }, 
-            "outputs": {
-                "output": "{cache}/{nodeType}/{uid0}/cameraInit.sfm"
-            }, 
             "position": [
                 -2, 
                 223
-            ], 
-            "internalFolder": "{cache}/{nodeType}/{uid0}/"
+            ]
         }, 
         "FeatureExtraction_2": {
             "inputs": {
                 "input": "{CameraInit_2.output}"
             }, 
             "nodeType": "FeatureExtraction", 
-            "parallelization": {
-                "blockSize": 40, 
-                "split": 0, 
-                "size": 0
-            }, 
-            "outputs": {
-                "output": "{cache}/{nodeType}/{uid0}/"
-            }, 
             "position": [
                 198, 
                 223
-            ], 
-            "internalFolder": "{cache}/{nodeType}/{uid0}/"
+            ]
         }, 
         "FeatureMatching_2": {
             "inputs": {
@@ -211,19 +125,10 @@
                 "featuresFolders": "{ImageMatchingMultiSfM_1.featuresFolders}"
             }, 
             "nodeType": "FeatureMatching", 
-            "parallelization": {
-                "blockSize": 20, 
-                "split": 0, 
-                "size": 0
-            }, 
-            "outputs": {
-                "output": "{cache}/{nodeType}/{uid0}/"
-            }, 
             "position": [
                 1229, 
                 212
-            ], 
-            "internalFolder": "{cache}/{nodeType}/{uid0}/"
+            ]
         }, 
         "FeatureMatching_1": {
             "inputs": {
@@ -233,19 +138,10 @@
                 "featuresFolders": "{ImageMatching_1.featuresFolders}"
             }, 
             "nodeType": "FeatureMatching", 
-            "parallelization": {
-                "blockSize": 20, 
-                "split": 0, 
-                "size": 0
-            }, 
-            "outputs": {
-                "output": "{cache}/{nodeType}/{uid0}/"
-            }, 
             "position": [
                 600, 
                 0
-            ], 
-            "internalFolder": "{cache}/{nodeType}/{uid0}/"
+            ]
         }, 
         "StructureFromMotion_2": {
             "inputs": {
@@ -261,21 +157,10 @@
                 "minAngleForTriangulation": 1.0
             }, 
             "nodeType": "StructureFromMotion", 
-            "parallelization": {
-                "blockSize": 0, 
-                "split": 1, 
-                "size": 0
-            }, 
-            "outputs": {
-                "output": "{cache}/{nodeType}/{uid0}/sfm.abc", 
-                "extraInfoFolder": "{cache}/{nodeType}/{uid0}/", 
-                "outputViewsAndPoses": "{cache}/{nodeType}/{uid0}/cameras.sfm"
-            }, 
             "position": [
                 1429, 
                 212
-            ], 
-            "internalFolder": "{cache}/{nodeType}/{uid0}/"
+            ]
         }
     }
 }

--- a/meshroom/pipelines/photogrammetryAndCameraTracking.mg
+++ b/meshroom/pipelines/photogrammetryAndCameraTracking.mg
@@ -21,9 +21,6 @@
                 "input": "{CameraInit_2.output}"
             }, 
             "nodeType": "DistortionCalibration", 
-            "uids": {
-                "0": "8afea9d171904cdb6ba1c0b116cb60de3ccb6fb4"
-            }, 
             "parallelization": {
                 "blockSize": 0, 
                 "split": 1, 
@@ -46,9 +43,6 @@
                 ]
             }, 
             "nodeType": "ImageMatching", 
-            "uids": {
-                "0": "46fb9072ac753d60bec7dda9c8674b0568506ddf"
-            }, 
             "parallelization": {
                 "blockSize": 0, 
                 "split": 1, 
@@ -68,9 +62,6 @@
                 "input": "{CameraInit_1.output}"
             }, 
             "nodeType": "FeatureExtraction", 
-            "uids": {
-                "0": "a07fb8d05b63327d05461954c2fd2a00f201275b"
-            }, 
             "parallelization": {
                 "blockSize": 40, 
                 "split": 0, 
@@ -95,9 +86,6 @@
                 ]
             }, 
             "nodeType": "StructureFromMotion", 
-            "uids": {
-                "0": "5af4f4052aa22b0450708941b40928d46170f364"
-            }, 
             "parallelization": {
                 "blockSize": 0, 
                 "split": 1, 
@@ -120,9 +108,6 @@
                 "input": "{StructureFromMotion_2.output}"
             }, 
             "nodeType": "ExportAnimatedCamera", 
-            "uids": {
-                "0": "c28dfbc702edbecf8bf6721224cf6b10799a6a5d"
-            }, 
             "parallelization": {
                 "blockSize": 0, 
                 "split": 1, 
@@ -142,9 +127,6 @@
         "CameraInit_1": {
             "inputs": {}, 
             "nodeType": "CameraInit", 
-            "uids": {
-                "0": "f9436e97e444fa71a05aa5cf7639b206df8ba282"
-            }, 
             "parallelization": {
                 "blockSize": 0, 
                 "split": 1, 
@@ -170,9 +152,6 @@
                 ]
             }, 
             "nodeType": "ImageMatchingMultiSfM", 
-            "uids": {
-                "0": "a789cef752e327c0f2ee58012ca4792e9ab6a70e"
-            }, 
             "parallelization": {
                 "blockSize": 0, 
                 "split": 1, 
@@ -191,9 +170,6 @@
         "CameraInit_2": {
             "inputs": {}, 
             "nodeType": "CameraInit", 
-            "uids": {
-                "0": "f9436e97e444fa71a05aa5cf7639b206df8ba282"
-            }, 
             "parallelization": {
                 "blockSize": 0, 
                 "split": 1, 
@@ -213,9 +189,6 @@
                 "input": "{CameraInit_2.output}"
             }, 
             "nodeType": "FeatureExtraction", 
-            "uids": {
-                "0": "a07fb8d05b63327d05461954c2fd2a00f201275b"
-            }, 
             "parallelization": {
                 "blockSize": 40, 
                 "split": 0, 
@@ -238,9 +211,6 @@
                 "featuresFolders": "{ImageMatchingMultiSfM_1.featuresFolders}"
             }, 
             "nodeType": "FeatureMatching", 
-            "uids": {
-                "0": "142e98e3637aedcd3ebc1e19a03878690896a35b"
-            }, 
             "parallelization": {
                 "blockSize": 20, 
                 "split": 0, 
@@ -263,9 +233,6 @@
                 "featuresFolders": "{ImageMatching_1.featuresFolders}"
             }, 
             "nodeType": "FeatureMatching", 
-            "uids": {
-                "0": "534c5224ba51c770ae3793cc085ae3aaa8c2c415"
-            }, 
             "parallelization": {
                 "blockSize": 20, 
                 "split": 0, 
@@ -294,9 +261,6 @@
                 "minAngleForTriangulation": 1.0
             }, 
             "nodeType": "StructureFromMotion", 
-            "uids": {
-                "0": "eddc0ed596eb15943d6acd74a7d64753344b40dd"
-            }, 
             "parallelization": {
                 "blockSize": 0, 
                 "split": 1, 

--- a/meshroom/pipelines/photogrammetryDraft.mg
+++ b/meshroom/pipelines/photogrammetryDraft.mg
@@ -21,9 +21,6 @@
                 "inputMesh": "{MeshFiltering_1.outputMesh}"
             }, 
             "nodeType": "Texturing", 
-            "uids": {
-                "0": "32a36e3e637609b4d5a6971606728b59f3e7e62c"
-            }, 
             "parallelization": {
                 "blockSize": 0, 
                 "split": 1, 
@@ -46,9 +43,6 @@
                 "input": "{StructureFromMotion_1.output}"
             }, 
             "nodeType": "Meshing", 
-            "uids": {
-                "0": "d2499e39c1dd2e30c366e3e912254fce9cd0ed59"
-            }, 
             "parallelization": {
                 "blockSize": 0, 
                 "split": 1, 
@@ -72,9 +66,6 @@
                 ]
             }, 
             "nodeType": "ImageMatching", 
-            "uids": {
-                "0": "46fb9072ac753d60bec7dda9c8674b0568506ddf"
-            }, 
             "parallelization": {
                 "blockSize": 0, 
                 "split": 1, 
@@ -94,9 +85,6 @@
                 "input": "{CameraInit_1.output}"
             }, 
             "nodeType": "FeatureExtraction", 
-            "uids": {
-                "0": "a07fb8d05b63327d05461954c2fd2a00f201275b"
-            }, 
             "parallelization": {
                 "blockSize": 40, 
                 "split": 0, 
@@ -121,9 +109,6 @@
                 ]
             }, 
             "nodeType": "StructureFromMotion", 
-            "uids": {
-                "0": "5af4f4052aa22b0450708941b40928d46170f364"
-            }, 
             "parallelization": {
                 "blockSize": 0, 
                 "split": 1, 
@@ -143,9 +128,6 @@
         "CameraInit_1": {
             "inputs": {}, 
             "nodeType": "CameraInit", 
-            "uids": {
-                "0": "f9436e97e444fa71a05aa5cf7639b206df8ba282"
-            }, 
             "parallelization": {
                 "blockSize": 0, 
                 "split": 1, 
@@ -165,9 +147,6 @@
                 "inputMesh": "{Meshing_1.outputMesh}"
             }, 
             "nodeType": "MeshFiltering", 
-            "uids": {
-                "0": "a5f72b9e67b26be5a4974c21b9d0bc0b3c34bea5"
-            }, 
             "parallelization": {
                 "blockSize": 0, 
                 "split": 1, 
@@ -190,9 +169,6 @@
                 "featuresFolders": "{ImageMatching_1.featuresFolders}"
             }, 
             "nodeType": "FeatureMatching", 
-            "uids": {
-                "0": "534c5224ba51c770ae3793cc085ae3aaa8c2c415"
-            }, 
             "parallelization": {
                 "blockSize": 20, 
                 "split": 0, 

--- a/meshroom/pipelines/photogrammetryDraft.mg
+++ b/meshroom/pipelines/photogrammetryDraft.mg
@@ -21,42 +21,20 @@
                 "inputMesh": "{MeshFiltering_1.outputMesh}"
             }, 
             "nodeType": "Texturing", 
-            "parallelization": {
-                "blockSize": 0, 
-                "split": 1, 
-                "size": 1
-            }, 
-            "outputs": {
-                "outputTextures": "{cache}/{nodeType}/{uid0}/texture_*.exr", 
-                "outputMesh": "{cache}/{nodeType}/{uid0}/texturedMesh.{outputMeshFileTypeValue}", 
-                "outputMaterial": "{cache}/{nodeType}/{uid0}/texturedMesh.mtl", 
-                "output": "{cache}/{nodeType}/{uid0}/"
-            }, 
             "position": [
                 1400, 
                 0
-            ], 
-            "internalFolder": "{cache}/{nodeType}/{uid0}/"
+            ]
         }, 
         "Meshing_1": {
             "inputs": {
                 "input": "{StructureFromMotion_1.output}"
             }, 
             "nodeType": "Meshing", 
-            "parallelization": {
-                "blockSize": 0, 
-                "split": 1, 
-                "size": 1
-            }, 
-            "outputs": {
-                "output": "{cache}/{nodeType}/{uid0}/densePointCloud.abc", 
-                "outputMesh": "{cache}/{nodeType}/{uid0}/mesh.{outputMeshFileTypeValue}"
-            }, 
             "position": [
                 1000, 
                 0
-            ], 
-            "internalFolder": "{cache}/{nodeType}/{uid0}/"
+            ]
         }, 
         "ImageMatching_1": {
             "inputs": {
@@ -66,38 +44,20 @@
                 ]
             }, 
             "nodeType": "ImageMatching", 
-            "parallelization": {
-                "blockSize": 0, 
-                "split": 1, 
-                "size": 0
-            }, 
-            "outputs": {
-                "output": "{cache}/{nodeType}/{uid0}/imageMatches.txt"
-            }, 
             "position": [
                 400, 
                 0
-            ], 
-            "internalFolder": "{cache}/{nodeType}/{uid0}/"
+            ]
         }, 
         "FeatureExtraction_1": {
             "inputs": {
                 "input": "{CameraInit_1.output}"
             }, 
             "nodeType": "FeatureExtraction", 
-            "parallelization": {
-                "blockSize": 40, 
-                "split": 0, 
-                "size": 0
-            }, 
-            "outputs": {
-                "output": "{cache}/{nodeType}/{uid0}/"
-            }, 
             "position": [
                 200, 
                 0
-            ], 
-            "internalFolder": "{cache}/{nodeType}/{uid0}/"
+            ]
         }, 
         "StructureFromMotion_1": {
             "inputs": {
@@ -109,57 +69,28 @@
                 ]
             }, 
             "nodeType": "StructureFromMotion", 
-            "parallelization": {
-                "blockSize": 0, 
-                "split": 1, 
-                "size": 0
-            }, 
-            "outputs": {
-                "output": "{cache}/{nodeType}/{uid0}/sfm.abc", 
-                "extraInfoFolder": "{cache}/{nodeType}/{uid0}/", 
-                "outputViewsAndPoses": "{cache}/{nodeType}/{uid0}/cameras.sfm"
-            }, 
             "position": [
                 800, 
                 0
-            ], 
-            "internalFolder": "{cache}/{nodeType}/{uid0}/"
+            ]
         }, 
         "CameraInit_1": {
             "inputs": {}, 
             "nodeType": "CameraInit", 
-            "parallelization": {
-                "blockSize": 0, 
-                "split": 1, 
-                "size": 0
-            }, 
-            "outputs": {
-                "output": "{cache}/{nodeType}/{uid0}/cameraInit.sfm"
-            }, 
             "position": [
                 0, 
                 0
-            ], 
-            "internalFolder": "{cache}/{nodeType}/{uid0}/"
+            ]
         }, 
         "MeshFiltering_1": {
             "inputs": {
                 "inputMesh": "{Meshing_1.outputMesh}"
             }, 
             "nodeType": "MeshFiltering", 
-            "parallelization": {
-                "blockSize": 0, 
-                "split": 1, 
-                "size": 1
-            }, 
-            "outputs": {
-                "outputMesh": "{cache}/{nodeType}/{uid0}/mesh.{outputMeshFileTypeValue}"
-            }, 
             "position": [
                 1200, 
                 0
-            ], 
-            "internalFolder": "{cache}/{nodeType}/{uid0}/"
+            ]
         }, 
         "FeatureMatching_1": {
             "inputs": {
@@ -169,19 +100,10 @@
                 "featuresFolders": "{ImageMatching_1.featuresFolders}"
             }, 
             "nodeType": "FeatureMatching", 
-            "parallelization": {
-                "blockSize": 20, 
-                "split": 0, 
-                "size": 0
-            }, 
-            "outputs": {
-                "output": "{cache}/{nodeType}/{uid0}/"
-            }, 
             "position": [
                 600, 
                 0
-            ], 
-            "internalFolder": "{cache}/{nodeType}/{uid0}/"
+            ]
         }
     }
 }

--- a/tests/test_templatesVersion.py
+++ b/tests/test_templatesVersion.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python
+# coding:utf-8
+
+from meshroom.core.graph import Graph
+from meshroom.core import pipelineTemplates, Version
+from meshroom.core.node import CompatibilityIssue, CompatibilityNode
+
+import json
+import meshroom
+
+
+def test_templateVersions():
+    """
+    This test checks that there is no compatibility issue with the nodes saved in the template files.
+    It fails when an upgrade of a templates is needed. Any template can still be opened even if its
+    nodes are not up-to-date, as they will be automatically upgraded.
+    """
+
+    assert len(pipelineTemplates) >= 1
+
+    for _, path in pipelineTemplates.items():
+        with open(path) as jsonFile:
+            fileData = json.load(jsonFile)
+
+        graphData = fileData.get(Graph.IO.Keys.Graph, fileData)
+
+        assert isinstance(graphData, dict)
+
+        header = fileData.get(Graph.IO.Keys.Header, {})
+        assert header.get("template", False)
+        nodesVersions = header.get(Graph.IO.Keys.NodesVersions, {})
+
+        for _, nodeData in graphData.items():
+            nodeType = nodeData["nodeType"]
+            assert nodeType in meshroom.core.nodesDesc
+
+            nodeDesc = meshroom.core.nodesDesc[nodeType]
+            currentNodeVersion = meshroom.core.nodeVersion(nodeDesc)
+
+            inputs = nodeData.get("inputs", {})
+            outputs = nodeData.get("outputs", {})
+            version = nodesVersions.get(nodeType, None)
+
+            compatibilityIssue = None
+
+            if version and currentNodeVersion and Version(version).major != Version(currentNodeVersion).major:
+                compatibilityIssue = CompatibilityIssue.VersionConflict
+            else:
+                for attrName, value in inputs.items():
+                    if not CompatibilityNode.attributeDescFromName(nodeDesc.inputs, attrName, value):
+                        compatibilityIssue = CompatibilityIssue.DescriptionConflict
+                        break
+                for attrName, value in outputs.items():
+                    if not CompatibilityNode.attributeDescFromName(nodeDesc.outputs, attrName, value):
+                        compatibilityIssue = CompatibilityIssue.DescriptionConflict
+                        break
+
+            assert compatibilityIssue is None

--- a/tests/test_templatesVersion.py
+++ b/tests/test_templatesVersion.py
@@ -38,7 +38,6 @@ def test_templateVersions():
             currentNodeVersion = meshroom.core.nodeVersion(nodeDesc)
 
             inputs = nodeData.get("inputs", {})
-            outputs = nodeData.get("outputs", {})
             version = nodesVersions.get(nodeType, None)
 
             compatibilityIssue = None
@@ -48,10 +47,6 @@ def test_templateVersions():
             else:
                 for attrName, value in inputs.items():
                     if not CompatibilityNode.attributeDescFromName(nodeDesc.inputs, attrName, value):
-                        compatibilityIssue = CompatibilityIssue.DescriptionConflict
-                        break
-                for attrName, value in outputs.items():
-                    if not CompatibilityNode.attributeDescFromName(nodeDesc.outputs, attrName, value):
                         compatibilityIssue = CompatibilityIssue.DescriptionConflict
                         break
 


### PR DESCRIPTION
## Description

This PR adds a unit test that checks, for every template, whether there are conflicts on the contained nodes: the test will fails if at least one node needs to be upgraded (either because its version is not the most recent or because there is a description conflict). Templates containing nodes that are not up-to-date can still be opened in Meshroom: they will still automatically be upgraded (unlike "regular" .mg files, which require user confirmation to be upgraded). The aim of this test is mainly to let committers know whether their changes affect the templates.

Additionally, node UIDs, outputs, internal folder and parallelization parameters are not saved anymore in templates as they are not relevant, and the existing templates have been cleansed of them.

## Features list

- [X] Add a unit test to check whether nodes in the templates need to be upgraded
- [X] Stop saving outputs, UIDs, internal folder and parallelization parameters in templates
- [X] Remove outputs, UIDs, internal folder and parallelization parameters from existing templates

