### PR TITLE
[ui] ImageGallery: Increase the GridView's cache capacity

### DIFF
--- a/meshroom/ui/qml/ImageGallery/ImageGallery.qml
+++ b/meshroom/ui/qml/ImageGallery/ImageGallery.qml
@@ -157,6 +157,7 @@ Panel {
 
             Layout.fillWidth: true
             Layout.fillHeight: true
+            cacheBuffer: 10000  // Magic number that seems to work well, even with lots of images
 
             visible: !intrinsicsFilterButton.checked
 


### PR DESCRIPTION
## Description

The "cacheBuffer" property determines whether delegates are retained outside the visible area of view. In the case of the ImageGallery, it determines whether the images that are not currently visible in the GridView (because we need to scroll up or down to be able to see them) will remain in the cache or not. The default value is platform-dependent (but seems to be 320 for maintream systems) and currently causes any image that is not directly visible to be lost, even if it was previously loaded when it appeared in the view: if we scroll up or down, we will necessarily need to wait for the images to be loaded again.

This PR increases the value of the "cacheBuffer" property to keep more images, even if they are not currently visible, in the cache. This improves the navigation in the Image Gallery, as shown below (left: previous behaviour with default cacheBuffer value; right: new behaviour with increased cacheBuffer value):


<img src="https://user-images.githubusercontent.com/11963329/209185750-cb6f171f-5664-4197-9353-509b421da99c.gif" height="300">             =>                <img src="https://user-images.githubusercontent.com/11963329/209188256-a998bfd4-1ac9-4beb-a51a-6f9daf9e53ff.gif" height="300">


## Implementation remarks

- 10000 is an arbitrary cacheBuffer value that seems to work correctly for most cases. 