### PR TITLE
[ui] Intrinsics: Fix warnings and exceptions

### DIFF
--- a/meshroom/ui/qml/ImageGallery/ImageGallery.qml
+++ b/meshroom/ui/qml/ImageGallery/ImageGallery.qml
@@ -514,7 +514,7 @@ Panel {
 
                 model: intrinsicModel
 
-                delegate: IntrinsicDisplayDelegate{}
+                delegate: IntrinsicDisplayDelegate { attribute: model.display }
 
                 ScrollBar.horizontal: ScrollBar { id: sb }
                 ScrollBar.vertical : ScrollBar { id: sbv }

--- a/meshroom/ui/qml/ImageGallery/IntrinsicDisplayDelegate.qml
+++ b/meshroom/ui/qml/ImageGallery/IntrinsicDisplayDelegate.qml
@@ -9,12 +9,12 @@ RowLayout {
 
     Layout.fillWidth: true
 
-    property variant attribute: model.display
+    property variant attribute: null
     property int rowIndex: model.row
     property int columnIndex: model.column
     property bool readOnly: false
     property string toolTipText: {
-        if(!attribute || Object.keys(attribute).length === 0)
+        if (!attribute || Object.keys(attribute).length === 0)
             return ""
         return attribute.fullLabel
     }
@@ -44,11 +44,11 @@ RowLayout {
             clip: true
             Loader {
                 id: loaderComponent
-                active: !!model.display // convert to bool with "!!"
+                active: !!attribute // convert to bool with "!!"
                 sourceComponent: {
-                    if(!model.display)
+                    if (!attribute)
                         return undefined
-                    switch(model.display.type)
+                    switch (attribute.type)
                     {
                        case "ChoiceParam": return choice_component
                        case "IntParam": return int_component
@@ -65,7 +65,7 @@ RowLayout {
     Component {
         id: textField_component
         TextInput{
-            text: model.display.value
+            text: attribute.value
             width: intrinsicModel.columnWidths[columnIndex]
             horizontalAlignment: TextInput.AlignRight
             color: 'white'
@@ -155,7 +155,7 @@ RowLayout {
     Component {
         id: float_component
         TextInput{
-            readonly property real formattedValue: model.display.value.toFixed(2)
+            readonly property real formattedValue: attribute.value.toFixed(2)
             property string displayValue: String(formattedValue)
 
             text: displayValue
@@ -179,8 +179,10 @@ RowLayout {
             //while keeping the trick for formatting the text
             //Timing issues otherwise
             onActiveFocusChanged: {
-                if(activeFocus) text = String(model.display.value)
-                else text = String(formattedValue)
+                if (activeFocus)
+                    text = String(attribute.value)
+                else
+                    text = String(formattedValue)
                 cursorPosition = 0
             }
 

--- a/meshroom/ui/reconstruction.py
+++ b/meshroom/ui/reconstruction.py
@@ -213,7 +213,8 @@ class ViewpointWrapper(QObject):
         else:
             self._initialIntrinsics = self._reconstruction.getIntrinsic(self._viewpoint)
             try:
-                self._metadata = json.loads(self._viewpoint.metadata.value) if self._viewpoint.metadata.value else None
+                # When the viewpoint attribute has already been deleted, metadata.value becomes a PySide property (whereas a string is expected)
+                self._metadata = json.loads(self._viewpoint.metadata.value) if isinstance(self._viewpoint.metadata.value, str) and self._viewpoint.metadata.value else None
             except Exception as e:
                 logging.warning("Failed to parse Viewpoint metadata: '{}', '{}'".format(str(e), str(self._viewpoint.metadata.value)))
                 self._metadata = {}


### PR DESCRIPTION
## Description

This PR fixes a QML warning and a raised exception related to the intrinsics:
- The QML warning "Unable to assign QJSValue to QObject*", which was related to the wrong initialisation of the `attribute` variant in the intrinsics table.
- The exception that raised with "Failed to parse Viewpoint metadata: 'the JSON object must be str, bytes or bytearray, not Property'" whenever there was a switch between the different CameraInit groups after all the intrinsics had been cleared. The metadata value is now accessed if and only if it exists, ie. if it is a string instance and not a PySide property (the metadata value becomes a PySide property when the viewpoint attribute is deleted).
