### PR TITLE
[ui] GraphEditor: create new pipelines with the node menu

### DIFF
--- a/meshroom/ui/app.py
+++ b/meshroom/ui/app.py
@@ -198,6 +198,9 @@ class MeshroomApp(QApplication):
             templates.append(variant)
         return templates
 
+    def _pipelineTemplateNames(self):
+        return [p["name"] for p in self.pipelineTemplateFiles]
+
     @Slot()
     def reloadTemplateList(self):
         for f in meshroom.core.pipelineTemplatesFolders:
@@ -352,5 +355,6 @@ class MeshroomApp(QApplication):
     pipelineTemplateFilesChanged = Signal()
     recentProjectFilesChanged = Signal()
     pipelineTemplateFiles = Property("QVariantList", _pipelineTemplateFiles, notify=pipelineTemplateFilesChanged)
+    pipelineTemplateNames = Property("QVariantList", _pipelineTemplateNames, notify=pipelineTemplateFilesChanged)
     recentProjectFiles = Property("QVariantList", _recentProjectFiles, notify=recentProjectFilesChanged)
     default8bitViewerEnabled = Property(bool, _default8bitViewerEnabled, constant=True)

--- a/meshroom/ui/commands.py
+++ b/meshroom/ui/commands.py
@@ -245,7 +245,7 @@ class ImportProjectCommand(GraphCommand):
             else:
                 self.graph.node(node.name).position = Position(node.x, node.y + lowestY + self.yOffset)
 
-        return status
+        return importedNodes
 
     def undoImpl(self):
         for nodeName in self.importedNames:

--- a/meshroom/ui/commands.py
+++ b/meshroom/ui/commands.py
@@ -221,10 +221,11 @@ class ImportProjectCommand(GraphCommand):
     """
     Handle the import of a project into a Graph.
     """
-    def __init__(self, graph, filepath=None, yOffset=0, parent=None):
+    def __init__(self, graph, filepath=None, position=None, yOffset=0, parent=None):
         super(ImportProjectCommand, self).__init__(graph, parent)
         self.filepath = filepath
         self.importedNames = []
+        self.position = position
         self.yOffset = yOffset
 
     def redoImpl(self):
@@ -239,7 +240,10 @@ class ImportProjectCommand(GraphCommand):
 
         for node in importedNodes:
             self.importedNames.append(node.name)
-            self.graph.node(node.name).position = Position(node.x, node.y + lowestY + self.yOffset)
+            if self.position is not None:
+                self.graph.node(node.name).position = Position(node.x + self.position.x, node.y + self.position.y)
+            else:
+                self.graph.node(node.name).position = Position(node.x, node.y + lowestY + self.yOffset)
 
         return status
 

--- a/meshroom/ui/graph.py
+++ b/meshroom/ui/graph.py
@@ -354,7 +354,8 @@ class UIGraph(QObject):
         return status
 
     @Slot(QUrl, result=bool)
-    def importProject(self, filepath):
+    @Slot(QUrl, QPoint, result=bool)
+    def importProject(self, filepath, position=None):
         if isinstance(filepath, (QUrl)):
             # depending how the QUrl has been initialized,
             # toLocalFile() may return the local path or an empty string
@@ -363,8 +364,10 @@ class UIGraph(QObject):
                 localFile = filepath.toString()
         else:
             localFile = filepath
+        if isinstance(position, QPoint):
+                position = Position(position.x(), position.y())
         yOffset = self.layout.gridSpacing + self.layout.nodeHeight
-        return self.push(commands.ImportProjectCommand(self._graph, localFile, yOffset=yOffset))
+        return self.push(commands.ImportProjectCommand(self._graph, localFile, position=position, yOffset=yOffset))
 
     @Slot(QUrl)
     def saveAs(self, url):

--- a/meshroom/ui/graph.py
+++ b/meshroom/ui/graph.py
@@ -353,8 +353,8 @@ class UIGraph(QObject):
         self.setGraph(g)
         return status
 
