### PR TITLE
[ui] Viewer2D: support all Exif orientation tags

### DIFF
--- a/meshroom/ui/qml/Controls/ExifOrientedViewer.qml
+++ b/meshroom/ui/qml/Controls/ExifOrientedViewer.qml
@@ -9,10 +9,10 @@ import QtQuick 2.11
  * - set the xOrigin/yOrigin properties to specify the transform origin.
  */
 Loader {
-	property var orientationTag: undefined
+    property var orientationTag: undefined
 
-	property real xOrigin: 0
-	property real yOrigin: 0
+    property real xOrigin: 0
+    property real yOrigin: 0
 
     transform: [
         Rotation {
@@ -53,6 +53,7 @@ Loader {
                 }
             }
             origin.x: xOrigin
+            origin.y: yOrigin
         }
     ]
 }

--- a/meshroom/ui/qml/Controls/ExifOrientedViewer.qml
+++ b/meshroom/ui/qml/Controls/ExifOrientedViewer.qml
@@ -1,0 +1,58 @@
+import QtQuick 2.11
+
+/**
+ * Loader with a predefined transform to orient its content according to the provided Exif tag.
+ * Useful when displaying images and overlayed information in the Viewer2D.
+ * 
+ * Usage:
+ * - set the orientationTag property to specify Exif orientation tag.
+ * - set the xOrigin/yOrigin properties to specify the transform origin.
+ */
+Loader {
+	property var orientationTag: undefined
+
+	property real xOrigin: 0
+	property real yOrigin: 0
+
+    transform: [
+        Rotation {
+            angle: {
+                switch(orientationTag) {
+                    case "3":
+                        return 180;
+                    case "4":
+                        return 180;
+                    case "5":
+                        return 90;
+                    case "6": 
+                        return 90;
+                    case "7":
+                        return -90;
+                    case "8": 
+                        return -90;
+                    default: 
+                        return 0;
+                }
+            }
+            origin.x: xOrigin
+            origin.y: yOrigin
+        }, 
+        Scale {
+            xScale : {
+                switch(orientationTag) {
+                    case "2":
+                        return -1;
+                    case "4":
+                        return -1;
+                    case "5":
+                        return -1;
+                    case "7":
+                        return -1;
+                    default: 
+                        return 1;
+                }
+            }
+            origin.x: xOrigin
+        }
+    ]
+}

--- a/meshroom/ui/qml/Controls/qmldir
+++ b/meshroom/ui/qml/Controls/qmldir
@@ -9,3 +9,4 @@ Panel 1.0 Panel.qml
 SearchBar 1.0 SearchBar.qml
 TabPanel 1.0 TabPanel.qml
 TextFileViewer 1.0 TextFileViewer.qml
+ExifOrientedViewer 1.0 ExifOrientedViewer.qml

--- a/meshroom/ui/qml/Viewer/Viewer2D.qml
+++ b/meshroom/ui/qml/Viewer/Viewer2D.qml
@@ -473,7 +473,6 @@ FocusScope {
                         asynchronous: true
                         smooth: false
                         fillMode: Image.PreserveAspectFit
-                        autoTransform: true
                         onWidthChanged: if(status==Image.Ready) fit()
                         source: getImageFile()
                         onStatusChanged: {
@@ -491,9 +490,19 @@ FocusScope {
                             asynchronous: true
                             smooth: parent.smooth
                             fillMode: parent.fillMode
-                            autoTransform: parent.autoTransform
 
                             visible: qtImageViewer.status === Image.Loading
+                        }
+                    }
+
+                    // handle rotation/position based on available metadata
+                    rotation: {
+                        var orientation = m.imgMetadata ? m.imgMetadata["Orientation"] : 0
+
+                        switch (orientation) {
+                            case "6": return 90;
+                            case "8": return -90;
+                            default: return 0;
                         }
                     }
                 }

--- a/meshroom/ui/qml/Viewer/Viewer2D.qml
+++ b/meshroom/ui/qml/Viewer/Viewer2D.qml
@@ -364,11 +364,14 @@ FocusScope {
                 transformOrigin: Item.TopLeft
 
                 // qtAliceVision Image Viewer
-                Loader {
+                ExifOrientedViewer {
                     id: floatImageViewerLoader
                     active: root.aliceVisionPluginAvailable && (root.useFloatImageViewer || root.useLensDistortionViewer) && !panoramaViewerLoader.active
                     visible: (floatImageViewerLoader.status === Loader.Ready) && active
                     anchors.centerIn: parent
+                    orientationTag: m.imgMetadata ? m.imgMetadata["Orientation"] : 0
+                    xOrigin: imgContainer.width / 2
+                    yOrigin: imgContainer.height / 2
                     property var fittedOnce: false
                     property var previousWidth: 0
                     property var previousHeight: 0
@@ -390,17 +393,6 @@ FocusScope {
                             fittedOnce = true;
                             previousWidth = width;
                             previousHeight = height;
-                        }
-                    }
-
-                    // handle rotation/position based on available metadata
-                    rotation: {
-                        var orientation = m.imgMetadata ? m.imgMetadata["Orientation"] : 0
-
-                        switch (orientation) {
-                            case "6": return 90;
-                            case "8": return -90;
-                            default: return 0;
                         }
                     }
 
@@ -432,7 +424,6 @@ FocusScope {
                                 fittedOnce = false
                           }
                     }
-
                 }
 
                 // qtAliceVision Panorama Viewer
