### PR TITLE
[pipelines] Panorama: Fix inputs of the "Publish" nodes

### DIFF
--- a/meshroom/pipelines/panoramaFisheyeHdr.mg
+++ b/meshroom/pipelines/panoramaFisheyeHdr.mg
@@ -241,7 +241,7 @@
             ],
             "inputs": {
                 "inputFiles": [
-                    "{ImageProcessing_1.outputImages}"
+                    "{PanoramaPostProcessing_1.outputPanorama}"
                 ]
             }
         }

--- a/meshroom/pipelines/panoramaHdr.mg
+++ b/meshroom/pipelines/panoramaHdr.mg
@@ -235,7 +235,7 @@
             ],
             "inputs": {
                 "inputFiles": [
-                    "{ImageProcessing_1.outputImages}"
+                    "{PanoramaPostProcessing_1.outputPanorama}"
                 ]
             }
         }


### PR DESCRIPTION
## Description

#1819 introduced a new node, `PanoramaPostProcessing`, that was added at the end of the Panorama templates to replace the `ImageProcessing` node. 

#1903 however added `Publish` nodes at the end of the Panorama templates with the pipelines using the `ImageProcessing` as a reference, which left us with templates that correctly used `PanoramaPostProcessing` instead of `ImageProcessing`, but expected the `Publish` node to be connected to the `ImageProcessing`'s output.

This PR correctly connects the `Publish` nodes to the `PanoramaPostProcessing` outputs.