-    @Slot(QUrl, result=bool)
-    @Slot(QUrl, QPoint, result=bool)
+    @Slot(QUrl, result="QVariantList")
+    @Slot(QUrl, QPoint, result="QVariantList")
     def importProject(self, filepath, position=None):
         if isinstance(filepath, (QUrl)):
             # depending how the QUrl has been initialized,

--- a/meshroom/ui/qml/GraphEditor/GraphEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/GraphEditor.qml
@@ -218,6 +218,8 @@ Item {
 
             function createNode(nodeType)
             {
+                uigraph.clearNodeSelection() // Ensures that only the created node / imported pipeline will be selected
+
                 // "nodeType" might be a pipeline (artificially added in the "Pipelines" category) instead of a node
                 // If it is not a pipeline to import, then it must be a node
                 if (!importPipeline(nodeType)) {

--- a/meshroom/ui/qml/GraphEditor/GraphEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/GraphEditor.qml
@@ -214,6 +214,7 @@ Item {
         Menu {
             id: newNodeMenu
             property point spawnPosition
+            property variant menuKeys: Object.keys(root.nodeTypesModel).concat(Object.values(MeshroomApp.pipelineTemplateNames))
 
             function createNode(nodeType)
             {
@@ -324,7 +325,7 @@ Item {
 
             Repeater {
                 id: nodeMenuRepeater
-                model: searchBar.text != "" ? Object.keys(root.nodeTypesModel) : undefined
+                model: searchBar.text != "" ? Object.values(newNodeMenu.menuKeys) : undefined
 
                 // create Menu items from available items
                 delegate: menuItemDelegateComponent

--- a/meshroom/ui/qml/GraphEditor/GraphEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/GraphEditor.qml
@@ -229,18 +229,9 @@ Item {
 
             function importPipeline(pipeline)
             {
-                var pipelineNames = []
-                var pipelinePaths = []
-                for (const [_, data] of Object.entries(MeshroomApp.pipelineTemplateFiles)) {
-                    let name = data["name"]
-                    let path = data["path"]
-                    pipelineNames.push(name)
-                    pipelinePaths.push(path)
-                }
-
-                if (pipelineNames.includes(pipeline)) {
-                    var url = Filepath.stringToUrl(pipelinePaths[pipelineNames.indexOf(pipeline)])
-                    uigraph.importProject(url, spawnPosition)
+                if (MeshroomApp.pipelineTemplateNames.includes(pipeline)) {
+                    var url = MeshroomApp.pipelineTemplateFiles[MeshroomApp.pipelineTemplateNames.indexOf(pipeline)]["path"]
+                    uigraph.importProject(Filepath.stringToUrl(url), spawnPosition)
                     return true
                 }
                 return false
@@ -259,12 +250,8 @@ Item {
                     categories[category].push(name)
                 }
 
-                // Add list of templates to create pipelines
-                categories["Pipelines"] = [];
-                for (const [_, data] of Object.entries(MeshroomApp.pipelineTemplateFiles)) {
-                    let pipeline = data["name"];
-                    categories["Pipelines"].push(pipeline)
-                }
+                // Add a "Pipelines" category, filled with the list of templates to create pipelines from the menu
+                categories["Pipelines"] = MeshroomApp.pipelineTemplateNames;
 
                 return categories
             }

--- a/meshroom/ui/qml/GraphEditor/GraphEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/GraphEditor.qml
@@ -240,7 +240,7 @@ Item {
 
                 if (pipelineNames.includes(pipeline)) {
                     var url = Filepath.stringToUrl(pipelinePaths[pipelineNames.indexOf(pipeline)])
-                    uigraph.importProject(url)
+                    uigraph.importProject(url, spawnPosition)
                     return true
                 }
                 return false

--- a/meshroom/ui/qml/GraphEditor/GraphEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/GraphEditor.qml
@@ -234,7 +234,9 @@ Item {
             {
                 if (MeshroomApp.pipelineTemplateNames.includes(pipeline)) {
                     var url = MeshroomApp.pipelineTemplateFiles[MeshroomApp.pipelineTemplateNames.indexOf(pipeline)]["path"]
-                    uigraph.importProject(Filepath.stringToUrl(url), spawnPosition)
+                    var nodes = uigraph.importProject(Filepath.stringToUrl(url), spawnPosition)
+                    uigraph.selectedNode = nodes[0]
+                    uigraph.selectNodes(nodes)
                     return true
                 }
                 return false

--- a/meshroom/ui/qml/GraphEditor/GraphEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/GraphEditor.qml
@@ -217,15 +217,38 @@ Item {
 
             function createNode(nodeType)
             {
-                // add node via the proper command in uigraph
-                var node = uigraph.addNewNode(nodeType, spawnPosition)
-                selectNode(node)
+                // "nodeType" might be a pipeline (artificially added in the "Pipelines" category) instead of a node
+                // If it is not a pipeline to import, then it must be a node
+                if (!importPipeline(nodeType)) {
+                    // Add node via the proper command in uigraph
+                    var node = uigraph.addNewNode(nodeType, spawnPosition)
+                    selectNode(node)
+                }
                 close()
+            }
+
+            function importPipeline(pipeline)
+            {
+                var pipelineNames = []
+                var pipelinePaths = []
+                for (const [_, data] of Object.entries(MeshroomApp.pipelineTemplateFiles)) {
+                    let name = data["name"]
+                    let path = data["path"]
+                    pipelineNames.push(name)
+                    pipelinePaths.push(path)
+                }
+
+                if (pipelineNames.includes(pipeline)) {
+                    var url = Filepath.stringToUrl(pipelinePaths[pipelineNames.indexOf(pipeline)])
+                    uigraph.importProject(url)
+                    return true
+                }
+                return false
             }
 
             function parseCategories()
             {
-                // organize nodes based on their category
+                // Organize nodes based on their category
                 // {"category1": ["node1", "node2"], "category2": ["node3", "node4"]}
                 let categories = {};
                 for (const [name, data] of Object.entries(root.nodeTypesModel)) {
@@ -235,11 +258,19 @@ Item {
                     }
                     categories[category].push(name)
                 }
+
+                // Add list of templates to create pipelines
+                categories["Pipelines"] = [];
+                for (const [_, data] of Object.entries(MeshroomApp.pipelineTemplateFiles)) {
+                    let pipeline = data["name"];
+                    categories["Pipelines"].push(pipeline)
+                }
+
                 return categories
             }
 
             onVisibleChanged: {
-                if(visible) {
+                if (visible) {
                     // when menu is shown,
                     // clear and give focus to the TextField filter
                     searchBar.clear()


### PR DESCRIPTION
## Description

This PR adds a "Pipelines" category to the node menu (opened with a right click or a press of the TAB key in the GraphEditor) which contains the list of available templates. Selecting a pipeline through the menu creates said pipeline into the current scene, with its top-left corner being placed on the mouse's position. Pipelines can be searched using the search bar at the same time as any node type.

## Features list

- [X] Add the list of available templates in a "Pipelines" category in the node menu
- [X] If a pipeline in the "Pipelines" category is clicked, create it and add it to the current scene (like any node type)
- [X] Support searching for a pipeline in the node menu's search bar (like any node type)


## Implementation remarks

- Creating a pipeline with the node menu is functionally akin to importing a template into the current project, and moving it to the mouse's position (instead of leaving it below the current graph).
- The "Pipelines" category's creation is hard-coded, and then filled with the list of the available templates' names. 
- Since the "Pipelines" category is added as a regular one, it is alphabetically sorted with the other categories, which only contain node types.