### PR TITLE
[ui] ImageGallery: Allow image drop if the active group is not computing

### DIFF
--- a/meshroom/ui/qml/ImageGallery/ImageGallery.qml
+++ b/meshroom/ui/qml/ImageGallery/ImageGallery.qml
@@ -39,7 +39,7 @@ Panel {
         property variant currentCameraInit: _reconstruction && _reconstruction.tempCameraInit ? _reconstruction.tempCameraInit : root.cameraInit
         property variant viewpoints: currentCameraInit ? currentCameraInit.attribute('viewpoints').value : undefined
         property variant intrinsics: currentCameraInit ? currentCameraInit.attribute('intrinsics').value : undefined
-        property bool readOnly: root.readOnly || displayHDR.checked
+        property bool readOnly: ((_reconstruction && currentCameraInit) ? currentCameraInit.locked : root.readOnly) || displayHDR.checked
 
         onViewpointsChanged: {
             ThumbnailCache.clearRequests()


### PR DESCRIPTION
## Description

This PR fixes the behaviour of the Image Gallery, which used to switch to read-only as soon as a node in the entire graph was being computed. This meant that no image could be dropped in the gallery if there was any ongoing computation, even if the nodes that were computed did not include or involve the active `CameraInit` node.

The computation status of the active `CameraInit` node is now taken into account when determining whether the Image Gallery should be read-only or not.


## Features list

- [x] Switch the Image Gallery to read-only if and only if the active `CameraInit` node is locked because of computations.
