### PR TITLE
[ui] Thumbnail cache

### DIFF
--- a/meshroom/ui/app.py
+++ b/meshroom/ui/app.py
@@ -15,6 +15,7 @@ from meshroom.ui import components
 from meshroom.ui.components.clipboard import ClipboardHelper
 from meshroom.ui.components.filepath import FilepathHelper
 from meshroom.ui.components.scene3D import Scene3DHelper, Transformations3DHelper
+from meshroom.ui.components.thumbnail import ThumbnailCache
 from meshroom.ui.palette import PaletteManager
 from meshroom.ui.reconstruction import Reconstruction
 from meshroom.ui.utils import QmlInstantEngine
@@ -146,6 +147,7 @@ class MeshroomApp(QApplication):
         self.engine.rootContext().setContextProperty("Scene3DHelper", Scene3DHelper(parent=self))
         self.engine.rootContext().setContextProperty("Transformations3DHelper", Transformations3DHelper(parent=self))
         self.engine.rootContext().setContextProperty("Clipboard", ClipboardHelper(parent=self))
+        self.engine.rootContext().setContextProperty("ThumbnailCache", ThumbnailCache(parent=self))
 
         # additional context properties
         self.engine.rootContext().setContextProperty("_PaletteManager", PaletteManager(self.engine, parent=self))

--- a/meshroom/ui/app.py
+++ b/meshroom/ui/app.py
@@ -121,6 +121,11 @@ class MeshroomApp(QApplication):
         if thumbnailDir is not None:
             ThumbnailCache.thumbnailDir = thumbnailDir
 
+        # User specifed time limit for thumbnails on disk (expressed in days)
+        thumbnailTimeLimit = float(os.getenv('MESHROOM_THUMBNAIL_TIME_LIMIT'))
+        if thumbnailTimeLimit is not None:
+            ThumbnailCache.storageTimeLimit = thumbnailTimeLimit
+
         # Clean thumbnail directory
         ThumbnailCache.clean()
 

--- a/meshroom/ui/app.py
+++ b/meshroom/ui/app.py
@@ -116,23 +116,10 @@ class MeshroomApp(QApplication):
         pwd = os.path.dirname(__file__)
         self.setWindowIcon(QIcon(os.path.join(pwd, "img/meshroom.svg")))
 
-        # User specified thumbnail directory
-        thumbnailDir = os.getenv('MESHROOM_THUMBNAIL_DIR')
-        if thumbnailDir is not None:
-            ThumbnailCache.thumbnailDir = thumbnailDir
-
-        # User specifed time limit for thumbnails on disk (expressed in days)
-        thumbnailTimeLimit = os.getenv('MESHROOM_THUMBNAIL_TIME_LIMIT')
-        if thumbnailTimeLimit is not None:
-            ThumbnailCache.storageTimeLimit = float(thumbnailTimeLimit)
-
-        # User specifed maximum number of thumbnails on disk
-        thumbnailMaxNumberOnDisk = os.getenv('MESHROOM_MAX_THUMBNAILS_ON_DISK')
-        if thumbnailMaxNumberOnDisk is not None:
-            ThumbnailCache.maxThumbnailsOnDisk = int(thumbnailMaxNumberOnDisk)
-
-        # Clean thumbnail directory
-        ThumbnailCache.clean()
+        # Initialize thumbnail cache:
+        # - read related environment variables
+        # - clean cache directory and make sure it exists on disk
+        ThumbnailCache.initialize()
 
         # QML engine setup
         qmlDir = os.path.join(pwd, "qml")

--- a/meshroom/ui/app.py
+++ b/meshroom/ui/app.py
@@ -122,9 +122,14 @@ class MeshroomApp(QApplication):
             ThumbnailCache.thumbnailDir = thumbnailDir
 
         # User specifed time limit for thumbnails on disk (expressed in days)
-        thumbnailTimeLimit = float(os.getenv('MESHROOM_THUMBNAIL_TIME_LIMIT'))
+        thumbnailTimeLimit = os.getenv('MESHROOM_THUMBNAIL_TIME_LIMIT')
         if thumbnailTimeLimit is not None:
-            ThumbnailCache.storageTimeLimit = thumbnailTimeLimit
+            ThumbnailCache.storageTimeLimit = float(thumbnailTimeLimit)
+
+        # User specifed maximum number of thumbnails on disk
+        thumbnailMaxNumberOnDisk = os.getenv('MESHROOM_MAX_THUMBNAILS_ON_DISK')
+        if thumbnailMaxNumberOnDisk is not None:
+            ThumbnailCache.maxThumbnailsOnDisk = int(thumbnailMaxNumberOnDisk)
 
         # Clean thumbnail directory
         ThumbnailCache.clean()

--- a/meshroom/ui/app.py
+++ b/meshroom/ui/app.py
@@ -116,6 +116,11 @@ class MeshroomApp(QApplication):
         pwd = os.path.dirname(__file__)
         self.setWindowIcon(QIcon(os.path.join(pwd, "img/meshroom.svg")))
 
