### PR TITLE
[nodes] ImageProcessing: Add and hide the fringing correction in the LCP

### DIFF
--- a/meshroom/nodes/aliceVision/ImageProcessing.py
+++ b/meshroom/nodes/aliceVision/ImageProcessing.py
@@ -132,6 +132,15 @@ Convert or apply filtering to the input images.
                 uid=[0],
                 enabled=lambda node: node.lensCorrection.lensCorrectionEnabled.value,
             ),
+            desc.BoolParam(
+                name='chromaticAberration',
+                label='Chromatic Aberration',
+                description='Chromatic aberration (fringing) correction if model parameters are available in metadata.',
+                value=False,
+                uid=[0],
+                enabled=False  # To replace with the line below when the correction of chromatic aberration will be available
+                # enabled=lambda node: node.lensCorrection.lensCorrectionEnabled.value
+            )
         ]),        
         desc.FloatParam(
             name='scaleFactor',


### PR DESCRIPTION
## Description

Add a parameter for the correction of chromatic aberrations in the LCP group but disable it. It will need to be re-enabled later on, when there will be a full support of the chromatic aberration correction.

This parameter is needed for the ImageProcessing binary on AliceVision's side to be properly executed.