### PR TITLE
Update bounding box display to use the correct geometric frame

### DIFF
--- a/meshroom/ui/components/scene3D.py
+++ b/meshroom/ui/components/scene3D.py
@@ -123,7 +123,7 @@ class Transformations3DHelper(QObject):
         viewMatrix = camera.transform().matrix().inverted()
         projectedPoint = (camera.projectionMatrix() * viewMatrix[0]).map(point)
         projectedPoint2D = QVector2D(
-            projectedPoint.x()/projectedPoint.w(), 
+            projectedPoint.x()/projectedPoint.w(),
             projectedPoint.y()/projectedPoint.w()
         )
 
@@ -145,7 +145,7 @@ class Transformations3DHelper(QObject):
                 initialScaleMat (QMatrix4x4): initial scale matrix
                 translateVec (QVector3D): vector used for the local translation
         """
-        # Compute the translation transformation matrix 
+        # Compute the translation transformation matrix
         translationMat = QMatrix4x4()
         translationMat.translate(translateVec)
 
@@ -246,11 +246,14 @@ class Transformations3DHelper(QObject):
         return modelMat
 
     @Slot(QVector3D, result=QVector3D)
-    def transformRotationGL(self, rotation):
+    def convertRotationFromCV2GL(self, rotation):
+        """ Convert rotation (euler angles) from Computer Vision
+            to Computer Graphics coordinate system (like opengl).
+        """
         M = QQuaternion.fromAxisAndAngle(QVector3D(1, 0, 0), 180.0)
-        
+
         quaternion = QQuaternion.fromEulerAngles(rotation)
-        
+
         U = M * quaternion * M
 
         return U.toEulerAngles()

--- a/meshroom/ui/components/scene3D.py
+++ b/meshroom/ui/components/scene3D.py
@@ -245,6 +245,16 @@ class Transformations3DHelper(QObject):
 
         return modelMat
 
+    @Slot(QVector3D, result=QVector3D)
+    def transformRotationGL(self, rotation):
+        M = QQuaternion.fromAxisAndAngle(QVector3D(1, 0, 0), 180.0)
+        
+        quaternion = QQuaternion.fromEulerAngles(rotation)
+        
+        U = M * quaternion * M
+
+        return U.toEulerAngles()
+
     @Slot(QVector3D, QMatrix4x4, Qt3DRender.QCamera, QSize, result=float)
     def computeScaleUnitFromModelMatrix(self, axis, modelMat, camera, windowSize):
         """ Compute the length of the screen projected vector axis unit transformed by the model matrix.

