### PR TITLE
[core] Add cgroups support to meshroom

### DIFF
--- a/meshroom/core/cgroup.py
+++ b/meshroom/core/cgroup.py
@@ -43,10 +43,10 @@ def getCgroupMemorySize():
 
     return size
 
-def parseNumericList(str):
+def parseNumericList(numericListString):
 
     nList = []
-    for item in str.split(','):
+    for item in numericListString.split(','):
         if '-' in item:
             start, end = item.split('-')
             start = int(start)

--- a/meshroom/core/cgroup.py
+++ b/meshroom/core/cgroup.py
@@ -25,7 +25,7 @@ def getCgroupMemorySize():
                     continue
                 if tokens[1] == "memory":
                     cgroup = tokens[2]
-    except IOError:
+    except OSError:
         pass
 
     if cgroup is None:
@@ -38,7 +38,7 @@ def getCgroupMemorySize():
             value = f.read().rstrip("\r\n")
             if value.isnumeric():
                 size = int(value)
-    except IOError:
+    except OSError:
         pass
 
     return size
@@ -80,7 +80,7 @@ def getCgroupCpuCount():
                     continue
                 if tokens[1] == "cpuset":
                     cgroup = tokens[2]
-    except IOError:
+    except OSError:
         pass
 
     if cgroup is None:
@@ -94,7 +94,7 @@ def getCgroupCpuCount():
             nlist = parseNumericList(value)
             size = len(nlist)
 
-    except IOError:
+    except OSError:
         pass
 
     return size

--- a/meshroom/core/cgroup.py
+++ b/meshroom/core/cgroup.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python
+# coding:utf-8
+
+import os
+
+#Try to retrieve limits of memory for the current process' cgroup
+def getCgroupMemorySize():
+
+    #first of all, get pid of process
+    pid = os.getpid()
+
+    #Get cgroup associated with pid
+    filename = f"/proc/{pid}/cgroup"
+
+    cgroup = None
+    try:
+        with open(filename, "r") as f :
+
+            #cgroup file is a ':' separated table
+            #lookup a line where the second field is "memory"
+            lines = f.readlines()
+            for line in lines:
+                tokens = line.rstrip("\r\n").split(":")
+                if len(tokens) < 3:
+                    continue
+                if tokens[1] == "memory":
+                    cgroup = tokens[2]
+    except IOError:
+        pass
+
+    if cgroup is None:
+        return -1
+
+    size = -1
+    filename = f"/sys/fs/cgroup/memory/{cgroup}"
+    try:
+        with open(filename, "r") as f :
+            value = f.read().rstrip("\r\n")
+            if value.isnumeric():
+                size = int(value)
+    except IOError:
+        pass
+
+    return size
+
+def parseNumericList(str):
+
+    nList = []
+    for item in str.split(','):
+        if '-' in item:
+            start, end = item.split('-')
+            start = int(start)
+            end = int(end)
+            nList.extend(range(start, end + 1))
+        else:
+            value = int(item)
+            nList.append(value)
+
+    return nList
+
+#Try to retrieve limits of cores for the current process' cgroup
+def getCgroupCpuCount():
+
+    #first of all, get pid of process
+    pid = os.getpid()
+
+    #Get cgroup associated with pid
+    filename = f"/proc/{pid}/cgroup"
+
+    cgroup = None
+    try:
+        with open(filename, "r") as f :
+
+            #cgroup file is a ':' separated table
+            #lookup a line where the second field is "memory"
+            lines = f.readlines()
+            for line in lines:
+                tokens = line.rstrip("\r\n").split(":")
+                if len(tokens) < 3:
+                    continue
+                if tokens[1] == "cpuset":
+                    cgroup = tokens[2]
+    except IOError:
+        pass
+
+    if cgroup is None:
+        return -1
+
+    size = -1
+    filename = f"/sys/fs/cgroup/cpuset/{cgroup}/cpuset.cpus"
+    try:
+        with open(filename, "r") as f :
+            value = f.read().rstrip("\r\n")
+            nlist = parseNumericList(value)
+            size = len(nlist)
+
+    except IOError:
+        pass
+
+    return size
+

--- a/meshroom/core/cgroup.py
+++ b/meshroom/core/cgroup.py
@@ -32,7 +32,7 @@ def getCgroupMemorySize():
         return -1
 
     size = -1
-    filename = f"/sys/fs/cgroup/memory/{cgroup}"
+    filename = f"/sys/fs/cgroup/memory/{cgroup}/memory.limit_in_bytes"
     try:
         with open(filename, "r") as f :
             value = f.read().rstrip("\r\n")

--- a/meshroom/core/desc.py
+++ b/meshroom/core/desc.py
@@ -595,21 +595,24 @@ class CommandLineNode(Node):
 
 #specific command line node for alicevision apps
 class AVCommandLineNode(CommandLineNode):
