### PR TITLE
Hide disabled File attributes and their connections

### DIFF
--- a/meshroom/core/attribute.py
+++ b/meshroom/core/attribute.py
@@ -251,7 +251,7 @@ class Attribute(BaseObject):
 
     @property
     def isLink(self):
-        """ Whether the attribute is a link to another attribute. """
+        """ Whether the input attribute is a link to another attribute. """
         # note: directly use self.node.graph._edges to avoid using the property that may become invalid at some point
         return self.node.graph and self.isInput and self.node.graph._edges and self in self.node.graph._edges.keys()
 

--- a/meshroom/ui/qml/GraphEditor/AttributeEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/AttributeEditor.qml
@@ -25,7 +25,7 @@ ListView {
     ScrollBar.vertical: ScrollBar { id: scrollBar }
 
     delegate: Loader {
-        active: object.enabled && (
+        active: (object.enabled || object.hasOutputConnections) && (
             !objectsHideable
             || ((!object.desc.advanced || GraphEditorSettings.showAdvancedAttributes)
             && (object.isDefault && GraphEditorSettings.showDefaultAttributes || !object.isDefault && GraphEditorSettings.showModifiedAttributes)

--- a/meshroom/ui/qml/GraphEditor/AttributeItemDelegate.qml
+++ b/meshroom/ui/qml/GraphEditor/AttributeItemDelegate.qml
@@ -66,7 +66,7 @@ RowLayout {
                 text: object.label
 
                 color: {
-                    if (object.hasOutputConnections && !object.enabled) return Colors.lightgrey
+                    if ((object.hasOutputConnections || object.isLink) && !object.enabled) return Colors.lightgrey
                     else return palette.text
                 }
 

--- a/meshroom/ui/qml/GraphEditor/AttributeItemDelegate.qml
+++ b/meshroom/ui/qml/GraphEditor/AttributeItemDelegate.qml
@@ -65,6 +65,11 @@ RowLayout {
 
                 text: object.label
 
+                color: {
+                    if (object.hasOutputConnections && !object.enabled) return "grey"
+                    else return "white"
+                }
+
                 // Tooltip hint with attribute's description
                 ToolTip {
                     id: parameterTooltip

--- a/meshroom/ui/qml/GraphEditor/AttributeItemDelegate.qml
+++ b/meshroom/ui/qml/GraphEditor/AttributeItemDelegate.qml
@@ -66,8 +66,8 @@ RowLayout {
                 text: object.label
 
                 color: {
-                    if (object.hasOutputConnections && !object.enabled) return "grey"
-                    else return "white"
+                    if (object.hasOutputConnections && !object.enabled) return Colors.lightgrey
+                    else return palette.text
                 }
 
                 // Tooltip hint with attribute's description

--- a/meshroom/ui/qml/GraphEditor/AttributePin.qml
+++ b/meshroom/ui/qml/GraphEditor/AttributePin.qml
@@ -201,7 +201,7 @@ RowLayout {
             anchors.right: attribute && attribute.isOutput ? parent.right : undefined
             rightPadding: 0
             color: {
-                if (object.hasOutputConnections && !object.enabled) return Colors.lightgrey
+                if ((object.hasOutputConnections || object.isLink) && !object.enabled) return Colors.lightgrey
                 return hovered ? palette.highlight : palette.text
             }
         }

--- a/meshroom/ui/qml/GraphEditor/AttributePin.qml
+++ b/meshroom/ui/qml/GraphEditor/AttributePin.qml
@@ -35,6 +35,16 @@ RowLayout {
     layoutDirection: Qt.LeftToRight
     spacing: 3
 
+    function updatePin(isSrc, isVisible)
+    {
+        if (isSrc) {
+            innerOutputAnchor.linkEnabled = isVisible
+        } else {
+            innerInputAnchor.linkEnabled = isVisible
+        }
+
+    }
+
     // Instantiate empty Items for each child attribute
     Repeater {
         id: childrenRepeater
@@ -59,7 +69,9 @@ RowLayout {
         color: Colors.sysPalette.base
 
         Rectangle {
-            visible: inputConnectMA.containsMouse || childrenRepeater.count > 0 || (attribute && attribute.isLink) || inputConnectMA.drag.active || inputDropArea.containsDrag
+            id: innerInputAnchor
+            property bool linkEnabled: true
+            visible: inputConnectMA.containsMouse || childrenRepeater.count > 0 || (attribute && attribute.isLink && linkEnabled) || inputConnectMA.drag.active || inputDropArea.containsDrag
             radius: isList ? 0 : 2
             anchors.fill: parent
             anchors.margins: 2
@@ -207,7 +219,9 @@ RowLayout {
         color: Colors.sysPalette.base
 
         Rectangle {
-            visible: attribute.hasOutputConnections || outputConnectMA.containsMouse || outputConnectMA.drag.active || outputDropArea.containsDrag
+            id: innerOutputAnchor
+            property bool linkEnabled: true
+            visible: (attribute.hasOutputConnections && linkEnabled) || outputConnectMA.containsMouse || outputConnectMA.drag.active || outputDropArea.containsDrag
             radius: isList ? 0 : 2
             anchors.fill: parent
             anchors.margins: 2

--- a/meshroom/ui/qml/GraphEditor/AttributePin.qml
+++ b/meshroom/ui/qml/GraphEditor/AttributePin.qml
@@ -200,7 +200,10 @@ RowLayout {
             horizontalAlignment: attribute && attribute.isOutput ? Text.AlignRight : Text.AlignLeft
             anchors.right: attribute && attribute.isOutput ? parent.right : undefined
             rightPadding: 0
-            color: hovered ? palette.highlight : palette.text
+            color: {
+                if (object.hasOutputConnections && !object.enabled) return "grey"
+                return hovered ? palette.highlight : palette.text
+            }
         }
     }
 
@@ -226,7 +229,7 @@ RowLayout {
             anchors.fill: parent
             anchors.margins: 2
             color: {
-                if (outputConnectMA.containsMouse || outputConnectMA.drag.active || (outputDropArea.containsDrag && outputDropArea.acceptableDrop))
+                if ((!object.hasOutputConnections && object.enabled) && outputConnectMA.containsMouse || outputConnectMA.drag.active || (outputDropArea.containsDrag && outputDropArea.acceptableDrop))
                     return Colors.sysPalette.highlight
                 return Colors.sysPalette.text
             }

--- a/meshroom/ui/qml/GraphEditor/AttributePin.qml
+++ b/meshroom/ui/qml/GraphEditor/AttributePin.qml
@@ -201,7 +201,7 @@ RowLayout {
             anchors.right: attribute && attribute.isOutput ? parent.right : undefined
             rightPadding: 0
             color: {
-                if (object.hasOutputConnections && !object.enabled) return "grey"
+                if (object.hasOutputConnections && !object.enabled) return Colors.lightgrey
                 return hovered ? palette.highlight : palette.text
             }
         }

--- a/meshroom/ui/qml/GraphEditor/GraphEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/GraphEditor.qml
@@ -383,7 +383,7 @@ Item {
                     property var src: root._attributeToDelegate[edge.src]
                     property var dst: root._attributeToDelegate[edge.dst]
                     property bool isValidEdge: src !== undefined && dst !== undefined
-                    visible: isValidEdge
+                    visible: isValidEdge && src.visible && dst.visible
 
                     property bool inFocus: containsMouse || (edgeMenu.opened && edgeMenu.currentEdge === edge)
 
@@ -406,6 +406,30 @@ Item {
                                 edgeMenu.popup()
                             }
                         }
+                    }
+                    onVisibleChanged: {
+                        if (visible) {
+                            // Enable the pins on both sides
+                            src.updatePin(true, true)  // isSrc = true, isVisible = true
+                            dst.updatePin(false, true)  // isSrc = false, isVisible = true
+                        } else {
+                            // One of the attributes is visible, we do not need to handle the case where both attributes are hidden
+                            if (isValidEdge && (src.visible || dst.visible)) {
+                                if (src.visible) {
+                                    src.updatePin(true, false)  // isSrc = true, isVisible = false
+                                } else {
+                                    dst.updatePin(false, false)  // isSrc = false, isVisible = false
+                                }
+                            }
+                        }
+                    }
+
+                    Component.onDestruction: {
+                        // Handles the case where the edge is destroyed while hidden because it is replaced: the pins should be re-enabled
+                        if (src && src !== undefined)
+                            src.updatePin(true, true)  // isSrc = true, isVisible = true
+                        if (dst && dst !== undefined)
+                            dst.updatePin(false, true)  // isSrc = false, isVisible = true
                     }
                 }
             }

--- a/meshroom/ui/qml/GraphEditor/Node.qml
+++ b/meshroom/ui/qml/GraphEditor/Node.qml
@@ -394,7 +394,7 @@ Item {
                                 delegate: Loader {
                                     id: outputLoader
                                     active: object.isOutput && isFileAttributeBaseType(object)
-                                    visible: object.enabled
+                                    visible: object.enabled || object.hasOutputConnections
                                     anchors.right: parent.right
                                     width: outputs.width
 

--- a/meshroom/ui/qml/GraphEditor/Node.qml
+++ b/meshroom/ui/qml/GraphEditor/Node.qml
@@ -487,6 +487,7 @@ Item {
                                     delegate: Loader {
                                         id: paramLoader
                                         active: !object.isOutput && !isFileAttributeBaseType(object)
+                                        visible: object.enabled || object.isLink || object.hasOutputConnections
                                         property bool isFullyActive: (m.displayParams || object.isLink || object.hasOutputConnections)
                                         width: parent.width
 

--- a/meshroom/ui/qml/GraphEditor/Node.qml
+++ b/meshroom/ui/qml/GraphEditor/Node.qml
@@ -387,12 +387,14 @@ Item {
                             id: outputs
                             width: parent.width
                             spacing: 3
+
                             Repeater {
                                 model: node ? node.attributes : undefined
 
                                 delegate: Loader {
                                     id: outputLoader
-                                    active: object.isOutput && isFileAttributeBaseType(object) && object.desc.visible
+                                    active: object.isOutput && isFileAttributeBaseType(object)
+                                    visible: object.enabled
                                     anchors.right: parent.right
                                     width: outputs.width
 
@@ -421,9 +423,11 @@ Item {
 
                             Repeater {
                                 model: node ? node.attributes : undefined
+
                                 delegate: Loader {
                                     id: inputLoader
                                     active: !object.isOutput && isFileAttributeBaseType(object)
+                                    visible: object.enabled
                                     width: inputs.width
 
                                     sourceComponent: AttributePin {


### PR DESCRIPTION
## Description

This PR effectively hides `File` attributes that are disabled. If these attributes have connections, the edges representing connections are hidden but preserved. 

- When the edges are hidden, if one of the connected attributes is still enabled, its pin becomes empty as if it was not connected to anything. If the disabled attribute is re-enabled and the connection has not been broken (if the enabled attribute on the other side of the edge has not been reconnected to another attribute, for example), the edge re-appears:
<div align="center"><img src="https://i.gyazo.com/c85dda91a99ac4390bffcac0ca4cf34a.gif" width=500></div>

- If the connection has been broken, then the attribute will re-appear as unconnected, as the edge has been removed:
<div align="center"><img src="https://i.gyazo.com/6cd2b0a2c90b3bfa1e4b71184c02734c.gif" width=500></div>

- Hidden connections are saved in project files in the same fashion as regular connections: no distinction is made between visible and hidden connections, only the `enabled` status of the connected attributes will determine whether they are hidden in the GraphEditor or not. When a project file containing some hidden attributes and connections is loaded, they are correctly taken into account and hidden.

- The list of the loaded node's viewable outputs in the 2D Viewer is updated accordingly: any attribute in the list that gets disabled will be automatically removed, and any disabled attribute that gets re-enabled will be added to it.

This PR also uncomments the conditional `enabled` status of some outputs in the DepthMap node.

## Features list

- [x] Hide the disabled File attributes in the GraphEditor and their connections, but preserve them;
- [x] Update the list of viewable outputs in the 2D Viewer depending on the loaded node's enabled outputs.

