### PR TITLE
[ui] fix "Sync Camera with Image Selection"

### DIFF
--- a/meshroom/ui/qml/Controls/ExifOrientedViewer.qml
+++ b/meshroom/ui/qml/Controls/ExifOrientedViewer.qml
@@ -1,8 +1,9 @@
 import QtQuick 2.11
+import Utils 1.0
 
 /**
  * Loader with a predefined transform to orient its content according to the provided Exif tag.
- * Useful when displaying images and overlayed information in the Viewer2D.
+ * Useful when displaying images and overlaid information in the Viewer2D.
  * 
  * Usage:
  * - set the orientationTag property to specify Exif orientation tag.
@@ -16,42 +17,12 @@ Loader {
 
     transform: [
         Rotation {
-            angle: {
-                switch(orientationTag) {
-                    case "3":
-                        return 180;
-                    case "4":
-                        return 180;
-                    case "5":
-                        return 90;
-                    case "6": 
-                        return 90;
-                    case "7":
-                        return -90;
-                    case "8": 
-                        return -90;
-                    default: 
-                        return 0;
-                }
-            }
+            angle: ExifOrientation.rotation(orientationTag)
             origin.x: xOrigin
             origin.y: yOrigin
-        }, 
+        },
         Scale {
-            xScale : {
-                switch(orientationTag) {
-                    case "2":
-                        return -1;
-                    case "4":
-                        return -1;
-                    case "5":
-                        return -1;
-                    case "7":
-                        return -1;
-                    default: 
-                        return 1;
-                }
-            }
+            xScale: ExifOrientation.xscale(orientationTag)
             origin.x: xOrigin
             origin.y: yOrigin
         }

--- a/meshroom/ui/qml/Utils/ExifOrientation.qml
+++ b/meshroom/ui/qml/Utils/ExifOrientation.qml
@@ -1,0 +1,49 @@
+pragma Singleton
+import QtQuick 2.11
+
+/**
+ * Singleton that defines utility functions for supporting exif orientation tags.
+ *
+ * If you are looking for a way to create a Loader that supports exif orientation tags,
+ * you can directly use ExifOrientedViewer instead.
+ *
+ * However if you want to apply an exif orientation tag to another type of QML component,
+ * you will need to redefine its transform property using the utility methods given below.
+ */
+QtObject {
+
+    function rotation(orientationTag) {
+        switch(orientationTag) {
+            case "3":
+                return 180;
+            case "4":
+                return 180;
+            case "5":
+                return 90;
+            case "6":
+                return 90;
+            case "7":
+                return -90;
+            case "8":
+                return -90;
+            default:
+                return 0;
+        }
+    }
+
+    function xscale(orientationTag) {
+        switch(orientationTag) {
+            case "2":
+                return -1;
+            case "4":
+                return -1;
+            case "5":
+                return -1;
+            case "7":
+                return -1;
+            default:
+                return 1;
+        }
+    }
+
+}

--- a/meshroom/ui/qml/Utils/qmldir
+++ b/meshroom/ui/qml/Utils/qmldir
@@ -5,6 +5,7 @@ SortFilterDelegateModel 1.0 SortFilterDelegateModel.qml
 Request 1.0 request.js
 Format 1.0 format.js
 ErrorHandler 1.0 errorHandler.js
+singleton ExifOrientation 1.0 ExifOrientation.qml
 # using singleton here causes random crash at application exit
 # singleton Clipboard 1.0 Clipboard.qml
 # singleton Filepath 1.0 Filepath.qml

--- a/meshroom/ui/qml/Viewer3D/ImageOverlay.qml
+++ b/meshroom/ui/qml/Viewer3D/ImageOverlay.qml
@@ -55,7 +55,6 @@ Item {
         visible: false
         // Preserver aspect fit while display ratio is aligned with image ratio, crop otherwise
         fillMode: width/height >= imageRatio ? Image.PreserveAspectFit : Image.PreserveAspectCrop
-        autoTransform: true
     }
 
 

--- a/meshroom/ui/qml/Viewer3D/ImageOverlay.qml
+++ b/meshroom/ui/qml/Viewer3D/ImageOverlay.qml
@@ -55,6 +55,7 @@ Item {
         visible: false
         // Preserver aspect fit while display ratio is aligned with image ratio, crop otherwise
         fillMode: width/height >= imageRatio ? Image.PreserveAspectFit : Image.PreserveAspectCrop
+        autoTransform: true
     }
 
 

--- a/meshroom/ui/qml/Viewer3D/Viewer3D.qml
+++ b/meshroom/ui/qml/Viewer3D/Viewer3D.qml
@@ -274,13 +274,9 @@ FocusScope {
     }
 
     // Image overlay when navigating reconstructed cameras