+        # User specified thumbnail directory
+        thumbnailDir = os.getenv('MESHROOM_THUMBNAIL_DIR')
+        if thumbnailDir is not None:
+            ThumbnailCache.thumbnailDir = thumbnailDir
+
         # QML engine setup
         qmlDir = os.path.join(pwd, "qml")
         url = os.path.join(qmlDir, "main.qml")

--- a/meshroom/ui/app.py
+++ b/meshroom/ui/app.py
@@ -121,6 +121,9 @@ class MeshroomApp(QApplication):
         if thumbnailDir is not None:
             ThumbnailCache.thumbnailDir = thumbnailDir
 
+        # Clean thumbnail directory
+        ThumbnailCache.clean()
+
         # QML engine setup
         qmlDir = os.path.join(pwd, "qml")
         url = os.path.join(qmlDir, "main.qml")

--- a/meshroom/ui/components/thumbnail.py
+++ b/meshroom/ui/components/thumbnail.py
@@ -102,6 +102,11 @@ class ThumbnailCache(QObject):
         Scan the thumbnail directory and
         remove all thumbnails that have not been used for more than storageTimeLimit days.
         """
+        # Check if thumbnail directory exists
+        if not os.path.exists(ThumbnailCache.thumbnailDir):
+            logging.debug('[ThumbnailCache] Thumbnail directory does not exist yet.')
+            return
+
         # Get current time
         now = time.time()
 

--- a/meshroom/ui/components/thumbnail.py
+++ b/meshroom/ui/components/thumbnail.py
@@ -200,7 +200,10 @@ class ThumbnailCache(QObject):
         # Remove all thumbnails marked as removable
         for path in toRemove:
             logging.debug(f'[ThumbnailCache] Remove {path}')
-            os.remove(path)
+            try:
+                os.remove(path)
+            except FileNotFoundError:
+                logging.error(f'[ThumbnailCache] Tried to remove {path} but this file does not exist')
 
         # Check if number of thumbnails on disk exceeds limit
         if len(remaining) > ThumbnailCache.maxThumbnailsOnDisk:
@@ -212,4 +215,7 @@ class ThumbnailCache(QObject):
             for i in range(nbToRemove):
                 path = remaining[i][0]
                 logging.debug(f'[ThumbnailCache] Remove {path}')
-                os.remove(path)
+                try:
+                    os.remove(path)
+                except FileNotFoundError:
+                    logging.error(f'[ThumbnailCache] Tried to remove {path} but this file does not exist')

--- a/meshroom/ui/components/thumbnail.py
+++ b/meshroom/ui/components/thumbnail.py
@@ -42,7 +42,7 @@ class ThumbnailCache(QObject):
     thumbnailDir = ''
 
     # Thumbnail dimensions limit (the actual dimensions of a thumbnail will depend on the aspect ratio)
-    thumbnailSize = QSize(100, 100)
+    thumbnailSize = QSize(256, 256)
 
     # Time limit for thumbnail storage on disk, expressed in days
     storageTimeLimit = 90
@@ -248,7 +248,9 @@ class ThumbnailCache(QObject):
             return
 
         # Scale image while preserving aspect ratio
-        thumbnail = img.scaled(ThumbnailCache.thumbnailSize, aspectMode=Qt.KeepAspectRatio)
+        thumbnail = img.scaled(ThumbnailCache.thumbnailSize,
+                               aspectMode=Qt.KeepAspectRatio,
+                               mode=Qt.SmoothTransformation)
 
         # Write thumbnail to disk and check for potential errors
         writer = QImageWriter(path)

--- a/meshroom/ui/components/thumbnail.py
+++ b/meshroom/ui/components/thumbnail.py
@@ -1,19 +1,23 @@
+from meshroom.common import Signal
+
 from PySide2.QtCore import QObject, Slot, QSize, QUrl, Qt
 from PySide2.QtGui import QImageReader, QImageWriter
 
 import os
-import pathlib
+from pathlib import Path
 import hashlib
 import time
 import logging
+from multiprocessing.pool import ThreadPool
 
 
 class ThumbnailCache(QObject):
-    """
-    ThumbnailCache provides an abstraction for the thumbnail cache on disk, available in QML.
+    """ThumbnailCache provides an abstraction for the thumbnail cache on disk, available in QML.
 
     For a given image file, it ensures the corresponding thumbnail exists (by creating it if necessary)
     and gives access to it.
+    Since creating thumbnails can be long (as it requires to read the full image from disk)
+    it is performed asynchronously to avoid blocking the main thread.
 
     The default cache location is a subdirectory of the user's home directory:
     ~/Meshroom/thumbnails.
@@ -34,7 +38,7 @@ class ThumbnailCache(QObject):
     """
 
     # Thumbnail cache directory
