### PR TITLE
[ui] Load 3D Depth Map: minor improvements

### DIFF
--- a/meshroom/ui/qml/Viewer/Viewer2D.qml
+++ b/meshroom/ui/qml/Viewer/Viewer2D.qml
@@ -1170,14 +1170,17 @@ FocusScope {
 
                         MaterialToolButton {
                             id: displayImageOutputIn3D
-                            enabled: root.aliceVisionPluginAvailable && Filepath.basename(root.source).includes("depthMap")
+                            enabled: root.aliceVisionPluginAvailable && _reconstruction && displayedNode && Filepath.basename(root.source).includes("depthMap")
                             ToolTip.text: "View Depth Map in 3D"
                             text: MaterialIcons.input
                             font.pointSize: 11
                             Layout.minimumWidth: 0
 
                             onClicked: {
-                                root.viewIn3D(root.source);
+                                root.viewIn3D(
+                                    root.source, 
+                                    displayedNode.name + ":" + outputAttribute.name + " " + String(_reconstruction.selectedViewId)
+                                );
                             }
                         }
 

--- a/meshroom/ui/qml/Viewer/Viewer2D.qml
+++ b/meshroom/ui/qml/Viewer/Viewer2D.qml
@@ -252,7 +252,8 @@ FocusScope {
     onDisplayedNodeChanged: {
         // clear metadata if no displayed node
         if (!displayedNode) {
-            metadata = {};
+            root.source = "";
+            root.metadata = {};
         }
 
         // update output attribute names
@@ -268,6 +269,9 @@ FocusScope {
         }
         names.push("gallery");
         outputAttribute.names = names;
+
+        root.source = getImageFile();
+        root.metadata = getMetadata();
     }
 
     Connections {
@@ -1157,18 +1161,23 @@ FocusScope {
                                 id: fontMetrics
                             }
                             Layout.preferredWidth: model.reduce((acc, label) => Math.max(acc, fontMetrics.boundingRect(label).width), 0) + 3.0 * Qt.application.font.pixelSize
+
+                            onNameChanged: {
+                                root.source = getImageFile();
+                                root.metadata = getMetadata();
+                            }
                         }
 
                         MaterialToolButton {
-                            property var activeNode: root.aliceVisionPluginAvailable && _reconstruction ? _reconstruction.activeNodes.get('allDepthMap').node : null
-                            enabled: activeNode
-                            ToolTip.text: "View Depth Map in 3D (" + (activeNode ? activeNode.label : "No DepthMap Node Selected") + ")"
+                            id: displayImageOutputIn3D
+                            enabled: root.aliceVisionPluginAvailable && Filepath.basename(root.source).includes("depthMap")
+                            ToolTip.text: "View Depth Map in 3D"
                             text: MaterialIcons.input
                             font.pointSize: 11
                             Layout.minimumWidth: 0
 
                             onClicked: {
-                                root.viewIn3D(root.getFileAttributePath(activeNode, "depth", _reconstruction.selectedViewId));
+                                root.viewIn3D(root.source);
                             }
                         }
 

--- a/meshroom/ui/qml/Viewer3D/MediaLibrary.qml
+++ b/meshroom/ui/qml/Viewer3D/MediaLibrary.qml
@@ -83,7 +83,7 @@ Entity {
         return -1;
     }
 
-    function load(filepath) {
+    function load(filepath, label = undefined) {
         var pathStr = Filepath.urlToString(filepath);
         if(!Filepath.exists(pathStr))
         {
@@ -99,11 +99,10 @@ Entity {
         // add file to the internal ListModel
         m.mediaModel.append(makeElement({
                     "source": pathStr,
-                    "label": Filepath.basename(pathStr),
+                    "label": label ? label : Filepath.basename(pathStr),
                     "section": "External"
         }));
     }
-
 
     function view(attribute) {
         if(m.sourceToEntity[attribute]) {

--- a/meshroom/ui/qml/Viewer3D/Viewer3D.qml
+++ b/meshroom/ui/qml/Viewer3D/Viewer3D.qml
@@ -36,8 +36,8 @@ FocusScope {
         mainCamera.viewCenter = defaultCamViewCenter;
     }
 
-    function load(filepath) {
-        mediaLibrary.load(filepath);
+    function load(filepath, label = undefined) {
+        mediaLibrary.load(filepath, label);
     }
 
     /// View 'attribute' in the 3D Viewer. Media will be loaded if needed.

--- a/meshroom/ui/qml/WorkspaceView.qml
+++ b/meshroom/ui/qml/WorkspaceView.qml
@@ -30,9 +30,9 @@ Item {
 
 
     // Load a 3D media file in the 3D viewer
-    function load3DMedia(filepath) {
+    function load3DMedia(filepath, label = undefined) {
         if(panel3dViewerLoader.active) {
-            panel3dViewerLoader.item.viewer3D.load(filepath);
+            panel3dViewerLoader.item.viewer3D.load(filepath, label);
         }
     }
 


### PR DESCRIPTION
## Description

This PR introduces some minor improvements around loading depth maps in 3D: 
- the "View Depth Map in 3D" button in the 2D viewer is enabled only when the currently viewed attribute corresponds to a depth map
- when loading a depth map in the 3D viewer with this button, a custom label is used in the 3D inspector composed of the node name, attribute name and view id.