### PR TITLE
[ui] Drag&Drop: Use a pool of threads for asynchronous intrinsics computations

### DIFF
--- a/meshroom/ui/reconstruction.py
+++ b/meshroom/ui/reconstruction.py
@@ -801,7 +801,7 @@ class Reconstruction(UIGraph):
         logging.debug("importImagesFromFolder: " + str(path))
         filesByType = multiview.findFilesByTypeInFolder(path, recursive)
         if filesByType.images:
-            self.buildIntrinsics(self.cameraInit, filesByType.images)
+            self.importImagesAsync(filesByType.images, self.cameraInit)
 
     @Slot("QVariant")
     def importImagesUrls(self, imagePaths, recursive=False):


### PR DESCRIPTION
## Description

This PR fixes an issue that occurred when dragging and dropping images from a folder into Meshroom's Image Gallery.

When dropping new images, the intrinsics were rebuilt asynchronously in a thread that was not attached to anything. The update of the intrinsics, performed in the main thead following a signal emitted in the detached thread, would block when there were already some existing intrinsics (and thus already some existing images in the gallery) because the garbage collector would destroy the thread in which the new intrinsics had been computed while the update was ongoing. It seems the issue did not appear when there was not any image in the gallery because the update of the intrinsics did not need to remove the previously existing ones before adding the new ones.

- This pull request adds a pool of threads (currently, the pool contains a single thread as the intrinsics computation is the only operation that needs to be performed asynchronously) to the Reconstruction object and uses it to perform the intrinsics computations asynchronously. As a consequence, the update of the intrinsics does not remain blocked and images can be dragged and dropped in the Image Gallery safely.

- Additionally, importing images through the "Import Images" menu action is now performed asynchronously as well. It used to be synchronous, and as such, not subject to the update issue, but as it was both a blocking and costly operations, it would freeze the application entirely until it was completed. "Import Images" now uses the same workflow as dragging and dropping images.


## Features list

- [x] Execute "Import Images" asynchronously to avoid freezing the application
- [x] Use a pool of threads instead of a detached thread to perform asynchronous operations


## Implementation remarks

- The "Update Intrinsics" button, which appears when the dialog to edit the sensor database is on display and caused the same issue as the drag and drop, now also uses the pool of threads to recompute the intrinsics when requested 
- The "runAsync" method, which spawned a thread without attaching it to anything, is removed.
- The "importImagesAsync" method, whose only goal was to call "runAsync" on "importImagesSync", is also removed. Instead, the pool of threads is directly used to call "importImagesSync" asynchronously.