+
+    def __init__(self):
+        
+        self._cmdMem = ''
+        memSize = cgroup.getCgroupMemorySize()
+        if memSize > 0:
+            self._cmdMem = ' --maxMemory={memSize}'.format(memSize=memSize)
+
+        self._cmdCore = ''
+        coresCount = cgroup.getCgroupCpuCount()
+        if coresCount > 0:
+            self._cmdCore = ' --maxCores={coresCount}'.format(coresCount=coresCount)
+
     def buildCommandLine(self, chunk):
 
         str = super(AVCommandLineNode, self).buildCommandLine(chunk)
 
-        cmdMem = ''
-        memSize = cgroup.getCgroupMemorySize()
-        if memSize > 0:
-            cmdMem = ' --maxMemory={memSize}'.format(memSize=memSize)
-
-        cmdCore = ''
-        coresCount = cgroup.getCgroupCpuCount()
-        if coresCount > 0:
-            cmdCore = ' --maxCores={coresCount}'.format(coresCount=coresCount)
-
-        return str + cmdMem + cmdCore
+        return str + self._cmdMem + self._cmdCore
 
 # Test abstract node
 class InitNode:

--- a/meshroom/core/desc.py
+++ b/meshroom/core/desc.py
@@ -618,9 +618,9 @@ class AVCommandLineNode(CommandLineNode):
 
     def buildCommandLine(self, chunk):
 
-        str = super(AVCommandLineNode, self).buildCommandLine(chunk)
+        commandLineString = super(AVCommandLineNode, self).buildCommandLine(chunk)
 
-        return str + AVCommandLineNode.cmdMem + AVCommandLineNode.cmdCore
+        return commandLineString + AVCommandLineNode.cmdMem + AVCommandLineNode.cmdCore
 
 # Test abstract node
 class InitNode:

--- a/meshroom/core/desc.py
+++ b/meshroom/core/desc.py
@@ -596,23 +596,31 @@ class CommandLineNode(Node):
 #specific command line node for alicevision apps
 class AVCommandLineNode(CommandLineNode):
 
+    cgroupParsed = False
+    cmdMem = ''
+    cmdCore = ''
+
     def __init__(self):
         
-        self._cmdMem = ''
-        memSize = cgroup.getCgroupMemorySize()
-        if memSize > 0:
-            self._cmdMem = ' --maxMemory={memSize}'.format(memSize=memSize)
+        if AVCommandLineNode.cgroupParsed is False:
 
-        self._cmdCore = ''
-        coresCount = cgroup.getCgroupCpuCount()
-        if coresCount > 0:
-            self._cmdCore = ' --maxCores={coresCount}'.format(coresCount=coresCount)
+            AVCommandLineNode.cmdMem = ''
+            memSize = cgroup.getCgroupMemorySize()
+            if memSize > 0:
+                AVCommandLineNode.cmdMem = ' --maxMemory={memSize}'.format(memSize=memSize)
+
+            AVCommandLineNode.cmdCore = ''
+            coresCount = cgroup.getCgroupCpuCount()
+            if coresCount > 0:
+                AVCommandLineNode.cmdCore = ' --maxCores={coresCount}'.format(coresCount=coresCount)
+
+            AVCommandLineNode.cgroupParsed = True
 
     def buildCommandLine(self, chunk):
 
         str = super(AVCommandLineNode, self).buildCommandLine(chunk)
 
-        return str + self._cmdMem + self._cmdCore
+        return str + AVCommandLineNode.cmdMem + AVCommandLineNode.cmdCore
 
 # Test abstract node
 class InitNode:

--- a/meshroom/core/desc.py
+++ b/meshroom/core/desc.py
@@ -1,5 +1,5 @@
 from meshroom.common import BaseObject, Property, Variant, VariantList, JSValue
-from meshroom.core import pyCompatibility, cgroup
+from meshroom.core import cgroup
 
 from collections.abc import Iterable
 from enum import Enum
@@ -608,7 +608,7 @@ class AVCommandLineNode(CommandLineNode):
         coresCount = cgroup.getCgroupCpuCount()
         if coresCount > 0:
             cmdCore = ' --maxCores={coresCount}'.format(coresCount=coresCount)
-        
+
         return str + cmdMem + cmdCore
 
 # Test abstract node

--- a/meshroom/core/desc.py
+++ b/meshroom/core/desc.py
@@ -548,17 +548,7 @@ class CommandLineNode(Node):
         if chunk.node.isParallelized and chunk.node.size > 1:
             cmdSuffix = ' ' + self.commandLineRange.format(**chunk.range.toDict())
 
