### PR TITLE
[ui] fix thumbnail cache bugs

### DIFF
--- a/meshroom/ui/components/thumbnail.py
+++ b/meshroom/ui/components/thumbnail.py
@@ -170,6 +170,22 @@ class ThumbnailCache(QObject):
         return path
 
     @staticmethod
+    def removeOutdated(imgPath, path):
+        """Remove thumbnail if its corresponding image has been modified after thumbnail creation.
+
+        Args:
+            imgPath (str): filepath to the input image
+            path (str): filepath to the corresponding thumbnail
+        """
+        try:
+            if os.path.getmtime(imgPath) > os.path.getmtime(path):
+                os.remove(path)
+        except OSError:
+            return
+        except FileNotFoundError:
+            return
+
+    @staticmethod
     def checkThumbnail(path):
         """Check if a thumbnail already exists on disk, and if so update its last modification time.
 
@@ -204,10 +220,13 @@ class ThumbnailCache(QObject):
 
         imgPath = imgSource.toLocalFile()
         path = ThumbnailCache.thumbnailPath(imgPath)
-        source = QUrl.fromLocalFile(path)
 
-        # Check if thumbnail already exists
+        # Remove thumbnail in case it is outdated (i.e. if image was modified)
+        ThumbnailCache.removeOutdated(imgPath, path)
+
+        # Check if thumbnail already exists (and update its last modification time)
         if ThumbnailCache.checkThumbnail(path):
+            source = QUrl.fromLocalFile(path)
             return source
 
         # Thumbnail does not exist

--- a/meshroom/ui/qml/ImageGallery/ImageDelegate.qml
+++ b/meshroom/ui/qml/ImageGallery/ImageDelegate.qml
@@ -41,18 +41,14 @@ Item {
         updateThumbnail();
     }
 
-    // Send a new request every 5 seconds until thumbnail is loaded
+    // Send a new request after 5 seconds if thumbnail is not loaded
     // This is meant to avoid deadlocks in case there is a synchronization problem
     Timer {
         interval: 5000
-        repeat: true
         running: true
         onTriggered: {
             if (thumbnail.status == Image.Null) {
                 updateThumbnail();
-            }
-            else {
-                running = false;
             }
         }
     }


### PR DESCRIPTION
## Description

In this PR we fix several bugs related to the thumbnail cache mechanism.

### Endless request loop

We fix a problem that can occur with the thumbnail cache when input images cannot be read: 
since each image delegate has a Timer that will send a new request every 5 seconds until a thumbnail can be loaded, in the case of images that cannot be read these requests will be sent endlessly.

The proposed fix is to stop the Timer after the 1st request, since it is the only one that is actually useful for preventing unwanted behaviour from the QML engine.

### Reload image after modification

Another problem that we fixed is that when an image was loaded once, then modified for any reason and then reloaded later on, its corresponding thumbnail will not be updated.

The proposed fix is to remove a thumbnail if its corresponding image has been modified after the thumbnail creation: this way, a new thumbnail will be generated, and it will match the modified image.