### PR TITLE
fix(sec): upgrade psutil to 5.6.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # runtime
-psutil>=5.6.3
+psutil>=5.6.7
 PySide2==5.14.1
 markdown==2.6.11
 requests==2.22.0


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in psutil 5.6.3
- [CVE-2019-18874](https://www.oscs1024.com/hd/CVE-2019-18874)


### What did I do？
Upgrade psutil from 5.6.3 to 5.6.7 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS
Signed-off-by:pen4<948453219@qq.com>