-        cmdMem = ''
-        memSize = cgroup.getCgroupMemorySize()
-        if memSize > 0:
-            cmdMem = ' --maxMemory={memSize}'.format(memSize=memSize)
-
-        cmdCore = ''
-        coresCount = cgroup.getCgroupCpuCount()
-        if coresCount > 0:
-            cmdCore = ' --maxCores={coresCount}'.format(coresCount=coresCount)
-
-        return cmdPrefix + chunk.node.nodeDesc.commandLine.format(**chunk.node._cmdVars) + cmdMem + cmdCore + cmdSuffix
+        return cmdPrefix + chunk.node.nodeDesc.commandLine.format(**chunk.node._cmdVars) + cmdSuffix
 
     def stopProcess(self, chunk):
         # the same node could exists several times in the graph and
@@ -603,6 +593,23 @@ class CommandLineNode(Node):
         finally:
             chunk.subprocess = None
 
+#specific command line node for alicevision apps
+class AVCommandLineNode(CommandLineNode):
+    def buildCommandLine(self, chunk):
+
+        str = super(AVCommandLineNode, self).buildCommandLine(chunk)
+
+        cmdMem = ''
+        memSize = cgroup.getCgroupMemorySize()
+        if memSize > 0:
+            cmdMem = ' --maxMemory={memSize}'.format(memSize=memSize)
+
+        cmdCore = ''
+        coresCount = cgroup.getCgroupCpuCount()
+        if coresCount > 0:
+            cmdCore = ' --maxCores={coresCount}'.format(coresCount=coresCount)
+        
+        return str + cmdMem + cmdCore
 
 # Test abstract node
 class InitNode:

--- a/meshroom/nodes/aliceVision/CameraCalibration.py
+++ b/meshroom/nodes/aliceVision/CameraCalibration.py
@@ -3,7 +3,7 @@ __version__ = "1.0"
 from meshroom.core import desc
 
 
-class CameraCalibration(desc.CommandLineNode):
+class CameraCalibration(desc.AVCommandLineNode):
     commandLine = 'aliceVision_cameraCalibration {allParams}'
 
     category = 'Utils'

--- a/meshroom/nodes/aliceVision/CameraInit.py
+++ b/meshroom/nodes/aliceVision/CameraInit.py
@@ -119,7 +119,7 @@ def readSfMData(sfmFile):
     return views, intrinsics
 
 
-class CameraInit(desc.CommandLineNode, desc.InitNode):
+class CameraInit(desc.AVCommandLineNode, desc.InitNode):
     commandLine = 'aliceVision_cameraInit {allParams} --allowSingleView 1' # don't throw an error if there is only one image
 
     size = desc.DynamicNodeSize('viewpoints')

--- a/meshroom/nodes/aliceVision/CameraLocalization.py
+++ b/meshroom/nodes/aliceVision/CameraLocalization.py
@@ -4,7 +4,7 @@ import os
 from meshroom.core import desc
 
 
-class CameraLocalization(desc.CommandLineNode):
+class CameraLocalization(desc.AVCommandLineNode):
     commandLine = 'aliceVision_cameraLocalization {allParams}'
 
     category = 'Utils'

--- a/meshroom/nodes/aliceVision/CameraRigCalibration.py
+++ b/meshroom/nodes/aliceVision/CameraRigCalibration.py
@@ -4,7 +4,7 @@ import os
 from meshroom.core import desc
 
 
-class CameraRigCalibration(desc.CommandLineNode):
+class CameraRigCalibration(desc.AVCommandLineNode):
     commandLine = 'aliceVision_rigCalibration {allParams}'
 
     category = 'Utils'

--- a/meshroom/nodes/aliceVision/CameraRigLocalization.py
+++ b/meshroom/nodes/aliceVision/CameraRigLocalization.py
@@ -4,7 +4,7 @@ import os
 from meshroom.core import desc
 
 
-class CameraRigLocalization(desc.CommandLineNode):
+class CameraRigLocalization(desc.AVCommandLineNode):
     commandLine = 'aliceVision_rigLocalization {allParams}'
 
     category = 'Utils'

--- a/meshroom/nodes/aliceVision/ColorCheckerCorrection.py
+++ b/meshroom/nodes/aliceVision/ColorCheckerCorrection.py
@@ -5,7 +5,7 @@ from meshroom.core import desc
 import os.path
 
 
-class ColorCheckerCorrection(desc.CommandLineNode):
+class ColorCheckerCorrection(desc.AVCommandLineNode):
     commandLine = 'aliceVision_utils_colorCheckerCorrection {allParams}'
     size = desc.DynamicNodeSize('input')
     # parallelization = desc.Parallelization(blockSize=40)

--- a/meshroom/nodes/aliceVision/ColorCheckerDetection.py
+++ b/meshroom/nodes/aliceVision/ColorCheckerDetection.py
@@ -5,7 +5,7 @@ from meshroom.core import desc
 import os.path
 
 
