### PR TITLE
[panorama] force pyramid levels count in compositing

### DIFF
--- a/meshroom/nodes/aliceVision/PanoramaCompositing.py
+++ b/meshroom/nodes/aliceVision/PanoramaCompositing.py
@@ -58,7 +58,7 @@ Multiple cameras are contributing to the low frequencies and only the best one c
         ),
         desc.IntParam(
             name='forceMinPyramidLevels',
-            label='Pyramid Levels',
+            label='Min Pyramid Levels',
             description='Force the minimal number of levels in the pyramid for multiband compositer.',
             value=0,
             range=(0, 16, 1),

--- a/meshroom/nodes/aliceVision/PanoramaCompositing.py
+++ b/meshroom/nodes/aliceVision/PanoramaCompositing.py
@@ -58,7 +58,7 @@ Multiple cameras are contributing to the low frequencies and only the best one c
         ),
         desc.IntParam(
             name='forceMinPyramidLevels',
-            label='Pyramid levels',
+            label='Pyramid Levels',
             description='Force the minimal number of levels in the pyramid for multiband compositer.',
             value=0,
             range=(0, 16, 1),

--- a/meshroom/nodes/aliceVision/PanoramaCompositing.py
+++ b/meshroom/nodes/aliceVision/PanoramaCompositing.py
@@ -57,9 +57,9 @@ Multiple cameras are contributing to the low frequencies and only the best one c
             uid=[0]
         ),
         desc.IntParam(
-            name='forcedLevelsCount',
+            name='forceMinPyramidLevels',
             label='Pyramid levels',
-            description='Force the number of levels in the pyramid for multiband compositer.',
+            description='Force the minimal number of levels in the pyramid for multiband compositer.',
             value=0,
             range=(0, 16, 1),
             uid=[0],

--- a/meshroom/nodes/aliceVision/PanoramaCompositing.py
+++ b/meshroom/nodes/aliceVision/PanoramaCompositing.py
@@ -61,7 +61,7 @@ Multiple cameras are contributing to the low frequencies and only the best one c
             label='Pyramid levels',
             description='Force the number of levels in the pyramid for multiband compositer.',
             value=0,
-            range=(0, 64, 1),
+            range=(0, 16, 1),
             uid=[0],
             enabled=lambda node: node.compositerType.value and node.compositerType.value == 'multiband',
         ),

--- a/meshroom/nodes/aliceVision/PanoramaCompositing.py
+++ b/meshroom/nodes/aliceVision/PanoramaCompositing.py
@@ -62,7 +62,7 @@ Multiple cameras are contributing to the low frequencies and only the best one c
             description='Force the number of levels in the pyramid for multiband compositer.',
             value=0,
             range=(0, 64, 1),
-            uid=[],
+            uid=[0],
             enabled=lambda node: node.compositerType.value and node.compositerType.value == 'multiband',
         ),
         desc.IntParam(

--- a/meshroom/nodes/aliceVision/PanoramaCompositing.py
+++ b/meshroom/nodes/aliceVision/PanoramaCompositing.py
@@ -57,6 +57,15 @@ Multiple cameras are contributing to the low frequencies and only the best one c
             uid=[0]
         ),
         desc.IntParam(
+            name='forcedLevelsCount',
+            label='Pyramid levels',
+            description='Force the number of levels in the pyramid for multiband compositer.',
+            value=0,
+            range=(0, 64, 1),
+            uid=[],
+            enabled=lambda node: node.compositerType.value and node.compositerType.value == 'multiband',
+        ),
+        desc.IntParam(
             name='maxThreads',
             label='Max Nb Threads',
             description='Specifies the maximum number of threads to run simultaneously.',


### PR DESCRIPTION
Add an option to manually set the number of pyramid levels in the laplacian compositing

Based on https://github.com/alicevision/AliceVision/pull/1369