### PR TITLE
Use DCP by default if the database is set and create errors on missing DCP files

### DIFF
--- a/meshroom/nodes/aliceVision/CameraInit.py
+++ b/meshroom/nodes/aliceVision/CameraInit.py
@@ -162,13 +162,6 @@ The metadata needed are:
             value='${ALICEVISION_SENSOR_DB}',
             uid=[],
         ),
-        desc.File(
-            name='colorProfileDatabase',
-            label='Color Profile Database',
-            description='''Color Profile database directory path.''',
-            value='${ALICEVISION_COLOR_PROFILE_DB}',
-            uid=[],
-        ),
         desc.FloatParam(
             name='defaultFieldOfView',
             label='Default Field Of View',
@@ -207,17 +200,32 @@ The metadata needed are:
         desc.ChoiceParam(
             name='rawColorInterpretation',
             label='RAW Color Interpretation',
-            description='Allows you to choose how raw data are color processed.',
-            value='LibRawWhiteBalancing',
+            description='Allows you to choose how raw data are color processed:\n'
+                        'None: Debayering without any color processing.\n'
+                        'LibRawNoWhiteBalancing: Simple neutralization.\n'
+                        'LibRawWhiteBalancing: Use internal white balancing from libraw.\n'
+                        'DCPLinearProcessing: Use DCP color profile.\n'
+                        'DCPMetadata: Same as None with DCP info added in metadata.\n',
+            value='DCPLinearProcessing' if os.environ.get('ALICEVISION_COLOR_PROFILE_DB', '') else 'LibRawWhiteBalancing',
             values=['None', 'LibRawNoWhiteBalancing', 'LibRawWhiteBalancing', 'DCPLinearProcessing', 'DCPMetadata'],
             exclusive=True,
             uid=[0],
         ),
+        desc.File(
+            name='colorProfileDatabase',
+            label='Color Profile Database',
+            description='''Color Profile database directory path.''',
+            value='${ALICEVISION_COLOR_PROFILE_DB}',
+            enabled=lambda node: node.rawColorInterpretation.value.startswith('DCP'),
+            uid=[],
+        ),
         desc.BoolParam(
             name='errorOnMissingColorProfile',
             label='Error On Missing DCP Color Profile',
-            description='If a color profile database is specified but no color profile is found for at least one image, then an error is thrown',
+            description='When enabled, if no color profile is found for at least one image, then an error is thrown.\n'
+                        'When disabled, if no color profile is found for some images, it will fallback to libRawWhiteBalancing for those images.',
             value=True,
+            enabled=lambda node: node.rawColorInterpretation.value.startswith('DCP'),
             uid=[0],
         ),
         desc.ChoiceParam(

--- a/meshroom/nodes/aliceVision/LdrToHdrCalibration.py
+++ b/meshroom/nodes/aliceVision/LdrToHdrCalibration.py
@@ -114,6 +114,17 @@ class LdrToHdrCalibration(desc.AVCommandLineNode):
             advanced=True,
             enabled= lambda node: node.byPass.enabled and not node.byPass.value,
         ),
+        desc.ChoiceParam(
+            name='workingColorSpace',
+            label='Working Color Space',
+            description='Allows you to choose the color space in which the data are processed.',
+            value='sRGB',
+            values=['sRGB', 'Linear', 'ACES2065-1', 'ACEScg'],
+            exclusive=True,
+            uid=[],
+            group='user',  # not used directly on the command line
+            enabled= lambda node: node.byPass.enabled and not node.byPass.value,
+        ),
         desc.IntParam(
             name='maxTotalPoints',
             label='Max Number of Points',

--- a/meshroom/nodes/aliceVision/LdrToHdrMerge.py
+++ b/meshroom/nodes/aliceVision/LdrToHdrMerge.py
@@ -105,6 +105,16 @@ class LdrToHdrMerge(desc.AVCommandLineNode):
             advanced=True,
             enabled= lambda node: node.byPass.enabled and not node.byPass.value,
         ),
+        desc.ChoiceParam(
+            name='workingColorSpace',
+            label='Working Color Space',
+            description='Allows you to choose the color space in which the data are processed.',
+            value='sRGB',
+            values=['sRGB', 'Linear', 'ACES2065-1', 'ACEScg'],
+            exclusive=True,
+            uid=[0],
+            enabled= lambda node: node.byPass.enabled and not node.byPass.value,
+        ),
         desc.BoolParam(
             name='enableHighlight',
             label='Enable Highlight',

--- a/meshroom/nodes/aliceVision/LdrToHdrSampling.py
+++ b/meshroom/nodes/aliceVision/LdrToHdrSampling.py
@@ -94,6 +94,16 @@ class LdrToHdrSampling(desc.AVCommandLineNode):
             advanced=True,
             enabled= lambda node: node.byPass.enabled and not node.byPass.value,
         ),
+        desc.ChoiceParam(
+            name='workingColorSpace',
+            label='Working Color Space',
+            description='Allows you to choose the color space in which the data are processed.',
+            value='sRGB',
+            values=['sRGB', 'Linear', 'ACES2065-1', 'ACEScg'],
+            exclusive=True,
+            uid=[0],
+            enabled= lambda node: node.byPass.enabled and not node.byPass.value,
+        ),
         desc.IntParam(
             name='blockSize',
             label='Block Size',

--- a/meshroom/pipelines/panoramaFisheyeHdr.mg
+++ b/meshroom/pipelines/panoramaFisheyeHdr.mg
@@ -29,7 +29,8 @@
                 "byPass": "{LdrToHdrCalibration_1.byPass}", 
                 "input": "{LdrToHdrCalibration_1.input}", 
                 "userNbBrackets": "{LdrToHdrCalibration_1.userNbBrackets}", 
-                "response": "{LdrToHdrCalibration_1.response}"
+                "response": "{LdrToHdrCalibration_1.response}",
+                "workingColorSpace": "{LdrToHdrCalibration_1.workingColorSpace}"
             }, 
             "nodeType": "LdrToHdrMerge", 
             "position": [
@@ -66,7 +67,8 @@
                 "channelQuantizationPower": "{LdrToHdrSampling_1.channelQuantizationPower}", 
                 "byPass": "{LdrToHdrSampling_1.byPass}", 
                 "input": "{LdrToHdrSampling_1.input}", 
-                "userNbBrackets": "{LdrToHdrSampling_1.userNbBrackets}"
+                "userNbBrackets": "{LdrToHdrSampling_1.userNbBrackets}",
+                "workingColorSpace": "{LdrToHdrSampling_1.workingColorSpace}"
             }, 
             "nodeType": "LdrToHdrCalibration", 
             "position": [

--- a/meshroom/pipelines/panoramaHdr.mg
+++ b/meshroom/pipelines/panoramaHdr.mg
@@ -29,7 +29,8 @@
                 "byPass": "{LdrToHdrCalibration_1.byPass}", 
                 "input": "{LdrToHdrCalibration_1.input}", 
                 "userNbBrackets": "{LdrToHdrCalibration_1.userNbBrackets}", 
-                "response": "{LdrToHdrCalibration_1.response}"
+                "response": "{LdrToHdrCalibration_1.response}",
+                "workingColorSpace": "{LdrToHdrCalibration_1.workingColorSpace}"
             }, 
             "nodeType": "LdrToHdrMerge", 
             "position": [
@@ -66,7 +67,8 @@
                 "channelQuantizationPower": "{LdrToHdrSampling_1.channelQuantizationPower}", 
                 "byPass": "{LdrToHdrSampling_1.byPass}", 
                 "input": "{LdrToHdrSampling_1.input}", 
-                "userNbBrackets": "{LdrToHdrSampling_1.userNbBrackets}"
+                "userNbBrackets": "{LdrToHdrSampling_1.userNbBrackets}",
+                "workingColorSpace": "{LdrToHdrSampling_1.workingColorSpace}"
             }, 
             "nodeType": "LdrToHdrCalibration", 
             "position": [


### PR DESCRIPTION
## Description
Update rawColorInterpretation default value and add some comments in cameraInit node.

Add working color space as input parameter in Sampling, Calibration and Merging HDR nodes.

Update HDR pipelines accordingly.


Based on https://github.com/alicevision/AliceVision/pull/1328