-class ColorCheckerDetection(desc.CommandLineNode):
+class ColorCheckerDetection(desc.AVCommandLineNode):
     commandLine = 'aliceVision_utils_colorCheckerDetection {allParams}'
     size = desc.DynamicNodeSize('input')
     # parallelization = desc.Parallelization(blockSize=40)

--- a/meshroom/nodes/aliceVision/ConvertMesh.py
+++ b/meshroom/nodes/aliceVision/ConvertMesh.py
@@ -3,7 +3,7 @@ __version__ = "1.0"
 from meshroom.core import desc
 
 
-class ConvertMesh(desc.CommandLineNode):
+class ConvertMesh(desc.AVCommandLineNode):
     commandLine = 'aliceVision_convertMesh {allParams}'
 
     category = 'Utils'

--- a/meshroom/nodes/aliceVision/ConvertSfMFormat.py
+++ b/meshroom/nodes/aliceVision/ConvertSfMFormat.py
@@ -3,7 +3,7 @@ __version__ = "2.0"
 from meshroom.core import desc
 
 
-class ConvertSfMFormat(desc.CommandLineNode):
+class ConvertSfMFormat(desc.AVCommandLineNode):
     commandLine = 'aliceVision_convertSfMFormat {allParams}'
     size = desc.DynamicNodeSize('input')
 

--- a/meshroom/nodes/aliceVision/DepthMap.py
+++ b/meshroom/nodes/aliceVision/DepthMap.py
@@ -3,7 +3,7 @@ __version__ = "2.0"
 from meshroom.core import desc
 
 
-class DepthMap(desc.CommandLineNode):
+class DepthMap(desc.AVCommandLineNode):
     commandLine = 'aliceVision_depthMapEstimation {allParams}'
     gpu = desc.Level.INTENSIVE
     size = desc.DynamicNodeSize('input')

--- a/meshroom/nodes/aliceVision/DepthMapFilter.py
+++ b/meshroom/nodes/aliceVision/DepthMapFilter.py
@@ -3,7 +3,7 @@ __version__ = "3.0"
 from meshroom.core import desc
 
 
-class DepthMapFilter(desc.CommandLineNode):
+class DepthMapFilter(desc.AVCommandLineNode):
     commandLine = 'aliceVision_depthMapFiltering {allParams}'
     gpu = desc.Level.NORMAL
     size = desc.DynamicNodeSize('input')

--- a/meshroom/nodes/aliceVision/DistortionCalibration.py
+++ b/meshroom/nodes/aliceVision/DistortionCalibration.py
@@ -3,7 +3,7 @@ __version__ = '2.0'
 from meshroom.core import desc
 
 
-class DistortionCalibration(desc.CommandLineNode):
+class DistortionCalibration(desc.AVCommandLineNode):
     commandLine = 'aliceVision_distortionCalibration {allParams}'
     size = desc.DynamicNodeSize('input')
 

--- a/meshroom/nodes/aliceVision/ExportAnimatedCamera.py
+++ b/meshroom/nodes/aliceVision/ExportAnimatedCamera.py
@@ -3,7 +3,7 @@ __version__ = "2.0"
 from meshroom.core import desc
 
 
-class ExportAnimatedCamera(desc.CommandLineNode):
+class ExportAnimatedCamera(desc.AVCommandLineNode):
     commandLine = 'aliceVision_exportAnimatedCamera {allParams}'
 
     category = 'Export'

--- a/meshroom/nodes/aliceVision/ExportColoredPointCloud.py
+++ b/meshroom/nodes/aliceVision/ExportColoredPointCloud.py
@@ -3,7 +3,7 @@ __version__ = "1.0"
 from meshroom.core import desc
 
 
-class ExportColoredPointCloud(desc.CommandLineNode):
+class ExportColoredPointCloud(desc.AVCommandLineNode):
     commandLine = 'aliceVision_exportColoredPointCloud {allParams}'
 
     category = 'Export'

--- a/meshroom/nodes/aliceVision/ExportMatches.py
+++ b/meshroom/nodes/aliceVision/ExportMatches.py
@@ -3,7 +3,7 @@ __version__ = "1.1"
 from meshroom.core import desc
 
 
-class ExportMatches(desc.CommandLineNode):
+class ExportMatches(desc.AVCommandLineNode):
     commandLine = 'aliceVision_exportMatches {allParams}'
     size = desc.DynamicNodeSize('input')
 

--- a/meshroom/nodes/aliceVision/ExportMaya.py
+++ b/meshroom/nodes/aliceVision/ExportMaya.py
@@ -3,7 +3,7 @@ __version__ = "1.0"
 from meshroom.core import desc
 
 
