### PR TITLE
[ui] Use the location of the most recently imported images as the base folder for the "Import Images" dialog

### DIFF
--- a/meshroom/ui/app.py
+++ b/meshroom/ui/app.py
@@ -252,7 +252,7 @@ class MeshroomApp(QApplication):
 
         settings = QSettings()
         settings.beginGroup("RecentFiles")
-        size = settings.beginWriteArray("Projects")
+        settings.beginWriteArray("Projects")
         for i, p in enumerate(projects):
             settings.setArrayIndex(i)
             settings.setValue("filepath", p)
@@ -289,7 +289,7 @@ class MeshroomApp(QApplication):
 
         settings = QSettings()
         settings.beginGroup("RecentFiles")
-        size = settings.beginWriteArray("Projects")
+        settings.beginWriteArray("Projects")
         for i, p in enumerate(projects):
             settings.setArrayIndex(i)
             settings.setValue("filepath", p)
@@ -337,7 +337,7 @@ class MeshroomApp(QApplication):
 
         settings = QSettings()
         settings.beginGroup("RecentFiles")
-        size = settings.beginWriteArray("ImagesFolders")
+        settings.beginWriteArray("ImagesFolders")
         for i, p in enumerate(folders):
             settings.setArrayIndex(i)
             settings.setValue("path", p)
@@ -369,7 +369,7 @@ class MeshroomApp(QApplication):
 
         settings = QSettings()
         settings.beginGroup("RecentFiles")
-        size = settings.beginWriteArray("ImagesFolders")
+        settings.beginWriteArray("ImagesFolders")
         for i, f in enumerate(folders):
             settings.setArrayIndex(i)
             settings.setValue("path", f)

--- a/meshroom/ui/app.py
+++ b/meshroom/ui/app.py
@@ -247,7 +247,7 @@ class MeshroomApp(QApplication):
         # add the new value in the first place
         projects.insert(0, projectFileNorm)
 
-        # keep only the 10 first elements
+        # keep only the 20 first elements
         projects = projects[0:20]
 
         settings = QSettings()