-    thumbnailDir = os.path.join(pathlib.Path.home(), 'Meshroom', 'thumbnails')
+    thumbnailDir = os.path.join(Path.home(), 'Meshroom', 'thumbnails')
 
     # Thumbnail dimensions limit (the actual dimensions of a thumbnail will depend on the aspect ratio)
     thumbnailSize = QSize(100, 100)
@@ -45,39 +49,90 @@ class ThumbnailCache(QObject):
     # Maximum number of thumbnails in the cache directory
     maxThumbnailsOnDisk = 100000
 
-    @Slot(QUrl, result=QUrl)
-    def thumbnail(self, imgSource):
-        """
-        Retrieve the filepath of the thumbnail corresponding to a given image.
-        If the thumbnail does not exist on disk, it is created.
+    # Signal to notify listeners that a thumbnail was created and written on disk
+    # This signal has one argument: the url of the image that the thumbnail is associated to
+    thumbnailCreated = Signal(QUrl)
+
+    # Thread pool for running createThumbnail asynchronously on a fixed number of worker threads
+    pool = ThreadPool()
+
+    @staticmethod
+    def initialize():
+        """Initialize static fields in cache class and cache directory on disk."""
+        # User specified thumbnail directory
+        dir = os.getenv('MESHROOM_THUMBNAIL_DIR')
+        if dir is not None:
+            ThumbnailCache.thumbnailDir = dir
+
+        # User specifed time limit for thumbnails on disk (expressed in days)
+        timeLimit = os.getenv('MESHROOM_THUMBNAIL_TIME_LIMIT')
+        if timeLimit is not None:
+            ThumbnailCache.storageTimeLimit = float(timeLimit)
+
+        # User specifed maximum number of thumbnails on disk
+        maxOnDisk = os.getenv('MESHROOM_MAX_THUMBNAILS_ON_DISK')
+        if maxOnDisk is not None:
+            ThumbnailCache.maxThumbnailsOnDisk = int(maxOnDisk)
+
+        # Clean thumbnail directory
+        ThumbnailCache.clean()
+
+        # Make sure the thumbnail directory exists before writing into it
+        os.makedirs(ThumbnailCache.thumbnailDir, exist_ok=True)
+
+    @staticmethod
+    def thumbnailPath(imgPath):
+        """Use SHA1 hashing to associate a unique thumbnail to an image.
 
         Args:
-            imgSource (QUrl): the filepath to the input image
+            imgPath (str): filepath to the input image
 
         Returns:
-            QUrl: the filepath to the corresponding thumbnail
+            str: filepath to the corresponding thumbnail
         """
-        # Safety check
+        digest = hashlib.sha1(imgPath.encode('utf-8')).hexdigest()
+        path = os.path.join(ThumbnailCache.thumbnailDir, f'{digest}.jpg')
+        return path
+
+    @Slot(QUrl, result=QUrl)
+    def thumbnail(self, imgSource):
+        """Retrieve the filepath of the thumbnail corresponding to a given image.
+
+        If the thumbnail does not exist on disk, it will be created asynchronously.
+        When this is done, the createdThumbnail signal is emitted.
+
+        Args:
+            imgSource (QUrl): location of the input image
+
+        Returns:
+            QUrl: location of the corresponding thumbnail if it exists, otherwise None
+        """
         if not imgSource.isValid():
             return None
 
         imgPath = imgSource.toLocalFile()
-
-        # Use SHA1 hashing to associate a unique thumbnail to the image
-        digest = hashlib.sha1(imgPath.encode('utf-8')).hexdigest()
-        path = os.path.join(ThumbnailCache.thumbnailDir, f'{digest}.jpg')
+        path = ThumbnailCache.thumbnailPath(imgPath)
         source = QUrl.fromLocalFile(path)
 
         # Check if thumbnail already exists
         if os.path.exists(path):
             # Update last modification time
-            pathlib.Path(path).touch(exist_ok=True)
+            Path(path).touch(exist_ok=True)
             return source
 
-        # Thumbnail does not exist, therefore we create it:
-        # 1. read the image
-        # 2. scale it to thumbnail dimensions
-        # 3. write it in the cache
+        # Thumbnail does not exist
+        # create it in a worker thread to avoid UI freeze
+        ThumbnailCache.pool.apply_async(self.createThumbnail, args=(imgSource,))
+        return None
+
+    def createThumbnail(self, imgSource):
+        """Load an image, resize it to thumbnail dimensions and save the result in the cache directory.
+
+        Args:
+            imgSource (QUrl): location of the input image
+        """
+        imgPath = imgSource.toLocalFile()
+        path = ThumbnailCache.thumbnailPath(imgPath)
         logging.debug(f'[ThumbnailCache] Creating thumbnail {path} for image {imgPath}')
 
         # Initialize image reader object
@@ -89,10 +144,7 @@ class ThumbnailCache(QObject):
         img = reader.read()
         if img.isNull():
             logging.error(f'[ThumbnailCache] Error when reading image: {reader.errorString()}')
-            return None
-
-        # Make sure the thumbnail directory exists before writing into it
-        os.makedirs(ThumbnailCache.thumbnailDir, exist_ok=True)
+            return
 
         # Scale image while preserving aspect ratio
         thumbnail = img.scaled(ThumbnailCache.thumbnailSize, aspectMode=Qt.KeepAspectRatio)
@@ -102,14 +154,13 @@ class ThumbnailCache(QObject):
         success = writer.write(thumbnail)
         if not success:
             logging.error(f'[ThumbnailCache] Error when writing thumbnail: {writer.errorString()}')
-            return None
 
-        return source
+        # Notify listeners
+        self.thumbnailCreated.emit(imgSource)
 
     @staticmethod
     def clean():
-        """
-        Scan the thumbnail directory and: 
+        """Scan the thumbnail directory and:
         1. remove all thumbnails that have not been used for more than storageTimeLimit days
         2. ensure that the number of thumbnails on disk does not exceed maxThumbnailsOnDisk.
         """