-class ExportMaya(desc.CommandLineNode):
+class ExportMaya(desc.AVCommandLineNode):
     commandLine = 'aliceVision_exportMeshroomMaya {allParams}'
 
     category = 'Export'

--- a/meshroom/nodes/aliceVision/FeatureExtraction.py
+++ b/meshroom/nodes/aliceVision/FeatureExtraction.py
@@ -3,7 +3,7 @@ __version__ = "1.1"
 from meshroom.core import desc
 
 
-class FeatureExtraction(desc.CommandLineNode):
+class FeatureExtraction(desc.AVCommandLineNode):
     commandLine = 'aliceVision_featureExtraction {allParams}'
     size = desc.DynamicNodeSize('input')
     parallelization = desc.Parallelization(blockSize=40)

--- a/meshroom/nodes/aliceVision/FeatureMatching.py
+++ b/meshroom/nodes/aliceVision/FeatureMatching.py
@@ -3,7 +3,7 @@ __version__ = "2.0"
 from meshroom.core import desc
 
 
-class FeatureMatching(desc.CommandLineNode):
+class FeatureMatching(desc.AVCommandLineNode):
     commandLine = 'aliceVision_featureMatching {allParams}'
     size = desc.DynamicNodeSize('input')
     parallelization = desc.Parallelization(blockSize=20)

--- a/meshroom/nodes/aliceVision/FeatureRepeatability.py
+++ b/meshroom/nodes/aliceVision/FeatureRepeatability.py
@@ -3,7 +3,7 @@ __version__ = "1.1"
 from meshroom.core import desc
 
 
-class FeatureRepeatability(desc.CommandLineNode):
+class FeatureRepeatability(desc.AVCommandLineNode):
     commandLine = 'aliceVision_samples_repeatabilityDataset {allParams}'
     size = desc.DynamicNodeSize('input')
     # parallelization = desc.Parallelization(blockSize=40)

--- a/meshroom/nodes/aliceVision/GlobalSfM.py
+++ b/meshroom/nodes/aliceVision/GlobalSfM.py
@@ -6,7 +6,7 @@ import os
 from meshroom.core import desc
 
 
-class GlobalSfM(desc.CommandLineNode):
+class GlobalSfM(desc.AVCommandLineNode):
     commandLine = 'aliceVision_globalSfM {allParams}'
     size = desc.DynamicNodeSize('input')
 

--- a/meshroom/nodes/aliceVision/ImageMasking.py
+++ b/meshroom/nodes/aliceVision/ImageMasking.py
@@ -3,7 +3,7 @@ __version__ = "3.0"
 from meshroom.core import desc
 
 
-class ImageMasking(desc.CommandLineNode):
+class ImageMasking(desc.AVCommandLineNode):
     commandLine = 'aliceVision_imageMasking {allParams}'
     size = desc.DynamicNodeSize('input')
     parallelization = desc.Parallelization(blockSize=40)

--- a/meshroom/nodes/aliceVision/ImageMatching.py
+++ b/meshroom/nodes/aliceVision/ImageMatching.py
@@ -4,7 +4,7 @@ import os
 from meshroom.core import desc
 
 
-class ImageMatching(desc.CommandLineNode):
+class ImageMatching(desc.AVCommandLineNode):
     commandLine = 'aliceVision_imageMatching {allParams}'
     size = desc.DynamicNodeSize('input')
 

--- a/meshroom/nodes/aliceVision/ImageMatchingMultiSfM.py
+++ b/meshroom/nodes/aliceVision/ImageMatchingMultiSfM.py
@@ -4,7 +4,7 @@ import os
 from meshroom.core import desc
 
 
-class ImageMatchingMultiSfM(desc.CommandLineNode):
+class ImageMatchingMultiSfM(desc.AVCommandLineNode):
     commandLine = 'aliceVision_imageMatching {allParams}'
     # use both SfM inputs to define Node's size
     size = desc.MultiDynamicNodeSize(['input', 'inputB'])

--- a/meshroom/nodes/aliceVision/ImageProcessing.py
+++ b/meshroom/nodes/aliceVision/ImageProcessing.py
@@ -28,7 +28,7 @@ def outputImagesValueFunct(attr):
     return desc.Node.internalFolder + '*' + (outputExt or '.*')
 
 
-class ImageProcessing(desc.CommandLineNode):
+class ImageProcessing(desc.AVCommandLineNode):
     commandLine = 'aliceVision_utils_imageProcessing {allParams}'
     size = desc.DynamicNodeSize('input')
     # parallelization = desc.Parallelization(blockSize=40)

--- a/meshroom/nodes/aliceVision/ImportKnownPoses.py
+++ b/meshroom/nodes/aliceVision/ImportKnownPoses.py
@@ -3,7 +3,7 @@ __version__ = "1.0"
 from meshroom.core import desc
 
 