-    ExifOrientedViewer {
+    Loader {
         id: imageOverlayLoader
         anchors.fill: parent
-
-        orientationTag: root.viewpoint ? root.viewpoint.orientation.toString() : "1"
-        xOrigin: width * 0.5
-        yOrigin: height * 0.5
 
         active: doSyncViewpointCamera
         visible: Viewer3DSettings.showViewpointImageOverlay

--- a/meshroom/ui/qml/Viewer3D/Viewer3D.qml
+++ b/meshroom/ui/qml/Viewer3D/Viewer3D.qml
@@ -63,7 +63,6 @@ FocusScope {
 
     SystemPalette { id: activePalette }
 
-
     Scene3D {
         id: scene3D
         anchors.fill: parent
@@ -72,46 +71,17 @@ FocusScope {
         aspects: ["logic", "input"]
         focus: true
 
-        property int orientationTag: (doSyncViewpointCamera && root.viewpoint) ? root.viewpoint.orientation : 1
-
+        // We cannot use directly an ExifOrientedViewer since this component is not a Loader
+        // so we redefine the transform using the ExifOrientation utility functions
+        property var orientationTag: (doSyncViewpointCamera && root.viewpoint) ? root.viewpoint.orientation.toString() : "1"
         transform: [
             Rotation {
-                angle: {
-                    switch(scene3D.orientationTag) {
-                        case 3:
-                            return 180;
-                        case 4:
-                            return 180;
-                        case 5:
-                            return 90;
-                        case 6:
-                            return 90;
-                        case 7:
-                            return -90;
-                        case 8:
-                            return -90;
-                        default:
-                            return 0;
-                    }
-                }
+                angle: ExifOrientation.rotation(scene3D.orientationTag)
                 origin.x: scene3D.width * 0.5
                 origin.y: scene3D.height * 0.5
             },
             Scale {
-                xScale : {
-                    switch(scene3D.orientationTag) {
-                        case 2:
-                            return -1;
-                        case 4:
-                            return -1;
-                        case 5:
-                            return -1;
-                        case 7:
-                            return -1;
-                        default:
-                            return 1;
-                    }
-                }
+                xScale: ExifOrientation.xscale(scene3D.orientationTag)
                 origin.x: scene3D.width * 0.5
                 origin.y: scene3D.height * 0.5
             }

--- a/meshroom/ui/qml/Viewer3D/Viewer3D.qml
+++ b/meshroom/ui/qml/Viewer3D/Viewer3D.qml
@@ -72,6 +72,50 @@ FocusScope {
         aspects: ["logic", "input"]
         focus: true
 
+        property int orientationTag: (doSyncViewpointCamera && root.viewpoint) ? root.viewpoint.orientation : 1
+
+        transform: [
+            Rotation {
+                angle: {
+                    switch(scene3D.orientationTag) {
+                        case 3:
+                            return 180;
+                        case 4:
+                            return 180;
+                        case 5:
+                            return 90;
+                        case 6:
+                            return 90;
+                        case 7:
+                            return -90;
+                        case 8:
+                            return -90;
+                        default:
+                            return 0;
+                    }
+                }
+                origin.x: scene3D.width * 0.5
+                origin.y: scene3D.height * 0.5
+            },
+            Scale {
+                xScale : {
+                    switch(scene3D.orientationTag) {
+                        case 2:
+                            return -1;
+                        case 4:
+                            return -1;
+                        case 5:
+                            return -1;
+                        case 7:
+                            return -1;
+                        default:
+                            return 1;
+                    }
+                }
+                origin.x: scene3D.width * 0.5
+                origin.y: scene3D.height * 0.5
+            }
+        ]
 
         Keys.onPressed: {
             if (event.key == Qt.Key_F) {
@@ -260,9 +304,13 @@ FocusScope {
     }
 
     // Image overlay when navigating reconstructed cameras
-    Loader {
+    ExifOrientedViewer {
         id: imageOverlayLoader
         anchors.fill: parent
+
+        orientationTag: root.viewpoint ? root.viewpoint.orientation.toString() : "1"
+        xOrigin: width * 0.5
+        yOrigin: height * 0.5
 
         active: doSyncViewpointCamera
         visible: Viewer3DSettings.showViewpointImageOverlay
@@ -270,7 +318,7 @@ FocusScope {
         sourceComponent: ImageOverlay {
             id: imageOverlay
             source: root.viewpoint.undistortedImageSource
-            imageRatio: root.viewpoint.orientedImageSize.width / root.viewpoint.orientedImageSize.height
+            imageRatio: root.viewpoint.imageSize.width / root.viewpoint.imageSize.height
             uvCenterOffset: root.viewpoint.uvCenterOffset
             showFrame: Viewer3DSettings.showViewpointImageFrame
             imageOpacity: Viewer3DSettings.viewpointImageOverlayOpacity

--- a/meshroom/ui/qml/Viewer3D/Viewer3D.qml
+++ b/meshroom/ui/qml/Viewer3D/Viewer3D.qml
@@ -288,7 +288,7 @@ FocusScope {
         sourceComponent: ImageOverlay {
             id: imageOverlay
             source: root.viewpoint.undistortedImageSource
-            imageRatio: root.viewpoint.imageSize.width / root.viewpoint.imageSize.height
+            imageRatio: root.viewpoint.orientedImageSize.width / root.viewpoint.orientedImageSize.height
             uvCenterOffset: root.viewpoint.uvCenterOffset
             showFrame: Viewer3DSettings.showViewpointImageFrame
             imageOpacity: Viewer3DSettings.viewpointImageOverlayOpacity

--- a/meshroom/ui/reconstruction.py
+++ b/meshroom/ui/reconstruction.py
@@ -271,7 +271,7 @@ class ViewpointWrapper(QObject):
     @Property(type=QSizeF, notify=initialParamsChanged)
     def orientedImageSize(self):
         """ Get image size taking into account its orientation. """
-        if self.orientation in (6, 8):
+        if self.orientation in (5, 6, 7, 8):
             return QSizeF(self.imageSize.height(), self.imageSize.width())
         else:
             return self.imageSize
@@ -322,13 +322,8 @@ class ViewpointWrapper(QObject):
 
     @Property(type=QVector3D, notify=sfmParamsChanged)
     def upVector(self):
-        """ Get camera up vector according to its orientation. """
-        if self.orientation == 6:
-            return QVector3D(-1.0, 0.0, 0.0)
-        elif self.orientation == 8:
-            return QVector3D(1.0, 0.0, 0.0)
-        else:
-            return QVector3D(0.0, 1.0, 0.0)
+        """ Get camera up vector. """
+        return QVector3D(0.0, 1.0, 0.0)
 
     @Property(type=QVector2D, notify=sfmParamsChanged)
     def uvCenterOffset(self):
@@ -338,11 +333,6 @@ class ViewpointWrapper(QObject):
         pp = self.solvedIntrinsics["principalPoint"]
         # compute principal point offset in UV space
         offset = QVector2D(float(pp[0]) / self.imageSize.width(), float(pp[1]) / self.imageSize.height())
-        # apply orientation to principal point correction
-        if self.orientation == 6:
-            offset = QVector2D(-offset.y(), offset.x())
-        elif self.orientation == 8:
-            offset = QVector2D(offset.y(), -offset.x())
         return offset
 
     @Property(type=float, notify=sfmParamsChanged)

--- a/meshroom/ui/reconstruction.py
+++ b/meshroom/ui/reconstruction.py
@@ -341,8 +341,12 @@ class ViewpointWrapper(QObject):
         if not self.solvedIntrinsics:
             return None
         focalLength = self.solvedIntrinsics["focalLength"]
-        sensorHeight = self.solvedIntrinsics["sensorHeight"]
-        return 2.0 * math.atan(float(sensorHeight) / (2.0 * float(focalLength))) * 180.0 / math.pi
+        if self.orientation in (5, 6, 7, 8):
+            sensorWidth = self.solvedIntrinsics["sensorWidth"]
+            return 2.0 * math.atan(float(sensorWidth) / (2.0 * float(focalLength))) * 180.0 / math.pi
+        else:
+            sensorHeight = self.solvedIntrinsics["sensorHeight"]
+            return 2.0 * math.atan(float(sensorHeight) / (2.0 * float(focalLength))) * 180.0 / math.pi
 
     @Property(type=QUrl, notify=denseSceneParamsChanged)
     def undistortedImageSource(self):

--- a/meshroom/ui/reconstruction.py
+++ b/meshroom/ui/reconstruction.py
@@ -290,7 +290,7 @@ class ViewpointWrapper(QObject):
         """ Get the camera translation as a 3D vector. """
         if self._T is None:
             return None
-        return QVector3D(*self._T)
+        return QVector3D(self._T[0], -self._T[1], -self._T[2])
 
     @Property(type=QQuaternion, notify=sfmParamsChanged)
     def rotation(self):
@@ -300,8 +300,8 @@ class ViewpointWrapper(QObject):
 
         rot = QMatrix3x3([
             self._R[0], -self._R[1], -self._R[2],
-            self._R[3], -self._R[4], -self._R[5],
-            self._R[6], -self._R[7], -self._R[8]]
+            -self._R[3], self._R[4], self._R[5],
+            -self._R[6], self._R[7], self._R[8]]
         )
 
         return QQuaternion.fromRotationMatrix(rot)
@@ -315,8 +315,8 @@ class ViewpointWrapper(QObject):
         # convert transform matrix for Qt
         return QMatrix4x4(
             self._R[0], -self._R[1], -self._R[2], self._T[0],
-            self._R[3], -self._R[4], -self._R[5], self._T[1],
-            self._R[6], -self._R[7], -self._R[8], self._T[2],
+            -self._R[3], self._R[4], self._R[5], -self._T[1],
+            -self._R[6], self._R[7], self._R[8], -self._T[2],
             0,          0,           0,           1
         )
 


### PR DESCRIPTION
## Description

This PR fixes the "Sync Camera with Image Selection" feature in the 3D viewer.

## Features

- use the correct formulas for the camera rotation and translation
- apply exif orientation tag of input image to 3D viewer in order to match 2D viewer.

## Implementation remarks

The image used as overlay is not exactly the input image but its undistorted version computed by the PrepareDenseScene node. This means that if the PrepareDenseScene node has not been computed or does not exist (for example in a CameraTracking pipeline), there won't be a background image.
A more robust solution should be imagined for handling such cases.