### PR TITLE
Fix missing Publish nodes in templates

### DIFF
--- a/bin/meshroom_batch
+++ b/bin/meshroom_batch
@@ -91,15 +91,6 @@ if args.verbose:
     logging.getLogger().setLevel(logStringToPython[args.verbose])
 
 
-def getOnlyNodeOfType(g, nodeType):
-    """ Helper function to get a node of 'nodeType' in the graph 'g' and raise if no or multiple candidates. """
-    nodes = g.nodesOfType(nodeType)
-    if len(nodes) != 1:
-        raise RuntimeError("meshroom_batch requires a pipeline graph with exactly one '{}' node, {} found."
-                           .format(nodeType, len(nodes)))
-    return nodes[0]
-
-
 def getInitNode(g):
     """
     Helper function to get the Init node in the graph 'g' and raise an exception if there is no or
@@ -124,10 +115,10 @@ with multiview.GraphModification(graph):
     # initialize template pipeline
     loweredPipelineTemplates = dict((k.lower(), v) for k, v in meshroom.core.pipelineTemplates.items())
     if args.pipeline.lower() in loweredPipelineTemplates:
-        graph.load(loweredPipelineTemplates[args.pipeline.lower()], setupProjectFile=False)
+        graph.load(loweredPipelineTemplates[args.pipeline.lower()], setupProjectFile=False, publishOutputs=True if args.output else False)
     else:
         # custom pipeline
-        graph.load(args.pipeline, setupProjectFile=False)
+        graph.load(args.pipeline, setupProjectFile=False, publishOutputs=True if args.output else False)
 
     # get init node and initialize it
     initNode = getInitNode(graph)
@@ -140,8 +131,15 @@ with multiview.GraphModification(graph):
         graph.setVerbose(args.verbose)
 
     if args.output:
-        publish = getOnlyNodeOfType(graph, 'Publish')
-        publish.output.value = args.output
+        # if there is more than 1 Publish node, they will all be set to the same output;
+        # depending on what they are connected to, some input files might be overwritten in the output folder
+        # (e.g. if two Publish nodes are connected to two Texturing nodes)
+        publishNodes = graph.nodesOfType('Publish')
+        if len(publishNodes) > 0:
+            for node in publishNodes:
+                node.output.value = args.output
+        else:
+            raise RuntimeError("meshroom_batch requires a pipeline graph with at least one Publish node, none found.")
 
     if args.overrides:
         import json

--- a/meshroom/core/graph.py
+++ b/meshroom/core/graph.py
@@ -241,7 +241,7 @@ class Graph(BaseObject):
         return Graph.IO.getFeaturesForVersion(self.header.get(Graph.IO.Keys.FileVersion, "0.0"))
 
     @Slot(str)
-    def load(self, filepath, setupProjectFile=True, importProject=False):
+    def load(self, filepath, setupProjectFile=True, importProject=False, publishOutputs=False):
         """
         Load a meshroom graph ".mg" file.
 
@@ -249,6 +249,9 @@ class Graph(BaseObject):
             filepath: project filepath to load
             setupProjectFile: Store the reference to the project file and setup the cache directory.
                               If false, it only loads the graph of the project file as a template.
