### PR TITLE
Image Gallery: Add a menu to set the StructureFromMotion initial pair from the gallery

### DIFF
--- a/meshroom/nodes/aliceVision/StructureFromMotion.py
+++ b/meshroom/nodes/aliceVision/StructureFromMotion.py
@@ -318,14 +318,14 @@ It iterates like that, adding cameras and triangulating new 2D features into 3D 
         desc.File(
             name='initialPairA',
             label='Initial Pair A',
-            description='Filename of the first image (without path).',
+            description='View ID or filename of the first image (either with or without the full path).',
             value='',
             uid=[0],
         ),
         desc.File(
             name='initialPairB',
             label='Initial Pair B',
-            description='Filename of the second image (without path).',
+            description='View ID or filename of the second image (either with or without the full path).',
             value='',
             uid=[0],
         ),

--- a/meshroom/ui/qml/ImageGallery/ImageDelegate.qml
+++ b/meshroom/ui/qml/ImageGallery/ImageDelegate.qml
@@ -84,6 +84,22 @@ Item {
                 enabled: !root.readOnly && _viewpoint.viewId != -1 && _reconstruction && activeNode
                 onClicked: activeNode.attribute("transformation").value = _viewpoint.viewId.toString()
             }
+            Menu {
+                id: sfmSetPairMenu
+                title: "SfM: Define Initial Pair"
+                property var activeNode: _reconstruction ? _reconstruction.activeNodes.get("StructureFromMotion").node : null
+                enabled: !root.readOnly && _viewpoint.viewId != -1 && _reconstruction && activeNode
+
+                MenuItem {
+                    text: "A"
+                    onClicked: sfmSetPairMenu.activeNode.attribute("initialPairA").value = _viewpoint.viewId.toString()
+                }
+
+                MenuItem {
+                    text: "B"
+                    onClicked: sfmSetPairMenu.activeNode.attribute("initialPairB").value = _viewpoint.viewId.toString()
+                }
+            }
         }
 
         ColumnLayout {


### PR DESCRIPTION
## Description

This PR adds a "SfM: Define Initial Pair" menu in the Image Gallery, which allows the user to set the "Initial Pair A" and "Initial Pair B" parameters from the `StructureFromMotion` node with the currently selected image's view ID. 

The menu is only enabled if there is a `StructureFromMotion` node in the active group. 

<div align="center"><img src="https://i.gyazo.com/6d392b359b2c39b2da2fb63f5d530f70.png" width=250></div>

The description of the `initialPairA` and `initialPairB` parameters in the `StructureFromMotion` node is also updated with the list of accepted values for these parameters (filename, filepath, or view ID).