### PR TITLE
[ui] Clear Images: Request a graph update after resetting the viewpoints and intrinsics

### DIFF
--- a/meshroom/ui/commands.py
+++ b/meshroom/ui/commands.py
@@ -370,9 +370,12 @@ class ClearImagesCommand(GraphCommand):
             # Reset viewpoints
             self.cameraInits[i].viewpoints.resetValue()
             self.cameraInits[i].viewpoints.valueChanged.emit()
+            self.cameraInits[i].viewpoints.requestGraphUpdate()
+
             # Reset intrinsics
             self.cameraInits[i].intrinsics.resetValue()
             self.cameraInits[i].intrinsics.valueChanged.emit()
+            self.cameraInits[i].intrinsics.requestGraphUpdate()
 
     def undoImpl(self):
         for cameraInit in self.viewpoints:


### PR DESCRIPTION
## Description

This PR fixes a bug introduced by #1897, which modified the way images were cleared. 

The viewpoints and intrinsics were correctly reset, but not followed by a request to update the graph. This meant that nodes' status was not updated (the cache for the CameraInit should be invalidated and propagated), and the filters in the Image Gallery were not all properly updated (in particular, the "Estimated Cameras" / "Non Estimated Cameras" were not reset.

A request to update the graph is now emitted after each attribute's reset. 