+            importProject: True if the project that is loaded will be imported in the current graph, instead
+                           of opened.
+            publishOutputs: True if "Publish" nodes from templates should not be ignored.
         """
         if not importProject:
             self.clear()
@@ -283,6 +286,11 @@ class Graph(BaseObject):
                 #   3. fallback to no version "0.0": retro-compatibility
                 if "version" not in nodeData:
                     nodeData["version"] = nodesVersions.get(nodeData["nodeType"], "0.0")
+
+                # if the node is a "Publish" node and comes from a template file, it should be ignored
+                # unless publishOutputs is True
+                if isTemplate and not publishOutputs and nodeData["nodeType"] == "Publish":
+                    continue
 
                 n = nodeFactory(nodeData, nodeName, template=isTemplate)
 

--- a/meshroom/pipelines/cameraTracking.mg
+++ b/meshroom/pipelines/cameraTracking.mg
@@ -11,7 +11,8 @@
             "CameraInit": "9.0", 
             "ImageMatching": "2.0", 
             "FeatureExtraction": "1.1", 
-            "StructureFromMotion": "2.0"
+            "StructureFromMotion": "2.0",
+            "Publish": "1.2"
         }
     }, 
     "graph": {
@@ -99,6 +100,18 @@
                 600, 
                 0
             ]
+        },
+        "Publish_1": {
+            "nodeType": "Publish",
+            "position": [
+                1200,
+                0
+            ],
+            "inputs": {
+                "inputFiles": [
+                    "{ExportAnimatedCamera_1.output}"
+                ]
+            }
         }
     }
 }

--- a/meshroom/pipelines/panoramaFisheyeHdr.mg
+++ b/meshroom/pipelines/panoramaFisheyeHdr.mg
@@ -16,7 +16,8 @@
             "ImageMatching": "2.0", 
             "FeatureExtraction": "1.1", 
             "PanoramaPrepareImages": "1.1", 
-            "PanoramaWarping": "1.0"
+            "PanoramaWarping": "1.0",
+            "Publish": "1.2"
         }, 
         "releaseVersion": "2021.1.0", 
         "fileVersion": "1.1", 
@@ -231,6 +232,18 @@
                 1600, 
                 0
             ]
+        },
+        "Publish_1": {
+            "nodeType": "Publish",
+            "position": [
+                3200,
+                0
+            ],
+            "inputs": {
+                "inputFiles": [
+                    "{ImageProcessing_1.outputImages}"
+                ]
+            }
         }
     }
 }

--- a/meshroom/pipelines/panoramaHdr.mg
+++ b/meshroom/pipelines/panoramaHdr.mg
@@ -16,7 +16,8 @@
             "ImageMatching": "2.0", 
             "FeatureExtraction": "1.1", 
             "PanoramaPrepareImages": "1.1", 
-            "PanoramaWarping": "1.0"
+            "PanoramaWarping": "1.0",
+            "Publish": "1.2"
         }, 
         "releaseVersion": "2021.1.0", 
         "fileVersion": "1.1", 
@@ -226,6 +227,18 @@
                 1600, 
                 0
             ]
+        },
+        "Publish_1": {
+            "nodeType": "Publish",
+            "position": [
+                3200,
+                0
+            ],
+            "inputs": {
+                "inputFiles": [
+                    "{ImageProcessing_1.outputImages}"
+                ]
+            }
         }
     }
 }

--- a/meshroom/pipelines/photogrammetry.mg
+++ b/meshroom/pipelines/photogrammetry.mg
@@ -15,10 +15,26 @@
             "ImageMatching": "2.0", 
             "FeatureExtraction": "1.1", 
             "Meshing": "7.0", 
-            "DepthMapFilter": "3.0"
+            "DepthMapFilter": "3.0",
+            "Publish": "1.0"
         }
     }, 
     "graph": {
+        "Publish_1": {
+            "inputs": {
+                "output": "",
+                "inputFiles": [
+                    "{Texturing_1.outputMesh}",
+                    "{Texturing_1.outputMaterial}",
+                    "{Texturing_1.outputTextures}"
+                ]
+            }, 
+            "nodeType": "Publish", 
+            "position": [
+                2200, 
+                0
+            ]
+        },
         "Texturing_1": {
             "inputs": {
                 "imagesFolder": "{DepthMap_1.imagesFolder}", 

--- a/meshroom/pipelines/photogrammetry.mg
+++ b/meshroom/pipelines/photogrammetry.mg
@@ -16,7 +16,7 @@
             "FeatureExtraction": "1.1", 
             "Meshing": "7.0", 
             "DepthMapFilter": "3.0",
-            "Publish": "1.0"
+            "Publish": "1.2"
         }
     }, 
     "graph": {

--- a/meshroom/pipelines/photogrammetryAndCameraTracking.mg
+++ b/meshroom/pipelines/photogrammetryAndCameraTracking.mg
@@ -12,7 +12,8 @@
             "ImageMatchingMultiSfM": "1.0", 
             "ImageMatching": "2.0", 
             "FeatureExtraction": "1.1", 
-            "StructureFromMotion": "2.0"
+            "StructureFromMotion": "2.0",
+            "Publish": "1.2"
         }
     }, 
     "graph": {
@@ -161,6 +162,18 @@
                 1429, 
                 212
             ]
+        },
+        "Publish_1": {
+            "nodeType": "Publish",
+            "position": [
+                1829,
+                212
+            ],
+            "inputs": {
+                "inputFiles": [
+                    "{ExportAnimatedCamera_1.output}"
+                ]
+            }
         }
     }
 }

--- a/meshroom/pipelines/photogrammetryDraft.mg
+++ b/meshroom/pipelines/photogrammetryDraft.mg
@@ -8,7 +8,8 @@
             "CameraInit": "9.0", 
             "ImageMatching": "2.0", 
             "FeatureExtraction": "1.1", 
-            "Meshing": "7.0"
+            "Meshing": "7.0",
+            "Publish": "1.2"
         }, 
         "releaseVersion": "2021.1.0", 
         "fileVersion": "1.1", 
@@ -104,6 +105,20 @@
                 600, 
                 0
             ]
+        },
+        "Publish_1": {
+            "nodeType": "Publish",
+            "position": [
+                1600,
+                0
+            ],
+            "inputs": {
+                "inputFiles": [
+                    "{Texturing_1.outputMesh}",
+                    "{Texturing_1.outputMaterial}",
+                    "{Texturing_1.outputTextures}"
+                ]
+            }
         }
     }
 }

--- a/meshroom/ui/graph.py
+++ b/meshroom/ui/graph.py
@@ -350,9 +350,9 @@ class UIGraph(QObject):
         self._chunksMonitor.stop()
 
     @Slot(str, result=bool)
-    def loadGraph(self, filepath, setupProjectFile=True):
+    def loadGraph(self, filepath, setupProjectFile=True, publishOutputs=False):
         g = Graph('')
-        status = g.load(filepath, setupProjectFile)
+        status = g.load(filepath, setupProjectFile, importProject=False, publishOutputs=publishOutputs)
         if not os.path.exists(g.cacheDir):
             os.mkdir(g.cacheDir)
         self.setGraph(g)

--- a/meshroom/ui/reconstruction.py
+++ b/meshroom/ui/reconstruction.py
@@ -488,9 +488,9 @@ class Reconstruction(UIGraph):
             self.load(p, setupProjectFile=False)
 
     @Slot(str, result=bool)
-    def load(self, filepath, setupProjectFile=True):
+    def load(self, filepath, setupProjectFile=True, publishOutputs=False):
         try:
-            status = super(Reconstruction, self).loadGraph(filepath, setupProjectFile)
+            status = super(Reconstruction, self).loadGraph(filepath, setupProjectFile, publishOutputs)
             # warn about pre-release projects being automatically upgraded
             if Version(self._graph.fileReleaseVersion).major == "0":
                 self.warning.emit(Message(


### PR DESCRIPTION
Closes #1900.

<!-- Checklist before submission:

 - I have read the [contribution guidelines](../CONTRIBUTING.md).
 - I have updated the documentation, if applicable.
 - I have ensured that the change is tested somewhere.
 - I have followed the prevailing code style (for history readability and limit conflicts for maintainance).

-->
## Description

This PR fixes an issue in `meshroom_batch` which was caused by the refactoring of hard-coded pipelines to .mg files. Specifically, this commit: 8fb0c778d12af5d3d51567407a6d38132e53d796 omitted the `Publish` node from the photogrammetry pipeline. This PR adds it back. Before this PR, if the `--output` argument was passed to `meshroom_batch`, it throws an error complaining from no Publish nodes as explained in the linked issue.

## Features list

<!--
- [ ] Feature one. Fix #XXX
- [ ] Improve something else
- [ ] Connect to #3 (to declare link to issues without closing it when the PR is merged).
- [X] Add "X" when it is done.
-->


## Implementation remarks


<!--
Explain main implementation choices.
It is also the right place to ask for feedback and help when you hesitate on the implementation.
-->
