### PR TITLE
Fix crash when importing images with non-ascii characters in their filepath

### DIFF
--- a/meshroom/ui/qml/main.qml
+++ b/meshroom/ui/qml/main.qml
@@ -316,7 +316,6 @@ ApplicationWindow {
         selectMultiple: true
         nameFilters: []
         onAccepted: {
-            console.warn("importFilesDialog fileUrls: " + importFilesDialog.fileUrls)
             _reconstruction.importImagesUrls(importFilesDialog.fileUrls)
         }
     }

--- a/meshroom/ui/qml/main.qml
+++ b/meshroom/ui/qml/main.qml
@@ -310,13 +310,13 @@ ApplicationWindow {
     }
 
     FileDialog {
-        id: importFilesDialog
+        id: importImagesDialog
         title: "Import Images"
         selectExisting: true
         selectMultiple: true
         nameFilters: []
         onAccepted: {
-            _reconstruction.importImagesUrls(importFilesDialog.fileUrls)
+            _reconstruction.importImagesUrls(importImagesDialog.fileUrls)
         }
     }
 
@@ -576,17 +576,17 @@ ApplicationWindow {
                 }
             }
             Action {
-                id: importActionItem
+                id: importImagesAction
                 text: "Import Images"
                 shortcut: "Ctrl+I"
                 onTriggered: {
-                    initFileDialogFolder(importFilesDialog);
-                    importFilesDialog.open();
+                    initFileDialogFolder(importImagesDialog);
+                    importImagesDialog.open();
                 }
             }
 
             Action {
-                id: clearActionItem
+                id: clearImagesAction
                 text: "Clear Images"
                 onTriggered: {
                     //Loop through all the camera inits


### PR DESCRIPTION
## Description

Importing images with the "Import Image" action causes a crash if the images contain non-ASCII characters in their filepath.

This was apparently a problem on the QML side, occurring when we were trying to log the urls. Removing the log line seems to have fixed the issue.

> However I did not find any issue online related to this specific logging problem, this might require further investigation to understand exactly the origin of the crash