### PR TITLE
[ui] ImageGallery: fix the DB path in the "Edit Sensor Database" dialog

### DIFF
--- a/meshroom/ui/qml/ImageGallery/ImageGallery.qml
+++ b/meshroom/ui/qml/ImageGallery/ImageGallery.qml
@@ -143,7 +143,7 @@ Panel {
 
     SensorDBDialog {
         id: sensorDBDialog
-        sensorDatabase: cameraInit ? Filepath.stringToUrl(cameraInit.attribute("sensorDatabase").value) : ""
+        sensorDatabase: cameraInit ? Filepath.stringToUrl(cameraInit.attribute("sensorDatabase").evalValue) : ""
         readOnly: _reconstruction ? _reconstruction.computing : false
         onUpdateIntrinsicsRequest: _reconstruction.rebuildIntrinsics(cameraInit)
     }


### PR DESCRIPTION
## Description

When opening the dialog to edit the sensor database, the displayed path of the database was not resolved. Instead, the environment variable that contains it was displayed:
<img src="https://i.gyazo.com/5a82541e0f8bab598dbcf00aa95c5a30.png" height=200>

This PR displays the resolved path to the sensor database instead. As a direct consequence, the "Copy Path" button does indeed copy the absolute path to the sensor database (rather than the environment variable itself), and the "Open in External Editor" button can be used again to open the database in the set editor. 