### PR TITLE
[nodes] PanoramaWarping: remove obsolete image output attributes

### DIFF
--- a/meshroom/nodes/aliceVision/PanoramaWarping.py
+++ b/meshroom/nodes/aliceVision/PanoramaWarping.py
@@ -97,31 +97,4 @@ Compute the image warping for each input image in the panorama coordinate system
             value=desc.Node.internalFolder,
             uid=[],
         ),
-        desc.File(
-            name='warping',
-            label='Warping',
-            description='',
-            group='', # do not export on the command line
-            semantic='image',
-            value=desc.Node.internalFolder+'<VIEW_ID>.exr',
-            uid=[]
-        ),
-        desc.File(
-            name='mask',
-            label='Mask',
-            description='',
-            group='', # do not export on the command line
-            semantic='image',
-            value=desc.Node.internalFolder+'<VIEW_ID>_mask.exr',
-            uid=[]
-        ),
-        desc.File(
-            name='weight',
-            label='Weight',
-            description='',
-            group='', # do not export on the command line
-            semantic='image',
-            value=desc.Node.internalFolder+'<VIEW_ID>_weight.exr',
-            uid=[]
-        ),
     ]


### PR DESCRIPTION
## Description

Since [this PR](https://github.com/alicevision/AliceVision/pull/1244) was merged, the output images of the PanoramaWarping node are stored on disk as several tiles, and there is currently no system to support tiles in the 2D viewer.
Therefore, double-clicking on the PanoramaWarping node results in an empty 2D viewer.

This PR simply removes the image attributes from the node description, thus double-clicking the node won't have any effect. 