### PR TITLE
[ui] Reorganize the "File" menu

### DIFF
--- a/meshroom/ui/qml/main.qml
+++ b/meshroom/ui/qml/main.qml
@@ -68,6 +68,13 @@ ApplicationWindow {
         settings_General.windowHeight = _window.height
     }
 
+    Shortcut {
+        // Ensures the Ctrl+N shortcut is always valid and creates a default pipeline
+        sequence: "Ctrl+N"
+        context: Qt.ApplicationShortcut
+        onActivated: ensureSaved(function() { _reconstruction.new() })
+    }
+
     MessageDialog {
         id: unsavedDialog
 
@@ -483,11 +490,6 @@ ApplicationWindow {
         palette.window: Qt.darker(activePalette.window, 1.15)
         Menu {
             title: "File"
-            Action {
-                text: "New"
-                shortcut: "Ctrl+N"
-                onTriggered: ensureSaved(function() { _reconstruction.new() })
-            }
             Menu {
                 id: newPipelineMenu
                 title: "New Pipeline"
@@ -572,15 +574,33 @@ ApplicationWindow {
                     }
                 }
             }
+            MenuSeparator { }
             Action {
-                id: importProjectAction
-                text: "Import Project"
-                shortcut: "Ctrl+Shift+I"
+                id: saveAction
+                text: "Save"
+                shortcut: "Ctrl+S"
+                enabled: _reconstruction ? (_reconstruction.graph && !_reconstruction.graph.filepath) || !_reconstruction.undoStack.clean : false
                 onTriggered: {
-                    initFileDialogFolder(importProjectDialog);
-                    importProjectDialog.open();
+                    if(_reconstruction.graph.filepath) {
+                        _reconstruction.save();
+                    }
+                    else
+                    {
+                        initFileDialogFolder(saveFileDialog);
+                        saveFileDialog.open();
+                    }
                 }
             }
+            Action {
+                id: saveAsAction
+                text: "Save As..."
+                shortcut: "Ctrl+Shift+S"
+                onTriggered: {
+                    initFileDialogFolder(saveFileDialog);
+                    saveFileDialog.open();
+                }
+            }
+            MenuSeparator { }
             Action {
                 id: importImagesAction
                 text: "Import Images"
@@ -613,39 +633,37 @@ ApplicationWindow {
                     }
                 }
             }
+            MenuSeparator { }
+            Menu {
+                id: advancedMenu
+                title: "Advanced"
 
-            Action {
-                id: saveAction
-                text: "Save"
-                shortcut: "Ctrl+S"
-                enabled: _reconstruction ? (_reconstruction.graph && !_reconstruction.graph.filepath) || !_reconstruction.undoStack.clean : false
-                onTriggered: {
-                    if(_reconstruction.graph.filepath) {
-                        _reconstruction.save()
+                Action {
+                    id: saveAsTemplateAction
+                    text: "Save As Template..."
+                    shortcut: Shortcut {
+                        sequence: "Ctrl+Shift+T"
+                        context: Qt.ApplicationShortcut
+                        onActivated: saveAsTemplateAction.triggered()
                     }
-                    else
-                    {
-                        initFileDialogFolder(saveFileDialog);
-                        saveFileDialog.open();
+                    onTriggered: {
+                            initFileDialogFolder(saveTemplateDialog);
+                            saveTemplateDialog.open();
                     }
                 }
-            }
-            Action {
-                id: saveAsAction
-                text: "Save As..."
-                shortcut: "Ctrl+Shift+S"
-                onTriggered: {
-                    initFileDialogFolder(saveFileDialog);
-                    saveFileDialog.open();
-                }
-            }
-            Action {
-                id: saveAsTemplateAction
-                text: "Save As Template..."
-                shortcut: "Ctrl+Shift+T"
-                onTriggered: {
-                    initFileDialogFolder(saveTemplateDialog);
-                    saveTemplateDialog.open();
+
+                Action {
+                    id: importProjectAction
+                    text: "Import Project"
+                    shortcut: Shortcut {
+                        sequence: "Ctrl+Shift+I"
+                        context: Qt.ApplicationShortcut
+                        onActivated: importProjectAction.triggered()
+                    }
+                    onTriggered: {
+                        initFileDialogFolder(importProjectDialog);
+                        importProjectDialog.open();
+                    }
                 }
             }
             MenuSeparator { }


### PR DESCRIPTION
## Description

This PR simplifies and reorganizes Meshroom's "File" menu as follows:
- The "New" action has been removed and the "Ctrl+N" shortcut that is used to create new default (photogrammetry) pipelines remains valid;
- The "Save As Template" and "Import Project" actions have been moved to the new "Advanced" sub-menu;
- Separators have been added between different menu categories (new/open files, save files, import images, advanced, quit).

The changes are shown below (left: before the PR; right: with the PR):

<img src="https://i.gyazo.com/e7d7cf01ae9a82c37f7f12219a2ac07d.png" height="300">      =>       <img src="https://i.gyazo.com/ba2e5bc78ed95694cbdda0e1ebc01416.png" height="300">
