### PR TITLE
[submitters] Add an option to update the job title on submitters

### DIFF
--- a/bin/meshroom_batch
+++ b/bin/meshroom_batch
@@ -64,6 +64,10 @@ parser.add_argument('--forceCompute', help='Compute in all cases even if already
 
 parser.add_argument('--submit', help='Submit on renderfarm instead of local computation.',
                     action='store_true')
+parser.add_argument("--submitLabel", 
+                    type=str, 
+                    default='{projectName} [Meshroom]',
+                    help="Label of a node in the submitter")
 parser.add_argument('--submitter',
                     type=str,
                     default='SimpleFarm',
@@ -193,7 +197,7 @@ if args.submit:
     if not args.save:
         raise ValueError('Need to save the project to file to submit on renderfarm.')
     # submit on renderfarm
-    meshroom.core.graph.submit(args.save, args.submitter, toNode=args.toNode)
+    meshroom.core.graph.submit(args.save, args.submitter, toNode=args.toNode, submitLabel=args.submitLabel)
 elif args.compute:
     # find end nodes (None will compute all graph)
     toNodes = graph.findNodes(args.toNode) if args.toNode else None

--- a/bin/meshroom_submit
+++ b/bin/meshroom_submit
@@ -16,7 +16,11 @@ parser.add_argument('--submitter',
                     type=str,
                     default='SimpleFarm',
                     help='Execute job with a specific submitter.')
+parser.add_argument("--submitLabel", 
+                    type=str, 
+                    default='{projectName} [Meshroom]',
+                    help="Label of a node in the submitter")
 
 args = parser.parse_args()
 
-meshroom.core.graph.submit(args.save, args.submitter, toNode=toNodes)
+meshroom.core.graph.submit(args.save, args.submitter, toNode=toNodes, submitLabel=args.submitLabel)

--- a/meshroom/core/graph.py
+++ b/meshroom/core/graph.py
@@ -1508,7 +1508,7 @@ def executeGraph(graph, toNodes=None, forceCompute=False, forceStatus=False):
         node.endSequence()
 
 
-def submitGraph(graph, submitter, toNodes=None):
+def submitGraph(graph, submitter, toNodes=None, submitLabel="{projectName}"):
     nodesToProcess, edgesToProcess = graph.dfsToProcess(startNodes=toNodes)
     flowEdges = graph.flowEdges(startNodes=toNodes)
     edgesToProcess = set(edgesToProcess).intersection(flowEdges)
@@ -1531,7 +1531,7 @@ def submitGraph(graph, submitter, toNodes=None):
             submitter=submitter, allSubmitters=str(meshroom.core.submitters.keys())))
 
     try:
-        res = sub.submit(nodesToProcess, edgesToProcess, graph.filepath)
+        res = sub.submit(nodesToProcess, edgesToProcess, graph.filepath, submitLabel=submitLabel)
         if res:
             for node in nodesToProcess:
                 node.submit()  # update node status
@@ -1539,11 +1539,11 @@ def submitGraph(graph, submitter, toNodes=None):
         logging.error("Error on submit : {}".format(e))
 
 
-def submit(graphFile, submitter, toNode=None):
+def submit(graphFile, submitter, toNode=None, submitLabel="{projectName}"):
     """
     Submit the given graph via the given submitter.
     """
     graph = loadGraph(graphFile)
     toNodes = graph.findNodes(toNode) if toNode else None
-    submitGraph(graph, submitter, toNodes)
+    submitGraph(graph, submitter, toNodes, submitLabel=submitLabel)
 

--- a/meshroom/core/submitter.py
+++ b/meshroom/core/submitter.py
@@ -9,7 +9,7 @@ class BaseSubmitter(BaseObject):
         super(BaseSubmitter, self).__init__(parent)
         self._name = name
 
-    def submit(self, nodes, edges, filepath):
+    def submit(self, nodes, edges, filepath, submitLabel="{projectName}"):
         """ Submit the given graph
          Returns:
              bool: whether the submission succeeded

--- a/meshroom/core/taskManager.py
+++ b/meshroom/core/taskManager.py
@@ -367,7 +367,7 @@ class TaskManager(BaseObject):
         raise RuntimeError("[{}] Impossible Process:\n"
                            "There is no node able to be processed.".format(context))
 
-    def submit(self, graph, submitter=None, toNodes=None):
+    def submit(self, graph, submitter=None, toNodes=None, submitLabel="{projectName}"):
         """
         Nodes are send to the renderfarm
         :param graph:
@@ -422,7 +422,7 @@ class TaskManager(BaseObject):
         logging.info("Edges to process: {}".format(edgesToProcess))
 
         try:
