### PR TITLE
[ui] image gallery search bar

### DIFF
--- a/meshroom/ui/qml/ImageGallery/ImageGallery.qml
+++ b/meshroom/ui/qml/ImageGallery/ImageGallery.qml
@@ -106,6 +106,14 @@ Panel {
     }
 
     headerBar: RowLayout {
+        SearchBar {
+            id: searchBar
+            width: 100
+            onTextChanged: {
+                sortedModel.updateFilter("path", text);
+            }
+        }
+
         MaterialToolButton {
             text: MaterialIcons.more_vert
             font.pointSize: 11


### PR DESCRIPTION
## Description

This PR introduces a new search bar in the image gallery to filter viewpoints using their filename or their uid.

## TODO

- [X] add search bar UI
- [X] search based on filename 
- [ ] search based on uid
- [ ] focus search bar from gallery with tab