### PR TITLE
[ui] GraphEditor: use maxZoom to fit on nodes

### DIFF
--- a/meshroom/ui/qml/GraphEditor/GraphEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/GraphEditor.qml
@@ -14,6 +14,7 @@ Item {
     property variant uigraph: null  /// Meshroom ui graph (UIGraph)
     readonly property variant graph: uigraph ? uigraph.graph : null  /// core graph contained in ui graph
     property variant nodeTypesModel: null  /// the list of node types that can be instantiated
+    property real maxZoom: 2.0
 
     property var edgeAboutToBeRemoved: undefined
 
@@ -152,7 +153,6 @@ Item {
         anchors.fill: parent
         property double factor: 1.15
         property real minZoom: 0.1
-        property real maxZoom: 2.0
         // Activate multisampling for edges antialiasing
         layer.enabled: true
         layer.samples: 8
@@ -800,7 +800,7 @@ Item {
         // compute bounding box
         var bbox = boundingBox()
         // rescale to fit the bounding box in the view, max zoom is limited to 120% to prevent huge text
-        draggable.scale = Math.min(Math.min(root.width/bbox.width, root.height/bbox.height),1.2)
+        draggable.scale = Math.min(Math.min(root.width/bbox.width, root.height/bbox.height),maxZoom)
         // recenter
         draggable.x = bbox.x*draggable.scale*-1 + (root.width-bbox.width*draggable.scale)*0.5
         draggable.y = bbox.y*draggable.scale*-1 + (root.height-bbox.height*draggable.scale)*0.5

--- a/meshroom/ui/qml/GraphEditor/GraphEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/GraphEditor.qml
@@ -799,7 +799,7 @@ Item {
     function fit() {
         // compute bounding box
         var bbox = boundingBox()
-        // rescale to fit the bounding box in the view, max zoom is limited to 120% to prevent huge text
+        // rescale to fit the bounding box in the view, zoom is limited to prevent huge text
         draggable.scale = Math.min(Math.min(root.width/bbox.width, root.height/bbox.height),maxZoom)
         // recenter
         draggable.x = bbox.x*draggable.scale*-1 + (root.width-bbox.width*draggable.scale)*0.5

--- a/meshroom/ui/qml/GraphEditor/GraphEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/GraphEditor.qml
@@ -799,7 +799,7 @@ Item {
     function fit() {
         // compute bounding box
         var bbox = boundingBox()
-        // rescale, if low number of node, zoom 100% to prevent huge text
+        // rescale to fit the bounding box in the view, max zoom is limited to 120% to prevent huge text
         draggable.scale = Math.min(Math.min(root.width/bbox.width, root.height/bbox.height),1.2)
         // recenter
         draggable.x = bbox.x*draggable.scale*-1 + (root.width-bbox.width*draggable.scale)*0.5

--- a/meshroom/ui/qml/GraphEditor/GraphEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/GraphEditor.qml
@@ -799,8 +799,8 @@ Item {
     function fit() {
         // compute bounding box
         var bbox = boundingBox()
-        // rescale
-        draggable.scale = Math.min(root.width/bbox.width, root.height/bbox.height)
+        // rescale, if low number of node, zomm 100% to prevent huge text
+        draggable.scale = nodeRepeater.count < 4 ? 1 :  Math.min(root.width/bbox.width, root.height/bbox.height)
         // recenter
         draggable.x = bbox.x*draggable.scale*-1 + (root.width-bbox.width*draggable.scale)*0.5
         draggable.y = bbox.y*draggable.scale*-1 + (root.height-bbox.height*draggable.scale)*0.5

--- a/meshroom/ui/qml/GraphEditor/GraphEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/GraphEditor.qml
@@ -15,6 +15,7 @@ Item {
     readonly property variant graph: uigraph ? uigraph.graph : null  /// core graph contained in ui graph
     property variant nodeTypesModel: null  /// the list of node types that can be instantiated
     property real maxZoom: 2.0
+    property real minZoom: 0.1
 
     property var edgeAboutToBeRemoved: undefined
 
@@ -152,7 +153,6 @@ Item {
         id: mouseArea
         anchors.fill: parent
         property double factor: 1.15
-        property real minZoom: 0.1
         // Activate multisampling for edges antialiasing
         layer.enabled: true
         layer.samples: 8

--- a/meshroom/ui/qml/GraphEditor/GraphEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/GraphEditor.qml
@@ -799,8 +799,8 @@ Item {
     function fit() {
         // compute bounding box
         var bbox = boundingBox()
-        // rescale, if low number of node, zomm 100% to prevent huge text
-        draggable.scale = nodeRepeater.count < 4 ? 1 :  Math.min(root.width/bbox.width, root.height/bbox.height)
+        // rescale, if low number of node, zoom 100% to prevent huge text
+        draggable.scale = Math.min(Math.min(root.width/bbox.width, root.height/bbox.height),1.2)
         // recenter
         draggable.x = bbox.x*draggable.scale*-1 + (root.width-bbox.width*draggable.scale)*0.5
         draggable.y = bbox.y*draggable.scale*-1 + (root.height-bbox.height*draggable.scale)*0.5


### PR DESCRIPTION
## Description
Put the scale to 1 when fitting the graph to prevent huge node/text when there are only a few nodes. 


## Features list
- [X] Scale to 1 when few nodes on graph display