--- a/meshroom/ui/qml/Viewer3D/MeshingBoundingBox.qml
+++ b/meshroom/ui/qml/Viewer3D/MeshingBoundingBox.qml
@@ -24,18 +24,22 @@ Entity {
 
         // Update node meshing slider values when the gizmo has changed: translation, rotation, scale, type
         transformGizmo.onGizmoChanged: {
+
+            var previous_euler = Qt.vector3d(rotation.x, rotation.y, rotation.z)
+            var updated_rotation = Transformations3DHelper.transformRotationGL(previous_euler)
+
             switch(type) {
                 case TransformGizmo.Type.TRANSLATION: {
                     _reconstruction.setAttribute(
                         root.currentMeshingNode.attribute("boundingBox.bboxTranslation"),
-                        JSON.stringify([translation.x, translation.y, translation.z])
+                        JSON.stringify([translation.x, -translation.y, -translation.z])
                     )
                     break
                 }
                 case TransformGizmo.Type.ROTATION: {
                     _reconstruction.setAttribute(
                         root.currentMeshingNode.attribute("boundingBox.bboxRotation"),
-                        JSON.stringify([rotation.x, rotation.y, rotation.z])
+                        JSON.stringify([updated_rotation.x, updated_rotation.y, updated_rotation.z])
                     )
                     break
                 }
@@ -50,8 +54,8 @@ Entity {
                     _reconstruction.setAttribute(
                         root.currentMeshingNode.attribute("boundingBox"),
                         JSON.stringify([
-                            [translation.x, translation.y, translation.z],
-                            [rotation.x, rotation.y, rotation.z],
+                            [translation.x, -translation.y, -translation.z],
+                            [updated_rotation.x, updated_rotation.y, updated_rotation.z],
                             [scale.x, scale.y, scale.z]
                         ])
                     )
@@ -63,13 +67,41 @@ Entity {
         // Translation values from node (vector3d because this is the type of QTransform.translation)
         property var nodeTranslation : Qt.vector3d(
             root.currentMeshingNode ? root.currentMeshingNode.attribute("boundingBox.bboxTranslation.x").value : 0,
-            root.currentMeshingNode ? root.currentMeshingNode.attribute("boundingBox.bboxTranslation.y").value : 0,
-            root.currentMeshingNode ? root.currentMeshingNode.attribute("boundingBox.bboxTranslation.z").value : 0
+            root.currentMeshingNode ? -root.currentMeshingNode.attribute("boundingBox.bboxTranslation.y").value : 0,
+            root.currentMeshingNode ? -root.currentMeshingNode.attribute("boundingBox.bboxTranslation.z").value : 0
         )
+
         // Rotation values from node (3 separated values because QTransform stores Euler angles like this)
-        property var nodeRotationX: root.currentMeshingNode ? root.currentMeshingNode.attribute("boundingBox.bboxRotation.x").value : 0
-        property var nodeRotationY: root.currentMeshingNode ? root.currentMeshingNode.attribute("boundingBox.bboxRotation.y").value : 0
-        property var nodeRotationZ: root.currentMeshingNode ? root.currentMeshingNode.attribute("boundingBox.bboxRotation.z").value : 0
+        property var nodeRotationX: {
+            var rx = root.currentMeshingNode ? root.currentMeshingNode.attribute("boundingBox.bboxRotation.x").value : 0
+            var ry = root.currentMeshingNode ? root.currentMeshingNode.attribute("boundingBox.bboxRotation.y").value : 0
+            var rz = root.currentMeshingNode ? root.currentMeshingNode.attribute("boundingBox.bboxRotation.z").value : 0
+
+            var previous_euler = Qt.vector3d(rx, ry, rz)
+            var updated_rotation = Transformations3DHelper.transformRotationGL(previous_euler)
+            return updated_rotation.x
+        }
+
+        property var nodeRotationY: {
+            var rx = root.currentMeshingNode ? root.currentMeshingNode.attribute("boundingBox.bboxRotation.x").value : 0
+            var ry = root.currentMeshingNode ? root.currentMeshingNode.attribute("boundingBox.bboxRotation.y").value : 0
+            var rz = root.currentMeshingNode ? root.currentMeshingNode.attribute("boundingBox.bboxRotation.z").value : 0
+
+            var previous_euler = Qt.vector3d(rx, ry, rz)
+            var updated_rotation = Transformations3DHelper.transformRotationGL(previous_euler)
+            return updated_rotation.y
+        }
+
+        property var nodeRotationZ: {
+            var rx = root.currentMeshingNode ? root.currentMeshingNode.attribute("boundingBox.bboxRotation.x").value : 0
+            var ry = root.currentMeshingNode ? root.currentMeshingNode.attribute("boundingBox.bboxRotation.y").value : 0
+            var rz = root.currentMeshingNode ? root.currentMeshingNode.attribute("boundingBox.bboxRotation.z").value : 0
+
+            var previous_euler = Qt.vector3d(rx, ry, rz)
+            var updated_rotation = Transformations3DHelper.transformRotationGL(previous_euler)
+            return updated_rotation.z
+        }
+
         // Scale values from node (vector3d because this is the type of QTransform.scale3D)
         property var nodeScale: Qt.vector3d(
             root.currentMeshingNode ? root.currentMeshingNode.attribute("boundingBox.bboxScale.x").value : 1,

--- a/meshroom/ui/qml/Viewer3D/MeshingBoundingBox.qml
+++ b/meshroom/ui/qml/Viewer3D/MeshingBoundingBox.qml
@@ -25,8 +25,8 @@ Entity {
         // Update node meshing slider values when the gizmo has changed: translation, rotation, scale, type
         transformGizmo.onGizmoChanged: {
 
-            var previous_euler = Qt.vector3d(rotation.x, rotation.y, rotation.z)
-            var updated_rotation = Transformations3DHelper.transformRotationGL(previous_euler)
+            var rotationEuler_cv = Qt.vector3d(rotation.x, rotation.y, rotation.z)
+            var rotation_gl = Transformations3DHelper.convertRotationFromCV2GL(rotationEuler_cv)
 
             switch(type) {
                 case TransformGizmo.Type.TRANSLATION: {
@@ -39,7 +39,7 @@ Entity {
                 case TransformGizmo.Type.ROTATION: {
                     _reconstruction.setAttribute(
                         root.currentMeshingNode.attribute("boundingBox.bboxRotation"),
-                        JSON.stringify([updated_rotation.x, updated_rotation.y, updated_rotation.z])
+                        JSON.stringify([rotation_gl.x, rotation_gl.y, rotation_gl.z])
                     )
                     break
                 }
@@ -55,7 +55,7 @@ Entity {
                         root.currentMeshingNode.attribute("boundingBox"),
                         JSON.stringify([
                             [translation.x, -translation.y, -translation.z],
-                            [updated_rotation.x, updated_rotation.y, updated_rotation.z],
+                            [rotation_gl.x, rotation_gl.y, rotation_gl.z],
                             [scale.x, scale.y, scale.z]
                         ])
                     )
@@ -77,9 +77,9 @@ Entity {
             var ry = root.currentMeshingNode ? root.currentMeshingNode.attribute("boundingBox.bboxRotation.y").value : 0
             var rz = root.currentMeshingNode ? root.currentMeshingNode.attribute("boundingBox.bboxRotation.z").value : 0
 
-            var previous_euler = Qt.vector3d(rx, ry, rz)
-            var updated_rotation = Transformations3DHelper.transformRotationGL(previous_euler)
-            return updated_rotation.x
+            var rotationEuler_cv = Qt.vector3d(rx, ry, rz)
+            var rotation_gl = Transformations3DHelper.convertRotationFromCV2GL(rotationEuler_cv)
+            return rotation_gl.x
         }
 
         property var nodeRotationY: {
@@ -87,9 +87,9 @@ Entity {
             var ry = root.currentMeshingNode ? root.currentMeshingNode.attribute("boundingBox.bboxRotation.y").value : 0
             var rz = root.currentMeshingNode ? root.currentMeshingNode.attribute("boundingBox.bboxRotation.z").value : 0
 
-            var previous_euler = Qt.vector3d(rx, ry, rz)
-            var updated_rotation = Transformations3DHelper.transformRotationGL(previous_euler)
-            return updated_rotation.y
+            var rotationEuler_cv = Qt.vector3d(rx, ry, rz)
+            var rotation_gl = Transformations3DHelper.convertRotationFromCV2GL(rotationEuler_cv)
+            return rotation_gl.y
         }
 
         property var nodeRotationZ: {
@@ -97,9 +97,9 @@ Entity {
             var ry = root.currentMeshingNode ? root.currentMeshingNode.attribute("boundingBox.bboxRotation.y").value : 0
             var rz = root.currentMeshingNode ? root.currentMeshingNode.attribute("boundingBox.bboxRotation.z").value : 0
 
-            var previous_euler = Qt.vector3d(rx, ry, rz)
-            var updated_rotation = Transformations3DHelper.transformRotationGL(previous_euler)
-            return updated_rotation.z
+            var rotationEuler_cv = Qt.vector3d(rx, ry, rz)
+            var rotation_gl = Transformations3DHelper.convertRotationFromCV2GL(rotationEuler_cv)
+            return rotation_gl.z
         }
 
         // Scale values from node (vector3d because this is the type of QTransform.scale3D)


### PR DESCRIPTION
Bounding box for the meshing node 

The bounding box manipulator was not storing parameters in the correct geometric frame