### PR TITLE
[nodes] KeyframeSelection: Rework the node and add parameters for new selection methods

### DIFF
--- a/meshroom/nodes/aliceVision/KeyframeSelection.py
+++ b/meshroom/nodes/aliceVision/KeyframeSelection.py
@@ -232,6 +232,14 @@ You can extract frames at regular interval by configuring only the min/maxFrameS
                             enabled=lambda node: node.debugOptions.debugScores.exportScores.value
                         )
                     ]
+                ),
+                desc.BoolParam(
+                    name="skipSelection",
+                    label="Skip Frame Selection",
+                    description="Compute the sharpness and optical flow scores, but do not proceed to the frame selection.",
+                    value=False,
+                    uid=[0],
+                    enabled=lambda node: node.debugOptions.enabled
                 )
             ]
         ),

--- a/meshroom/nodes/aliceVision/KeyframeSelection.py
+++ b/meshroom/nodes/aliceVision/KeyframeSelection.py
@@ -136,7 +136,7 @@ You can extract frames at regular interval by configuring only the min/maxFrameS
                             name="pxDisplacement",
                             label="Pixel Displacement",
                             description="The percentage of pixels in the frame that need to have moved since the last keyframe to be considered for the selection",
-                            value=3.0,
+                            value=10.0,
                             range=(0.0, 100.0, 1.0),
                             uid=[0],
                             enabled=lambda node: node.smartSelection.enabled

--- a/meshroom/nodes/aliceVision/KeyframeSelection.py
+++ b/meshroom/nodes/aliceVision/KeyframeSelection.py
@@ -193,6 +193,30 @@ You can extract frames at regular interval by configuring only the min/maxFrameS
                 )
             ]
         ),
+        desc.ChoiceParam(
+            name="outputExtension",
+            label="Keyframes File Extension",
+            description="File extension of the written keyframes.",
+            value="jpg",
+            values=["exr", "jpg", "png"],
+            exclusive=True,
+            uid=[0],
+        ),
+        desc.ChoiceParam(
+            name="storageDataType",
+            label="EXR Storage Data Type",
+            description="Storage image data type for keyframes written to EXR files:\n"
+                        " * float: Use full floating point (32 bits per channel)\n"
+                        " * half: Use half float (16 bits per channel)\n"
+                        " * halfFinite: Use half float, but clamp values to avoid non-finite values\n"
+                        " * auto: Use half float if all values can fit, else use full float\n",
+            value="float",
+            values=["float", "half", "halfFinite", "auto"],
+            exclusive=True,
+            uid=[0],
+            enabled=lambda node: node.outputExtension.value == "exr",
+            advanced=True
+        ),
         desc.GroupAttribute(
             name="debugOptions",
             label="Debug Options",

--- a/meshroom/nodes/aliceVision/KeyframeSelection.py
+++ b/meshroom/nodes/aliceVision/KeyframeSelection.py
@@ -24,9 +24,9 @@ You can extract frames at regular interval by configuring only the min/maxFrameS
                 value="",
                 uid=[0],
             ),
