### PR TITLE
[ImageGallery] Match the filter selection with the gallery's display

### DIFF
--- a/meshroom/ui/qml/ImageGallery/ImageGallery.qml
+++ b/meshroom/ui/qml/ImageGallery/ImageGallery.qml
@@ -629,12 +629,15 @@ Panel {
             checkable: true
             checked: true
 
-            onCheckedChanged:{
-                if(checked) {
+            onCheckedChanged: {
+                if (checked) {
                     sortedModel.reconstructionFilter = undefined;
                     estimatedCamerasFilterButton.checked = false;
                     nonEstimatedCamerasFilterButton.checked = false;
                     intrinsicsFilterButton.checked = false;
+                } else {
+                    if (estimatedCamerasFilterButton.checked === false && nonEstimatedCamerasFilterButton.checked === false && intrinsicsFilterButton.checked === false)
+                        inputImagesFilterButton.checked = true
                 }
             }
         }
@@ -651,12 +654,15 @@ Panel {
             checkable: true
             checked: false
 
-            onCheckedChanged:{
-                if(checked) {
+            onCheckedChanged: {
+                if (checked) {
                     sortedModel.reconstructionFilter = true;
                     inputImagesFilterButton.checked = false;
                     nonEstimatedCamerasFilterButton.checked = false;
                     intrinsicsFilterButton.checked = false;
+                } else {
+                    if (inputImagesFilterButton.checked === false && nonEstimatedCamerasFilterButton.checked === false && intrinsicsFilterButton.checked === false)
+                        inputImagesFilterButton.checked = true
                 }
             }
             onEnabledChanged:{
@@ -680,12 +686,15 @@ Panel {
             checkable: true
             checked: false
 
-            onCheckedChanged:{
-                if(checked) {
+            onCheckedChanged: {
+                if (checked) {
                     sortedModel.reconstructionFilter = false;
                     inputImagesFilterButton.checked = false;
                     estimatedCamerasFilterButton.checked = false;
                     intrinsicsFilterButton.checked = false;
+                } else {
+                    if (inputImagesFilterButton.checked === false && estimatedCamerasFilterButton.checked === false && intrinsicsFilterButton.checked === false)
+                        inputImagesFilterButton.checked = true
                 }
             }
             onEnabledChanged:{
@@ -709,11 +718,14 @@ Panel {
             checkable: true
             checked: false
 
-            onCheckedChanged:{
-                if(checked) {
+            onCheckedChanged: {
+                if (checked) {
                     inputImagesFilterButton.checked = false
                     estimatedCamerasFilterButton.checked = false
                     nonEstimatedCamerasFilterButton.checked = false
+                } else {
+                    if (inputImagesFilterButton.checked === false && estimatedCamerasFilterButton.checked === false && nonEstimatedCamerasFilterButton.checked === false)
+                            inputImagesFilterButton.checked = true
                 }
             }
             onEnabledChanged:{


### PR DESCRIPTION
## Description

Selecting any filter in the Image Gallery changes the displayed content of the gallery according to the filter. Unselecting any filter automatically switches the displayed content back to the "input images" filter (which simply displays all the input images), but the "input images" button is never reselected, meaning that there can be a display corresponding to a filter without any filter being selected, as shown in the image below.

<div align="center"><img src="https://i.gyazo.com/9b7efcb7e0bb375003410f9a44c76573.png" height=300></div>

This PR prevents unselecting a filter without reselecting the one corresponding to the display. Since the "input images" is always the display that is reverted back to, unselecting any filter automatically selects its button:

<div align="center"><img src="https://i.gyazo.com/216551533f588e1e42c6c16d3ca5967c.png" height=300></div>
