### PR TITLE
Fix the documentation related to Panorama nodes

### DIFF
--- a/meshroom/nodes/aliceVision/LdrToHdrCalibration.py
+++ b/meshroom/nodes/aliceVision/LdrToHdrCalibration.py
@@ -31,7 +31,7 @@ class LdrToHdrCalibration(desc.AVCommandLineNode):
 
     category = 'Panorama HDR'
     documentation = '''
-    Calibrate LDR to HDR response curve from samples
+Calibrate LDR to HDR response curve from samples.
 '''
 
     inputs = [

--- a/meshroom/nodes/aliceVision/LdrToHdrCalibration.py
+++ b/meshroom/nodes/aliceVision/LdrToHdrCalibration.py
@@ -81,8 +81,7 @@ class LdrToHdrCalibration(desc.AVCommandLineNode):
                         " * Linear: Disable the calibration and assumes a linear Camera Response Function. If images are encoded in a known colorspace (like sRGB for JPEG), the images will be automatically converted to linear. \n"
                         " * Debevec: This is the standard method for HDR calibration. \n"
                         " * Grossberg: Based on learned database of cameras, it allows to reduce the CRF to few parameters while keeping all the precision. \n"
-                        " * Laguerre: Simple but robust method estimating the minimal number of parameters. \n"
-                        " * Robertson: First method for HDR calibration in the literature. \n",
+                        " * Laguerre: Simple but robust method estimating the minimal number of parameters.",
             values=['linear', 'debevec', 'grossberg', 'laguerre'],
             value='debevec',
             exclusive=True,

--- a/meshroom/nodes/aliceVision/LdrToHdrMerge.py
+++ b/meshroom/nodes/aliceVision/LdrToHdrMerge.py
@@ -30,7 +30,7 @@ class LdrToHdrMerge(desc.AVCommandLineNode):
 
     category = 'Panorama HDR'
     documentation = '''
-    Calibrate LDR to HDR response curve from samples
+Merge LDR images into HDR images.
 '''
 
     inputs = [

--- a/meshroom/nodes/aliceVision/LdrToHdrSampling.py
+++ b/meshroom/nodes/aliceVision/LdrToHdrSampling.py
@@ -47,7 +47,7 @@ class LdrToHdrSampling(desc.AVCommandLineNode):
 
     category = 'Panorama HDR'
     documentation = '''
-    Sample pixels from Low range images for HDR creation
+Sample pixels from Low range images for HDR creation.
 '''
 
     inputs = [

--- a/meshroom/nodes/aliceVision/LdrToHdrSampling.py
+++ b/meshroom/nodes/aliceVision/LdrToHdrSampling.py
@@ -90,8 +90,7 @@ class LdrToHdrSampling(desc.AVCommandLineNode):
                         " * Linear: Disable the calibration and assumes a linear Camera Response Function. If images are encoded in a known colorspace (like sRGB for JPEG), the images will be automatically converted to linear. \n"
                         " * Debevec: This is the standard method for HDR calibration. \n"
                         " * Grossberg: Based on learned database of cameras, it allows to reduce the CRF to few parameters while keeping all the precision. \n"
-                        " * Laguerre: Simple but robust method estimating the minimal number of parameters. \n"
-                        " * Robertson: First method for HDR calibration in the literature. \n",
+                        " * Laguerre: Simple but robust method estimating the minimal number of parameters.",
             values=['linear', 'debevec', 'grossberg', 'laguerre'],
             value='debevec',
             exclusive=True,

--- a/meshroom/nodes/aliceVision/PanoramaPostProcessing.py
+++ b/meshroom/nodes/aliceVision/PanoramaPostProcessing.py
@@ -13,8 +13,8 @@ class PanoramaPostProcessing(desc.CommandLineNode):
 
     category = 'Panorama HDR'
     documentation = '''
-    Post process the panorama
-    '''
+Post process the panorama.
+'''
 
     inputs = [
         desc.File(

--- a/meshroom/pipelines/panoramaFisheyeHdr.mg
+++ b/meshroom/pipelines/panoramaFisheyeHdr.mg
@@ -153,8 +153,8 @@
             }, 
             "nodeType": "PanoramaPostProcessing", 
             "position": [
-                3005, 
-                -19
+                3000,
+                0
             ]
         }, 
         "PanoramaPrepareImages_1": {

--- a/meshroom/pipelines/panoramaHdr.mg
+++ b/meshroom/pipelines/panoramaHdr.mg
@@ -149,7 +149,7 @@
             }, 
             "nodeType": "PanoramaPostProcessing", 
             "position": [
-                3007, 
+                3000,
                 0
             ]
         }, 


### PR DESCRIPTION
## Description

This PR updates the documentation strings of the `LdrToHdrSampling`, `LdrToHdrCalibration`, `LdrToHdrMerging` and `PanoramaPostProcessing` nodes so that they are both correct (in the case of the `LdrToHdrMerge` node) and displayed correctly. 

Prior to this PR, these nodes' documentation was displayed as
<div align="center"><img src="https://i.gyazo.com/c8f0c52a1e249858dd58aa608b3f8c99.png" width=300></div>
instead of 
<div align="center"><img src="https://i.gyazo.com/bdd2226418be2b09d54f2652bc54e7a6.png" width=300></div>

For the `LdrToHdrSampling` and `LdrToHdrCalibration` nodes, any references to Robertson have been removed from the description of the `calibrationMethod` attribute, as it is not an available value for it anymore.

Finally, the `PanoramaPostProcessing` nodes that are located at the end of the "Panorama HDR" and "Fisheye Panorama HDR" templates have been slightly moved so that they are perfectly aligned with the rest of the nodes.

## Features list

- [x] Fix display and update content of the documentation string for the `LdrToHdrSampling`, `LdrToHdrCalibration`, `LdrToHdrMerging` and `PanoramaPostProcessing` nodes;
- [x] Update the description of the `calibrationMethod` attribute for the `LdrToHdrSampling`, `LdrToHdrCalibration` nodes;
- [x] Align the `PanoramaPostProcessing` nodes in the templates with all the other nodes.


