### PR TITLE
[nodes] KeyframeSelection: Add support for SfMData files as inputs and outputs

### DIFF
--- a/meshroom/nodes/aliceVision/KeyframeSelection.py
+++ b/meshroom/nodes/aliceVision/KeyframeSelection.py
@@ -1,4 +1,4 @@
-__version__ = "3.0"
+__version__ = "4.0"
 
 import os
 from meshroom.core import desc

--- a/meshroom/nodes/aliceVision/KeyframeSelection.py
+++ b/meshroom/nodes/aliceVision/KeyframeSelection.py
@@ -351,7 +351,8 @@ You can extract frames at regular interval by configuring only the min/maxFrameS
         desc.File(
             name="outputSfMDataFrames",
             label="Frames SfMData",
-            description="Output SfMData file containing all the frames that were not selected as keyframes.",
+            description="Output SfMData file containing all the frames that were not selected as keyframes.\n"
+                        "If the input contains videos, this file will not be written since all the frames that were not selected do not actually exist on disk.",
             value=desc.Node.internalFolder + "frames.sfm",
             uid=[]
         )

--- a/meshroom/nodes/aliceVision/KeyframeSelection.py
+++ b/meshroom/nodes/aliceVision/KeyframeSelection.py
@@ -18,15 +18,15 @@ You can extract frames at regular interval by configuring only the min/maxFrameS
     inputs = [
         desc.ListAttribute(
             elementDesc=desc.File(
-                name="mediaPath",
-                label="Media Path",
-                description="Media path.",
+                name="inputPath",
+                label="Input Path",
+                description="Input path.",
                 value="",
                 uid=[0],
             ),
-            name="mediaPaths",
-            label="Media Paths",
-            description="Input video files or image sequence directories.",
+            name="inputPaths",
+            label="Input Paths",
+            description="Input video files, image sequence directories or SfMData file.",
         ),
         desc.ListAttribute(
             elementDesc=desc.File(
@@ -341,5 +341,19 @@ You can extract frames at regular interval by configuring only the min/maxFrameS
             value=desc.Node.internalFolder,
             uid=[],
         ),
+        desc.File(
+            name="outputSfMDataKeyframes",
+            label="Keyframes SfMData",
+            description="Output SfMData file containing all the selected keyframes.",
+            value=desc.Node.internalFolder + "keyframes.sfm",
+            uid=[],
+        ),
+        desc.File(
+            name="outputSfMDataFrames",
+            label="Frames SfMData",
+            description="Output SfMData file containing all the frames that were not selected as keyframes.",
+            value=desc.Node.internalFolder + "frames.sfm",
+            uid=[]
+        )
     ]
 

--- a/meshroom/nodes/aliceVision/KeyframeSelection.py
+++ b/meshroom/nodes/aliceVision/KeyframeSelection.py
@@ -67,7 +67,7 @@ You can extract frames at regular interval by configuring only the min/maxFrameS
         ),
         desc.File(
             name="sensorDbPath",
-            label="Sensor Db Path",
+            label="Sensor Database",
             description="Camera sensor width database path.",
             value="${ALICEVISION_SENSOR_DB}",
             uid=[0],

--- a/meshroom/ui/reconstruction.py
+++ b/meshroom/ui/reconstruction.py
@@ -712,7 +712,7 @@ class Reconstruction(UIGraph):
         if filesByType.videos:
             boundingBox = self.layout.boundingBox()
             keyframeNode = self.addNewNode("KeyframeSelection", position=Position(boundingBox[0], boundingBox[1] + boundingBox[3]))
-            keyframeNode.mediaPaths.value = filesByType.videos
+            keyframeNode.inputPaths.value = filesByType.videos
             if len(filesByType.videos) == 1:
                 newVideoNodeMessage = "New node '{}' added for the input video.".format(keyframeNode.getLabel())
             else:


### PR DESCRIPTION
## Description

This PR is related to https://github.com/alicevision/AliceVision/pull/1406, and adds the support of `SfMData` files as inputs and outputs.

In particular:
- It adds two new output parameters, `outputSfMDataKeyframes` and `outputSfMDataFrames` which are `SfMData` files which respectively contain all the selected keyframes and all the input frames that were not selected as keyframes;
- It updates the description of the input `inputPaths` parameter to indicate the `SfMData` files are supported;
- It updates the label of the `sensorDbPath` parameter (trivial).


## Features list

- [x] Update input's description to include `SfMData` files;
- [x] Add new output parameters for `SfMData` files.