### PR TITLE
[tests] TemplatesVersion: Add message when compatibility assertion is raised

### DIFF
--- a/tests/test_templatesVersion.py
+++ b/tests/test_templatesVersion.py
@@ -55,4 +55,4 @@ def test_templateVersions():
                         compatibilityIssue = CompatibilityIssue.DescriptionConflict
                         break
 
-            assert compatibilityIssue is None
+            assert compatibilityIssue is None, "{} in {} for node {}".format(compatibilityIssue, path, nodeType)


### PR DESCRIPTION
## Description

This PR adds a message when an assertion is raised because of compatibility issues in the test on templates' versions. 

If such a compatibility issue is found and the corresponding assertion is raised, a message is now displayed to indicate which template (with its path) and which node (with its node type) caused the issue.
