### PR TITLE
Fix exceptions raised when accessing attributes that either do not exist or are not associated to a graph

### DIFF
--- a/meshroom/core/attribute.py
+++ b/meshroom/core/attribute.py
@@ -92,7 +92,8 @@ class Attribute(BaseObject):
 
     def getFullNameToGraph(self):
         """ Name inside the Graph: graphName.nodeName.groupName.name """
-        return '{}.{}'.format(self.node.graph.name, self.getFullNameToNode())
+        graphName = self.node.graph.name if self.node.graph else "UNDEFINED"
+        return '{}.{}'.format(graphName, self.getFullNameToNode())
 
     def asLinkExpr(self):
         """ Return link expression for this Attribute """
@@ -124,7 +125,8 @@ class Attribute(BaseObject):
 
     def getFullLabelToGraph(self):
         """ Label inside the Graph: graphName nodeLabel groupLabel Label """
-        return '{} {}'.format(self.node.graph.name, self.getFullLabelToNode())
+        graphName = self.node.graph.name if self.node.graph else "UNDEFINED"
+        return '{} {}'.format(graphName, self.getFullLabelToNode())
 
     def getEnabled(self):
         if isinstance(self.desc.enabled, types.FunctionType):

--- a/meshroom/ui/qml/Viewer/Viewer2D.qml
+++ b/meshroom/ui/qml/Viewer/Viewer2D.qml
@@ -1003,9 +1003,9 @@ FocusScope {
                                 {
                                     return true;
                                 }
-                                var inputAttr = activeNode.attribute("input");
-                                if(!inputAttr)
+                                if(!activeNode.hasAttribute("input"))
                                     return false;
+                                var inputAttr = activeNode.attribute("input");
                                 var inputAttrLink = inputAttr.rootLinkParam;
                                 if(!inputAttrLink)
                                     return false;


### PR DESCRIPTION
## Description

This PR fixes two exceptions related to attributes that were raised in some cases:
- In the Viewer2D, when determining whether the active node relates to the lens distortion viewer, check if the "input" attribute exists for that node before trying to access it. _(fixes a `KeyError` exception)_
- When the attribute's full name and full label within the graph are evaluated, check that the node it belongs to is associated to an existing graph (some nodes may be created temporarily in some specific cases without ever being attached to a graph): if it is, then the attribute's full name/label can be returned, otherwise "UNDEFINED" is. _(fixes a `ValueError` exception)_