### PR TITLE
[ui] Correctly update the Viewer 2D when there are temporary CameraInit nodes

### DIFF
--- a/meshroom/ui/qml/ImageGallery/ImageGallery.qml
+++ b/meshroom/ui/qml/ImageGallery/ImageGallery.qml
@@ -201,6 +201,10 @@ Panel {
             }
             onCurrentItemChanged: {
                 if (grid.updateSelectedViewFromGrid && grid.currentItem) {
+                    // If tempCameraInit is set and the first image in the GridView is selected, there has been a change of the CameraInit group and the viewId might be the same
+                    // Forcing the index to -1 before re-setting it will always cause a refresh on the Viewer2D's side, even if the viewId has not changed
+                    if (tempCameraInit !== null && grid.currentIndex == 0)
+                        _reconstruction.selectedViewId = -1
                     _reconstruction.selectedViewId = grid.currentItem.viewpoint.get("viewId").value
                 }
             }

--- a/meshroom/ui/reconstruction.py
+++ b/meshroom/ui/reconstruction.py
@@ -599,6 +599,9 @@ class Reconstruction(UIGraph):
         views, intrinsics = nodeDesc.readSfMData(sfmFile)
         tmpCameraInit = Node("CameraInit", viewpoints=views, intrinsics=intrinsics)
         self.tempCameraInit = tmpCameraInit
+        rootNode = self.graph.dfsOnFinish([node])[0][0]
+        if rootNode.nodeType == "CameraInit":
+            self.setCameraInitIndex(self._cameraInits.indexOf(rootNode))
 
     @Slot(QObject, result=QVector3D)
     def getAutoFisheyeCircle(self, panoramaInit):


### PR DESCRIPTION
## Description

This PR fixes an issue that appeared when switching between several temporary `CameraInit` nodes, which are used for example when enabling the "Visualize HDR Images" option: although the thumbnails in the Image Gallery were correctly updated, the 2D Viewer was not always updated with the newest selected item in the grid view, which caused a mismatch between what was shown in the Image Gallery and what was displayed in the 2D Viewer. 

There are two cases to switch between temporary `CameraInit` nodes: 
1.  By changing the active `CameraInit` group in the ImageGallery: changing the active group would not lead to any update of the 2D Viewer, while the thumbnails were always up-to-date. Indeed, if several `CameraInit` groups are available, and if the currently selected image in the grid view is the first one (index = 0), there is a possibility, depending on the input images, that the first images in two different groups are not identical but have the same view ID. If that happens, there will be no update of the 2D Viewer, as the selectedViewId property will not have been modified.
2. By setting another `LdrToHdrMerge` node as the active node: in that case, the thumbnails in the Image Gallery were updated but the 2D Viewer was not, no matter how many times the active `LdrToHdrMerge` node was changed. As the active `CameraInit` group remained the same, no update was triggered for the 2D Viewer. 

The proposed fixes are:
1. Resetting the selectedViewId property to -1 when there is a temporary CameraInit and the current index in the GridView is 0. This will trigger an update of the 2D Viewer even if the view ID is technically the same as before.
2. Updating the active `CameraInit` group when the active `LdrToHdrMerge` node changes. By updating the active CameraInit's index, not only will the Image Gallery display the newly selected `LdrToHdrMerge` thumbnails, but the 2D Viewer will also be updated to reflect the Gallery's selected thumbnail correctly. Information provided by the Gallery will also reflect its content, as the active group will correspond to the shown images, which was not the case before.


## Features list

- [X] Reset the selected view ID when changing the active `CameraInit` group if the active `CameraInit` is a temporary node;
- [X] Update the active CameraInit group when the active `LdrToHdrMerge` node is changed.

