### PR TITLE
[ui] Fix all "TypeError" QML warnings

### DIFF
--- a/meshroom/ui/qml/GraphEditor/CompatibilityManager.qml
+++ b/meshroom/ui/qml/GraphEditor/CompatibilityManager.qml
@@ -14,7 +14,7 @@ MessageDialog {
     // the UIGraph instance
     property var uigraph
     // alias to underlying compatibilityNodes model
-    readonly property var nodesModel: uigraph.graph.compatibilityNodes
+    readonly property var nodesModel: uigraph ? uigraph.graph.compatibilityNodes : undefined
     // the total number of compatibility issues
     readonly property int issueCount: (nodesModel != undefined) ? nodesModel.count : 0
     // the number of CompatibilityNodes that can be upgraded
@@ -47,7 +47,10 @@ MessageDialog {
 
     title: "Compatibility issues detected"
     text: "This project contains " + issueCount + " node(s) incompatible with the current version of Meshroom."
-    detailedText: "Project was created with Meshroom " + uigraph.graph.fileReleaseVersion + "."
+    detailedText: {
+        let releaseVersion = uigraph ? uigraph.graph.fileReleaseVersion : "0.0"
+        return "Project was created with Meshroom " + releaseVersion + "."
+    }
 
     helperText: upgradableCount ?
                 upgradableCount + " node(s) can be upgraded but this might invalidate already computed data.\n"

--- a/meshroom/ui/qml/GraphEditor/GraphEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/GraphEditor.qml
@@ -418,7 +418,7 @@ Item {
                 MenuItem {
                     text: "Submit"
                     enabled: nodeMenu.canComputeNode && nodeMenu.canSubmitOrCompute > 1
-                    visible: uigraph.canSubmit
+                    visible: uigraph ? uigraph.canSubmit : false
                     height: visible ? implicitHeight : 0
                     onTriggered: submitRequest(nodeMenu.currentNode)
                 }
@@ -736,7 +736,7 @@ Item {
                             flat: true
                             model: ['Minimum', 'Maximum']
                             implicitWidth: 80
-                            currentIndex: uigraph.layout.depthMode
+                            currentIndex: uigraph ? uigraph.layout.depthMode : -1
                             onActivated: {
                                 uigraph.layout.depthMode = currentIndex
                             }

--- a/meshroom/ui/qml/GraphEditor/NodeDocumentation.qml
+++ b/meshroom/ui/qml/GraphEditor/NodeDocumentation.qml
@@ -31,7 +31,7 @@ FocusScope {
             selectByMouse: true
             selectionColor: activePalette.highlight
             color: activePalette.text
-            text: node.documentation
+            text: node ? node.documentation : ""
             wrapMode: TextEdit.Wrap
         }
     }

--- a/meshroom/ui/qml/GraphEditor/TaskManager.qml
+++ b/meshroom/ui/qml/GraphEditor/TaskManager.qml
@@ -39,7 +39,7 @@ Item {
 
     TextMetrics {
         id: nbMetrics
-        text: root.taskManager.nodes.count
+        text: root.taskManager ? root.taskManager.nodes.count : "0"
     }
 
     TextMetrics {
@@ -67,7 +67,7 @@ Item {
         anchors.fill: parent
         ScrollBar.vertical: ScrollBar {}
 
-        model: parent.taskManager.nodes
+        model: parent.taskManager ? parent.taskManager.nodes : null
         spacing: 3
 
         headerPositioning: ListView.OverlayHeader

--- a/meshroom/ui/qml/ImageGallery/ImageDelegate.qml
+++ b/meshroom/ui/qml/ImageGallery/ImageDelegate.qml
@@ -58,7 +58,7 @@ Item {
             }
             MenuItem {
                 text: "Define As Center Image"
-                property var activeNode: _reconstruction.activeNodes.get("SfMTransform").node
+                property var activeNode: _reconstruction ? _reconstruction.activeNodes.get("SfMTransform").node : null
                 enabled: !root.readOnly && _viewpoint.viewId != -1 && _reconstruction && activeNode
                 onClicked: activeNode.attribute("transformation").value = _viewpoint.viewId.toString()
             }

--- a/meshroom/ui/qml/LiveSfmView.qml
+++ b/meshroom/ui/qml/LiveSfmView.qml
@@ -13,7 +13,7 @@ Panel {
     id: root
 
     property variant reconstruction
-    readonly property variant liveSfmManager: reconstruction.liveSfmManager
+    readonly property variant liveSfmManager: reconstruction ? reconstruction.liveSfmManager : null
 
     title: "Live Reconstruction"
     icon: Label {
@@ -41,7 +41,7 @@ Panel {
             width: parent.width
             GroupBox {
                 Layout.fillWidth: true
-                enabled: !liveSfmManager.running
+                enabled: liveSfmManager ? !liveSfmManager.running : false
 
                 GridLayout {
                     width: parent.width
@@ -59,7 +59,7 @@ Panel {
                             id: folderPath
                             Layout.fillWidth: true
                             selectByMouse: true
-                            text: liveSfmManager.folder
+                            text: liveSfmManager ? liveSfmManager.folder : ""
                             placeholderText: "Select a Folder"
                         }
                         ToolButton {
@@ -90,8 +90,8 @@ Panel {
             Button {                
                 Layout.alignment: Qt.AlignCenter
                 text: checked ? "Stop" : "Start"
-                enabled: liveSfmManager.running || folderPath.text.trim() != ''
-                checked: liveSfmManager.running
+                enabled: liveSfmManager ? liveSfmManager.running || folderPath.text.trim() != '' : false
+                checked: liveSfmManager ? liveSfmManager.running : false
                 onClicked: {
                     if(!liveSfmManager.running)
                         liveSfmManager.start(folderPath.text, minImg_SB.value)

--- a/meshroom/ui/qml/Viewer/Viewer2D.qml
+++ b/meshroom/ui/qml/Viewer/Viewer2D.qml
@@ -24,7 +24,7 @@ FocusScope {
     property alias useLensDistortionViewer: displayLensDistortionViewer.checked
     property alias usePanoramaViewer: displayPanoramaViewer.checked
 
-    property var activeNodeFisheye: _reconstruction.activeNodes.get("PanoramaInit").node
+    property var activeNodeFisheye: _reconstruction ? _reconstruction.activeNodes.get("PanoramaInit").node : null
     property bool cropFisheye : activeNodeFisheye ? activeNodeFisheye.attribute("useFisheye").value : false
     property bool enable8bitViewer: MeshroomApp.default8bitViewerEnabled
 
@@ -202,15 +202,15 @@ FocusScope {
         if (useExternal) {
             return sourceExternal;
         }
-        if (!displayedNode || outputAttribute.name == "gallery") {
+        if (_reconstruction && (!displayedNode || outputAttribute.name == "gallery")) {
             return getViewpointPath(_reconstruction.selectedViewId);
         } 
-        return getFileAttributePath(displayedNode, outputAttribute.name, _reconstruction.selectedViewId);
+        return getFileAttributePath(displayedNode, outputAttribute.name, _reconstruction ? _reconstruction.selectedViewId : -1);
     }
 
     function getMetadata() {
         // entry point for getting the image metadata
-        if (useExternal) {
+        if (useExternal || !_reconstruction) {
             return {};
         } else {
             return getViewpointMetadata(_reconstruction.selectedViewId);
@@ -220,6 +220,8 @@ FocusScope {
     function getFileAttributePath(node, attrName, viewId) {
         // get output attribute with matching name
         // and parse its value to get the image filepath
+        if (!node)
+            return "";
         for (var i = 0; i < node.attributes.count; i++) {
             var attr = node.attributes.at(i);
             if (attr.name == attrName) {
@@ -429,7 +431,7 @@ FocusScope {
                                 'sfmRequired': Qt.binding(function(){ return displayLensDistortionViewer.checked ? true : false;}),
                                 'surface.msfmData': Qt.binding(function() { return (msfmDataLoader.status === Loader.Ready && msfmDataLoader.item != null && msfmDataLoader.item.status === 2) ? msfmDataLoader.item : null; }),
                                 'canBeHovered': false,
-                                'idView': Qt.binding(function() { return _reconstruction.selectedViewId; }),
+                                'idView': Qt.binding(function() { return (_reconstruction ? _reconstruction.selectedViewId : -1); }),
                                 'cropFisheye': false
                                 })
                           } else {
@@ -521,7 +523,7 @@ FocusScope {
                 Loader {
                     id: featuresViewerLoader
                     active: displayFeatures.checked
-                    property var activeNode: _reconstruction.activeNodes.get("FeatureExtraction").node
+                    property var activeNode: _reconstruction ? _reconstruction.activeNodes.get("FeatureExtraction").node : null
 
                     // handle rotation/position based on available metadata
                     rotation: {
@@ -554,7 +556,7 @@ FocusScope {
                 // note: use a Loader to evaluate if a PanoramaInit node exist and displayFisheyeCircle checked at runtime
                 Loader {
                     anchors.centerIn: parent
-                    property var activeNode: _reconstruction.activeNodes.get("PanoramaInit").node
+                    property var activeNode: _reconstruction ? _reconstruction.activeNodes.get("PanoramaInit").node : null
                     active: (displayFisheyeCircleLoader.checked && activeNode)
 
                     // handle rotation/position based on available metadata
@@ -602,7 +604,7 @@ FocusScope {
                 Loader {
                     id: colorCheckerViewerLoader
                     anchors.centerIn: parent
-                    property var activeNode: _reconstruction.activeNodes.get("ColorCheckerDetection").node
+                    property var activeNode: _reconstruction ? _reconstruction.activeNodes.get("ColorCheckerDetection").node : null
                     active: (displayColorCheckerViewerLoader.checked && activeNode)
 
 
@@ -706,7 +708,7 @@ FocusScope {
                         id: mfeaturesLoader
 
                         property bool isUsed: displayFeatures.checked
-                        property var activeNode: root.aliceVisionPluginAvailable ? _reconstruction.activeNodes.get("FeatureExtraction").node : null
+                        property var activeNode: root.aliceVisionPluginAvailable && _reconstruction ? _reconstruction.activeNodes.get("FeatureExtraction").node : null
                         property bool isComputed: activeNode && activeNode.isComputed
                         active: false
 
@@ -749,7 +751,7 @@ FocusScope {
                             }
                             // For lens distortion viewer: use all nodes creating a sfmData file
                             var nodeType = displayLensDistortionViewer.checked ? 'sfmData' : 'sfm'
-                            var sfmNode = _reconstruction.activeNodes.get(nodeType).node
+                            var sfmNode = _reconstruction ? _reconstruction.activeNodes.get(nodeType).node : null
                             if(sfmNode === null){
                                 return null
                             }
@@ -827,7 +829,7 @@ FocusScope {
                         id: mtracksLoader
 
                         property bool isUsed: displayFeatures.checked || displaySfmStatsView.checked || displaySfmDataGlobalStats.checked || displayPanoramaViewer.checked
-                        property var activeNode: root.aliceVisionPluginAvailable ? _reconstruction.activeNodes.get('FeatureMatching').node : null
+                        property var activeNode: root.aliceVisionPluginAvailable && _reconstruction ? _reconstruction.activeNodes.get('FeatureMatching').node : null
                         property bool isComputed: activeNode && activeNode.isComputed
 
                         active: false
@@ -921,7 +923,7 @@ FocusScope {
                         id: ldrHdrCalibrationGraph
                         anchors.fill: parent
 
-                        property var activeNode: _reconstruction.activeNodes.get('LdrToHdrCalibration').node
+                        property var activeNode: _reconstruction ? _reconstruction.activeNodes.get('LdrToHdrCalibration').node : null
                         property var isEnabled: displayLdrHdrCalibrationGraph.checked && activeNode && activeNode.isComputed
                         // active: isEnabled
                         // Setting "active" from true to false creates a crash on linux with Qt 5.14.2.
@@ -995,7 +997,7 @@ FocusScope {
                         }
                         MaterialToolButton {
                             id: displayLensDistortionViewer
-                            property var activeNode: root.aliceVisionPluginAvailable ? _reconstruction.activeNodes.get('sfmData').node : null
+                            property var activeNode: root.aliceVisionPluginAvailable && _reconstruction ? _reconstruction.activeNodes.get('sfmData').node : null
                             property bool isComputed: {
                                 if(!activeNode)
                                     return false;
@@ -1031,7 +1033,7 @@ FocusScope {
                         }
                         MaterialToolButton {
                             id: displayPanoramaViewer
-                            property var activeNode: root.aliceVisionPluginAvailable ? _reconstruction.activeNodes.get('SfMTransform').node : null
+                            property var activeNode: root.aliceVisionPluginAvailable && _reconstruction ? _reconstruction.activeNodes.get('SfMTransform').node : null
                             property bool isComputed: {
                                 if(!activeNode)
                                     return false;
@@ -1083,7 +1085,7 @@ FocusScope {
                         }
                         MaterialToolButton {
                             id: displayFisheyeCircleLoader
-                            property var activeNode: _reconstruction.activeNodes.get('PanoramaInit').node
+                            property var activeNode: _reconstruction ? _reconstruction.activeNodes.get('PanoramaInit').node : null
                             ToolTip.text: "Display Fisheye Circle: " + (activeNode ? activeNode.label : "No Node")
                             text: MaterialIcons.vignette
                             // text: MaterialIcons.panorama_fish_eye
@@ -1096,7 +1098,7 @@ FocusScope {
                         }
                         MaterialToolButton {
                             id: displayColorCheckerViewerLoader
-                            property var activeNode: _reconstruction.activeNodes.get('ColorCheckerDetection').node
+                            property var activeNode: _reconstruction ? _reconstruction.activeNodes.get('ColorCheckerDetection').node : null
                             ToolTip.text: "Display Color Checker: " + (activeNode ? activeNode.label : "No Node")
                             text: MaterialIcons.view_comfy //view_module grid_on gradient view_comfy border_all
                             font.pointSize: 11
@@ -1121,7 +1123,7 @@ FocusScope {
 
                         MaterialToolButton {
                             id: displayLdrHdrCalibrationGraph
-                            property var activeNode: _reconstruction.activeNodes.get("LdrToHdrCalibration").node
+                            property var activeNode: _reconstruction ? _reconstruction.activeNodes.get("LdrToHdrCalibration").node : null
                             property bool isComputed: activeNode && activeNode.isComputed
                             ToolTip.text: "Display Camera Response Function: " + (activeNode ? activeNode.label : "No Node")
                             text: MaterialIcons.timeline
@@ -1166,7 +1168,7 @@ FocusScope {
                         }
 
                         MaterialToolButton {
-                            property var activeNode: root.oiioPluginAvailable ? _reconstruction.activeNodes.get('allDepthMap').node : null
+                            property var activeNode: root.oiioPluginAvailable && _reconstruction ? _reconstruction.activeNodes.get('allDepthMap').node : null
                             enabled: activeNode
                             ToolTip.text: "View Depth Map in 3D (" + (activeNode ? activeNode.label : "No DepthMap Node Selected") + ")"
                             text: MaterialIcons.input
@@ -1180,7 +1182,7 @@ FocusScope {
 
                         MaterialToolButton {
                             id: displaySfmStatsView
-                            property var activeNode: root.aliceVisionPluginAvailable ? _reconstruction.activeNodes.get('sfm').node : null
+                            property var activeNode: root.aliceVisionPluginAvailable && _reconstruction ? _reconstruction.activeNodes.get('sfm').node : null
 
                             font.family: MaterialIcons.fontFamily
                             text: MaterialIcons.assessment
@@ -1205,7 +1207,7 @@ FocusScope {
 
                         MaterialToolButton {
                             id: displaySfmDataGlobalStats
-                            property var activeNode: root.aliceVisionPluginAvailable ? _reconstruction.activeNodes.get('sfm').node : null
+                            property var activeNode: root.aliceVisionPluginAvailable && _reconstruction ? _reconstruction.activeNodes.get('sfm').node : null
 
                             font.family: MaterialIcons.fontFamily
                             text: MaterialIcons.language

--- a/meshroom/ui/qml/Viewer3D/AlembicLoader.qml
+++ b/meshroom/ui/qml/Viewer3D/AlembicLoader.qml
@@ -64,7 +64,7 @@ AlembicEntity {
                 */
                 PhongMaterial{
                     id: mat
-                    ambient: viewId === _reconstruction.selectedViewId ? activePalette.highlight : customColor // "#CCC"
+                    ambient: _reconstruction && viewId === _reconstruction.selectedViewId ? activePalette.highlight : customColor // "#CCC"
                     diffuse: cameraPicker.containsMouse ? Qt.lighter(activePalette.highlight, 1.2) : ambient
                 },
                 ObjectPicker {

--- a/meshroom/ui/qml/Viewer3D/Inspector3D.qml
+++ b/meshroom/ui/qml/Viewer3D/Inspector3D.qml
@@ -112,7 +112,7 @@ FloatingPane {
                     // Synchronization
                     MaterialToolButton {
                         id: syncViewpointCamera
-                        enabled: _reconstruction.sfmReport
+                        enabled: _reconstruction ? _reconstruction.sfmReport : false
                         text: MaterialIcons.linked_camera
                         ToolTip.text: "Sync with Image Selection"
                         checked: enabled && Viewer3DSettings.syncViewpointCamera
@@ -200,8 +200,8 @@ FloatingPane {
                     // add mediaLibrary.count in the binding to ensure 'entity'
                     // is re-evaluated when mediaLibrary delegates are modified
                     property bool loading: model.status === SceneLoader.Loading
-                    property bool hovered:  model.attribute ? uigraph.hoveredNode === model.attribute.node : containsMouse
-                    property bool isSelectedNode: model.attribute ? uigraph.selectedNode === model.attribute.node : false
+                    property bool hovered:  model.attribute ? (uigraph ? uigraph.hoveredNode === model.attribute.node : false) : containsMouse
+                    property bool isSelectedNode: model.attribute ? (uigraph ? uigraph.selectedNode === model.attribute.node : false) : false
 
                     onIsSelectedNodeChanged: updateCurrentIndex()
 

--- a/meshroom/ui/qml/Viewer3D/Viewer3D.qml
+++ b/meshroom/ui/qml/Viewer3D/Viewer3D.qml
@@ -26,7 +26,7 @@ FocusScope {
     readonly property vector3d defaultCamUpVector: Qt.vector3d(0.0, 1.0, 0.0)
     readonly property vector3d defaultCamViewCenter: Qt.vector3d(0.0, 0.0, 0.0)
 
-    readonly property var viewpoint: _reconstruction.selectedViewpoint
+    readonly property var viewpoint: _reconstruction ? _reconstruction.selectedViewpoint : null
     readonly property bool doSyncViewpointCamera: Viewer3DSettings.syncViewpointCamera && (viewpoint && viewpoint.isReconstructed)
 
     // functions

--- a/meshroom/ui/qml/WorkspaceView.qml
+++ b/meshroom/ui/qml/WorkspaceView.qml
@@ -20,7 +20,7 @@ Item {
     id: root
 
     property variant reconstruction: _reconstruction
-    readonly property variant cameraInits: _reconstruction.cameraInits
+    readonly property variant cameraInits: _reconstruction ? _reconstruction.cameraInits : null
     property bool readOnly: false
     property alias panel3dViewer: panel3dViewerLoader.item
     readonly property Viewer2D viewer2D: viewer2D
@@ -50,7 +50,7 @@ Item {
 
     // Load reconstruction's current SfM file
     function viewSfM() {
-        var activeNode = _reconstruction.activeNodes.get('sfm').node;
+        var activeNode = _reconstruction.activeNodes ? _reconstruction.activeNodes.get('sfm').node : null;
         if(!activeNode)
             return;
         if(panel3dViewerLoader.active) {
@@ -75,9 +75,9 @@ Item {
                 Layout.fillHeight: true
                 readOnly: root.readOnly
                 cameraInits: root.cameraInits
-                cameraInit: reconstruction.cameraInit
-                tempCameraInit: reconstruction.tempCameraInit
-                cameraInitIndex: reconstruction.cameraInitIndex
+                cameraInit: reconstruction ? reconstruction.cameraInit : null
+                tempCameraInit: reconstruction ? reconstruction.tempCameraInit : null
+                cameraInitIndex: reconstruction ? reconstruction.cameraInitIndex : -1
                 onRemoveImageRequest: reconstruction.removeAttribute(attribute)
                 onFilesDropped: reconstruction.handleFilesDrop(drop, augmentSfm ? null : cameraInit)
             }
@@ -208,7 +208,7 @@ Item {
                         
                         // Load reconstructed model
                         Button {
-                            readonly property var outputAttribute: _reconstruction.texturing ? _reconstruction.texturing.attribute("outputMesh") : null
+                            readonly property var outputAttribute: _reconstruction && _reconstruction.texturing ? _reconstruction.texturing.attribute("outputMesh") : null
                             readonly property bool outputReady: outputAttribute && _reconstruction.texturing.globalStatus === "SUCCESS"
                             readonly property int outputMediaIndex: c_viewer3D.library.find(outputAttribute)
 


### PR DESCRIPTION
## Description

Some QML properties access exposed Python objects that may or may not be null upon their access. When these objects are accessed while null, QML issues "TypeError" warnings. These warnings have no functional impact as QML correctly handles trying to access null objects, but can spam the logs.

This PR fixes all these warnings by ensuring that the Python objects are not null before they are accessed by QML properties. In case the objects are null, default values are returned instead of still attempting to access them anyway.