### PR TITLE
Set GLTF as the default output format in Texturing

### DIFF
--- a/meshroom/nodes/aliceVision/Texturing.py
+++ b/meshroom/nodes/aliceVision/Texturing.py
@@ -74,7 +74,7 @@ Many cameras are contributing to the low frequencies and only the best ones cont
             name='outputMeshFileType',
             label='Mesh File Type',
             description='File Type',
-            value='obj',
+            value='gltf',
             values=('obj', 'gltf', 'fbx', 'stl'),
             exclusive=True,
             uid=[0],
@@ -329,7 +329,7 @@ Many cameras are contributing to the low frequencies and only the best ones cont
             name='outputMesh',
             label='Mesh',
             description='Output Mesh file.',
-            value=desc.Node.internalFolder + 'texturedMesh.{outputMeshFileTypeValue}',
+            value=desc.Node.internalFolder + 'texturedMesh.*', # gltf generates an additional .bin file
             uid=[],
             group='',
             ),


### PR DESCRIPTION
<!-- Checklist before submission:

 - I have read the [contribution guidelines](../CONTRIBUTING.md).
 - I have updated the documentation, if applicable.
 - I have ensured that the change is tested somewhere.
 - I have followed the prevailing code style (for history readability and limit conflicts for maintainance).

-->
## Description

This sets GLTF as the default output format in Texturing. It applies to the UI and built-in scripts like `meshroom_batch`.

## Features list

<!--
- [ ] Feature one. Fix #XXX
- [ ] Improve something else
- [ ] Connect to #3 (to declare link to issues without closing it when the PR is merged).
- [X] Add "X" when it is done.
-->


## Implementation remarks
Note that GLTF generates an additional .bin file.
For this, I had to include .* in the output file pattern. An alternative was to add an additional output parameter to be enabled only when GLTF is selected (like the MTL file). Also note that with this .* pattern, the MTL output is redundant.

<!--
Explain main implementation choices.
It is also the right place to ask for feedback and help when you hesitate on the implementation.
-->
