### PR TITLE
[nodes] Distortion calibration

### DIFF
--- a/meshroom/nodes/aliceVision/ApplyCalibration.py
+++ b/meshroom/nodes/aliceVision/ApplyCalibration.py
@@ -31,8 +31,8 @@ Overwrite intrinsics with a calibrated intrinsic.
     outputs = [
         desc.File(
             name='output',
-            label='SfMData File.',
-            description='Path to the output sfmData file.',
+            label='SfMData File',
+            description='Path to the output SfMData file.',
             value=desc.Node.internalFolder + 'sfmData.sfm',
             uid=[],
         ),

--- a/meshroom/nodes/aliceVision/ApplyCalibration.py
+++ b/meshroom/nodes/aliceVision/ApplyCalibration.py
@@ -1,0 +1,38 @@
+__version__ = "1.0"
+
+from meshroom.core import desc
+
+class ApplyCalibration(desc.AVCommandLineNode):
+    commandLine = 'aliceVision_applyCalibration {allParams}'
+
+    category = 'Utils'
+    documentation = '''
+Overwrite intrinsics with a calibrated intrinsic.
+'''
+
+    inputs = [
+        desc.File(
+            name='input',
+            label='Input SfMData',
+            description='SfMData file.',
+            value='',
+            uid=[0],
+        ),
+        desc.File(
+            name='calibration',
+            label='Calibration',
+            description='Calibration SfMData file.',
+            value='',
+            uid=[0],
+        ),
+    ]
+
+    outputs = [
+        desc.File(
+            name='output',
+            label='SfMData File.',
+            description='Path to the output sfmData file.',
+            value=desc.Node.internalFolder + 'sfmData.sfm',
+            uid=[],
+        ),
+    ]

--- a/meshroom/nodes/aliceVision/ApplyCalibration.py
+++ b/meshroom/nodes/aliceVision/ApplyCalibration.py
@@ -4,6 +4,7 @@ from meshroom.core import desc
 
 class ApplyCalibration(desc.AVCommandLineNode):
     commandLine = 'aliceVision_applyCalibration {allParams}'
+    size = desc.DynamicNodeSize('input')
 
     category = 'Utils'
     documentation = '''

--- a/meshroom/nodes/aliceVision/CameraInit.py
+++ b/meshroom/nodes/aliceVision/CameraInit.py
@@ -89,12 +89,12 @@ Intrinsic = [
             name="distortionParams",
             elementDesc=desc.FloatParam(name="p", label="", description="", value=0.0, uid=[0], range=(-0.1, 0.1, 0.01)),
             label="Distortion Params",
-            description="Distortion Parameters",
+            description="Distortion parameters.",
         ),
     desc.GroupAttribute(
             name="undistortionOffset",
             label="Undistortion Offset",
-            description="Undistortion Offset",
+            description="Undistortion offset.",
             groupDesc=[
                 desc.FloatParam(name="x", label="x", description="", value=0.0, uid=[0], range=(0.0, 10000.0, 1.0)),
                 desc.FloatParam(name="y", label="y", description="", value=0.0, uid=[0], range=(0.0, 10000.0, 1.0)),
@@ -104,7 +104,7 @@ Intrinsic = [
             name="undistortionParams",
             elementDesc=desc.FloatParam(name="p", label="", description="", value=0.0, uid=[0], range=(-0.1, 0.1, 0.01)),
             label="Undistortion Params",
-            description="Undistortion Parameters"
+            description="Undistortion parameters."
         ),
     desc.BoolParam(name='locked', label='Locked',
                    description='If the camera has been calibrated, the internal camera parameters (intrinsics) can be locked. It should improve robustness and speedup the reconstruction.',

--- a/meshroom/nodes/aliceVision/CameraInit.py
+++ b/meshroom/nodes/aliceVision/CameraInit.py
@@ -91,7 +91,21 @@ Intrinsic = [
             label="Distortion Params",
             description="Distortion Parameters",
         ),
-
+    desc.GroupAttribute(
+            name="undistortionOffset",
+            label="Undistortion Offset",
+            description="Undistortion Offset",
+            groupDesc=[
+                desc.FloatParam(name="x", label="x", description="", value=0.0, uid=[0], range=(0.0, 10000.0, 1.0)),
+                desc.FloatParam(name="y", label="y", description="", value=0.0, uid=[0], range=(0.0, 10000.0, 1.0)),
+            ]
+        ),
+    desc.ListAttribute(
+            name="undistortionParams",
+            elementDesc=desc.FloatParam(name="p", label="", description="", value=0.0, uid=[0], range=(-0.1, 0.1, 0.01)),
+            label="Undistortion Params",
+            description="Undistortion Parameters"
+        ),
     desc.BoolParam(name='locked', label='Locked',
                    description='If the camera has been calibrated, the internal camera parameters (intrinsics) can be locked. It should improve robustness and speedup the reconstruction.',
                    value=False, uid=[0]),
@@ -122,6 +136,14 @@ def readSfMData(sfmFile):
         # convert empty string distortionParams (i.e: Pinhole model) to empty list
         if intrinsic['distortionParams'] == '':
             intrinsic['distortionParams'] = list()
+
+        offset = intrinsic['undistortionOffset']
+        intrinsic['undistortionOffset'] = {}
+        intrinsic['undistortionOffset']['x'] = offset[0]
+        intrinsic['undistortionOffset']['y'] = offset[1]
+
+        if intrinsic['undistortionParams'] == '':
+            intrinsic['undistortionParams'] = list()
 
     viewsKeys = [v.name for v in Viewpoint]
     views = [{k: v for k, v in item.items() if k in viewsKeys} for item in data.get("views", [])]
@@ -411,6 +433,7 @@ The metadata needed are:
             intrinsics = node.intrinsics.getPrimitiveValue(exportDefault=True)
             for intrinsic in intrinsics:
                 intrinsic['principalPoint'] = [intrinsic['principalPoint']['x'], intrinsic['principalPoint']['y']]
+                intrinsic['undistortionOffset'] = [intrinsic['undistortionOffset']['x'], intrinsic['undistortionOffset']['y']]
             views = node.viewpoints.getPrimitiveValue(exportDefault=False)
 
             # convert the metadata string into a map

--- a/meshroom/nodes/aliceVision/DistortionCalibration.py
+++ b/meshroom/nodes/aliceVision/DistortionCalibration.py
@@ -16,16 +16,25 @@ Calibration of a camera/lens couple distortion using a full screen checkerboard.
         desc.File(
             name='input',
             label='SfmData',
-            description='SfmData File',
+            description='SfmData File.',
             value='',
             uid=[0],
         ),
         desc.File(
             name='checkerboards',
             label='Checkerboards folder',
-            description='Folder containing checkerboard JSON files',
+            description='Folder containing checkerboard JSON files.',
             value='',
-            uid=[0]
+            uid=[0],
+        ),
+        desc.ChoiceParam(
+            name='cameraModel',
+            label='Camera Model',
+            description='Camera model used to estimate distortion.',
+            value='3deanamorphic4',
+            values=['3deanamorphic4'],
+            exclusive=True,
+            uid=[0],
         ),
     ]
 
@@ -33,7 +42,7 @@ Calibration of a camera/lens couple distortion using a full screen checkerboard.
         desc.File(
             name='outSfMData',
             label='SfmData File',
-            description='Path to the output sfmData file',
+            description='Path to the output sfmData file.',
             value=desc.Node.internalFolder + 'sfmData.sfm',
             uid=[],
         )

--- a/meshroom/nodes/aliceVision/DistortionCalibration.py
+++ b/meshroom/nodes/aliceVision/DistortionCalibration.py
@@ -40,7 +40,7 @@ Calibration of a camera/lens couple distortion using a full screen checkerboard.
 
     outputs = [
         desc.File(
-            name='outSfMData',
+            name='output',
             label='SfmData File',
             description='Path to the output sfmData file.',
             value=desc.Node.internalFolder + 'sfmData.sfm',

--- a/meshroom/nodes/aliceVision/DistortionCalibration.py
+++ b/meshroom/nodes/aliceVision/DistortionCalibration.py
@@ -15,14 +15,14 @@ Calibration of a camera/lens couple distortion using a full screen checkerboard.
     inputs = [
         desc.File(
             name='input',
-            label='SfmData',
-            description='SfmData File.',
+            label='Input SfMData',
+            description='SfMData file.',
             value='',
             uid=[0],
         ),
         desc.File(
             name='checkerboards',
-            label='Checkerboards folder',
+            label='Checkerboards Folder',
             description='Folder containing checkerboard JSON files.',
             value='',
             uid=[0],
@@ -41,8 +41,8 @@ Calibration of a camera/lens couple distortion using a full screen checkerboard.
     outputs = [
         desc.File(
             name='output',
-            label='SfmData File',
-            description='Path to the output sfmData file.',
+            label='SfMData File',
+            description='Path to the output SfMData file.',
             value=desc.Node.internalFolder + 'sfmData.sfm',
             uid=[],
         )

--- a/meshroom/nodes/aliceVision/DistortionCalibration.py
+++ b/meshroom/nodes/aliceVision/DistortionCalibration.py
@@ -1,4 +1,4 @@
-__version__ = '2.0'
+__version__ = '3.0'
 
 from meshroom.core import desc
 
@@ -7,8 +7,9 @@ class DistortionCalibration(desc.AVCommandLineNode):
     commandLine = 'aliceVision_distortionCalibration {allParams}'
     size = desc.DynamicNodeSize('input')
 
+    category = 'Other'
     documentation = '''
-    Calibration of a camera/lens couple distortion using a full screen checkerboard
+Calibration of a camera/lens couple distortion using a full screen checkerboard.
 '''
 
     inputs = [
@@ -19,26 +20,12 @@ class DistortionCalibration(desc.AVCommandLineNode):
             value='',
             uid=[0],
         ),
-        desc.ListAttribute(
-            elementDesc=desc.File(
-                name='lensGridImage',
-                label='Lens Grid Image',
-                description='',
-                value='',
-                uid=[0],
-            ),
-            name='lensGrid',
-            label='Lens Grid Images',
-            description='Lens grid images to estimate the optical distortions.',
-        ),
-        desc.ChoiceParam(
-            name='verboseLevel',
-            label='Verbose Level',
-            description='Verbosity level (fatal, error, warning, info, debug, trace).',
-            value='info',
-            values=['fatal', 'error', 'warning', 'info', 'debug', 'trace'],
-            exclusive=True,
-            uid=[],
+        desc.File(
+            name='checkerboards',
+            label='Checkerboards folder',
+            description='Folder containing checkerboard JSON files',
+            value='',
+            uid=[0]
         ),
     ]
 

--- a/meshroom/nodes/aliceVision/ExportDistortion.py
+++ b/meshroom/nodes/aliceVision/ExportDistortion.py
@@ -28,4 +28,22 @@ Export the distortion model and parameters of cameras in a SfM scene.
             value=desc.Node.internalFolder,
             uid=[],
         ),
+        desc.File(
+            name='distoStMap',
+            label='Distortion ST Map',
+            description='Calibrated distortion ST map.',
+            semantic='image',
+            value=desc.Node.internalFolder + '<INTRINSIC_ID>_distort.exr',
+            group='',  # do not export on the command line
+            uid=[],
+        ),
+        desc.File(
+            name='undistoStMap',
+            label='Undistortion ST Map',
+            description='Calibrated undistortion ST map.',
+            semantic='image',
+            value=desc.Node.internalFolder + '<INTRINSIC_ID>_undistort.exr',
+            group='',  # do not export on the command line
+            uid=[],
+        ),
     ]

--- a/meshroom/nodes/aliceVision/ExportDistortion.py
+++ b/meshroom/nodes/aliceVision/ExportDistortion.py
@@ -24,7 +24,7 @@ Export the distortion model and parameters of cameras in a SfM scene.
         desc.File(
             name='output',
             label='Folder',
-            description='',
+            description='Output folder.',
             value=desc.Node.internalFolder,
             uid=[],
         ),

--- a/meshroom/nodes/aliceVision/ExportDistortion.py
+++ b/meshroom/nodes/aliceVision/ExportDistortion.py
@@ -1,0 +1,31 @@
+__version__ = "1.0"
+
+from meshroom.core import desc
+
+class ExportDistortion(desc.AVCommandLineNode):
+    commandLine = 'aliceVision_exportDistortion {allParams}'
+
+    category = 'Export'
+    documentation = '''
+Export the distortion model and parameters of cameras in a SfM scene.
+'''
+
+    inputs = [
+        desc.File(
+            name='input',
+            label='Input SfMData',
+            description='SfMData file.',
+            value='',
+            uid=[0],
+        ),
+    ]
+
+    outputs = [
+        desc.File(
+            name='output',
+            label='Folder',
+            description='',
+            value=desc.Node.internalFolder,
+            uid=[],
+        ),
+    ]

--- a/meshroom/pipelines/cameraTracking.mg
+++ b/meshroom/pipelines/cameraTracking.mg
@@ -1,105 +1,94 @@
 {
     "header": {
-        "pipelineVersion": "2.2", 
-        "releaseVersion": "2023.1.0",
-        "fileVersion": "1.1", 
-        "template": true, 
+        "pipelineVersion": "2.2",
+        "releaseVersion": "2023.2.0-develop",
+        "fileVersion": "1.1",
+        "template": true,
         "nodesVersions": {
-            "ExportAnimatedCamera": "2.0", 
-            "FeatureMatching": "2.0", 
-            "DistortionCalibration": "2.0", 
-            "CameraInit": "9.0", 
-            "ImageMatching": "2.0", 
-            "FeatureExtraction": "1.1", 
+            "ExportAnimatedCamera": "2.0",
+            "Publish": "1.2",
             "StructureFromMotion": "3.0",
-            "Publish": "1.2"
+            "FeatureExtraction": "1.1",
+            "FeatureMatching": "2.0",
+            "CameraInit": "9.0",
+            "ImageMatching": "2.0"
         }
-    }, 
+    },
     "graph": {
-        "DistortionCalibration_1": {
-            "inputs": {
-                "input": "{CameraInit_1.output}"
-            }, 
-            "nodeType": "DistortionCalibration", 
-            "position": [
-                200, 
-                160
-            ]
-        }, 
         "ImageMatching_1": {
+            "nodeType": "ImageMatching",
+            "position": [
+                400,
+                0
+            ],
             "inputs": {
-                "nbNeighbors": 10, 
-                "nbMatches": 5, 
-                "input": "{FeatureExtraction_1.input}", 
+                "input": "{FeatureExtraction_1.input}",
                 "featuresFolders": [
                     "{FeatureExtraction_1.output}"
-                ]
-            }, 
-            "nodeType": "ImageMatching", 
-            "position": [
-                400, 
-                0
-            ]
-        }, 
+                ],
+                "nbMatches": 5,
+                "nbNeighbors": 10
+            }
+        },
         "FeatureExtraction_1": {
+            "nodeType": "FeatureExtraction",
+            "position": [
+                200,
+                0
+            ],
             "inputs": {
                 "input": "{CameraInit_1.output}"
-            }, 
-            "nodeType": "FeatureExtraction", 
-            "position": [
-                200, 
-                0
-            ]
-        }, 
+            }
+        },
         "StructureFromMotion_1": {
+            "nodeType": "StructureFromMotion",
+            "position": [
+                800,
+                0
+            ],
             "inputs": {
-                "minAngleForLandmark": 0.5, 
-                "minNumberOfObservationsForTriangulation": 3, 
-                "describerTypes": "{FeatureMatching_1.describerTypes}", 
-                "input": "{FeatureMatching_1.input}", 
-                "featuresFolders": "{FeatureMatching_1.featuresFolders}", 
+                "input": "{FeatureMatching_1.input}",
+                "featuresFolders": "{FeatureMatching_1.featuresFolders}",
                 "matchesFolders": [
                     "{FeatureMatching_1.output}"
-                ], 
-                "minInputTrackLength": 5, 
-                "minAngleForTriangulation": 1.0
-            }, 
-            "nodeType": "StructureFromMotion", 
-            "position": [
-                800, 
-                0
-            ]
-        }, 
+                ],
+                "describerTypes": "{FeatureMatching_1.describerTypes}",
+                "minInputTrackLength": 5,
+                "minNumberOfObservationsForTriangulation": 3,
+                "minAngleForTriangulation": 1.0,
+                "minAngleForLandmark": 0.5
+            }
+        },
         "ExportAnimatedCamera_1": {
+            "nodeType": "ExportAnimatedCamera",
+            "position": [
+                1000,
+                0
+            ],
             "inputs": {
                 "input": "{StructureFromMotion_1.output}"
-            }, 
-            "nodeType": "ExportAnimatedCamera", 
-            "position": [
-                1000, 
-                0
-            ]
-        }, 
+            }
+        },
         "CameraInit_1": {
-            "inputs": {}, 
-            "nodeType": "CameraInit", 
+            "nodeType": "CameraInit",
             "position": [
-                0, 
+                0,
                 0
-            ]
-        }, 
+            ],
+            "inputs": {}
+        },
         "FeatureMatching_1": {
-            "inputs": {
-                "describerTypes": "{FeatureExtraction_1.describerTypes}", 
-                "imagePairsList": "{ImageMatching_1.output}", 
-                "input": "{DistortionCalibration_1.outSfMData}", 
-                "featuresFolders": "{ImageMatching_1.featuresFolders}"
-            }, 
-            "nodeType": "FeatureMatching", 
+            "nodeType": "FeatureMatching",
             "position": [
-                600, 
+                600,
                 0
-            ]
+            ],
+            "inputs": {
+                "input": "{ImageMatching_1.input}",
+                "featuresFolders": "{ImageMatching_1.featuresFolders}",
+                "imagePairsList": "{ImageMatching_1.output}",
+                "describerTypes": "{FeatureExtraction_1.describerTypes}"
+            }
         },
         "Publish_1": {
             "nodeType": "Publish",

--- a/meshroom/pipelines/distortionCalibration.mg
+++ b/meshroom/pipelines/distortionCalibration.mg
@@ -1,0 +1,69 @@
+{
+    "header": {
+        "pipelineVersion": "2.2",
+        "releaseVersion": "2023.2.0-develop",
+        "fileVersion": "1.1",
+        "template": true,
+        "nodesVersions": {
+            "Publish": "1.2",
+            "ExportDistortion": "1.0",
+            "CameraInit": "9.0",
+            "CheckerboardDetection": "1.0",
+            "DistortionCalibration": "3.0"
+        }
+    },
+    "graph": {
+        "CheckerboardDetection_1": {
+            "nodeType": "CheckerboardDetection",
+            "position": [
+                200,
+                0
+            ],
+            "inputs": {
+                "input": "{CameraInit_1.output}",
+                "exportDebugImages": true
+            }
+        },
+        "DistortionCalibration_1": {
+            "nodeType": "DistortionCalibration",
+            "position": [
+                400,
+                0
+            ],
+            "inputs": {
+                "input": "{CheckerboardDetection_1.input}",
+                "checkerboards": "{CheckerboardDetection_1.output}"
+            }
+        },
+        "ExportDistortion_1": {
+            "nodeType": "ExportDistortion",
+            "position": [
+                600,
+                0
+            ],
+            "inputs": {
+                "input": "{DistortionCalibration_1.output}"
+            }
+        },
+        "Publish_1": {
+            "nodeType": "Publish",
+            "position": [
+                800,
+                0
+            ],
+            "inputs": {
+                "inputFiles": [
+                    "{ExportDistortion_1.output}"
+                ]
+            }
+        },
+        "CameraInit_1": {
+            "nodeType": "CameraInit",
+            "position": [
+                0,
+                0
+            ],
+            "inputs": {}
+        }
+    }
+}

--- a/meshroom/pipelines/photogrammetryAndCameraTracking.mg
+++ b/meshroom/pipelines/photogrammetryAndCameraTracking.mg
@@ -1,167 +1,106 @@
 {
     "header": {
-        "pipelineVersion": "2.2", 
-        "releaseVersion": "2023.1.0",
-        "fileVersion": "1.1", 
-        "template": true, 
+        "pipelineVersion": "2.2",
+        "releaseVersion": "2023.2.0-develop",
+        "fileVersion": "1.1",
+        "template": true,
         "nodesVersions": {
-            "ExportAnimatedCamera": "2.0", 
-            "FeatureMatching": "2.0", 
-            "DistortionCalibration": "2.0", 
-            "CameraInit": "9.0", 
-            "ImageMatchingMultiSfM": "1.0", 
-            "ImageMatching": "2.0", 
-            "FeatureExtraction": "1.1", 
+            "Publish": "1.2",
             "StructureFromMotion": "3.0",
-            "Publish": "1.2"
+            "FeatureExtraction": "1.1",
+            "FeatureMatching": "2.0",
+            "CameraInit": "9.0",
+            "ImageMatchingMultiSfM": "1.0",
+            "ImageMatching": "2.0",
+            "ExportAnimatedCamera": "2.0"
         }
-    }, 
+    },
     "graph": {
-        "DistortionCalibration_1": {
-            "inputs": {
-                "input": "{CameraInit_2.output}"
-            }, 
-            "nodeType": "DistortionCalibration", 
-            "position": [
-                1024, 
-                393
-            ]
-        }, 
         "ImageMatching_1": {
+            "nodeType": "ImageMatching",
+            "position": [
+                400,
+                0
+            ],
             "inputs": {
-                "input": "{FeatureExtraction_1.input}", 
+                "input": "{FeatureExtraction_1.input}",
                 "featuresFolders": [
                     "{FeatureExtraction_1.output}"
                 ]
-            }, 
-            "nodeType": "ImageMatching", 
-            "position": [
-                400, 
-                0
-            ]
-        }, 
+            }
+        },
         "FeatureExtraction_1": {
+            "nodeType": "FeatureExtraction",
+            "position": [
+                200,
+                0
+            ],
             "inputs": {
                 "input": "{CameraInit_1.output}"
-            }, 
-            "nodeType": "FeatureExtraction", 
-            "position": [
-                200, 
-                0
-            ]
-        }, 
+            }
+        },
         "StructureFromMotion_1": {
+            "nodeType": "StructureFromMotion",
+            "position": [
+                800,
+                0
+            ],
             "inputs": {
-                "describerTypes": "{FeatureMatching_1.describerTypes}", 
-                "input": "{FeatureMatching_1.input}", 
-                "featuresFolders": "{FeatureMatching_1.featuresFolders}", 
+                "input": "{FeatureMatching_1.input}",
+                "featuresFolders": "{FeatureMatching_1.featuresFolders}",
                 "matchesFolders": [
                     "{FeatureMatching_1.output}"
-                ]
-            }, 
-            "nodeType": "StructureFromMotion", 
-            "position": [
-                800, 
-                0
-            ]
-        }, 
+                ],
+                "describerTypes": "{FeatureMatching_1.describerTypes}"
+            }
+        },
         "ExportAnimatedCamera_1": {
-            "inputs": {
-                "sfmDataFilter": "{StructureFromMotion_1.output}", 
-                "input": "{StructureFromMotion_2.output}"
-            }, 
-            "nodeType": "ExportAnimatedCamera", 
+            "nodeType": "ExportAnimatedCamera",
             "position": [
-                1629, 
+                1629,
                 212
-            ]
-        }, 
-        "CameraInit_1": {
-            "inputs": {}, 
-            "nodeType": "CameraInit", 
-            "position": [
-                0, 
-                0
-            ]
-        }, 
-        "ImageMatchingMultiSfM_1": {
+            ],
             "inputs": {
-                "nbNeighbors": 10, 
-                "nbMatches": 5, 
-                "input": "{FeatureExtraction_2.input}", 
-                "inputB": "{StructureFromMotion_1.output}", 
+                "input": "{StructureFromMotion_2.output}",
+                "sfmDataFilter": "{StructureFromMotion_1.output}"
+            }
+        },
+        "CameraInit_1": {
+            "nodeType": "CameraInit",
+            "position": [
+                0,
+                0
+            ],
+            "inputs": {}
+        },
+        "ImageMatchingMultiSfM_1": {
+            "nodeType": "ImageMatchingMultiSfM",
+            "position": [
+                1029,
+                212
+            ],
+            "inputs": {
+                "input": "{FeatureExtraction_2.input}",
+                "inputB": "{StructureFromMotion_1.output}",
                 "featuresFolders": [
                     "{FeatureExtraction_2.output}"
-                ]
-            }, 
-            "nodeType": "ImageMatchingMultiSfM", 
-            "position": [
-                1029, 
-                212
-            ]
-        }, 
-        "CameraInit_2": {
-            "inputs": {}, 
-            "nodeType": "CameraInit", 
-            "position": [
-                -2, 
-                223
-            ]
-        }, 
-        "FeatureExtraction_2": {
-            "inputs": {
-                "input": "{CameraInit_2.output}"
-            }, 
-            "nodeType": "FeatureExtraction", 
-            "position": [
-                198, 
-                223
-            ]
-        }, 
-        "FeatureMatching_2": {
-            "inputs": {
-                "describerTypes": "{FeatureExtraction_2.describerTypes}", 
-                "imagePairsList": "{ImageMatchingMultiSfM_1.output}", 
-                "input": "{DistortionCalibration_1.outSfMData}", 
-                "featuresFolders": "{ImageMatchingMultiSfM_1.featuresFolders}"
-            }, 
-            "nodeType": "FeatureMatching", 
-            "position": [
-                1229, 
-                212
-            ]
-        }, 
+                ],
+                "nbMatches": 5,
+                "nbNeighbors": 10
+            }
+        },
         "FeatureMatching_1": {
-            "inputs": {
-                "describerTypes": "{FeatureExtraction_1.describerTypes}", 
-                "imagePairsList": "{ImageMatching_1.output}", 
-                "input": "{ImageMatching_1.input}", 
-                "featuresFolders": "{ImageMatching_1.featuresFolders}"
-            }, 
-            "nodeType": "FeatureMatching", 
+            "nodeType": "FeatureMatching",
             "position": [
-                600, 
+                600,
                 0
-            ]
-        }, 
-        "StructureFromMotion_2": {
+            ],
             "inputs": {
-                "minAngleForLandmark": 0.5, 
-                "minNumberOfObservationsForTriangulation": 3, 
-                "describerTypes": "{FeatureMatching_2.describerTypes}", 
-                "input": "{FeatureMatching_2.input}", 
-                "featuresFolders": "{FeatureMatching_2.featuresFolders}", 
-                "matchesFolders": [
-                    "{FeatureMatching_2.output}"
-                ], 
-                "minInputTrackLength": 5, 
-                "minAngleForTriangulation": 1.0
-            }, 
-            "nodeType": "StructureFromMotion", 
-            "position": [
-                1429, 
-                212
-            ]
+                "input": "{ImageMatching_1.input}",
+                "featuresFolders": "{ImageMatching_1.featuresFolders}",
+                "imagePairsList": "{ImageMatching_1.output}",
+                "describerTypes": "{FeatureExtraction_1.describerTypes}"
+            }
         },
         "Publish_1": {
             "nodeType": "Publish",
@@ -173,6 +112,55 @@
                 "inputFiles": [
                     "{ExportAnimatedCamera_1.output}"
                 ]
+            }
+        },
+        "CameraInit_2": {
+            "nodeType": "CameraInit",
+            "position": [
+                -2,
+                223
+            ],
+            "inputs": {}
+        },
+        "FeatureExtraction_2": {
+            "nodeType": "FeatureExtraction",
+            "position": [
+                198,
+                223
+            ],
+            "inputs": {
+                "input": "{CameraInit_2.output}"
+            }
+        },
+        "FeatureMatching_2": {
+            "nodeType": "FeatureMatching",
+            "position": [
+                1229,
+                212
+            ],
+            "inputs": {
+                "featuresFolders": "{ImageMatchingMultiSfM_1.featuresFolders}",
+                "imagePairsList": "{ImageMatchingMultiSfM_1.output}",
+                "describerTypes": "{FeatureExtraction_2.describerTypes}"
+            }
+        },
+        "StructureFromMotion_2": {
+            "nodeType": "StructureFromMotion",
+            "position": [
+                1429,
+                212
+            ],
+            "inputs": {
+                "input": "{FeatureMatching_2.input}",
+                "featuresFolders": "{FeatureMatching_2.featuresFolders}",
+                "matchesFolders": [
+                    "{FeatureMatching_2.output}"
+                ],
+                "describerTypes": "{FeatureMatching_2.describerTypes}",
+                "minInputTrackLength": 5,
+                "minNumberOfObservationsForTriangulation": 3,
+                "minAngleForTriangulation": 1.0,
+                "minAngleForLandmark": 0.5
             }
         }
     }


### PR DESCRIPTION
## Description

The goal of this PR is to reflect the changes made in [this PR](https://github.com/alicevision/AliceVision/pull/1415) in Meshroom.

## Features list

- [X] add undistortion parameters to intrinsic attributes
- [X] update DistortionCalibration node
- [X] new ExportDistortion node for `aliceVision_exportDistortion` software
- [X] new ApplyCalibration node for `aliceVision_applyCalibration` software

## New workflows

### Distortion calibration pipeline

![undisto_calib_pipeline](https://user-images.githubusercontent.com/70104194/232545995-0d016351-3a92-43d9-9d07-d197d119ecb3.PNG)

### Integration in reconstruction pipeline

![undisto_apply_calib](https://user-images.githubusercontent.com/70104194/232546082-b2281a7b-f758-4f1e-afa5-fe2dae40be54.PNG)

