### PR TITLE
[bin] meshroom_batch: allow passing list of values to param overrides

### DIFF
--- a/bin/meshroom_batch
+++ b/bin/meshroom_batch
@@ -157,9 +157,6 @@ with multiview.GraphModification(graph):
             if not result:
                 raise ValueError('Invalid param override: ' + str(p))
             node, t, param, value = result.groups()
-            multiValues = value.split(',')
-            if len(multiValues) > 1:
-                value = multiValues
             if t == ':':
                 nodesOfType = graph.nodesOfType(node)
                 if not nodesOfType:

--- a/bin/meshroom_batch
+++ b/bin/meshroom_batch
@@ -157,6 +157,9 @@ with multiview.GraphModification(graph):
             if not result:
                 raise ValueError('Invalid param override: ' + str(p))
             node, t, param, value = result.groups()
+            multiValues = value.split(',')
+            if len(multiValues) > 1:
+                value = multiValues
             if t == ':':
                 nodesOfType = graph.nodesOfType(node)
                 if not nodesOfType:

--- a/meshroom/core/desc.py
+++ b/meshroom/core/desc.py
@@ -311,6 +311,9 @@ class ChoiceParam(Param):
         if self.exclusive:
             return self.conformValue(value)
 
+        if isinstance(value, pyCompatibility.basestring):
+            value = value.split(',')
+
         if not isinstance(value, pyCompatibility.Iterable):
             raise ValueError('Non exclusive ChoiceParam value should be iterable (param:{}, value:{}, type:{})'.format(self.name, value, type(value)))
         return [self.conformValue(v) for v in value]


### PR DESCRIPTION
## Description

Fix https://github.com/alicevision/Meshroom/issues/1797

Currently it is not possible to pass a list of values with the `--paramOverrides` argument of `meshroom_batch`, which is problematic when overriding non-exclusive choice parameters, such as `FeatureExtraction:describerTypes`.

This PR provides the following mechanism to fix this issue: if the input string contains at least one comma it will be interpreted as a list of values (split around the commas), otherwise it will be interpreted as a single value.