### PR TITLE
[ui] node time computation and chunks count in node editor header

### DIFF
--- a/meshroom/core/node.py
+++ b/meshroom/core/node.py
@@ -412,6 +412,7 @@ class NodeChunk(BaseObject):
             self.node.nodeDesc.processChunk(self)
         except Exception as e:
             if self._status.status != Status.STOPPED:
+                self._status.elapsedTime = time.time() - startTime
                 self.upgradeStatusTo(Status.ERROR)
             raise
         except (KeyboardInterrupt, SystemError, GeneratorExit) as e:

--- a/meshroom/core/node.py
+++ b/meshroom/core/node.py
@@ -810,9 +810,8 @@ class BaseNode(BaseObject):
     @Slot(result=str)
     def getStartDateTime(self):
         """ Return the date (str) of the first running chunk """
-        if not self.isAlreadySubmittedOrFinished() or len(self._chunks) == 0:
-            return ""
-        dateTime = [chunk._status.startDateTime for chunk in self._chunks if chunk._status.startDateTime != ""]
+        dateTime = [chunk._status.startDateTime for chunk in self._chunks if chunk._status.status
+                    not in (Status.NONE, Status.SUBMITTED) and chunk._status.startDateTime != ""]
         return min(dateTime) if len(dateTime) != 0 else ""
 
     def isAlreadySubmitted(self):

--- a/meshroom/core/node.py
+++ b/meshroom/core/node.py
@@ -827,6 +827,14 @@ class BaseNode(BaseObject):
                 return True
         return False
 
+    @Slot(result=str)
+    def getFirstChunkRunning(self):
+        """ Return the date (str) of the first running chunk """
+        if not self.isAlreadySubmittedOrFinished() or len(self._chunks) == 0:
+            return ""
+        dateTime = [chunk._status.startDateTime for chunk in self._chunks if chunk._status.startDateTime != ""]
+        return min(dateTime) if len(dateTime) != 0 else ""
+
     @Slot(result=bool)
     def isFinishedOrRunning(self):
         """ Return True if all chunks of this Node is either finished or running, False otherwise. """