-            name='mediaPaths',
-            label='Media Paths',
-            description='Input video files or image sequence directories.',
+            name="mediaPaths",
+            label="Media Paths",
+            description="Input video files or image sequence directories.",
         ),
         desc.ListAttribute(
             elementDesc=desc.File(
@@ -56,124 +56,73 @@ You can extract frames at regular interval by configuring only the min/maxFrameS
             elementDesc=desc.FloatParam(
                 name="mmFocal",
                 label="mmFocal",
-                description="Focal in mm (will be use if not 0).",
+                description="Focal in mm (will be used if not 0).",
                 value=0.0,
                 range=(0.0, 500.0, 1.0),
                 uid=[0],
             ),
             name="mmFocals",
             label="mmFocals",
-            description="Focals in mm (will be use if not 0)."
-        ),
-        desc.ListAttribute(
-            elementDesc=desc.FloatParam(
-                name="pxFocal",
-                label="pxFocal",
-                description="Focal in px (will be use and convert in mm if not 0).",
-                value=0.0,
-                range=(0.0, 500.0, 1.0),
-                uid=[0],
-            ),
-            name="pxFocals",
-            label="pxFocals",
-            description="Focals in px (will be use and convert in mm if not 0)."
-        ),
-        desc.ListAttribute(
-            elementDesc=desc.IntParam(
-                name="frameOffset",
-                label="Frame Offset",
-                description="Frame offset.",
-                value=0,
-                range=(0, 100, 1),
-                uid=[0],
-            ),
-            name="frameOffsets",
-            label="Frame Offsets",
-            description="Frame offsets."
+            description="Focals in mm (will be used if not 0)."
         ),
         desc.File(
-            name='sensorDbPath',
-            label='Sensor Db Path',
-            description='''Camera sensor width database path.''',
-            value='${ALICEVISION_SENSOR_DB}',
+            name="sensorDbPath",
+            label="Sensor Db Path",
+            description="Camera sensor width database path.",
+            value="${ALICEVISION_SENSOR_DB}",
             uid=[0],
         ),
-        desc.File(
-            name='voctreePath',
-            label='Voctree Path',
-            description='''Vocabulary tree path.''',
-            value='${ALICEVISION_VOCTREE}',
-            uid=[0],
-        ),
-        desc.BoolParam(
-            name='useSparseDistanceSelection',
-            label='Use Sparse Distance Selection',
-            description='Use sparseDistance selection in order to avoid similar keyframes.',
-            value=False,
-            uid=[0],
-        ),
-        desc.BoolParam(
-            name='useSharpnessSelection',
-            label='Use Sharpness Selection',
-            description='Use frame sharpness score for keyframe selection.',
-            value=False,
-            uid=[0],
-        ),
-        desc.FloatParam(
-            name='sparseDistMaxScore',
-            label='Sparse Distance Max Score',
-            description='Maximum number of strong common points between two keyframes.',
-            value=100.0,
-            range=(1.0, 200.0, 1.0),
-            uid=[0],
-        ),
-        desc.ChoiceParam(
-            name='sharpnessPreset',
-            label='Sharpness Preset',
-            description='Preset for sharpnessSelection : {ultra, high, normal, low, very_low, none}',
-            value='normal',
-            values=['ultra', 'high', 'normal', 'low', 'very_low', 'none'],
-            exclusive=True,
-            uid=[0],
-        ),
-        desc.IntParam(
-            name='sharpSubset',
-            label='Sharp Subset',
-            description='''sharp part of the image (1 = all, 2 = size/2, ...)''',
-            value=4,
-            range=(1, 100, 1),
-            uid=[0],
-        ),
-        desc.IntParam(
-            name='minFrameStep',
-            label='Min Frame Step',
-            description='''minimum number of frames between two keyframes''',
-            value=1,
-            range=(1, 100, 1),
-            uid=[0],
-        ),
-        desc.IntParam(
-            name='maxFrameStep',
-            label='Max Frame Step',
-            description='''maximum number of frames after which a keyframe can be taken''',
-            value=2,
-            range=(2, 1000, 1),
-            uid=[0],
-        ),
-        desc.IntParam(
-            name='maxNbOutFrame',
-            label='Max Nb Out Frame',
-            description='''maximum number of output frames (0 = no limit)''',
-            value=0,
-            range=(0, 10000, 1),
-            uid=[0],
+        desc.GroupAttribute(
+            name="regularSelection",
+            label="Regular Keyframe Selection",
+            description="Parameters for the regular keyframe selection.\nKeyframes are selected regularly over the sequence with respect to the set parameters.",
+            group=None,  # skip group from command line
+            groupDesc=[
+                desc.BoolParam(
+                    name="useRegularSelection",
+                    label="Use Regular Selection",
+                    description="Enable and use the regular keyframe selection.",
+                    value=True,
+                    uid=[0],
+                    enabled=False,  # only method for now, it must always be enabled
+                ),
+                desc.IntParam(
+                    name="minFrameStep",
+                    label="Min Frame Step",
+                    description="Minimum number of frames between two keyframes.",
+                    value=12,
+                    range=(1, 1000, 1),
+                    uid=[0],
+                    enabled=lambda node: node.regularSelection.useRegularSelection.value
+                ),
+                desc.IntParam(
+                    name="maxFrameStep",
+                    label="Max Frame Step",
+                    description="Maximum number of frames between two keyframes. Ignored if equal to 0.",
+                    value=0,
+                    range=(0, 1000, 1),
+                    uid=[0],
+                    enabled=lambda node: node.regularSelection.useRegularSelection.value
+                ),
+                desc.IntParam(
+                    name="maxNbOutFrames",
+                    label="Max Nb Output Frames",
+                    description="Maximum number of output frames (0 = no limit).\n"
+                                "'minFrameStep' and 'maxFrameStep' will always be respected, so combining them with this parameter\n"
+                                "might cause the selection to stop before reaching the end of the input sequence(s).",
+                    value=0,
+                    range=(0, 10000, 1),
+                    uid=[0],
+                    enabled=lambda node: node.regularSelection.useRegularSelection.value
+                ),
+            ],
         ),
         desc.ChoiceParam(
-            name='verboseLevel',
-            label='Verbose Level',
-            description='verbosity level (fatal, error, warning, info, debug, trace).',
-            value='info',
-            values=['fatal', 'error', 'warning', 'info', 'debug', 'trace'],
+            name="verboseLevel",
+            label="Verbose Level",
+            description="Verbosity level (fatal, error, warning, info, debug, trace).",
+            value="info",
+            values=["fatal", "error", "warning", "info", "debug", "trace"],
             exclusive=True,
             uid=[],
         ),
@@ -181,9 +130,9 @@ You can extract frames at regular interval by configuring only the min/maxFrameS
 
     outputs = [
         desc.File(
-            name='outputFolder',
-            label='Folder',
-            description='''Output keyframes folder for extracted frames.''',
+            name="outputFolder",
+            label="Folder",
+            description="Output keyframes folder for extracted frames.",
             value=desc.Node.internalFolder,
             uid=[],
         ),

--- a/meshroom/nodes/aliceVision/KeyframeSelection.py
+++ b/meshroom/nodes/aliceVision/KeyframeSelection.py
@@ -305,6 +305,14 @@ You can extract frames at regular interval by configuring only the min/maxFrameS
                     ]
                 ),
                 desc.BoolParam(
+                    name="skipSharpnessComputation",
+                    label="Skip Sharpness Computation",
+                    description="Skip the sharpness score computation. A fixed score of 1.0 will be applied by default to all the frames.",
+                    value=False,
+                    uid=[0],
+                    enabled=lambda node: node.debugOptions.enabled
+                ),
+                desc.BoolParam(
                     name="skipSelection",
                     label="Skip Frame Selection",
                     description="Compute the sharpness and optical flow scores, but do not proceed to the frame selection.",

--- a/meshroom/nodes/aliceVision/KeyframeSelection.py
+++ b/meshroom/nodes/aliceVision/KeyframeSelection.py
@@ -160,9 +160,21 @@ You can extract frames at regular interval by configuring only the min/maxFrameS
                             enabled=lambda node: node.smartSelection.enabled
                         ),
                         desc.IntParam(
-                            name="rescaledWidth",
-                            label="Rescaled Frame's Width",
-                            description="Width, in pixels, of the frame after a rescale. Aspect ratio will be preserved. No rescale will be performed if equal to 0.",
+                            name="rescaledWidthSharpness",
+                            label="Rescaled Frame's Width For Sharpness",
+                            description="Width, in pixels, of the frame used for the sharpness score computation after a rescale.\n"
+                                        "Aspect ratio will be preserved. No rescale will be performed if equal to 0.",
+                            value=720,
+                            range=(0, 4000, 1),
+                            uid=[0],
+                            enabled=lambda node: node.smartSelection.enabled,
+                            advanced=True
+                        ),
+                        desc.IntParam(
+                            name="rescaledWidthFlow",
+                            label="Rescaled Frame's Width For Motion",
+                            description="Width, in pixels, of the frame used for the motion score computation after a rescale.\n"
+                                        "Aspect ratio will be preserved. No rescale will be performed if equal to 0.",
                             value=720,
                             range=(0, 4000, 1),
                             uid=[0],

--- a/meshroom/nodes/aliceVision/KeyframeSelection.py
+++ b/meshroom/nodes/aliceVision/KeyframeSelection.py
@@ -193,6 +193,48 @@ You can extract frames at regular interval by configuring only the min/maxFrameS
                 )
             ]
         ),
