### PR TITLE
[ui] Correctly determine if a graph is being computed locally and update nodes' statuses accordingly

### DIFF
--- a/meshroom/core/graph.py
+++ b/meshroom/core/graph.py
@@ -1366,6 +1366,11 @@ class Graph(BaseObject):
         for node in self.nodes:
             node.clearSubmittedChunks()
 
+    def clearLocallySubmittedNodes(self):
+        """ Reset the status of already locally submitted nodes to Status.NONE """
+        for node in self.nodes:
+            node.clearLocallySubmittedChunks()
+
     def iterChunksByStatus(self, status):
         """ Iterate over NodeChunks with the given status """
         for node in self.nodes:

--- a/meshroom/core/node.py
+++ b/meshroom/core/node.py
@@ -433,7 +433,8 @@ class NodeChunk(BaseObject):
         self.node.nodeDesc.stopProcess(self)
 
     def isExtern(self):
-        return self._status.execMode == ExecMode.EXTERN
+        return self._status.execMode == ExecMode.EXTERN or (
+            self._status.execMode == ExecMode.LOCAL and self._status.sessionUid != meshroom.core.sessionUid)
 
     statusChanged = Signal()
     status = Property(Variant, lambda self: self._status, notify=statusChanged)

--- a/meshroom/core/node.py
+++ b/meshroom/core/node.py
@@ -779,6 +779,12 @@ class BaseNode(BaseObject):
             if chunk.isAlreadySubmitted():
                 chunk.upgradeStatusTo(Status.NONE, ExecMode.NONE)
 
+    def clearLocallySubmittedChunks(self):
+        """ Reset all locally submitted chunks to Status.NONE. """
+        for chunk in self._chunks:
+            if chunk.isAlreadySubmitted() and not chunk.isExtern():
+                chunk.upgradeStatusTo(Status.NONE, ExecMode.NONE)
+
     def upgradeStatusTo(self, newStatus):
         """
         Upgrade node to the given status and save it on disk.

--- a/meshroom/ui/graph.py
+++ b/meshroom/ui/graph.py
@@ -284,6 +284,9 @@ class UIGraph(QObject):
         """ Set the internal graph. """
         if self._graph:
             self.stopExecution()
+            # Clear all the locally submitted nodes at once before the graph gets changed, as it won't receive further updates
+            if self._computingLocally:
+                self._graph.clearLocallySubmittedNodes()
             self.clear()
         oldGraph = self._graph
         self._graph = g

--- a/meshroom/ui/graph.py
+++ b/meshroom/ui/graph.py
@@ -11,6 +11,7 @@ from multiprocessing.pool import ThreadPool
 from PySide2.QtCore import Slot, QJsonValue, QObject, QUrl, Property, Signal, QPoint
 
 from meshroom import multiview
+from meshroom.core import sessionUid
 from meshroom.common.qt import QObjectListModel
 from meshroom.core.attribute import Attribute, ListAttribute
 from meshroom.core.graph import Graph, Edge
@@ -454,7 +455,11 @@ class UIGraph(QObject):
 
     def updateGraphComputingStatus(self):
         # update graph computing status
-        computingLocally = any([ch.status.execMode == ExecMode.LOCAL and ch.status.status in (Status.RUNNING, Status.SUBMITTED) for ch in self._sortedDFSChunks])
+        computingLocally = any([
+                                (ch.status.execMode == ExecMode.LOCAL and
+                                ch.status.sessionUid == sessionUid and
+                                ch.status.status in (Status.RUNNING, Status.SUBMITTED))
+                                    for ch in self._sortedDFSChunks])
         submitted = any([ch.status.status == Status.SUBMITTED for ch in self._sortedDFSChunks])
         if self._computingLocally != computingLocally or self._submitted != submitted:
             self._computingLocally = computingLocally


### PR DESCRIPTION
## Description

This PR fixes two bugs related to local graph computations:
- When computing a graph in an instance of Meshroom, and opening the same computing graph in another instance of Meshroom, the second instance of Meshroom behaves as if it was performing the computations even though it was not. As a consequence, trying to open a new graph was failing (Meshroom would try stopping the computations, but fail since they were carried out by the first instance), and so was closing the instance, with a "Please stop any local computation before exiting Meshroom" error message. Only the chunks' statuses were taken into account to determine whether local computations were ongoing.
- When loading a new graph while the opened one was locally computing nodes, computations were automatically stopped to be able to load the new graph. However, the computing chunks' statuses were not being updated before the graphs were switched up. This meant that opening that previously computing graph again was leading to a display in which nodes appeared to be computing although there was no ongoing computations. The only way to get back to a correct state was manually unlocking the nodes and clearing the pending statuses.

## Features list

- [X] Take the Meshroom instance's session ID when determining whether computations are made locally, and not only the chunks' statuses.
- [X] Clear locally submitted nodes before loading a new graph to avoid stopping the computations without updating the chunks' statuses.