-class ImportKnownPoses(desc.CommandLineNode):
+class ImportKnownPoses(desc.AVCommandLineNode):
     commandLine = 'aliceVision_importKnownPoses {allParams}'
     size = desc.DynamicNodeSize('sfmData')
 

--- a/meshroom/nodes/aliceVision/KeyframeSelection.py
+++ b/meshroom/nodes/aliceVision/KeyframeSelection.py
@@ -4,7 +4,7 @@ import os
 from meshroom.core import desc
 
 
-class KeyframeSelection(desc.CommandLineNode):
+class KeyframeSelection(desc.AVCommandLineNode):
     commandLine = 'aliceVision_utils_keyframeSelection {allParams}'
 
     category = 'Utils'

--- a/meshroom/nodes/aliceVision/LdrToHdrCalibration.py
+++ b/meshroom/nodes/aliceVision/LdrToHdrCalibration.py
@@ -23,7 +23,7 @@ def findMetadata(d, keys, defaultValue):
 
 
 
-class LdrToHdrCalibration(desc.CommandLineNode):
+class LdrToHdrCalibration(desc.AVCommandLineNode):
     commandLine = 'aliceVision_LdrToHdrCalibration {allParams}'
     size = desc.DynamicNodeSize('input')
     cpu = desc.Level.INTENSIVE

--- a/meshroom/nodes/aliceVision/LdrToHdrMerge.py
+++ b/meshroom/nodes/aliceVision/LdrToHdrMerge.py
@@ -22,7 +22,7 @@ def findMetadata(d, keys, defaultValue):
     return defaultValue
 
 
-class LdrToHdrMerge(desc.CommandLineNode):
+class LdrToHdrMerge(desc.AVCommandLineNode):
     commandLine = 'aliceVision_LdrToHdrMerge {allParams}'
     size = desc.DynamicNodeSize('input')
     parallelization = desc.Parallelization(blockSize=2)

--- a/meshroom/nodes/aliceVision/LdrToHdrSampling.py
+++ b/meshroom/nodes/aliceVision/LdrToHdrSampling.py
@@ -39,7 +39,7 @@ class DividedInputNodeSize(desc.DynamicNodeSize):
         return s / divParam.value
 
 
-class LdrToHdrSampling(desc.CommandLineNode):
+class LdrToHdrSampling(desc.AVCommandLineNode):
     commandLine = 'aliceVision_LdrToHdrSampling {allParams}'
     size = DividedInputNodeSize('input', 'nbBrackets')
     parallelization = desc.Parallelization(blockSize=2)

--- a/meshroom/nodes/aliceVision/LightingEstimation.py
+++ b/meshroom/nodes/aliceVision/LightingEstimation.py
@@ -3,7 +3,7 @@ __version__ = "1.0"
 from meshroom.core import desc
 
 
-class LightingEstimation(desc.CommandLineNode):
+class LightingEstimation(desc.AVCommandLineNode):
     commandLine = 'aliceVision_utils_lightingEstimation {allParams}'
 
     category = 'Utils'

--- a/meshroom/nodes/aliceVision/MergeMeshes.py
+++ b/meshroom/nodes/aliceVision/MergeMeshes.py
@@ -3,7 +3,7 @@ __version__ = "1.0"
 from meshroom.core import desc
 
 
-class MergeMeshes(desc.CommandLineNode):
+class MergeMeshes(desc.AVCommandLineNode):
     commandLine = 'aliceVision_utils_mergeMeshes {allParams}'
 
     category = 'Utils'

--- a/meshroom/nodes/aliceVision/MeshDecimate.py
+++ b/meshroom/nodes/aliceVision/MeshDecimate.py
@@ -3,7 +3,7 @@ __version__ = "1.0"
 from meshroom.core import desc
 
 
-class MeshDecimate(desc.CommandLineNode):
+class MeshDecimate(desc.AVCommandLineNode):
     commandLine = 'aliceVision_meshDecimate {allParams}'
     cpu = desc.Level.NORMAL
     ram = desc.Level.NORMAL

--- a/meshroom/nodes/aliceVision/MeshDenoising.py
+++ b/meshroom/nodes/aliceVision/MeshDenoising.py
@@ -3,7 +3,7 @@ __version__ = "1.0"
 from meshroom.core import desc
 
 
-class MeshDenoising(desc.CommandLineNode):
+class MeshDenoising(desc.AVCommandLineNode):
     commandLine = 'aliceVision_meshDenoising {allParams}'
 
     category = 'Mesh Post-Processing'

--- a/meshroom/nodes/aliceVision/MeshFiltering.py
+++ b/meshroom/nodes/aliceVision/MeshFiltering.py
@@ -3,7 +3,7 @@ __version__ = "3.0"
 from meshroom.core import desc
 
 
