### PR TITLE
StructureFromMotion: Add new inputs parameters

### DIFF
--- a/meshroom/nodes/aliceVision/StructureFromMotion.py
+++ b/meshroom/nodes/aliceVision/StructureFromMotion.py
@@ -1,4 +1,4 @@
-__version__ = "2.0"
+__version__ = "3.0"
 
 from meshroom.core import desc
 
@@ -168,6 +168,27 @@ It iterates like that, adding cameras and triangulating new 2D features into 3D 
             range=(2, 10, 1),
             uid=[0],
             advanced=True,
+        ),
+        desc.IntParam(
+            name='nbFirstUnstableCameras',
+            label='First Unstable Cameras Nb',
+            description='Number of cameras for which the bundle adjustment is performed every single time a camera is added.\n'
+                        'This leads to more stable results while computations are not too expensive, as there is little data.\n'
+                        'Past this number, the bundle adjustment will only be performed once for N added cameras.',
+            value=30,
+            range=(1, 100, 1),
+            uid=[0],
+            advanced=True
+        ),
+        desc.IntParam(
+            name='maxImagesPerGroup',
+            label='Max Images Per Group',
+            description='Maximum number of cameras that can be added before the bundle adjustment has to be performed again.\n'
+                        'This prevents adding too much data at once without performing the bundle adjustment.',
+            value=30,
+            range=(1, 100, 1),
+            uid=[0],
+            advanced=True
         ),
         desc.IntParam(
             name='maxNumberOfMatches',

--- a/meshroom/pipelines/cameraTracking.mg
+++ b/meshroom/pipelines/cameraTracking.mg
@@ -11,7 +11,7 @@
             "CameraInit": "9.0", 
             "ImageMatching": "2.0", 
             "FeatureExtraction": "1.1", 
-            "StructureFromMotion": "2.0",
+            "StructureFromMotion": "3.0",
             "Publish": "1.2"
         }
     }, 

--- a/meshroom/pipelines/photogrammetry.mg
+++ b/meshroom/pipelines/photogrammetry.mg
@@ -10,7 +10,7 @@
             "Texturing": "6.0", 
             "PrepareDenseScene": "3.0", 
             "DepthMap": "3.0", 
-            "StructureFromMotion": "2.0", 
+            "StructureFromMotion": "3.0",
             "CameraInit": "9.0", 
             "ImageMatching": "2.0", 
             "FeatureExtraction": "1.1", 

--- a/meshroom/pipelines/photogrammetryAndCameraTracking.mg
+++ b/meshroom/pipelines/photogrammetryAndCameraTracking.mg
@@ -12,7 +12,7 @@
             "ImageMatchingMultiSfM": "1.0", 
             "ImageMatching": "2.0", 
             "FeatureExtraction": "1.1", 
-            "StructureFromMotion": "2.0",
+            "StructureFromMotion": "3.0",
             "Publish": "1.2"
         }
     }, 

--- a/meshroom/pipelines/photogrammetryDraft.mg
+++ b/meshroom/pipelines/photogrammetryDraft.mg
@@ -4,7 +4,7 @@
             "FeatureMatching": "2.0", 
             "MeshFiltering": "3.0", 
             "Texturing": "6.0", 
-            "StructureFromMotion": "2.0", 
+            "StructureFromMotion": "3.0",
             "CameraInit": "9.0", 
             "ImageMatching": "2.0", 
             "FeatureExtraction": "1.1", 


### PR DESCRIPTION
## Description 

Add two new input parameters to the `StructureFromMotion` node:
- `nbFirstUnstableCameras` which sets the number of cameras for which a bundle adjustment is performed every time a camera is added;
- `maxImagesPerGroup` which sets the maximum number of cameras that can be added before the bundle adjustment has to be performed again.

By default, the bundle adjustment will be performed every time one of the first 30 cameras is added, as computations are not too expensive while there are few cameras. Past that number, the bundle adjustment will only be performed when up to 30 cameras have been added.

The node's version and the templates using the `StructureFromMotion` node are updated accordingly.

Related AliceVision pull request: https://github.com/alicevision/AliceVision/pull/1413