### PR TITLE
Node to split reconstructed and not reconstructed cameras

### DIFF
--- a/meshroom/nodes/aliceVision/SfMSplitReconstructed.py
+++ b/meshroom/nodes/aliceVision/SfMSplitReconstructed.py
@@ -1,8 +1,6 @@
-__version__ = "2.0"
+__version__ = "1.0"
 
 from meshroom.core import desc
-
-import os.path
 
 
 class SfMSplitReconstructed(desc.AVCommandLineNode):
@@ -11,6 +9,9 @@ class SfMSplitReconstructed(desc.AVCommandLineNode):
 
     category = 'Utils'
     documentation = '''
+    This nodes takes a sfmData file and split it in two
+    - One sfmData with the reconstructed views
+    - One sfmData with the non reconstructed views
 '''
 
     inputs = [

--- a/meshroom/nodes/aliceVision/SfMSplitReconstructed.py
+++ b/meshroom/nodes/aliceVision/SfMSplitReconstructed.py
@@ -1,0 +1,50 @@
+__version__ = "2.0"
+
+from meshroom.core import desc
+
+import os.path
+
+
+class SfMSplitReconstructed(desc.AVCommandLineNode):
+    commandLine = 'aliceVision_sfmSplitReconstructed {allParams}'
+    size = desc.DynamicNodeSize('input')
+
+    category = 'Utils'
+    documentation = '''
+'''
+
+    inputs = [
+        desc.File(
+            name='input',
+            label='Input',
+            description='''SfMData file .''',
+            value='',
+            uid=[0],
+        ),
+        desc.ChoiceParam(
+            name='verboseLevel',
+            label='Verbose Level',
+            description='''verbosity level (fatal, error, warning, info, debug, trace).''',
+            value='info',
+            values=['fatal', 'error', 'warning', 'info', 'debug', 'trace'],
+            exclusive=True,
+            uid=[],
+        ),
+    ]
+
+    outputs = [
+        desc.File(
+            name='reconstructedOutput',
+            label='Reconstructed SfMData File',
+            description='SfMData file with reconstructed cameras',
+            value=desc.Node.internalFolder + 'sfmReconstructed.abc',
+            uid=[],
+        ),
+        desc.File(
+            name='notReconstructedOutput',
+            label='Not Reconstructed SfMData File',
+            description='SfMData file with non reconstructed cameras',
+            value=desc.Node.internalFolder + 'sfmNonReconstructed.abc',
+            uid=[],
+        )
+    ]


### PR DESCRIPTION
Take an input sfmdata

- Create 1 sfmdata with reconstructed views only (and landmarks)
- Create 1 sfmdata with non reconstructed views only (without landmarks)

TCSR-305
see https://github.com/alicevision/AliceVision/pull/1409