-            res = sub.submit(nodesToProcess, edgesToProcess, graph.filepath)
+            res = sub.submit(nodesToProcess, edgesToProcess, graph.filepath, submitLabel=submitLabel)
             if res:
                 for node in nodesToProcess:
                     node.destroyed.connect(lambda obj=None, name=node.name: self.onNodeDestroyed(obj, name))
@@ -436,12 +436,12 @@ class TaskManager(BaseObject):
         except Exception as e:
             logging.error("Error on submit : {}".format(e))
 
-    def submitFromFile(self, graphFile, submitter, toNode=None):
+    def submitFromFile(self, graphFile, submitter, toNode=None, submitLabel="{projectName}"):
         """
         Submit the given graph via the given submitter.
         """
         graph = meshroom.core.graph.loadGraph(graphFile)
-        self.submit(graph, submitter, toNode)
+        self.submit(graph, submitter, toNode, submitLabel=submitLabel)
 
     def getAlreadySubmittedChunks(self, nodes):
         """

--- a/meshroom/submitters/simpleFarmSubmitter.py
+++ b/meshroom/submitters/simpleFarmSubmitter.py
@@ -83,8 +83,11 @@ class SimpleFarmSubmitter(BaseSubmitter):
             **arguments)
         return task
 
-    def submit(self, nodes, edges, filepath):
-        name = os.path.splitext(os.path.basename(filepath))[0] + ' [Meshroom]'
+    def submit(self, nodes, edges, filepath, submitLabel="{projectName}"):
+
+        projectName = os.path.splitext(os.path.basename(filepath))[0]
+        name = submitLabel.format(projectName=projectName)
+
         comment = filepath
         nbFrames = max([node.size for node in nodes])
 

--- a/meshroom/ui/app.py
+++ b/meshroom/ui/app.py
@@ -85,6 +85,7 @@ class MeshroomApp(QApplication):
         parser.add_argument('-p', '--pipeline', metavar="FILE.mg/" + "/".join(meshroom.core.pipelineTemplates), type=str,
                             default=os.environ.get("MESHROOM_DEFAULT_PIPELINE", "photogrammetry"),
                             help='Override the default Meshroom pipeline with this external or template graph.')
+        parser.add_argument("--submitLabel", metavar='SUBMITLABEL', type=str, help="Label of a node in the submitter", default='{projectName} [Meshroom]')
         parser.add_argument("--verbose", help="Verbosity level", default='warning',
                             choices=['fatal', 'error', 'warning', 'info', 'debug', 'trace'],)
 
@@ -135,6 +136,7 @@ class MeshroomApp(QApplication):
         self._undoStack = commands.UndoStack(self)
         self._taskManager = TaskManager(self)
         r = Reconstruction(undoStack=self._undoStack, taskManager=self._taskManager, defaultPipeline=args.pipeline, parent=self)
+        r.setSubmitLabel(args.submitLabel)
         self.engine.rootContext().setContextProperty("_reconstruction", r)
 
         # those helpers should be available from QML Utils module as singletons, but:

--- a/meshroom/ui/graph.py
+++ b/meshroom/ui/graph.py
@@ -277,6 +277,7 @@ class UIGraph(QObject):
         self._selectedNodes = QObjectListModel(parent=self)
         self._hoveredNode = None
 
+        self.submitLabel = "{projectName}"
         self.computeStatusChanged.connect(self.updateLockedUndoStack)
 
     def setGraph(self, g):
@@ -450,7 +451,7 @@ class UIGraph(QObject):
         self.save()  # graph must be saved before being submitted
         self._undoStack.clear()  # the undo stack must be cleared
         node = [node] if node else None
-        self._taskManager.submit(self._graph, os.environ.get('MESHROOM_DEFAULT_SUBMITTER', ''), node)
+        self._taskManager.submit(self._graph, os.environ.get('MESHROOM_DEFAULT_SUBMITTER', ''), node, submitLabel=self.submitLabel)
 
     def updateGraphComputingStatus(self):
         # update graph computing status

--- a/meshroom/ui/reconstruction.py
+++ b/meshroom/ui/reconstruction.py
@@ -461,6 +461,9 @@ class Reconstruction(UIGraph):
     def setDefaultPipeline(self, defaultPipeline):
         self._defaultPipeline = defaultPipeline
 
+    def setSubmitLabel(self, submitLabel):
+        self.submitLabel = submitLabel
+
     def initActiveNodes(self):
         # Create all possible entries
         for category, _ in self.activeNodeCategories.items():


### PR DESCRIPTION
## Description

This PR adds an option, `--submitLabel`, to both the scripts (meshroom_batch) and the Meshroom app to set the title of jobs that are submitted. If a job is submitted with `--submitLabel` unset, the default name of the job will be "x [Meshroom]", with x the name of the submitted .mg file.