### PR TITLE
[Viewer] Load and unload the SfMStats components explicitly every time they are shown and hidden 

### DIFF
--- a/meshroom/ui/qml/Viewer/Viewer2D.qml
+++ b/meshroom/ui/qml/Viewer/Viewer2D.qml
@@ -53,7 +53,7 @@ FocusScope {
         active: true
         source: "TestAliceVisionPlugin.qml"
     }
-    
+
     readonly property bool aliceVisionPluginAvailable: aliceVisionPluginLoader.status === Component.Ready
 
     Component.onCompleted: {
@@ -177,7 +177,7 @@ FocusScope {
 
     function tryLoadNode(node) {
         useExternal = false;
-        
+
         // safety check
         if (!node) {
             return false;
@@ -218,7 +218,7 @@ FocusScope {
         }
         if (_reconstruction && (!displayedNode || outputAttribute.name == "gallery")) {
             return getViewpointPath(_reconstruction.selectedViewId);
-        } 
+        }
         return getFileAttributePath(displayedNode, outputAttribute.name, _reconstruction ? _reconstruction.selectedViewId : -1);
     }
 
@@ -1188,7 +1188,7 @@ FocusScope {
 
                             onClicked: {
                                 root.viewIn3D(
-                                    root.source, 
+                                    root.source,
                                     displayedNode.name + ":" + outputAttribute.name + " " + String(_reconstruction.selectedViewId)
                                 );
                             }

--- a/meshroom/ui/qml/Viewer/Viewer2D.qml
+++ b/meshroom/ui/qml/Viewer/Viewer2D.qml
@@ -876,13 +876,17 @@ FocusScope {
                         anchors.fill: parent
                         active: msfmDataLoader.status === Loader.Ready && displaySfmStatsView.checked
 
-                        Component.onCompleted: {
-                            // instantiate and initialize a SfmStatsView component dynamically using Loader.setSource
-                            // so it can fail safely if the c++ plugin is not available
-                            setSource("SfmStatsView.qml", {
-                                'msfmData': Qt.binding(function() { return msfmDataLoader.item; }),
-                                'viewId': Qt.binding(function() { return _reconstruction.selectedViewId; }),
-                            })
+                        onActiveChanged: {
+                            // Load and unload the component explicitly
+                            // (necessary since Qt 5.14, Component.onCompleted cannot be used anymore to load the data once and for all)
+                            if (active) {
+                                setSource("SfmStatsView.qml", {
+                                    "msfmData": Qt.binding(function() { return msfmDataLoader.item; }),
+                                    "viewId": Qt.binding(function() { return _reconstruction.selectedViewId; }),
+                                })
+                            } else {
+                                setSource("", {})
+                            }
                         }
                     }
                     Loader {
@@ -890,14 +894,18 @@ FocusScope {
                         anchors.fill: parent
                         active: msfmDataLoader.status === Loader.Ready && displaySfmDataGlobalStats.checked
 
-                        Component.onCompleted: {
-                            // instantiate and initialize a SfmStatsView component dynamically using Loader.setSource
-                            // so it can fail safely if the c++ plugin is not available
-                            setSource("SfmGlobalStats.qml", {
-                                'msfmData': Qt.binding(function() { return msfmDataLoader.item; }),
-                                'mTracks': Qt.binding(function() { return mtracksLoader.item; }),
+                        onActiveChanged: {
+                            // Load and unload the component explicitly
+                            // (necessary since Qt 5.14, Component.onCompleted cannot be used anymore to load the data once and for all)
+                            if (active) {
+                                setSource("SfmGlobalStats.qml", {
+                                    'msfmData': Qt.binding(function() { return msfmDataLoader.item; }),
+                                    'mTracks': Qt.binding(function() { return mtracksLoader.item; }),
 
-                            })
+                                })
+                            } else {
+                                setSource("", {})
+                            }
                         }
                     }
                     Loader {

--- a/meshroom/ui/qml/Viewer/Viewer2D.qml
+++ b/meshroom/ui/qml/Viewer/Viewer2D.qml
@@ -1197,11 +1197,12 @@ FocusScope {
                         MaterialToolButton {
                             id: displaySfmStatsView
                             property var activeNode: root.aliceVisionPluginAvailable && _reconstruction ? _reconstruction.activeNodes.get('sfm').node : null
+                            property bool isComputed: activeNode && activeNode.isComputed
 
                             font.family: MaterialIcons.fontFamily
                             text: MaterialIcons.assessment
 
-                            ToolTip.text: "StructureFromMotion Statistics"
+                            ToolTip.text: "StructureFromMotion Statistics" + (isComputed ? (": " + activeNode.label) : "")
                             ToolTip.visible: hovered
 
                             font.pointSize: 14
@@ -1222,11 +1223,12 @@ FocusScope {
                         MaterialToolButton {
                             id: displaySfmDataGlobalStats
                             property var activeNode: root.aliceVisionPluginAvailable && _reconstruction ? _reconstruction.activeNodes.get('sfm').node : null
+                            property bool isComputed: activeNode && activeNode.isComputed
 
                             font.family: MaterialIcons.fontFamily
                             text: MaterialIcons.language
 
-                            ToolTip.text: "StructureFromMotion Global Statistics"
+                            ToolTip.text: "StructureFromMotion Global Statistics" + (isComputed ? (": " + activeNode.label) : "")
                             ToolTip.visible: hovered
 
                             font.pointSize: 14


### PR DESCRIPTION
## Description

This PR fixes an issue that occurs when displaying the "StructureFromMotion Statistics" and "StructureFromMotion Global Statistics" components more than once per session. The components would be correctly loaded upon their first display, but disabling them and redisplaying them would lead to empty graphs, as the SfMData would not be correctly reloaded.

The SfMData is now provided to the components every time they are to be displayed (instead of providing it only once the first time they were to be displayed, and then never again), and the components' source is explicitly unloaded when they are hidden again. The behaviour of the statistics components is now similar to the other components' (such as the FeatureViewer, for example).

The image on the left below shows the statistics graphs that were displayed upon the SfMStats components' second display, while the image on the right shows how they always are with this PR (and not only for the first display).

<div align="center"><img src="https://i.gyazo.com/11258c85479c3b86e8b90e87cc5681b4.png" width=343> ==> <img src="https://i.gyazo.com/21d5a232fe48b76eab1228726af8f97b.png" width=350></div>


## Features list

- [x] Explicitly reset the source of the SfMStats components when they are hidden;
- [x] Explicitly provide the SfMData every time the SfMStats components are displayed.  