--- a/meshroom/ui/components/thumbnail.py
+++ b/meshroom/ui/components/thumbnail.py
@@ -15,6 +15,7 @@ class ThumbnailCache(QObject):
 
     The default cache location is a subdirectory of the user's home directory:
     ~/Meshroom/thumbnails.
+    This location can be overriden with the MESHROOM_THUMBNAIL_DIR environment variable.
 
     The main use case for thumbnails in Meshroom is in the ImageGallery.
     """

--- a/meshroom/ui/components/thumbnail.py
+++ b/meshroom/ui/components/thumbnail.py
@@ -5,6 +5,7 @@ import os
 import pathlib
 import hashlib
 import time
+import logging
 
 
 class ThumbnailCache(QObject):
@@ -67,7 +68,7 @@ class ThumbnailCache(QObject):
         # 1. read the image
         # 2. scale it to thumbnail dimensions
         # 3. write it in the cache
-        print(f'[ThumbnailCache] Creating thumbnail {path} for image {imgPath}')
+        logging.debug(f'[ThumbnailCache] Creating thumbnail {path} for image {imgPath}')
 
         # Initialize image reader object
         reader = QImageReader()
@@ -77,7 +78,7 @@ class ThumbnailCache(QObject):
         # Read image and check for potential errors
         img = reader.read()
         if img.isNull():
-            print(f'[ThumbnailCache] Error when reading image: {reader.errorString()}')
+            logging.error(f'[ThumbnailCache] Error when reading image: {reader.errorString()}')
             return None
 
         # Make sure the thumbnail directory exists before writing into it
@@ -90,7 +91,7 @@ class ThumbnailCache(QObject):
         writer = QImageWriter(path)
         success = writer.write(thumbnail)
         if not success:
-            print(f'[ThumbnailCache] Error when writing thumbnail: {writer.errorString()}')
+            logging.error(f'[ThumbnailCache] Error when writing thumbnail: {writer.errorString()}')
             return None
 
         return source
@@ -113,14 +114,14 @@ class ThumbnailCache(QObject):
             # Compute storage duration since last usage of thumbnail
             lastUsage = os.path.getmtime(entry.path)
             storageTime = now - lastUsage
-            print(f'[ThumbnailCache] Thumbnail {entry.name} has been stored for {storageTime}s')
+            logging.debug(f'[ThumbnailCache] Thumbnail {entry.name} has been stored for {storageTime}s')
 
             # Mark as removable if storage time exceeds limit
             if storageTime > ThumbnailCache.storageTimeLimit * 3600 * 24:
-                print(f'[ThumbnailCache] {entry.name} exceeded storage time limit')
+                logging.debug(f'[ThumbnailCache] {entry.name} exceeded storage time limit')
                 toRemove.append(entry.path)
 
         # Remove all thumbnails marked as removable
         for path in toRemove:
-            print(f'[ThumbnailCache] Remove {path}')
+            logging.debug(f'[ThumbnailCache] Remove {path}')
             os.remove(path)

--- a/meshroom/ui/components/thumbnail.py
+++ b/meshroom/ui/components/thumbnail.py
@@ -52,7 +52,7 @@ class ThumbnailCache(QObject):
     thumbnailCreated = Signal(QUrl)
 
     # Thread pool for running createThumbnail asynchronously on a fixed number of worker threads
-    pool = ThreadPool()
+    pool = ThreadPool(processes=3)
 
     @staticmethod
     def initialize():

--- a/meshroom/ui/components/thumbnail.py
+++ b/meshroom/ui/components/thumbnail.py
@@ -21,7 +21,8 @@ class ThumbnailCache(QObject):
 
     This class also takes care of cleaning the thumbnail directory,
     i.e. scanning this directory and removing thumbnails that have not been used for too long.
-    The default time limit is one week.
+    The default time limit is 90 days.
+    This time limit can be overriden with the MESHROOM_THUMBNAIL_TIME_LIMIT environment variable.
 
     The main use case for thumbnails in Meshroom is in the ImageGallery.
     """
