### PR TITLE
[ui] Viewer2D: fix minor issues

### DIFF
--- a/meshroom/ui/qml/Viewer/Viewer2D.qml
+++ b/meshroom/ui/qml/Viewer/Viewer2D.qml
@@ -665,6 +665,7 @@ FocusScope {
                             text: MaterialIcons.close
                             ToolTip.text: "Clear node"
                             enabled: root.displayedNode
+                            visible: root.displayedNode
                             onClicked: {
                                 root.displayedNode = null
                             }

--- a/meshroom/ui/qml/Viewer/Viewer2D.qml
+++ b/meshroom/ui/qml/Viewer/Viewer2D.qml
@@ -281,6 +281,8 @@ FocusScope {
         onSelectedViewIdChanged: {
             root.source = getImageFile();
             root.metadata = getMetadata();
+            if (useExternal)
+                useExternal = false;
         }
     }
 

--- a/meshroom/ui/qml/Viewer/Viewer2D.qml
+++ b/meshroom/ui/qml/Viewer/Viewer2D.qml
@@ -1157,12 +1157,12 @@ FocusScope {
                             property string name: names[currentIndex]
 
                             model: names.map(n => (n == "gallery") ? "Image Gallery" : displayedNode.attributes.get(n).label)
-                            enabled: count > 0
+                            enabled: count > 1
 
                             FontMetrics {
                                 id: fontMetrics
                             }
-                            Layout.preferredWidth: model.reduce((acc, label) => Math.max(acc, fontMetrics.boundingRect(label).width), 0) + 3.0*Qt.application.font.pixelSize
+                            Layout.preferredWidth: model.reduce((acc, label) => Math.max(acc, fontMetrics.boundingRect(label).width), 0) + 3.0 * Qt.application.font.pixelSize
                         }
 
                         MaterialToolButton {


### PR DESCRIPTION
## Description

This PR fixes one actual bug with the Viewer2D, and two minor UI issues:
- After dropping an external image in the 2D viewer, it was impossible to display another image from the Image Gallery, no matter whether it was selected with a click or with the arrow keys;
- The "Clear node" button was displayed in the 2D viewer, although disabled, even when there was no node to unload, hence creating some confusion;
- The ComboBox containing the currently loaded node's output attributes could be opened even when no node was loaded (the only default option, "Image Gallery", was dropping down when the user clicked on it).


## Features list

- [X] Correctly display images selected from the Image Gallery in the Viewer2D after an external image has been dropped in it and displayed
- [X] Hide the "Clear node" button when no node is loaded in the Viewer2D
- [X] Disable the ComboBox containing the currently loaded node's output attributes when no node is loaded in the Viewer2D

