### PR TITLE
[ui] keyboard shortcut: press tab to open node menu

### DIFF
--- a/meshroom/ui/qml/GraphEditor/GraphEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/GraphEditor.qml
@@ -118,19 +118,30 @@ Item {
     }
 
     Keys.onPressed: {
-        if (event.key === Qt.Key_F)
-            fit()
-        if (event.key === Qt.Key_Delete)
-            if (event.modifiers == Qt.AltModifier)
-                uigraph.removeNodesFrom(uigraph.selectedNodes)
-            else
-                uigraph.removeNodes(uigraph.selectedNodes)
-        if (event.key === Qt.Key_D)
-            duplicateNode(event.modifiers == Qt.AltModifier)
-        if (event.key === Qt.Key_C && event.modifiers == Qt.ControlModifier)
-            copyNodes()
-        if (event.key === Qt.Key_V && event.modifiers == Qt.ControlModifier)
-            pasteNodes()
+        if (event.key === Qt.Key_F) {
+            fit();
+        } 
+        else if (event.key === Qt.Key_Delete) {
+            if (event.modifiers == Qt.AltModifier) {
+                uigraph.removeNodesFrom(uigraph.selectedNodes);
+            }
+            else {
+                uigraph.removeNodes(uigraph.selectedNodes);
+            }
+        }
+        else if (event.key === Qt.Key_D) {
+            duplicateNode(event.modifiers == Qt.AltModifier);
+        }
+        else if (event.key === Qt.Key_C && event.modifiers == Qt.ControlModifier) {
+            copyNodes();
+        }
+        else if (event.key === Qt.Key_V && event.modifiers == Qt.ControlModifier) {
+            pasteNodes();
+        }
+        else if (event.key == Qt.Key_Tab) {
+            newNodeMenu.spawnPosition = mouseArea.mapToItem(draggable, mouseArea.mouseX, mouseArea.mouseY);
+            newNodeMenu.popup();
+        }
     }
 
     MouseArea {

--- a/meshroom/ui/qml/GraphEditor/GraphEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/GraphEditor.qml
@@ -140,8 +140,10 @@ Item {
         }
         else if (event.key == Qt.Key_Tab) {
             event.accepted = true;
-            newNodeMenu.spawnPosition = mouseArea.mapToItem(draggable, mouseArea.mouseX, mouseArea.mouseY);
-            newNodeMenu.popup();
+            if (mouseArea.containsMouse) {
+                newNodeMenu.spawnPosition = mouseArea.mapToItem(draggable, mouseArea.mouseX, mouseArea.mouseY);
+                newNodeMenu.popup();
+            }
         }
     }
 

--- a/meshroom/ui/qml/GraphEditor/GraphEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/GraphEditor.qml
@@ -139,6 +139,7 @@ Item {
             pasteNodes();
         }
         else if (event.key == Qt.Key_Tab) {
+            event.accepted = true;
             newNodeMenu.spawnPosition = mouseArea.mapToItem(draggable, mouseArea.mouseX, mouseArea.mouseY);
             newNodeMenu.popup();
         }


### PR DESCRIPTION
## Description

This PR introduces a new keyboard shortcut in the graph editor: TAB to open the node menu (same behavior as right clicking).

This has been requested by a user, the main reason being that this shortcut is used in several other programs (Houdini, Maya, Nuke, etc.).