@@ -33,7 +34,7 @@ class ThumbnailCache(QObject):
     thumbnailSize = QSize(100, 100)
 
     # Time limit for thumbnail storage on disk, expressed in days
-    storageTimeLimit = 7
+    storageTimeLimit = 90
 
     @Slot(QUrl, result=QUrl)
     def thumbnail(self, imgSource):

--- a/meshroom/ui/components/thumbnail.py
+++ b/meshroom/ui/components/thumbnail.py
@@ -271,3 +271,11 @@ class ThumbnailCache(QObject):
             # No more request to process
             # Unregister worker thread
             ThumbnailCache.activeWorkerThreads -= 1
+
+    @Slot()
+    def clearRequests(self):
+        """Clear all pending thumbnail creation requests.
+
+        Requests already under treatment by a worker thread will still be completed.
+        """
+        ThumbnailCache.requests.clear()

--- a/meshroom/ui/components/thumbnail.py
+++ b/meshroom/ui/components/thumbnail.py
@@ -1,0 +1,82 @@
+from PySide2.QtCore import QObject, Slot, QSize, QUrl, Qt
+from PySide2.QtGui import QImageReader, QImageWriter
+
+import hashlib
+import pathlib
+import os
+
+
+class ThumbnailCache(QObject):
+    """
+    ThumbnailCache provides an abstraction for the thumbnail cache on disk, available in QML.
+
+    For a given image file, it ensures the corresponding thumbnail exists (by creating it if necessary)
+    and gives access to it.
+
+    The default cache location is a subdirectory of the user's home directory:
+    ~/Meshroom/thumbnails.
+
+    The main use case for thumbnails in Meshroom is in the ImageGallery.
+    """
+
+    thumbnailDir = os.path.join(pathlib.Path.home(), 'Meshroom', 'thumbnails')
+    thumbnailSize = QSize(100, 100)
+
+    @Slot(QUrl, result=QUrl)
+    def thumbnail(self, imgSource):
+        """
+        Retrieve the filepath of the thumbnail corresponding to a given image.
+        If the thumbnail does not exist on disk, it is created.
+
+        Args:
+            imgSource (QUrl): the filepath to the input image
+
+        Returns:
+            QUrl: the filepath to the corresponding thumbnail
+        """
+        # Safety check
+        if not imgSource.isValid():
+            return None
+
+        imgPath = imgSource.toLocalFile()
+
+        # Use SHA1 hashing to associate a unique thumbnail to the image
+        digest = hashlib.sha1(imgPath.encode('utf-8')).hexdigest()
+        path = os.path.join(ThumbnailCache.thumbnailDir, f'{digest}.jpg')
+        source = QUrl.fromLocalFile(path)
+
+        # Check if thumbnail already exists
+        if os.path.exists(path):
+            return source
+
+        # Thumbnail does not exist, therefore we create it:
+        # 1. read the image
+        # 2. scale it to thumbnail dimensions
+        # 3. write it in the cache
+        print(f'[ThumbnailCache] Creating thumbnail {path} for image {imgPath}')
+
+        # Initialize image reader object
+        reader = QImageReader()
+        reader.setFileName(imgPath)
+        reader.setAutoTransform(True)
+
+        # Read image and check for potential errors
+        img = reader.read()
+        if img.isNull():
+            print(f'[ThumbnailCache] Error when reading image: {reader.errorString()}')
+            return None
+
+        # Make sure the thumbnail directory exists before writing into it
+        os.makedirs(ThumbnailCache.thumbnailDir, exist_ok=True)
+
+        # Scale image while preserving aspect ratio
+        thumbnail = img.scaled(ThumbnailCache.thumbnailSize, aspectMode=Qt.KeepAspectRatio)
+
+        # Write thumbnail to disk and check for potential errors
+        writer = QImageWriter(path)
+        success = writer.write(thumbnail)
+        if not success:
+            print(f'[ThumbnailCache] Error when writing thumbnail: {writer.errorString()}')
+            return None
+
+        return source

--- a/meshroom/ui/components/thumbnail.py
+++ b/meshroom/ui/components/thumbnail.py
@@ -1,6 +1,6 @@
 from meshroom.common import Signal
 
-from PySide2.QtCore import QObject, Slot, QSize, QUrl, Qt
+from PySide2.QtCore import QObject, Slot, QSize, QUrl, Qt, QStandardPaths
 from PySide2.QtGui import QImageReader, QImageWriter
 
 import os
@@ -19,9 +19,7 @@ class ThumbnailCache(QObject):
     Since creating thumbnails can be long (as it requires to read the full image from disk)
     it is performed asynchronously to avoid blocking the main thread.
 