+        desc.GroupAttribute(
+            name="debugOptions",
+            label="Debug Options",
+            description="Debug options for the Smart keyframe selection method.",
+            group=None,  # skip group from command line
+            enabled=lambda node: node.selectionMethod.useSmartSelection.value,
+            advanced=True,
+            groupDesc=[
+                desc.GroupAttribute(
+                    name="debugScores",
+                    label="Export Scores",
+                    description="Export the computed sharpness and optical flow scores to a file.",
+                    group=None,  # skip group from command line
+                    enabled=lambda node: node.debugOptions.enabled,
+                    groupDesc=[
+                        desc.BoolParam(
+                            name="exportScores",
+                            label="Export Scores To CSV",
+                            description="Export the computed sharpness and optical flow scores to a CSV file.",
+                            value=False,
+                            uid=[0]
+                        ),
+                        desc.StringParam(
+                            name="csvFilename",
+                            label="CSV Filename",
+                            description="Name of the CSV file to export. It will be written in the node's output folder.",
+                            value="scores.csv",
+                            uid=[0],
+                            enabled=lambda node: node.debugOptions.debugScores.exportScores.value
+                        ),
+                        desc.BoolParam(
+                            name="exportSelectedFrames",
+                            label="Export Selected Frames",
+                            description="Add a column in the CSV file containing 1s for frames that were selected and 0s for those that were not.",
+                            value=False,
+                            uid=[0],
+                            enabled=lambda node: node.debugOptions.debugScores.exportScores.value
+                        )
+                    ]
+                )
+            ]
+        ),
         desc.ChoiceParam(
             name="verboseLevel",
             label="Verbose Level",

--- a/meshroom/nodes/aliceVision/KeyframeSelection.py
+++ b/meshroom/nodes/aliceVision/KeyframeSelection.py
@@ -205,6 +205,15 @@ You can extract frames at regular interval by configuring only the min/maxFrameS
                 )
             ]
         ),