@@ -464,10 +455,13 @@ FocusScope {
                 }
 
                 // Simple QML Image Viewer (using Qt or qtAliceVisionImageIO to load images)
-                Loader {
+                ExifOrientedViewer {
                     id: qtImageViewerLoader
                     active: !floatImageViewerLoader.active && !panoramaViewerLoader.active
                     anchors.centerIn: parent
+                    orientationTag: m.imgMetadata ? m.imgMetadata["Orientation"] : 0
+                    xOrigin: imgContainer.width / 2
+                    yOrigin: imgContainer.height / 2
                     sourceComponent: Image {
                         id: qtImageViewer
                         asynchronous: true
@@ -494,17 +488,6 @@ FocusScope {
                             visible: qtImageViewer.status === Image.Loading
                         }
                     }
-
-                    // handle rotation/position based on available metadata
-                    rotation: {
-                        var orientation = m.imgMetadata ? m.imgMetadata["Orientation"] : 0
-
-                        switch (orientation) {
-                            case "6": return 90;
-                            case "8": return -90;
-                            default: return 0;
-                        }
-                    }
                 }
 
                 property var image: {
@@ -521,24 +504,16 @@ FocusScope {
 
                 // FeatureViewer: display view extracted feature points
                 // note: requires QtAliceVision plugin - use a Loader to evaluate plugin availability at runtime
-                Loader {
+                ExifOrientedViewer {
                     id: featuresViewerLoader
                     active: displayFeatures.checked
                     property var activeNode: _reconstruction ? _reconstruction.activeNodes.get("FeatureExtraction").node : null
-
-                    anchors.centerIn: parent
                     width: imgContainer.width
                     height: imgContainer.height
-
-                    // handle rotation/position based on available metadata
-                    rotation: {
-                        var orientation = m.imgMetadata ? m.imgMetadata["Orientation"] : 0
-                        switch(orientation) {
-                            case "6": return 90;
-                            case "8": return -90;
-                            default: return 0;
-                        }
-                    }
+                    anchors.centerIn: parent
+                    orientationTag: m.imgMetadata ? m.imgMetadata["Orientation"] : 0
+                    xOrigin: imgContainer.width / 2
+                    yOrigin: imgContainer.height / 2
 
                     onActiveChanged: {
                         if(active) {
@@ -557,20 +532,13 @@ FocusScope {
 
                 // FisheyeCircleViewer: display fisheye circle
                 // note: use a Loader to evaluate if a PanoramaInit node exist and displayFisheyeCircle checked at runtime
-                Loader {
+                ExifOrientedViewer {
                     anchors.centerIn: parent
+                    orientationTag: m.imgMetadata ? m.imgMetadata["Orientation"] : 0
+                    xOrigin: imgContainer.width / 2
+                    yOrigin: imgContainer.height / 2
                     property var activeNode: _reconstruction ? _reconstruction.activeNodes.get("PanoramaInit").node : null
                     active: (displayFisheyeCircleLoader.checked && activeNode)
-
-                    // handle rotation/position based on available metadata
-                    rotation: {
-                        var orientation = m.imgMetadata ? m.imgMetadata["Orientation"] : 0
-                        switch(orientation) {
-                            case "6": return 90;
-                            case "8": return -90;
-                            default: return 0;
-                        }
-                    }
 
                     sourceComponent: CircleGizmo {
                         property bool useAuto: activeNode.attribute("estimateFisheyeCircle").value

--- a/meshroom/ui/qml/Viewer/Viewer2D.qml
+++ b/meshroom/ui/qml/Viewer/Viewer2D.qml
@@ -526,6 +526,10 @@ FocusScope {
                     active: displayFeatures.checked
                     property var activeNode: _reconstruction ? _reconstruction.activeNodes.get("FeatureExtraction").node : null
 
+                    anchors.centerIn: parent
+                    width: imgContainer.width
+                    height: imgContainer.height
+
                     // handle rotation/position based on available metadata
                     rotation: {
                         var orientation = m.imgMetadata ? m.imgMetadata["Orientation"] : 0
@@ -535,8 +539,6 @@ FocusScope {
                             default: return 0;
                         }
                     }
-                    x: (imgContainer.image && rotation === 90) ? imgContainer.image.paintedWidth : 0
-                    y: (imgContainer.image && rotation === -90) ? imgContainer.image.paintedHeight : 0
 
                     onActiveChanged: {
                         if(active) {


### PR DESCRIPTION
## Description

The goal of this PR is to support all [Exif orientation tags](http://sylvana.net/jpegcrop/exif_orientation.html) in the 2D viewer, which only handles tags 6 and 8 at the moment.

We also solved a bug with the features viewer not being at the right position with some orientation tag (noticed with orientation tag 6): 
![orientation_bug_small](https://user-images.githubusercontent.com/70104194/209966351-153ff85e-379c-4441-b8a0-1ccde21b1a6b.png)
## Implementation remarks

Historically the 8bit viewer had to be handled differently than the other viewers because it is backed by Qt Images which handle orientation at the C++ level (therefore in the qtAliceVisionImageIO plugin in our case). 
This automatic transform has been disabled to make sure we can control all viewers with the same mechanism.

## Tests

The float viewer, 8bit viewer and features viewer have been tested on all Exif orientations (including images with no orientation metadata) on several datasets. 