-    The default cache location is a subdirectory of the user's home directory:
-    ~/Meshroom/thumbnails.
-    This location can be overriden with the MESHROOM_THUMBNAIL_DIR environment variable.
+    The default cache location can be overriden with the MESHROOM_THUMBNAIL_DIR environment variable.
 
     This class also takes care of cleaning the thumbnail directory,
     i.e. scanning this directory and removing thumbnails that have not been used for too long.
@@ -38,7 +36,7 @@ class ThumbnailCache(QObject):
     """
 
     # Thumbnail cache directory
-    thumbnailDir = os.path.join(Path.home(), 'Meshroom', 'thumbnails')
+    thumbnailDir = os.path.join(QStandardPaths.writableLocation(QStandardPaths.CacheLocation), 'Meshroom', 'thumbnails')
 
     # Thumbnail dimensions limit (the actual dimensions of a thumbnail will depend on the aspect ratio)
     thumbnailSize = QSize(100, 100)

--- a/meshroom/ui/components/thumbnail.py
+++ b/meshroom/ui/components/thumbnail.py
@@ -37,7 +37,8 @@ class ThumbnailCache(QObject):
     """
 
     # Thumbnail cache directory
-    thumbnailDir = os.path.join(QStandardPaths.writableLocation(QStandardPaths.CacheLocation), 'Meshroom', 'thumbnails')
+    # Cannot be initialized here as it depends on the organization and application names
+    thumbnailDir = ''
 
     # Thumbnail dimensions limit (the actual dimensions of a thumbnail will depend on the aspect ratio)
     thumbnailSize = QSize(100, 100)
@@ -60,10 +61,13 @@ class ThumbnailCache(QObject):
     @staticmethod
     def initialize():
         """Initialize static fields in cache class and cache directory on disk."""
-        # User specified thumbnail directory
+        # Thumbnail directory: default or user specified
         dir = os.getenv('MESHROOM_THUMBNAIL_DIR')
         if dir is not None:
             ThumbnailCache.thumbnailDir = dir
+        else:
+            ThumbnailCache.thumbnailDir = os.path.join(QStandardPaths.writableLocation(QStandardPaths.CacheLocation),
+                                                       'thumbnails')
 
         # User specifed time limit for thumbnails on disk (expressed in days)
         timeLimit = os.getenv('MESHROOM_THUMBNAIL_TIME_LIMIT')

--- a/meshroom/ui/qml/ImageGallery/ImageDelegate.qml
+++ b/meshroom/ui/qml/ImageGallery/ImageDelegate.qml
@@ -93,6 +93,10 @@ Item {
                     autoTransform: true
                     fillMode: Image.PreserveAspectFit
                 }
