### PR TITLE
[nodes] CameraInit: upgrade version following the parameters changes

### DIFF
--- a/meshroom/nodes/aliceVision/CameraInit.py
+++ b/meshroom/nodes/aliceVision/CameraInit.py
@@ -1,4 +1,4 @@
-__version__ = "8.0"
+__version__ = "9.0"
 
 import os
 import json

--- a/meshroom/pipelines/cameraTracking.mg
+++ b/meshroom/pipelines/cameraTracking.mg
@@ -8,7 +8,7 @@
             "ExportAnimatedCamera": "2.0", 
             "FeatureMatching": "2.0", 
             "DistortionCalibration": "2.0", 
-            "CameraInit": "8.0", 
+            "CameraInit": "9.0", 
             "ImageMatching": "2.0", 
             "FeatureExtraction": "1.1", 
             "StructureFromMotion": "2.0"

--- a/meshroom/pipelines/panoramaFisheyeHdr.mg
+++ b/meshroom/pipelines/panoramaFisheyeHdr.mg
@@ -10,7 +10,7 @@
             "LdrToHdrCalibration": "3.0", 
             "LdrToHdrSampling": "4.0", 
             "PanoramaInit": "2.0", 
-            "CameraInit": "8.0", 
+            "CameraInit": "9.0", 
             "SfMTransform": "3.0", 
             "PanoramaMerging": "1.0", 
             "ImageMatching": "2.0", 

--- a/meshroom/pipelines/panoramaHdr.mg
+++ b/meshroom/pipelines/panoramaHdr.mg
@@ -10,7 +10,7 @@
             "LdrToHdrCalibration": "3.0", 
             "LdrToHdrSampling": "4.0", 
             "PanoramaInit": "2.0", 
-            "CameraInit": "8.0", 
+            "CameraInit": "9.0", 
             "SfMTransform": "3.0", 
             "PanoramaMerging": "1.0", 
             "ImageMatching": "2.0", 

--- a/meshroom/pipelines/photogrammetry.mg
+++ b/meshroom/pipelines/photogrammetry.mg
@@ -11,7 +11,7 @@
             "PrepareDenseScene": "3.0", 
             "DepthMap": "2.0", 
             "StructureFromMotion": "2.0", 
-            "CameraInit": "8.0", 
+            "CameraInit": "9.0", 
             "ImageMatching": "2.0", 
             "FeatureExtraction": "1.1", 
             "Meshing": "7.0", 

--- a/meshroom/pipelines/photogrammetryAndCameraTracking.mg
+++ b/meshroom/pipelines/photogrammetryAndCameraTracking.mg
@@ -8,7 +8,7 @@
             "ExportAnimatedCamera": "2.0", 
             "FeatureMatching": "2.0", 
             "DistortionCalibration": "2.0", 
-            "CameraInit": "8.0", 
+            "CameraInit": "9.0", 
             "ImageMatchingMultiSfM": "1.0", 
             "ImageMatching": "2.0", 
             "FeatureExtraction": "1.1", 

--- a/meshroom/pipelines/photogrammetryDraft.mg
+++ b/meshroom/pipelines/photogrammetryDraft.mg
@@ -5,7 +5,7 @@
             "MeshFiltering": "3.0", 
             "Texturing": "6.0", 
             "StructureFromMotion": "2.0", 
-            "CameraInit": "8.0", 
+            "CameraInit": "9.0", 
             "ImageMatching": "2.0", 
             "FeatureExtraction": "1.1", 
             "Meshing": "7.0"


### PR DESCRIPTION
The PR https://github.com/alicevision/Meshroom/pull/1863 changes the order of parameters and modify the node UID, so it requires a version upgrade.
