### PR TITLE
[ui] ImageGallery: update the Viewer2D correctly when the GridView's current item changes

### DIFF
--- a/meshroom/ui/qml/ImageGallery/ImageGallery.qml
+++ b/meshroom/ui/qml/ImageGallery/ImageGallery.qml
@@ -173,7 +173,9 @@ Panel {
             Connections {
                 target: _reconstruction
                 onSelectedViewIdChanged: {
-                    grid.updateCurrentIndexFromSelectionViewId()
+                    if (_reconstruction.selectedViewId > -1) {
+                        grid.updateCurrentIndexFromSelectionViewId()
+                    }
                 }
             }
             function makeCurrentItemVisible()
@@ -183,12 +185,12 @@ Panel {
             function updateCurrentIndexFromSelectionViewId()
             {
                 var idx = grid.model.find(_reconstruction.selectedViewId, "viewId")
-                if(idx >= 0 && grid.currentIndex != idx) {
+                if (idx >= 0 && grid.currentIndex != idx) {
                     grid.currentIndex = idx
                 }
             }
-            onCurrentIndexChanged: {
-                if(grid.updateSelectedViewFromGrid) {
+            onCurrentItemChanged: {
+                if (grid.updateSelectedViewFromGrid && grid.currentItem) {
                     _reconstruction.selectedViewId = grid.currentItem.viewpoint.get("viewId").value
                 }
             }


### PR DESCRIPTION
## Description

When a project file is opened, its images are first loaded in the ImageGallery, which displays them in a GridView. The first image in the gallery is automatically selected within that GridView and then displayed in the Viewer2D, with an auto-fit applied so it can fit in the viewer. The image displayed in the Viewer2D is then updated according to the one that is selected in the ImageGallery, in which every image is identified by its index within the GridView. 

This PR addresses two issues related to the indices update within the GridView:

1. If the currently selected image is the first one in the gallery and another .mg file is opened, the new first image in the gallery, which will automatically be selected, will not properly be displayed in the Viewer2D: the auto-fit will not be applied upon the opening of the .mg file, and any manual auto-fit will fail until another image in the gallery is selected. The Viewer2D is only updated when there is an index change in the GridView, and when a new project file is opened while the first image in the gallery is selected, the GridView's current index goes from 0 to 0, hence the lack of update. 
2. If an image in the gallery is removed (if it is removed, then it was necessarily selected), the next image in the GridView takes its place as the currently selected image, but is not displayed in the Viewer2D; instead of the removed image, nothing is displayed. The reason is identical: if the fifth image in the gallery (with a GridView index of 4) is removed, the sixth image (with an index of 5) takes its place, and becomes the fifth image (with an index of 4). The GridView's current index thus goes from 4 to 4, not triggering any update for the Viewer2D.

Both issues are fixed by using the change of the GridView's current item instead of its current index to trigger the Viewer2D display updates.

## Features list

- [X] Trigger Viewer2D display updates when the current item of the ImageGallery's GridView is changed, instead of its current index