+                BusyIndicator {
+                    anchors.centerIn: parent
+                    running: !Filepath.exists(thumbnail.source)
+                }
             }
             // Image basename
             Label {

--- a/meshroom/ui/qml/ImageGallery/ImageDelegate.qml
+++ b/meshroom/ui/qml/ImageGallery/ImageDelegate.qml
@@ -109,7 +109,6 @@ Item {
                     asynchronous: true
                     autoTransform: true
                     fillMode: Image.PreserveAspectFit
-                    sourceSize: Qt.size(100, 100)
                 }
                 BusyIndicator {
                     anchors.centerIn: parent

--- a/meshroom/ui/qml/ImageGallery/ImageDelegate.qml
+++ b/meshroom/ui/qml/ImageGallery/ImageDelegate.qml
@@ -109,6 +109,7 @@ Item {
                     asynchronous: true
                     autoTransform: true
                     fillMode: Image.PreserveAspectFit
+                    sourceSize: Qt.size(100, 100)
                 }
                 BusyIndicator {
                     anchors.centerIn: parent

--- a/meshroom/ui/qml/ImageGallery/ImageDelegate.qml
+++ b/meshroom/ui/qml/ImageGallery/ImageDelegate.qml
@@ -31,6 +31,19 @@ Item {
         property var metadata: metadataStr ? JSON.parse(viewpoint.get("metadata").value) : {}
     }
 
+    onSourceChanged: {
+        thumbnail.source = ThumbnailCache.thumbnail(root.source)
+    }
+
+    Connections {
+        target: ThumbnailCache
+        function onThumbnailCreated(imgSource) {
+            if (imgSource == root.source) {
+                thumbnail.source = ThumbnailCache.thumbnail(root.source)
+            }
+        }
+    }
+
     MouseArea {
         id: imageMA
         anchors.fill: parent
@@ -77,9 +90,9 @@ Item {
                 border.color: isCurrentItem ? imageLabel.palette.highlight : Qt.darker(imageLabel.palette.highlight)
                 border.width: imageMA.containsMouse || root.isCurrentItem ? 2 : 0
                 Image {
+                    id: thumbnail
                     anchors.fill: parent
                     anchors.margins: 4
-                    source: ThumbnailCache.thumbnail(root.source)
                     asynchronous: true
                     autoTransform: true
                     fillMode: Image.PreserveAspectFit

--- a/meshroom/ui/qml/ImageGallery/ImageDelegate.qml
+++ b/meshroom/ui/qml/ImageGallery/ImageDelegate.qml
@@ -109,6 +109,8 @@ Item {
                     asynchronous: true
                     autoTransform: true
                     fillMode: Image.PreserveAspectFit
+                    smooth: false
+                    cache: false
                 }
                 BusyIndicator {
                     anchors.centerIn: parent

--- a/meshroom/ui/qml/ImageGallery/ImageDelegate.qml
+++ b/meshroom/ui/qml/ImageGallery/ImageDelegate.qml
@@ -95,7 +95,7 @@ Item {
                 }
                 BusyIndicator {
                     anchors.centerIn: parent
-                    running: !Filepath.exists(thumbnail.source)
+                    running: Filepath.urlToString(thumbnail.source).length === 0
                 }
             }
             // Image basename

--- a/meshroom/ui/qml/ImageGallery/ImageDelegate.qml
+++ b/meshroom/ui/qml/ImageGallery/ImageDelegate.qml
@@ -41,10 +41,10 @@ Item {
         updateThumbnail();
     }
 
-    // Send a new request every 2 seconds until thumbnail is loaded
+    // Send a new request every 5 seconds until thumbnail is loaded
     // This is meant to avoid deadlocks in case there is a synchronization problem
     Timer {
-        interval: 2000
+        interval: 5000
         repeat: true
         running: true
         onTriggered: {

--- a/meshroom/ui/qml/ImageGallery/ImageDelegate.qml
+++ b/meshroom/ui/qml/ImageGallery/ImageDelegate.qml
@@ -31,17 +31,13 @@ Item {
         property var metadata: metadataStr ? JSON.parse(viewpoint.get("metadata").value) : {}
     }
 
-    onSourceChanged: {
-        thumbnail.source = ThumbnailCache.thumbnail(root.source)
+    // update thumbnail location
+    // can be called from the GridView when a new thumbnail has been written on disk
+    function updateThumbnail() {
+        thumbnail.source = ThumbnailCache.thumbnail(root.source);
     }
-
-    Connections {
-        target: ThumbnailCache
-        function onThumbnailCreated(imgSource) {
-            if (imgSource == root.source) {
-                thumbnail.source = ThumbnailCache.thumbnail(root.source)
-            }
-        }
+    onSourceChanged: {
+        updateThumbnail();
     }
 
     MouseArea {

--- a/meshroom/ui/qml/ImageGallery/ImageDelegate.qml
+++ b/meshroom/ui/qml/ImageGallery/ImageDelegate.qml
@@ -11,6 +11,7 @@ Item {
     id: root
 
     property variant viewpoint
+    property int cellID
     property bool isCurrentItem: false
     property alias source: _viewpoint.source
     property alias metadata: _viewpoint.metadata
@@ -34,7 +35,7 @@ Item {
     // update thumbnail location
     // can be called from the GridView when a new thumbnail has been written on disk
     function updateThumbnail() {
-        thumbnail.source = ThumbnailCache.thumbnail(root.source);
+        thumbnail.source = ThumbnailCache.thumbnail(root.source, cellID);
     }
     onSourceChanged: {
         updateThumbnail();

--- a/meshroom/ui/qml/ImageGallery/ImageDelegate.qml
+++ b/meshroom/ui/qml/ImageGallery/ImageDelegate.qml
@@ -79,8 +79,7 @@ Item {
                 Image {
                     anchors.fill: parent
                     anchors.margins: 4
-                    source: root.source
-                    sourceSize: Qt.size(100, 100)
+                    source: ThumbnailCache.thumbnail(root.source)
                     asynchronous: true
                     autoTransform: true
                     fillMode: Image.PreserveAspectFit

--- a/meshroom/ui/qml/ImageGallery/ImageGallery.qml
+++ b/meshroom/ui/qml/ImageGallery/ImageGallery.qml
@@ -207,6 +207,14 @@ Panel {
                     let item = grid.itemAtIndex(callerID);  // item is an ImageDelegate
                     if (item && item.source == imgSource) {
                         item.updateThumbnail();
+                        return;
+                    }
+                    // fallback in case the ImageDelegate cellID changed
+                    for (let idx = 0; idx < grid.count; idx++) {
+                        item = grid.itemAtIndex(idx);
+                        if (item && item.source == imgSource) {
+                            item.updateThumbnail();
+                        }
                     }
                 }
             }

--- a/meshroom/ui/qml/ImageGallery/ImageGallery.qml
+++ b/meshroom/ui/qml/ImageGallery/ImageGallery.qml
@@ -201,6 +201,19 @@ Panel {
                 }
             }
 
+            // Update grid item when corresponding thumbnail is computed
+            Connections {
+                target: ThumbnailCache
+                function onThumbnailCreated(imgSource) {
+                    for (let i = 0; i < grid.count; i++) {
+                        let item = grid.itemAtIndex(i);  // item is an ImageDelegate
+                        if (item && item.source == imgSource) {
+                            item.updateThumbnail();
+                        }
+                    }
+                }
+            }
+
             model: SortFilterDelegateModel {
                 id: sortedModel
                 model: m.viewpoints

--- a/meshroom/ui/qml/ImageGallery/ImageGallery.qml
+++ b/meshroom/ui/qml/ImageGallery/ImageGallery.qml
@@ -157,7 +157,6 @@ Panel {
 
             Layout.fillWidth: true
             Layout.fillHeight: true
-            cacheBuffer: 10000  // Magic number that seems to work well, even with lots of images
 
             visible: !intrinsicsFilterButton.checked
 

--- a/meshroom/ui/qml/ImageGallery/ImageGallery.qml
+++ b/meshroom/ui/qml/ImageGallery/ImageGallery.qml
@@ -203,12 +203,10 @@ Panel {
             // Update grid item when corresponding thumbnail is computed
             Connections {
                 target: ThumbnailCache
-                function onThumbnailCreated(imgSource) {
-                    for (let i = 0; i < grid.count; i++) {
-                        let item = grid.itemAtIndex(i);  // item is an ImageDelegate
-                        if (item && item.source == imgSource) {
-                            item.updateThumbnail();
-                        }
+                function onThumbnailCreated(imgSource, callerID) {
+                    let item = grid.itemAtIndex(callerID);  // item is an ImageDelegate
+                    if (item && item.source == imgSource) {
+                        item.updateThumbnail();
                     }
                 }
             }
@@ -257,6 +255,7 @@ Panel {
                     id: imageDelegate
 
                     viewpoint: object.value
+                    cellID: DelegateModel.filteredIndex
                     width: grid.cellWidth
                     height: grid.cellHeight
                     readOnly: m.readOnly

--- a/meshroom/ui/qml/ImageGallery/ImageGallery.qml
+++ b/meshroom/ui/qml/ImageGallery/ImageGallery.qml
@@ -39,6 +39,10 @@ Panel {
         property variant viewpoints: currentCameraInit ? currentCameraInit.attribute('viewpoints').value : undefined
         property variant intrinsics: currentCameraInit ? currentCameraInit.attribute('intrinsics').value : undefined
         property bool readOnly: root.readOnly || displayHDR.checked
+
+        onViewpointsChanged: {
+            ThumbnailCache.clearRequests();
+        }
     }
 
     property variant parsedIntrinsic


### PR DESCRIPTION
## Description

This PR introduces a new caching mechanism for thumbnails to improve interactivity when navigating in the Image Gallery.

This cache associates to each image a unique thumbnail, which is stored on disk for later reuse.

### Cache directory

The storing location is global (i.e not specific to a Meshroom scene).
The default location can be overriden with the `MESHROOM_THUMBNAIL_DIR` environment variable.

The thumbnails dimensions cannot exceed 256x256, and are stored on disk in JPEG format.
On the tested dataset, their size vary between 6 and 11 Ko (per thumbnail).

### Automatic cleaning process

When launching the application, the cache directory is scanned and all thumbnails that haven't been used for more than a certain time limit are removed. This process also makes sure that the number of thumbnails on disk does not exceed a certain limit.

The default time limit is 90 days, and can be overriden with the `MESHROOM_THUMBNAIL_TIME_LIMIT` environment variable.

The default maximum number of thumbnails on disk is 100000, and can be overriden with the `MESHROOM_MAX_THUMBNAILS_ON_DISK` environment variable.

### Asynchronous thumbnail creation

Since thumbnail creation can be quite long on large image datasets it is performed asynchronously (using 3 worker threads) to avoid blocking the UI.
A loading circle is displayed during the thumbnail creation process to let the user know that computations are undergoing.

When a thumbnail is created, a signal is sent to the Image Gallery, and the grid view is in charge of dispatching it to the corresponding Image Delegate.

#### Details on thumbnail creation requests

Thumbnail creation requests are stored in a LIFO (last-in-first-out) structure: this way, when scrolling through the image gallery, the items that the user is currently viewing have priority in the calculations.

Also, to avoid situations in which thumbnails are never retrieved, a timer is used to re-send some requests every 2 seconds if needed.

Finally, all requests are cleared when the viewpoints change. This way, when changing the scene, if thumbnail calculations of the previous scene are not finished (which can happen if the image dataset is quite large), they won't slow done calculations of the current scene.

## Tests

Tested on Windows and Linux, using images with different formats (JPEG, EXR, RAW), aspect ratio and Exif orientation tags.

Tested varying the storage time limit and maximum number of thumbnails on disk.

Tested with existing and non-existing thumbnail directory (in the second case, the directory is created recursively).

Stress tested on a 12000 high resolution images dataset and compared to current develop branch to check that fluidity has improved.