### PR TITLE
Display the changelog in the "About" dialog and update copyrights

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -16,7 +16,7 @@ sys.path.append(os.path.abspath(os.getenv('PROJECT_DIR')))
 sys.path.append(os.path.abspath('./_ext'))
 
 project = 'Meshroom'
-copyright = '2022, AliceVision Association'
+copyright = '2023, AliceVision Association'
 author = 'AliceVision Association'
 
 # -- General configuration ---------------------------------------------------

--- a/meshroom/ui/app.py
+++ b/meshroom/ui/app.py
@@ -416,6 +416,23 @@ class MeshroomApp(QApplication):
 
     systemInfo = Property(QJsonValue, _systemInfo, constant=True)
 
+    def _changelogModel(self):
+        """
+        Get the complete changelog for the application.
+        Model provides:
+            title: the name of the changelog
+            localUrl: the local path to CHANGES.md
+            onlineUrl: the remote path to CHANGES.md
+        """
+        rootDir = os.environ.get("MESHROOM_INSTALL_DIR", os.getcwd())
+        return [
+            {
+                "title": "Changelog",
+                "localUrl": os.path.join(rootDir, "CHANGES.md"),
+                "onlineUrl": "https://raw.githubusercontent.com/alicevision/meshroom/develop/CHANGES.md"
+            }
+        ]
+
     def _licensesModel(self):
         """
         Get info about open-source licenses for the application.
@@ -442,6 +459,7 @@ class MeshroomApp(QApplication):
         return bool(os.environ.get("MESHROOM_USE_8BIT_VIEWER", False))
 
 
+    changelogModel = Property("QVariantList", _changelogModel, constant=True)
     licensesModel = Property("QVariantList", _licensesModel, constant=True)
     pipelineTemplateFilesChanged = Signal()
     recentProjectFilesChanged = Signal()

--- a/meshroom/ui/qml/AboutDialog.qml
+++ b/meshroom/ui/qml/AboutDialog.qml
@@ -132,7 +132,7 @@ Dialog {
 
         // OpenSource licenses
         Label {
-             text: "Open Source Licenses"
+             text: "Changelog & Open Source Licenses"
              Layout.alignment: Qt.AlignHCenter
         }
 
@@ -142,7 +142,7 @@ Dialog {
             spacing: 2
             interactive: false
 
-            model: MeshroomApp.licensesModel
+            model: MeshroomApp.changelogModel.concat(MeshroomApp.licensesModel)
 
             // Exclusive ButtonGroup for licenses entries
             ButtonGroup { id: licensesGroup; exclusive: true }

--- a/meshroom/ui/qml/AboutDialog.qml
+++ b/meshroom/ui/qml/AboutDialog.qml
@@ -118,7 +118,7 @@ Dialog {
                 font.pointSize: 10
             }
             Label {
-                text: "2010-2022 AliceVision contributors"
+                text: "2010-2023 AliceVision contributors"
             }
         }
 


### PR DESCRIPTION
## Description

This PR does the following:
- Update all the copyrights dates from 2022 to 2023;
- Add Meshroom's changelog to the "About" dialog, along with the licenses. The changelog model is concatenated with the licenses model for display purposes, but is retrieved separately. 