### PR TITLE
[ui] Improve "Clear Images" action's behaviour and performance

### DIFF
--- a/meshroom/ui/graph.py
+++ b/meshroom/ui/graph.py
@@ -733,6 +733,16 @@ class UIGraph(QObject):
     def removeAttribute(self, attribute):
         self.push(commands.ListAttributeRemoveCommand(self._graph, attribute))
 
+    @Slot()
+    def clearImages(self):
+        with self.groupedGraphModification("Clear Images"):
+            self.push(commands.ClearImagesCommand(self._graph, [self.cameraInit]))
+
+    @Slot()
+    def clearAllImages(self):
+        with self.groupedGraphModification("Clear All Images"):
+            self.push(commands.ClearImagesCommand(self._graph, list(self.cameraInits)))
+
     @Slot(Node)
     def appendSelection(self, node):
         """ Append 'node' to the selection if it is not already part of the selection. """

--- a/meshroom/ui/qml/main.qml
+++ b/meshroom/ui/qml/main.qml
@@ -428,6 +428,26 @@ ApplicationWindow {
     }
 
     Action {
+        id: clearImagesAction
+        property string tooltip: "Clear images for the current CameraInit group"
+        text: "Clear Images"
+        onTriggered: {
+            _reconstruction.clearImages()
+            _reconstruction.selectedViewId = "-1"
+        }
+    }
+
+    Action {
+        id: clearAllImagesAction
+        property string tooltip: "Clear all the images for all the CameraInit groups"
+        text: "Clear All Images"
+        onTriggered: {
+            _reconstruction.clearAllImages()
+            _reconstruction.selectedViewId = "-1"
+        }
+    }
+
+    Action {
         id: undoAction
 
         property string tooltip: 'Undo "' + (_reconstruction ? _reconstruction.undoStack.undoText : "Unknown") + '"'
@@ -638,13 +658,12 @@ ApplicationWindow {
                 }
             }
 
-            Action {
-                id: clearImagesAction
-                text: "Clear Images"
-                onTriggered: {
-                    _reconstruction.clearImages()
-                }
+            MenuItem {
+                action: clearImagesAction
+                ToolTip.visible: hovered
+                ToolTip.text: clearImagesAction.tooltip
             }
+
             MenuSeparator { }
             Menu {
                 id: advancedMenu
@@ -676,6 +695,12 @@ ApplicationWindow {
                         initFileDialogFolder(importProjectDialog);
                         importProjectDialog.open();
                     }
+                }
+
+                MenuItem {
+                    action: clearAllImagesAction
+                    ToolTip.visible: hovered
+                    ToolTip.text: clearAllImagesAction.tooltip
                 }
             }
             MenuSeparator { }

--- a/meshroom/ui/qml/main.qml
+++ b/meshroom/ui/qml/main.qml
@@ -642,22 +642,7 @@ ApplicationWindow {
                 id: clearImagesAction
                 text: "Clear Images"
                 onTriggered: {
-                    //Loop through all the camera inits
-                    for(var i = 0 ; i < _reconstruction.cameraInits.count; i++){
-                        var cameraInit = _reconstruction.cameraInits.at(i)
-
-                        //Delete all viewpoints
-                        var viewpoints = cameraInit.attribute('viewpoints')
-                        for(var y = viewpoints.value.count - 1 ; y >= 0 ; y--){
-                              _reconstruction.removeAttribute(viewpoints.value.at(y))
-                        }
-
-                        //Delete all intrinsics
-                        var intrinsics = cameraInit.attribute('intrinsics')
-                        for(var z = intrinsics.value.count - 1 ; z >= 0 ; z--){
-                              _reconstruction.removeAttribute(intrinsics.value.at(z))
-                        }
-                    }
+                    _reconstruction.clearImages()
                 }
             }
             MenuSeparator { }

--- a/meshroom/ui/reconstruction.py
+++ b/meshroom/ui/reconstruction.py
@@ -694,26 +694,6 @@ class Reconstruction(UIGraph):
         """ Get all view Ids involved in the reconstruction. """
         return [vp.viewId.value for node in self._cameraInits for vp in node.viewpoints.value]
 
-    @Slot()
-    def clearImages(self):
-        """ Clear the list of viewpoints and intrinsics for all the CameraInit nodes. """
-        with self.groupedGraphModification("Clear Images"):
-            for cameraInit in self._cameraInits:
-                # Delete all viewpoints
-                viewpoints = cameraInit.attribute("viewpoints")
-                y = len(viewpoints.value) - 1
-                while y >= 0:
-                    self.removeAttribute(viewpoints.value[y])
-                    y = y - 1
-
-                # Delete all intrinsics
-                intrinsics = cameraInit.attribute("intrinsics")
-                z = len(intrinsics.value) - 1
-                while z >= 0:
-                    self.removeAttribute(intrinsics.value[z])
-                    z = z - 1
-
-
     @Slot(QObject, Node)
     def handleFilesDrop(self, drop, cameraInit):
         """ Handle drop events aiming to add images to the Reconstruction.

--- a/meshroom/ui/reconstruction.py
+++ b/meshroom/ui/reconstruction.py
@@ -694,6 +694,26 @@ class Reconstruction(UIGraph):
         """ Get all view Ids involved in the reconstruction. """
         return [vp.viewId.value for node in self._cameraInits for vp in node.viewpoints.value]
 
+    @Slot()
+    def clearImages(self):
+        """ Clear the list of viewpoints and intrinsics for all the CameraInit nodes. """
+        with self.groupedGraphModification("Clear Images"):
+            for cameraInit in self._cameraInits:
+                # Delete all viewpoints
+                viewpoints = cameraInit.attribute("viewpoints")
+                y = len(viewpoints.value) - 1
+                while y >= 0:
+                    self.removeAttribute(viewpoints.value[y])
+                    y = y - 1
+
+                # Delete all intrinsics
+                intrinsics = cameraInit.attribute("intrinsics")
+                z = len(intrinsics.value) - 1
+                while z >= 0:
+                    self.removeAttribute(intrinsics.value[z])
+                    z = z - 1
+
+
     @Slot(QObject, Node)
     def handleFilesDrop(self, drop, cameraInit):
         """ Handle drop events aiming to add images to the Reconstruction.


### PR DESCRIPTION
## Description

This PR modifies the behaviour of the "Clear Images" menu action as follows:
- It is now executed on the Python side instead of the QML side, which makes it more than 4x faster:
   - For 500 PNG images, it used to take ~38s, it now takes less than 0.5s.
   - For 1000 PNG images, it used to take ~2m39, it now takes 1s.
- "Clear Images" now only clears the images for the active group (meaning the active CameraInit node), instead of clearing all the images for all groups (all CameraInit nodes).
- When using "Clear Images", the "Undo" stack used to be filled with individual intrinsics and viewpoints images. Calling "Clear Images" when 500 images were in the gallery was thus requiring at least 500 calls to "Undo" to be fully reverted. It is now considered as a single action, meaning a single call to "Undo" is enough to recover all the cleared images.

A "Clear All Images" action has been added in the "Advanced" sub-menu to clear the images of all the groups.

<div align="center"><img src="https://i.gyazo.com/04164761ce99aa684027f96563b36bc0.png" width=300></div>

Tooltips have been added over both "Clear Images" and "Clear All Images" to make the distinction clear for users. 

## Features list

- [x] Execute "Clear Images" on the Python side rather than the QML side;
- [x] Make "Clear Images" remove only the images of the current CameraInit node;
- [x] Add a "Clear All Images" action in the "Advanced" sub-menu to remove the images of all the CameraInit nodes.