+        desc.BoolParam(
+            name="renameKeyframes",
+            label="Rename Output Keyframes",
+            description="Instead of using the selected keyframes' index as their name, name them as consecutive output frames.\n"
+                        "If the selected keyframes are at index [15, 294, 825], they will be written as [00000.exr, 00001.exr, 00002.exr] with this\n"
+                        "option enabled instead of [00015.exr, 00294.exr, 00825.exr].",
+            value=False,
+            uid=[0]
+        ),
         desc.ChoiceParam(
             name="outputExtension",
             label="Keyframes File Extension",

--- a/meshroom/nodes/aliceVision/KeyframeSelection.py
+++ b/meshroom/nodes/aliceVision/KeyframeSelection.py
@@ -1,4 +1,4 @@
-__version__ = "2.0"
+__version__ = "3.0"
 
 import os
 from meshroom.core import desc

--- a/meshroom/nodes/aliceVision/KeyframeSelection.py
+++ b/meshroom/nodes/aliceVision/KeyframeSelection.py
@@ -233,6 +233,32 @@ You can extract frames at regular interval by configuring only the min/maxFrameS
                         )
                     ]
                 ),
+                desc.GroupAttribute(
+                    name="opticalFlowVisualisation",
+                    label="Optical Flow Visualisation",
+                    description="Visualise the motion vectors for each input frame in HSV.",
+                    group=None,  # skip group from command line
+                    enabled=lambda node: node.debugOptions.enabled,
+                    groupDesc=[
+                        desc.BoolParam(
+                            name="exportFlowVisualisation",
+                            label="Visualise Optical Flow",
+                            description="Export each frame's optical flow HSV visualisation as PNG images.",
+                            value=False,
+                            uid=[0],
+                            enabled=lambda node: node.debugOptions.opticalFlowVisualisation.enabled
+                        ),
+                        desc.BoolParam(
+                            name="flowVisualisationOnly",
+                            label="Only Visualise Optical Flow",
+                            description="Export each frame's optical flow HSV visualisation as PNG images, but do not perform any score computation or frame selection.\n"
+                                        "If this option is selected, all the other options will be ignored.",
+                            value=False,
+                            uid=[0],
+                            enabled=lambda node: node.debugOptions.opticalFlowVisualisation.enabled
+                        )
+                    ]
+                ),
                 desc.BoolParam(
                     name="skipSelection",
                     label="Skip Frame Selection",


### PR DESCRIPTION
## Description

This PR is related to https://github.com/alicevision/AliceVision/pull/1343 and replaces #1765.

It removes the parameters that were previously used for the Keyframe Selection and replaces them with new ones, corresponding to the two newly added selection methods:
- The regular method, that samples frames regularly over time;
- The smart method, that scores all the frames based on their sharpness and optical flow, and selects the most relevant.


## Features list

- [x] Remove parameters from the previously existing selection methods
- [x] Add parameters for the regular selection method
- [x] Add parameters for the smart selection method
- [x] Add debugging options related to the smart selection method  
