### PR TITLE
added an explicit debug message for missing nodes

### DIFF
--- a/meshroom/core/node.py
+++ b/meshroom/core/node.py
@@ -408,6 +408,8 @@ class NodeChunk(BaseObject):
         self.statThread = stats.StatisticsThread(self)
         self.statThread.start()
         try:
+            if self.node.nodeDesc is None:
+                raise RuntimeError("Node description empty. This could be coming from a wrong MESHROOM_NODES_PATH environement variable.")
             self.node.nodeDesc.processChunk(self)
         except Exception as e:
             if self._status.status != Status.STOPPED:

--- a/meshroom/core/node.py
+++ b/meshroom/core/node.py
@@ -409,7 +409,7 @@ class NodeChunk(BaseObject):
         self.statThread.start()
         try:
             if self.node.nodeDesc is None:
-                raise RuntimeError("Node description empty. This could be coming from a wrong MESHROOM_NODES_PATH environement variable.")
+                raise RuntimeError("Node description empty. This could be coming from a wrong MESHROOM_NODES_PATH environment variable.")
             self.node.nodeDesc.processChunk(self)
         except Exception as e:
             if self._status.status != Status.STOPPED:


### PR DESCRIPTION
Added an error message to replace 'NoneType' object has no attribute 'processChunk' when encountering a missing node description