### PR TITLE
[ui] Display nodes computed in another Meshroom instance as "Computed Externally"

### DIFF
--- a/meshroom/core/node.py
+++ b/meshroom/core/node.py
@@ -1085,6 +1085,7 @@ class BaseNode(BaseObject):
 
     globalExecModeChanged = Signal()
     globalExecMode = Property(str, globalExecMode.fget, notify=globalExecModeChanged)
+    isExternal = Property(bool, isExtern, notify=globalExecModeChanged)
     isComputed = Property(bool, _isComputed, notify=globalStatusChanged)
     aliveChanged = Signal()
     alive = Property(bool, alive.fget, alive.fset, notify=aliveChanged)

--- a/meshroom/core/node.py
+++ b/meshroom/core/node.py
@@ -764,7 +764,14 @@ class BaseNode(BaseObject):
         return [ch for ch in self._chunks if ch.isAlreadySubmitted()]
 
     def isExtern(self):
-        return self._chunks.at(0).isExtern()
+        """ Return True if at least one chunk of this Node has an external execution mode, False otherwise.
+
+        It is not enough to check whether the first chunk's execution mode is external, because computations
+        may have been started locally, interrupted, and restarted externally. In that case, if the first
+        chunk has completed locally before the computations were interrupted, its execution mode will always
+        be local, even if computations resume externally.
+        """
+        return any(chunk.isExtern() for chunk in self._chunks)
 
     @Slot()
     def clearSubmittedChunks(self):

--- a/meshroom/ui/qml/GraphEditor/Node.qml
+++ b/meshroom/ui/qml/GraphEditor/Node.qml
@@ -235,7 +235,7 @@ Item {
 
                             // Submitted externally indicator
                             MaterialLabel {
-                                visible: ["SUBMITTED", "RUNNING"].includes(node.globalStatus) && node.chunks.count > 0 && node.globalExecMode === "EXTERN"
+                                visible: ["SUBMITTED", "RUNNING"].includes(node.globalStatus) && node.chunks.count > 0 && node.isExternal
                                 text: MaterialIcons.cloud
                                 padding: 2
                                 font.pointSize: 7


### PR DESCRIPTION
## Description

This PR contains a bugfix and a minor UI improvement:
- Bugfix: a node used to be considered as computed externally if and only if its first chunk's execution mode was external. This is true in most cases but it does not cover the cases of nodes that are computed both locally and externally: if computations are started locally, interrupted and resumed externally, any chunk that completed its computations locally will have its execution mode set as such. When resuming the computations externally, the first chunk will still indicate that its execution mode is local, so the whole node will be treated as computed locally.
A node is now considered as computed externally if at least one of its chunks' execution mode is external.
- The "Computed Externally" icon used to be display on a node only when it was computing on the render farm. It is now also displayed when a node is computing in another instance of Meshroom.

## Features list

- [x] Fix the method determining whether a node is submitted externally: a node is submitted externally if at least one of its chunks' execution mode is external
- [x] Display the "Computed Externally" icon on a node if it is being computed in another instance of Meshroom (or on a render farm)


