### PR TITLE
[ui] Fix conditions on which the prompt asking the user to save a project before submitting it to the render farm relies

### DIFF
--- a/meshroom/ui/qml/main.qml
+++ b/meshroom/ui/qml/main.qml
@@ -184,17 +184,9 @@ ApplicationWindow {
 
         property bool warnIfUnsaved: true
 
-        // evaluate if global reconstruction computation can be started
-        property bool canStartComputation: _reconstruction ?
-                                           _reconstruction.viewpoints.count >= 2       // at least 2 images
-                                           && !_reconstruction.computing               // computation is not started
-                                           && _reconstruction.graph.canComputeLeaves : // graph has no uncomputable nodes
-                                           false
-
         // evaluate if graph computation can be submitted externally
         property bool canSubmit: _reconstruction ?
                                  _reconstruction.canSubmit                             // current setup allows to compute externally
-                                 && canStartComputation                                // can be computed
                                  && _reconstruction.graph.filepath :                   // graph is saved on disk
                                  false
 


### PR DESCRIPTION
## Description

This PR fixes an issue introduced by #1927, which aimed at displaying a warning pop-up whenever the user attempted to submit a project file that was not saved to the render farm. 

To do so, it relied on an already existing `canSubmit` variable, which itself depended on a `canStartComputation` variable that was not used anywhere else and was actually outdated.

In particular, the `canStartComputation` variable required to have more than one image for any computation to be allowed, and it was automatically set to false if there was any ongoing computation.  This was not compatible with what is expected of `canSubmit`, which should be set to true as soon as submitters are available and the project file is saved, independently from what is (or is not) being computed.

As a consequence, attempting to submit more than one computation to the render farm caused the warning pop-up to appear, even though the project file was correctly saved. 

With this PR, we remove `canStartComputation` which is now useless, and we fix the conditions on which the warning pop-up relies to appear or not.

## Features list

- [x] Remove unused and outdated `canStartComputation` variable;
- [x] Fix the conditions for the `canSubmit` variable, prompting the warning dialog if and only if the project file is not saved on disk.