-class MeshFiltering(desc.CommandLineNode):
+class MeshFiltering(desc.AVCommandLineNode):
     commandLine = 'aliceVision_meshFiltering {allParams}'
 
     category = 'Dense Reconstruction'

--- a/meshroom/nodes/aliceVision/MeshMasking.py
+++ b/meshroom/nodes/aliceVision/MeshMasking.py
@@ -3,7 +3,7 @@ __version__ = "1.0"
 from meshroom.core import desc
 
 
-class MeshMasking(desc.CommandLineNode):
+class MeshMasking(desc.AVCommandLineNode):
     commandLine = 'aliceVision_meshMasking {allParams}'
     category = 'Mesh Post-Processing'
     documentation = '''

--- a/meshroom/nodes/aliceVision/MeshResampling.py
+++ b/meshroom/nodes/aliceVision/MeshResampling.py
@@ -3,7 +3,7 @@ __version__ = "1.0"
 from meshroom.core import desc
 
 
-class MeshResampling(desc.CommandLineNode):
+class MeshResampling(desc.AVCommandLineNode):
     commandLine = 'aliceVision_meshResampling {allParams}'
     cpu = desc.Level.NORMAL
     ram = desc.Level.NORMAL

--- a/meshroom/nodes/aliceVision/Meshing.py
+++ b/meshroom/nodes/aliceVision/Meshing.py
@@ -3,7 +3,7 @@ __version__ = "7.0"
 from meshroom.core import desc
 
 
-class Meshing(desc.CommandLineNode):
+class Meshing(desc.AVCommandLineNode):
     commandLine = 'aliceVision_meshing {allParams}'
 
     cpu = desc.Level.INTENSIVE

--- a/meshroom/nodes/aliceVision/PanoramaCompositing.py
+++ b/meshroom/nodes/aliceVision/PanoramaCompositing.py
@@ -6,7 +6,7 @@ import os
 from meshroom.core import desc
 
 
-class PanoramaCompositing(desc.CommandLineNode):
+class PanoramaCompositing(desc.AVCommandLineNode):
     commandLine = 'aliceVision_panoramaCompositing {allParams}'
     size = desc.DynamicNodeSize('input')
     parallelization = desc.Parallelization(blockSize=5)

--- a/meshroom/nodes/aliceVision/PanoramaEstimation.py
+++ b/meshroom/nodes/aliceVision/PanoramaEstimation.py
@@ -6,7 +6,7 @@ import os
 from meshroom.core import desc
 
 
-class PanoramaEstimation(desc.CommandLineNode):
+class PanoramaEstimation(desc.AVCommandLineNode):
     commandLine = 'aliceVision_panoramaEstimation {allParams}'
     size = desc.DynamicNodeSize('input')
 

--- a/meshroom/nodes/aliceVision/PanoramaInit.py
+++ b/meshroom/nodes/aliceVision/PanoramaInit.py
@@ -3,7 +3,7 @@ __version__ = "2.0"
 from meshroom.core import desc
 
 
-class PanoramaInit(desc.CommandLineNode):
+class PanoramaInit(desc.AVCommandLineNode):
     commandLine = 'aliceVision_panoramaInit {allParams}'
     size = desc.DynamicNodeSize('input')
 

--- a/meshroom/nodes/aliceVision/PanoramaMerging.py
+++ b/meshroom/nodes/aliceVision/PanoramaMerging.py
@@ -6,7 +6,7 @@ import os
 from meshroom.core import desc
 
 
-class PanoramaMerging(desc.CommandLineNode):
+class PanoramaMerging(desc.AVCommandLineNode):
     commandLine = 'aliceVision_panoramaMerging {allParams}'
     size = desc.DynamicNodeSize('input')
     cpu = desc.Level.NORMAL

--- a/meshroom/nodes/aliceVision/PanoramaPrepareImages.py
+++ b/meshroom/nodes/aliceVision/PanoramaPrepareImages.py
@@ -5,7 +5,7 @@ from meshroom.core import desc
 import os.path
 
 
-class PanoramaPrepareImages(desc.CommandLineNode):
+class PanoramaPrepareImages(desc.AVCommandLineNode):
     commandLine = 'aliceVision_panoramaPrepareImages {allParams}'
     size = desc.DynamicNodeSize('input')
 

--- a/meshroom/nodes/aliceVision/PanoramaSeams.py
+++ b/meshroom/nodes/aliceVision/PanoramaSeams.py
@@ -6,7 +6,7 @@ import os
 from meshroom.core import desc
 
 
-class PanoramaSeams(desc.CommandLineNode):
+class PanoramaSeams(desc.AVCommandLineNode):
     commandLine = 'aliceVision_panoramaSeams {allParams}'
     size = desc.DynamicNodeSize('input')
     cpu = desc.Level.INTENSIVE

--- a/meshroom/nodes/aliceVision/PanoramaWarping.py
+++ b/meshroom/nodes/aliceVision/PanoramaWarping.py
@@ -6,7 +6,7 @@ import os
 from meshroom.core import desc
 
 
-class PanoramaWarping(desc.CommandLineNode):
+class PanoramaWarping(desc.AVCommandLineNode):
     commandLine = 'aliceVision_panoramaWarping {allParams}'
     size = desc.DynamicNodeSize('input')
     parallelization = desc.Parallelization(blockSize=5)

--- a/meshroom/nodes/aliceVision/PrepareDenseScene.py
+++ b/meshroom/nodes/aliceVision/PrepareDenseScene.py
@@ -3,7 +3,7 @@ __version__ = "3.0"
 from meshroom.core import desc
 
 
-class PrepareDenseScene(desc.CommandLineNode):
+class PrepareDenseScene(desc.AVCommandLineNode):
     commandLine = 'aliceVision_prepareDenseScene {allParams}'
     size = desc.DynamicNodeSize('input')
     parallelization = desc.Parallelization(blockSize=40)

--- a/meshroom/nodes/aliceVision/SfMAlignment.py
+++ b/meshroom/nodes/aliceVision/SfMAlignment.py
@@ -5,7 +5,7 @@ from meshroom.core import desc
 import os.path
 
 
-class SfMAlignment(desc.CommandLineNode):
+class SfMAlignment(desc.AVCommandLineNode):
     commandLine = 'aliceVision_utils_sfmAlignment {allParams}'
     size = desc.DynamicNodeSize('input')
 

--- a/meshroom/nodes/aliceVision/SfMDistances.py
+++ b/meshroom/nodes/aliceVision/SfMDistances.py
@@ -3,7 +3,7 @@ __version__ = "3.0"
 from meshroom.core import desc
 
 
-class SfMDistances(desc.CommandLineNode):
+class SfMDistances(desc.AVCommandLineNode):
     commandLine = 'aliceVision_utils_sfmDistances {allParams}'
     size = desc.DynamicNodeSize('input')
 

--- a/meshroom/nodes/aliceVision/SfMTransfer.py
+++ b/meshroom/nodes/aliceVision/SfMTransfer.py
@@ -5,7 +5,7 @@ from meshroom.core import desc
 import os.path
 
 
-class SfMTransfer(desc.CommandLineNode):
+class SfMTransfer(desc.AVCommandLineNode):
     commandLine = 'aliceVision_utils_sfmTransfer {allParams}'
     size = desc.DynamicNodeSize('input')
 

--- a/meshroom/nodes/aliceVision/SfMTransform.py
+++ b/meshroom/nodes/aliceVision/SfMTransform.py
@@ -5,7 +5,7 @@ from meshroom.core import desc
 import os.path
 
 
-class SfMTransform(desc.CommandLineNode):
+class SfMTransform(desc.AVCommandLineNode):
     commandLine = 'aliceVision_utils_sfmTransform {allParams}'
     size = desc.DynamicNodeSize('input')
 

--- a/meshroom/nodes/aliceVision/Split360Images.py
+++ b/meshroom/nodes/aliceVision/Split360Images.py
@@ -2,7 +2,7 @@ __version__ = "1.0"
 
 from meshroom.core import desc
 
-class Split360Images(desc.CommandLineNode):
+class Split360Images(desc.AVCommandLineNode):
     commandLine = 'aliceVision_utils_split360Images {allParams}'
     
     category = 'Utils'

--- a/meshroom/nodes/aliceVision/StructureFromMotion.py
+++ b/meshroom/nodes/aliceVision/StructureFromMotion.py
@@ -3,7 +3,7 @@ __version__ = "2.0"
 from meshroom.core import desc
 
 
-class StructureFromMotion(desc.CommandLineNode):
+class StructureFromMotion(desc.AVCommandLineNode):
     commandLine = 'aliceVision_incrementalSfM {allParams}'
     size = desc.DynamicNodeSize('input')
 

--- a/meshroom/nodes/aliceVision/Texturing.py
+++ b/meshroom/nodes/aliceVision/Texturing.py
@@ -4,7 +4,7 @@ from meshroom.core import desc, Version
 import logging
 
 
-class Texturing(desc.CommandLineNode):
+class Texturing(desc.AVCommandLineNode):
     commandLine = 'aliceVision_texturing {allParams}'
     cpu = desc.Level.INTENSIVE
     ram = desc.Level.INTENSIVE


### PR DESCRIPTION
CGroups on linux may limit the memory and the number of cpus

Without getting the specific information about these limits, we may overshoot our memory usage and core usage, creating crashes.

This PR will read the values as specified by the specifications.

Rely on https://github.com/alicevision/AliceVision/pull/1304.