--- a/meshroom/ui/qml/GraphEditor/NodeEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/NodeEditor.qml
@@ -27,7 +27,7 @@ Panel {
 
     onNodeChanged: {
         nodeStartDateTime = ""
-        if (node !== null && node.isSubmittedOrRunning()) {
+        if (node !== null && node.isRunning()) {
             timer.start()
         }
         else if (node !== null && (node.isFinishedOrRunning() || node.globalStatus=="ERROR")) {
@@ -46,23 +46,25 @@ Panel {
                 interval: 2500
                 triggeredOnStart: true
                 repeat: true
-                running: node !== null && node.isSubmittedOrRunning()
+                running: node !== null && node.isRunning()
                 onTriggered: {
                     if (nodeStartDateTime === "") {
-                        nodeStartDateTime = new Date(node.getFirstChunkRunning()).getTime()
-                    }
+                        nodeStartDateTime = new Date(node.getStartDateTime()).getTime()
+                     }
                     var now = new Date().getTime()
-                    parent.text=Format.getTimeStr((now-nodeStartDateTime)/1000)
+                    var runningTime=Format.getTimeStr((now-nodeStartDateTime)/1000)
 
-                    var chunkCompletion=0
-                    if (node.chunks.count>1) {
+                    var chunksCompleted = 0
+                    var chunkCompletion = ""
+                    if (node.chunks.count>0) {
                         for (var i = 0; i < node.chunks.count; i++) {
                             if (node.chunks.at(i).statusName == "SUCCESS") {
-                                chunkCompletion++
+                                chunksCompleted++
                             }
                         }
-                        parent.text+= " | "+ chunkCompletion + "/" + node.chunks.count + " chunks"
+                        chunkCompletion = " | "+ chunksCompleted + "/" + node.chunks.count + " chunk" + (node.chunks.count == 1 ? "" : "s")
                     }
+                    parent.text = runningTime + chunkCompletion
 
                 }
             }

--- a/meshroom/ui/qml/GraphEditor/NodeEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/NodeEditor.qml
@@ -45,6 +45,7 @@ Panel {
     headerBar: RowLayout {
         Label {
             id: computationInfo
+            color: node ? Colors.statusColors[node.globalStatus] : palette.text
             Timer {
                 id: timer
                 interval: 2500

--- a/meshroom/ui/qml/GraphEditor/NodeEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/NodeEditor.qml
@@ -15,6 +15,7 @@ Panel {
     id: root
 
     property variant node
+    property string globalStatus : node !== null ? node.globalStatus : ""
     property bool readOnly: false
     property bool isCompatibilityNode: node && node.compatibilityIssue !== undefined
     property string nodeStartDateTime: ""
@@ -25,16 +26,19 @@ Panel {
     title: "Node" + (node !== null ? " - <b>" + node.label + "</b>" + (node.label !== node.defaultLabel ? " (" + node.defaultLabel + ")" : "") : "")
     icon: MaterialLabel { text: MaterialIcons.tune }
 
-    onNodeChanged: {
+    onGlobalStatusChanged: {
         nodeStartDateTime = ""
         if (node !== null && node.isRunning()) {
             timer.start()
         }
-        else if (node !== null && (node.isFinishedOrRunning() || node.globalStatus=="ERROR")) {
-            computationInfo.text = Format.getTimeStr(node.elapsedTime)
-        }
         else {
-            computationInfo.text =  ""
+            timer.stop()
+            if (node !== null && (node.isFinishedOrRunning() || globalStatus == "ERROR")) {
+                computationInfo.text = Format.getTimeStr(node.elapsedTime)
+            }
+            else{
+                computationInfo.text =  ""
+            }
         }
     }
 
@@ -50,22 +54,9 @@ Panel {
                 onTriggered: {
                     if (nodeStartDateTime === "") {
                         nodeStartDateTime = new Date(node.getStartDateTime()).getTime()
-                     }
-                    var now = new Date().getTime()
-                    var runningTime=Format.getTimeStr((now-nodeStartDateTime)/1000)
-
-                    var chunksCompleted = 0
-                    var chunkCompletion = ""
-                    if (node.chunks.count>0) {
-                        for (var i = 0; i < node.chunks.count; i++) {
-                            if (node.chunks.at(i).statusName == "SUCCESS") {
-                                chunksCompleted++
-                            }
-                        }
-                        chunkCompletion = " | "+ chunksCompleted + "/" + node.chunks.count + " chunk" + (node.chunks.count == 1 ? "" : "s")
                     }
-                    parent.text = runningTime + chunkCompletion
-
+                    var now = new Date().getTime()
+                    parent.text = Format.getTimeStr((now-nodeStartDateTime)/1000)
                 }
             }
             padding: 2

--- a/meshroom/ui/qml/GraphEditor/NodeEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/NodeEditor.qml
@@ -53,6 +53,17 @@ Panel {
                     }
                     var now = new Date().getTime()
                     parent.text=Format.getTimeStr((now-nodeStartDateTime)/1000)
+
+                    var chunkCompletion=0
+                    if (node.chunks.count>1) {
+                        for (var i = 0; i < node.chunks.count; i++) {
+                            if (node.chunks.at(i).statusName == "SUCCESS") {
+                                chunkCompletion++
+                            }
+                        }
+                        parent.text+= " | "+ chunkCompletion + "/" + node.chunks.count + " chunks"
+                    }
+
                 }
             }
             padding: 2

--- a/meshroom/ui/qml/GraphEditor/NodeEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/NodeEditor.qml
@@ -30,7 +30,7 @@ Panel {
         if (node !== null && node.isSubmittedOrRunning()) {
             timer.start()
         }
-        else if (node !== null && node.isFinishedOrRunning()) {
+        else if (node !== null && (node.isFinishedOrRunning() || node.globalStatus=="ERROR")) {
             computationInfo.text = Format.getTimeStr(node.elapsedTime)
         }
         else {
@@ -70,7 +70,7 @@ Panel {
             font.italic: true
             visible: {
                 if (node !== null) {
-                    if ((node.isFinishedOrRunning() || node.isSubmittedOrRunning())) {
+                    if (node.isFinishedOrRunning() || node.isSubmittedOrRunning() || node.globalStatus=="ERROR") {
                         return true
                     }
                 }


### PR DESCRIPTION
## Description
Improvement of computation information in node editor header

## Features list
[X] update computation time every 2.5 seconds in header
[X] computation time when error occurs 
[X] chunk computed counter in node editor header

## Implementation remarks
The previous label text logic is moved to the nodeChanged signal because the logic is overwritten by the timer when setting the text time. 
I don't know if 2.5 seconds is the best choice, feel free to give other refresh timing ideas.  