--- a/meshroom/ui/qml/ImageGallery/ImageGallery.qml
+++ b/meshroom/ui/qml/ImageGallery/ImageGallery.qml
@@ -23,6 +23,7 @@ Panel {
     readonly property string currentItemSource: grid.currentItem ? grid.currentItem.source : ""
     readonly property var currentItemMetadata: grid.currentItem ? grid.currentItem.metadata : undefined
     readonly property int centerViewId: (_reconstruction && _reconstruction.sfmTransform) ? parseInt(_reconstruction.sfmTransform.attribute("transformation").value) : 0
+    readonly property alias galleryGrid: grid
 
     property int defaultCellSize: 160
     property bool readOnly: false

--- a/meshroom/ui/qml/WorkspaceView.qml
+++ b/meshroom/ui/qml/WorkspaceView.qml
@@ -24,6 +24,7 @@ Item {
     property bool readOnly: false
     property alias panel3dViewer: panel3dViewerLoader.item
     readonly property Viewer2D viewer2D: viewer2D
+    readonly property alias imageGallery: imageGallery
 
     implicitWidth: 300
     implicitHeight: 400

--- a/meshroom/ui/qml/main.qml
+++ b/meshroom/ui/qml/main.qml
@@ -46,7 +46,18 @@ ApplicationWindow {
     SystemPalette { id: activePalette }
     SystemPalette { id: disabledPalette; colorGroup: SystemPalette.Disabled }
 
-    property url imagesFolder: ""
+    property url imagesFolder: {
+        var recentImportedImagesFolders = MeshroomApp.recentImportedImagesFolders
+        if (recentImportedImagesFolders.length > 0) {
+            for (var i = 0; i < recentImportedImagesFolders.length; i++) {
+                if (Filepath.exists(recentImportedImagesFolders[i]))
+                    return Filepath.stringToUrl(recentImportedImagesFolders[i])
+                else
+                    MeshroomApp.removeRecentImportedImagesFolder(Filepath.stringToUrl(recentImportedImagesFolders[i]))
+            }
+        }
+        return ""
+    }
 
     Settings {
         id: settings_General
@@ -331,6 +342,7 @@ ApplicationWindow {
         onAccepted: {
             _reconstruction.importImagesUrls(importImagesDialog.fileUrls)
             imagesFolder = Filepath.dirname(importImagesDialog.fileUrls[0])
+            MeshroomApp.addRecentImportedImagesFolder(imagesFolder)
         }
     }
 
@@ -480,6 +492,7 @@ ApplicationWindow {
 
     function initFileDialogFolder(dialog, importImages = false) {
         let folder = "";
+
         if (_reconstruction.graph && _reconstruction.graph.filepath) {
             folder = Filepath.stringToUrl(Filepath.dirname(_reconstruction.graph.filepath));
             if (imagesFolder.toString() === "" && workspaceView.imageGallery.galleryGrid.itemAtIndex(0) !== null) {

--- a/meshroom/ui/qml/main.qml
+++ b/meshroom/ui/qml/main.qml
@@ -482,6 +482,9 @@ ApplicationWindow {
         let folder = "";
         if (_reconstruction.graph && _reconstruction.graph.filepath) {
             folder = Filepath.stringToUrl(Filepath.dirname(_reconstruction.graph.filepath));
+            if (imagesFolder.toString() === "" && workspaceView.imageGallery.galleryGrid.itemAtIndex(0) !== null) {
+                imagesFolder = Filepath.dirname(workspaceView.imageGallery.galleryGrid.itemAtIndex(0).source);
+            }
         } else {
             var projects = MeshroomApp.recentProjectFiles;
             if (projects.length > 0 && Filepath.exists(projects[0])) {

--- a/meshroom/ui/qml/main.qml
+++ b/meshroom/ui/qml/main.qml
@@ -46,6 +46,8 @@ ApplicationWindow {
     SystemPalette { id: activePalette }
     SystemPalette { id: disabledPalette; colorGroup: SystemPalette.Disabled }
 
+    property url imagesFolder: ""
+
     Settings {
         id: settings_General
         category: 'General'
@@ -328,6 +330,7 @@ ApplicationWindow {
         nameFilters: []
         onAccepted: {
             _reconstruction.importImagesUrls(importImagesDialog.fileUrls)
+            imagesFolder = Filepath.dirname(importImagesDialog.fileUrls[0])
         }
     }
 
@@ -475,15 +478,22 @@ ApplicationWindow {
 
     // Utility functions for elements in the menubar
 
-    function initFileDialogFolder(dialog) {
-        if(_reconstruction.graph && _reconstruction.graph.filepath) {
-            dialog.folder = Filepath.stringToUrl(Filepath.dirname(_reconstruction.graph.filepath));
+    function initFileDialogFolder(dialog, importImages = false) {
+        let folder = "";
+        if (_reconstruction.graph && _reconstruction.graph.filepath) {
+            folder = Filepath.stringToUrl(Filepath.dirname(_reconstruction.graph.filepath));
         } else {
             var projects = MeshroomApp.recentProjectFiles;
             if (projects.length > 0 && Filepath.exists(projects[0])) {
-                dialog.folder = Filepath.stringToUrl(Filepath.dirname(projects[0]));
+                folder = Filepath.stringToUrl(Filepath.dirname(projects[0]));
             }
         }
+
+        if (importImages && imagesFolder.toString() !== "" && Filepath.exists(imagesFolder)) {
+            folder = imagesFolder;
+        }
+
+        dialog.folder = folder;
     }
 
     header: MenuBar {
@@ -606,7 +616,7 @@ ApplicationWindow {
                 text: "Import Images"
                 shortcut: "Ctrl+I"
                 onTriggered: {
-                    initFileDialogFolder(importImagesDialog);
+                    initFileDialogFolder(importImagesDialog, true);
                     importImagesDialog.open();
                 }
             }

--- a/meshroom/ui/qml/main.qml
+++ b/meshroom/ui/qml/main.qml
@@ -493,11 +493,12 @@ ApplicationWindow {
     function initFileDialogFolder(dialog, importImages = false) {
         let folder = "";
 
+        if (imagesFolder.toString() === "" && workspaceView.imageGallery.galleryGrid.itemAtIndex(0) !== null) {
+            imagesFolder = Filepath.stringToUrl(Filepath.dirname(workspaceView.imageGallery.galleryGrid.itemAtIndex(0).source));
+        }
+
         if (_reconstruction.graph && _reconstruction.graph.filepath) {
             folder = Filepath.stringToUrl(Filepath.dirname(_reconstruction.graph.filepath));
-            if (imagesFolder.toString() === "" && workspaceView.imageGallery.galleryGrid.itemAtIndex(0) !== null) {
-                imagesFolder = Filepath.dirname(workspaceView.imageGallery.galleryGrid.itemAtIndex(0).source);
-            }
         } else {
             var projects = MeshroomApp.recentProjectFiles;
             if (projects.length > 0 && Filepath.exists(projects[0])) {


### PR DESCRIPTION
## Description

Since #1778, all the actions from the "File" menu that open dialogs use the folder of the .mg file that was opened last as the base folder. 

This is also the case for the "Import Images" dialog, which means that at each import, the dialog opens in the folder containing the most recently opened .mg file rather than the most recently imported images. 

This PR changes that behaviour by saving the location of the last imported images, and using it as the base folder specifically for the "Import Images" dialog. The new behaviour can be summed up as follows:
- The last 3 locations of the imported images are saved across Meshroom sessions and used as a base folder (if the most recent location is not valid anymore, it is dropped and the second most recent location is used, and so on until either the list is empty or a valid location in it has been found);
- If no location has been saved when Meshroom is started (or if they are all invalid) and a graph with images has already been loaded, then the base folder will be the location of the graph's images;
- If no location has been saved when Meshroom is started (or if they are all invalid), and if the "Import Images" is the first dialog to be opened (or the already loaded graph has no image), then the same base folder as the other file dialogs is used.

The base folder for all the other file dialogs ("Open", "Save As", "Import Project", "Save As Template") remains unchanged. 


## Features list

- [x] Save the locations of the most recently imported images across sessions
- [x] Use the saved locations of the most recently imported images as the "Import Images" dialog's base folder