### PR TITLE
[ui] Viewer2D: fix displayed metadata

### DIFF
--- a/meshroom/ui/qml/Viewer/Viewer2D.qml
+++ b/meshroom/ui/qml/Viewer/Viewer2D.qml
@@ -43,6 +43,10 @@ FocusScope {
             if (floatImageViewerLoader.active) {
                 return floatImageViewerLoader.item.metadata;
             }
+            // Use viewpoint metadata for the special case of the 8-bit viewer
+            if (qtImageViewerLoader.active) {
+                return viewpointMetadata;
+            }
             return {};
         }
     }

--- a/meshroom/ui/qml/Viewer/Viewer2D.qml
+++ b/meshroom/ui/qml/Viewer/Viewer2D.qml
@@ -15,7 +15,6 @@ FocusScope {
     property url sourceExternal
 
     property url source
-    property var metadata
     property var viewIn3D
 
     property Component floatViewerComp: Qt.createComponent("FloatImage.qml")
@@ -30,24 +29,21 @@ FocusScope {
 
     QtObject {
         id: m
+        property variant viewpointMetadata: {
+            // Metadata from viewpoint attribute
+            // Read from the reconstruction object
+            if (_reconstruction) {
+                return getViewpointMetadata(_reconstruction.selectedViewId);
+            }
+            return {};
+        }
         property variant imgMetadata: {
-            // Use metadata from FloatImage viewer in priority
-            // since it directly reads them from the image file
-            if(floatImageViewerLoader.active)
-            {
-                return floatImageViewerLoader.item.metadata
+            // Metadata from FloatImage viewer
+            // Directly read from the image file on disk
+            if (floatImageViewerLoader.active) {
+                return floatImageViewerLoader.item.metadata;
             }
-
-            // I did not find a direct way to check if the map is empty or not...
-            var sfmHasImgMetadata = 0;
-            for(var key in root.metadata) { sfmHasImgMetadata = 1; break; }
-
-            if(sfmHasImgMetadata) // check if root.metadata is not empty
-            {
-                return root.metadata
-            }
-
-            return {}
+            return {};
         }
     }
 
@@ -105,7 +101,6 @@ FocusScope {
     function clear()
     {
         source = ''
-        metadata = {}
     }
 
     // slots
@@ -225,15 +220,6 @@ FocusScope {
         return getFileAttributePath(displayedNode, outputAttribute.name, _reconstruction ? _reconstruction.selectedViewId : -1);
     }
 
-    function getMetadata() {
-        // entry point for getting the image metadata
-        if (useExternal || !_reconstruction) {
-            return {};
-        } else {
-            return getViewpointMetadata(_reconstruction.selectedViewId);
-        }
-    }
-
     function getFileAttributePath(node, attrName, viewId) {
         // get output attribute with matching name
         // and parse its value to get the image filepath
@@ -275,10 +261,8 @@ FocusScope {
     }
 
     onDisplayedNodeChanged: {
-        // clear metadata if no displayed node
         if (!displayedNode) {
             root.source = "";
-            root.metadata = {};
         }
 
         // update output attribute names
@@ -296,14 +280,12 @@ FocusScope {
         outputAttribute.names = names;
 
         root.source = getImageFile();
-        root.metadata = getMetadata();
     }
 
     Connections {
         target: _reconstruction
         onSelectedViewIdChanged: {
             root.source = getImageFile();
-            root.metadata = getMetadata();
             if (useExternal)
                 useExternal = false;
         }
@@ -691,7 +673,17 @@ FocusScope {
 
                         visible: metadataCB.checked
                         // only load metadata model if visible
-                        metadata: visible ? m.imgMetadata : {}
+                        metadata: {
+                            if (visible) {
+                                if (root.useExternal || outputAttribute.name != "gallery") {
+                                    return m.imgMetadata;
+                                }
+                                else {
+                                    return m.viewpointMetadata;
+                                }
+                            }
+                            return {};
+                        }
                     }
 
                     ColorCheckerPane {
@@ -1169,7 +1161,6 @@ FocusScope {
 
                             onNameChanged: {
                                 root.source = getImageFile();
-                                root.metadata = getMetadata();
                             }
                         }
 

--- a/meshroom/ui/qml/Viewer/Viewer2D.qml
+++ b/meshroom/ui/qml/Viewer/Viewer2D.qml
@@ -31,6 +31,13 @@ FocusScope {
     QtObject {
         id: m
         property variant imgMetadata: {
+            // Use metadata from FloatImage viewer in priority
+            // since it directly reads them from the image file
+            if(floatImageViewerLoader.active)
+            {
+                return floatImageViewerLoader.item.metadata
+            }
+
             // I did not find a direct way to check if the map is empty or not...
             var sfmHasImgMetadata = 0;
             for(var key in root.metadata) { sfmHasImgMetadata = 1; break; }
@@ -40,10 +47,6 @@ FocusScope {
                 return root.metadata
             }
 
-            if(floatImageViewerLoader.active)
-            {
-                return floatImageViewerLoader.item.metadata
-            }
             return {}
         }
     }


### PR DESCRIPTION
## Description

When double-clicking on a node with image output attributes, even though the image shown is not the view itself, the metadata used are the viewpoint's metadata, taken from the CameraInit's sfm data.
This can lead to problems, for example with the orientation metadata: if the viewpoint and the image displayed have a different orientation, the image will appear flipped and/or rotated.

However, whenever we use the FloatImage viewer, the displayed image's metadata are available (directly loaded from disk using the aliceVision::image module).
Therefore the purpose of this PR is to use in priority the metadata retrieved by the FloatImage viewer when it is available.