### PR TITLE
[ui] 2D viewer: image sequence player

### DIFF
--- a/meshroom/ui/qml/Viewer/FloatImage.qml
+++ b/meshroom/ui/qml/Viewer/FloatImage.qml
@@ -62,7 +62,6 @@ AliceVision.FloatImageViewer {
 
     property int pointsNumber: (surface.subdivisions + 1) * (surface.subdivisions + 1);
 
-    property int index: 0;
     property int idView: 0;
 
     clearBeforeLoad: false

--- a/meshroom/ui/qml/Viewer/FloatImage.qml
+++ b/meshroom/ui/qml/Viewer/FloatImage.qml
@@ -13,7 +13,7 @@ AliceVision.FloatImageViewer {
 
     width: textureSize.width
     height: textureSize.height
-    visible: (status === Image.Ready)
+    visible: true
 
     // paintedWidth / paintedHeight / status for compatibility with standard Image
     property int paintedWidth: textureSize.width
@@ -65,7 +65,7 @@ AliceVision.FloatImageViewer {
     property int index: 0;
     property int idView: 0;
 
-    clearBeforeLoad: true
+    clearBeforeLoad: false
 
     property alias containsMouse: mouseArea.containsMouse
     property alias mouseX: mouseArea.mouseX

--- a/meshroom/ui/qml/Viewer/PanoramaViewer.qml
+++ b/meshroom/ui/qml/Viewer/PanoramaViewer.qml
@@ -293,7 +293,6 @@ AliceVision.PanoramaViewer {
                         'surface.pitch': Qt.binding(function() { return root.pitch; }),
                         'surface.yaw': Qt.binding(function() { return root.yaw; }),
                         'surface.roll': Qt.binding(function() { return root.roll; }),
-                        'index' : index,
                         'idView': Qt.binding(function() { return idViewItem; }),
                         'gamma': Qt.binding(function() { return hdrImageToolbar.gammaValue; }),
                         'gain': Qt.binding(function() { return hdrImageToolbar.gainValue; }),
@@ -301,7 +300,8 @@ AliceVision.PanoramaViewer {
                         'downscaleLevel' : Qt.binding(function() { return downscale; }),
                         'source':  Qt.binding(function() { return sourceItem; }),
                         'surface.msfmData': Qt.binding(function() { return root.msfmData }),
-                        'canBeHovered': true
+                        'canBeHovered': true,
+                        'useSequence': false
                     })
                     imageLoaded = Qt.binding(function() { return repeater.itemAt(index).item.status === Image.Ready ? true : false; })
                 }

--- a/meshroom/ui/qml/Viewer/SequencePlayer.qml
+++ b/meshroom/ui/qml/Viewer/SequencePlayer.qml
@@ -1,0 +1,45 @@
+import QtQuick 2.11
+import QtQuick.Controls 2.0
+
+Slider {
+
+    function sequence(vps) {
+        let objs = []
+        for (let i = 0; i < vps.count; i++) {
+            objs.push({
+                viewId: m.viewpoints.at(i).childAttribute("viewId").value,
+                filename: Filepath.basename(m.viewpoints.at(i).childAttribute("path").value)
+            });
+        }
+        objs.sort((a, b) => { return a.filename < b.filename ? -1 : 1; });
+
+        let viewIds = [];
+        for (let i = 0; i < objs.length; i++) {
+            viewIds.push(objs[i].viewId);
+        }
+
+        return viewIds;
+    }
+
+    QtObject {
+        id: m
+        property var currentCameraInit: _reconstruction && _reconstruction.cameraInit ? _reconstruction.cameraInit : undefined
+        property var viewpoints: currentCameraInit ? currentCameraInit.attribute('viewpoints').value : undefined
+        property var sortedViewIds: viewpoints ? sequence(viewpoints) : []
+    }
+
+    stepSize: 1
+    snapMode: Slider.SnapAlways
+    live: true
+
+    from: 0
+    to: Math.max(m.sortedViewIds.length, 1)
+
+    onValueChanged: {
+        let idx = Math.floor(value);
+        if (_reconstruction && idx >= 0 && idx < m.sortedViewIds.length - 1) {
+            _reconstruction.selectedViewId = m.sortedViewIds[idx];
+        }
+    }
+
+}

--- a/meshroom/ui/qml/Viewer/SequencePlayer.qml
+++ b/meshroom/ui/qml/Viewer/SequencePlayer.qml
@@ -25,8 +25,8 @@ FloatingPane {
         let objs = []
         for (let i = 0; i < vps.count; i++) {
             objs.push({
-                viewId: m.viewpoints.at(i).childAttribute("viewId").value,
-                filename: Filepath.basename(m.viewpoints.at(i).childAttribute("path").value)
+                viewId: vps.at(i).childAttribute("viewId").value,
+                filename: Filepath.basename(vps.at(i).childAttribute("path").value)
             });
         }
         objs.sort((a, b) => { return a.filename < b.filename ? -1 : 1; });

--- a/meshroom/ui/qml/Viewer/SequencePlayer.qml
+++ b/meshroom/ui/qml/Viewer/SequencePlayer.qml
@@ -96,6 +96,12 @@ FloatingPane {
                 viewSlider.value += 1;
             }
         }
+
+        Label {
+            id: frameLabel
+
+            text: viewSlider.value
+        }
     
         Slider {
             id: viewSlider
@@ -107,7 +113,7 @@ FloatingPane {
             live: true
 
             from: 0
-            to: m.sortedViewIds.length + 1
+            to: m.sortedViewIds.length - 1
 
             onValueChanged: {
                 let idx = Math.floor(value);

--- a/meshroom/ui/qml/Viewer/SequencePlayer.qml
+++ b/meshroom/ui/qml/Viewer/SequencePlayer.qml
@@ -5,9 +5,21 @@ import QtQuick.Layouts 1.3
 import Controls 1.0
 import MaterialIcons 2.2
 
+/**
+ * The Sequence Player is a UI for manipulating
+ * the currently selected (and displayed) viewpoint
+ * in an ordered set of viewpoints (i.e. a sequence).
+ *
+ * The viewpoint manipulation process can be manual
+ * (for example by dragging a slider to change the current frame)
+ * or automatic
+ * (by playing the sequence, i.e. incrementing the current frame at a given time rate).
+ */
 FloatingPane {
     id: root
 
+    // Utility function to sort a set of viewpoints
+    // using their corresponding image filenames
     function sequence(vps) {
         let objs = []
         for (let i = 0; i < vps.count; i++) {
@@ -26,6 +38,10 @@ FloatingPane {
         return viewIds;
     }
 
+    // Sequence player model:
+    // - ordered set of viewpoints
+    // - current frame
+    // - data related to automatic sequence playing
     QtObject {
         id: m
 
@@ -44,6 +60,8 @@ FloatingPane {
         }
     }
 
+    // Update the frame property
+    // when the selected view ID is changed externally
     Connections {
         target: _reconstruction
         onSelectedViewIdChanged: {
@@ -55,6 +73,9 @@ FloatingPane {
         }
     }
 
+    // In play mode
+    // we use a timer to increment the frame property
+    // at a given time rate (defined by the fps property)
     Timer {
         id: timer
 
@@ -77,14 +98,15 @@ FloatingPane {
             m.frame = nextIndex;
         }
     }
-
-    TextMetrics {
-        id: fpsMetrics
-
-        font: fpsSpinBox.font
-        text: "100"
-    }
     
+    // Widgets:
+    // - "Previous Frame" button
+    // - "Play - Pause" button
+    // - "Next Frame" button
+    // - frame label
+    // - frame slider
+    // - FPS spin box
+    // - "Repeat" button
     RowLayout {
 
         anchors.fill: parent
@@ -194,5 +216,12 @@ FloatingPane {
                 m.repeat = checked;
             }
         }
+    }
+
+    TextMetrics {
+        id: fpsMetrics
+
+        font: fpsSpinBox.font
+        text: "100"
     }
 }

--- a/meshroom/ui/qml/Viewer/SequencePlayer.qml
+++ b/meshroom/ui/qml/Viewer/SequencePlayer.qml
@@ -42,7 +42,18 @@ FloatingPane {
         interval: 1000 / fpsSpinBox.value
 
         onTriggered: {
-            viewSlider.value += 1;
+            let nextIndex = viewSlider.value + 1;
+            if (nextIndex == m.sortedViewIds.length) {
+                if (repeatButton.checked) {
+                    viewSlider.value = 0;
+                    return;
+                }
+                else {
+                    playButton.checked = false;
+                    return;
+                }
+            }
+            viewSlider.value = nextIndex;
         }
     }
 
@@ -138,6 +149,15 @@ FloatingPane {
                 to: 60
                 stepSize: 1
             }
+        }
+
+        MaterialToolButton {
+            id: repeatButton
+
+            checkable: true
+            checked: false
+            text: MaterialIcons.replay
+            ToolTip.text: "Repeat"
         }
     }
 }

--- a/meshroom/ui/qml/Viewer/SequencePlayer.qml
+++ b/meshroom/ui/qml/Viewer/SequencePlayer.qml
@@ -200,9 +200,9 @@ FloatingPane {
                     model: viewer ? viewer.cachedFrames : []
 
                     Rectangle {
-                        x: modelData * frameSlider.frameLength
+                        x: modelData.x * frameSlider.frameLength
                         y: 0
-                        width: frameSlider.frameLength
+                        width: frameSlider.frameLength * (modelData.y - modelData.x + 1)
                         height: 4
                         radius: 2
                         color: Colors.blue

--- a/meshroom/ui/qml/Viewer/SequencePlayer.qml
+++ b/meshroom/ui/qml/Viewer/SequencePlayer.qml
@@ -64,7 +64,7 @@ FloatingPane {
         target: _reconstruction
         function onSelectedViewIdChanged() {
             for (let idx = 0; idx < sortedViewIds.length; idx++) {
-                if (_reconstruction.selectedViewId == sortedViewIds[idx] && (m.frame != idx)) {
+                if (_reconstruction.selectedViewId === sortedViewIds[idx] && (m.frame != idx)) {
                     m.frame = idx;
                 }
             }

--- a/meshroom/ui/qml/Viewer/SequencePlayer.qml
+++ b/meshroom/ui/qml/Viewer/SequencePlayer.qml
@@ -72,6 +72,10 @@ FloatingPane {
         onSyncSelectedChanged: {
             updateReconstructionView();
         }
+
+        onPlayingChanged: {
+            syncSelected = !playing;
+        }
     }
 
     // Exposed properties
@@ -174,6 +178,7 @@ FloatingPane {
             id: frameLabel
 
             text: m.frame
+            Layout.preferredWidth: frameMetrics.width
         }
     
         Slider {
@@ -203,8 +208,6 @@ FloatingPane {
                 }
             }
 
-            property real frameLength: m.sortedViewIds.length > 0 ? width / m.sortedViewIds.length : 0
-
             background: Rectangle {
                 x: frameSlider.leftPadding
                 y: frameSlider.topPadding + frameSlider.height / 2 - height / 2
@@ -214,12 +217,15 @@ FloatingPane {
                 color: Colors.grey
 
                 Repeater {
+                    id: cacheView
+
                     model: viewer ? viewer.cachedFrames : []
+                    property real frameLength: m.sortedViewIds.length > 0 ? frameSlider.width / m.sortedViewIds.length : 0
 
                     Rectangle {
-                        x: modelData.x * frameSlider.frameLength
+                        x: modelData.x * cacheView.frameLength
                         y: 0
-                        width: frameSlider.frameLength * (modelData.y - modelData.x + 1)
+                        width: cacheView.frameLength * (modelData.y - modelData.x + 1)
                         height: 4
                         radius: 2
                         color: Colors.blue
@@ -261,6 +267,13 @@ FloatingPane {
                 m.repeat = checked;
             }
         }
+    }
+
+    TextMetrics {
+        id: frameMetrics
+
+        font: frameLabel.font
+        text: "10000"
     }
 
     TextMetrics {

--- a/meshroom/ui/qml/Viewer/SequencePlayer.qml
+++ b/meshroom/ui/qml/Viewer/SequencePlayer.qml
@@ -7,6 +7,8 @@ import Controls 1.0
 FloatingPane {
     id: root
 
+    property real fps: 4
+
     function sequence(vps) {
         let objs = []
         for (let i = 0; i < vps.count; i++) {
@@ -27,16 +29,48 @@ FloatingPane {
 
     QtObject {
         id: m
+
         property var currentCameraInit: _reconstruction && _reconstruction.cameraInit ? _reconstruction.cameraInit : undefined
         property var viewpoints: currentCameraInit ? currentCameraInit.attribute('viewpoints').value : undefined
         property var sortedViewIds: viewpoints ? sequence(viewpoints) : []
+    }
+
+    Timer {
+        id: timer
+
+        repeat: true
+        running: false
+        interval: 1000 / fps
+
+        onTriggered: {
+            viewSlider.value = viewSlider.value + 1;
+        }
     }
     
     RowLayout {
 
         anchors.fill: parent
+
+        Button {
+            id: playButton
+
+            checkable: true
+            checked: false
+            text: checked ? "pause" : "play"
+
+            onCheckedChanged: {
+                if (checked) {
+                    timer.running = true;
+                }
+                else {
+                    timer.running = false;
+                }
+            }
+
+        }
     
         Slider {
+            id: viewSlider
 
             Layout.fillWidth: true
 
@@ -45,7 +79,7 @@ FloatingPane {
             live: true
 
             from: 0
-            to: Math.max(m.sortedViewIds.length, 1)
+            to: m.sortedViewIds.length + 1
 
             onValueChanged: {
                 let idx = Math.floor(value);

--- a/meshroom/ui/qml/Viewer/SequencePlayer.qml
+++ b/meshroom/ui/qml/Viewer/SequencePlayer.qml
@@ -4,6 +4,7 @@ import QtQuick.Layouts 1.3
 
 import Controls 1.0
 import MaterialIcons 2.2
+import Utils 1.0
 
 /**
  * The Sequence Player is a UI for manipulating
@@ -59,6 +60,9 @@ FloatingPane {
             }
         }
     }
+
+    // Exposed properties
+    property var viewer: null
 
     // Update the frame property
     // when the selected view ID is changed externally
@@ -179,6 +183,30 @@ FloatingPane {
                 target: m
                 onFrameChanged: {
                     frameSlider.value = m.frame;
+                }
+            }
+
+            property real frameLength: m.sortedViewIds.length > 0 ? width / m.sortedViewIds.length : 0
+
+            background: Rectangle {
+                x: frameSlider.leftPadding
+                y: frameSlider.topPadding + frameSlider.height / 2 - height / 2
+                width: frameSlider.availableWidth
+                height: 4
+                radius: 2
+                color: Colors.grey
+
+                Repeater {
+                    model: viewer ? viewer.cachedFrames : []
+
+                    Rectangle {
+                        x: modelData * frameSlider.frameLength
+                        y: 0
+                        width: frameSlider.frameLength
+                        height: 4
+                        radius: 2
+                        color: Colors.blue
+                    }
                 }
             }
         }

--- a/meshroom/ui/qml/Viewer/SequencePlayer.qml
+++ b/meshroom/ui/qml/Viewer/SequencePlayer.qml
@@ -3,11 +3,10 @@ import QtQuick.Controls 2.0
 import QtQuick.Layouts 1.3
 
 import Controls 1.0
+import MaterialIcons 2.2
 
 FloatingPane {
     id: root
-
-    property real fps: 4
 
     function sequence(vps) {
         let objs = []
@@ -40,33 +39,42 @@ FloatingPane {
 
         repeat: true
         running: false
-        interval: 1000 / fps
+        interval: 1000 / fpsSpinBox.value
 
         onTriggered: {
             viewSlider.value += 1;
         }
+    }
+
+    TextMetrics {
+        id: fpsMetrics
+
+        font: fpsSpinBox.font
+        text: "100"
     }
     
     RowLayout {
 
         anchors.fill: parent
 
-        Button {
+        MaterialToolButton {
             id: prevButton
 
-            text: "prev"
+            text: MaterialIcons.skip_previous
+            ToolTip.text: "Previous Frame"
 
             onClicked: {
                 viewSlider.value -= 1;
             }
         }
 
-        Button {
+        MaterialToolButton {
             id: playButton
 
             checkable: true
             checked: false
-            text: checked ? "pause" : "play"
+            text: checked ? MaterialIcons.pause : MaterialIcons.play_arrow
+            ToolTip.text: checked ? "Pause Player" : "Play Sequence"
 
             onCheckedChanged: {
                 if (checked) {
@@ -78,10 +86,11 @@ FloatingPane {
             }
         }
 
-        Button {
+        MaterialToolButton {
             id: nextButton
 
-            text: "next"
+            text: MaterialIcons.skip_next
+            ToolTip.text: "Next Frame"
 
             onClicked: {
                 viewSlider.value += 1;
@@ -105,6 +114,23 @@ FloatingPane {
                 if (_reconstruction && idx >= 0 && idx < m.sortedViewIds.length - 1) {
                     _reconstruction.selectedViewId = m.sortedViewIds[idx];
                 }
+            }
+        }
+
+        RowLayout {
+            Label {
+                text: "FPS:"
+                ToolTip.text: "Frame Per Second"
+            }
+
+            SpinBox {
+                id: fpsSpinBox
+
+                Layout.preferredWidth: fpsMetrics.width + up.implicitIndicatorWidth
+
+                from: 1
+                to: 60
+                stepSize: 1
             }
         }
     }

--- a/meshroom/ui/qml/Viewer/SequencePlayer.qml
+++ b/meshroom/ui/qml/Viewer/SequencePlayer.qml
@@ -62,7 +62,7 @@ FloatingPane {
     // when the selected view ID is changed externally
     Connections {
         target: _reconstruction
-        onSelectedViewIdChanged: {
+        function onSelectedViewIdChanged() {
             for (let idx = 0; idx < sortedViewIds.length; idx++) {
                 if (_reconstruction.selectedViewId == sortedViewIds[idx] && (m.frame != idx)) {
                     m.frame = idx;
@@ -134,7 +134,7 @@ FloatingPane {
 
             Connections {
                 target: m
-                onPlayingChanged: {
+                function onPlayingChanged() {
                     playButton.checked = m.playing;
                 }
             }
@@ -180,7 +180,7 @@ FloatingPane {
 
             Connections {
                 target: m
-                onFrameChanged: {
+                function onFrameChanged() {
                     frameSlider.value = m.frame;
                 }
             }

--- a/meshroom/ui/qml/Viewer/SequencePlayer.qml
+++ b/meshroom/ui/qml/Viewer/SequencePlayer.qml
@@ -1,7 +1,11 @@
 import QtQuick 2.11
 import QtQuick.Controls 2.0
+import QtQuick.Layouts 1.3
 
-Slider {
+import Controls 1.0
+
+FloatingPane {
+    id: root
 
     function sequence(vps) {
         let objs = []
@@ -27,19 +31,31 @@ Slider {
         property var viewpoints: currentCameraInit ? currentCameraInit.attribute('viewpoints').value : undefined
         property var sortedViewIds: viewpoints ? sequence(viewpoints) : []
     }
+    
+    RowLayout {
 
-    stepSize: 1
-    snapMode: Slider.SnapAlways
-    live: true
+        anchors.fill: parent
+    
+        Slider {
 
-    from: 0
-    to: Math.max(m.sortedViewIds.length, 1)
+            Layout.fillWidth: true
 
-    onValueChanged: {
-        let idx = Math.floor(value);
-        if (_reconstruction && idx >= 0 && idx < m.sortedViewIds.length - 1) {
-            _reconstruction.selectedViewId = m.sortedViewIds[idx];
+            stepSize: 1
+            snapMode: Slider.SnapAlways
+            live: true
+
+            from: 0
+            to: Math.max(m.sortedViewIds.length, 1)
+
+            onValueChanged: {
+                let idx = Math.floor(value);
+                if (_reconstruction && idx >= 0 && idx < m.sortedViewIds.length - 1) {
+                    _reconstruction.selectedViewId = m.sortedViewIds[idx];
+                }
+            }
+
         }
+
     }
 
 }

--- a/meshroom/ui/qml/Viewer/SequencePlayer.qml
+++ b/meshroom/ui/qml/Viewer/SequencePlayer.qml
@@ -1,6 +1,6 @@
-import QtQuick 2.11
-import QtQuick.Controls 2.0
-import QtQuick.Layouts 1.3
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.11
 
 import Controls 1.0
 import MaterialIcons 2.2

--- a/meshroom/ui/qml/Viewer/SequencePlayer.qml
+++ b/meshroom/ui/qml/Viewer/SequencePlayer.qml
@@ -39,6 +39,16 @@ FloatingPane {
         return viewIds;
     }
 
+    function updateReconstructionView() {
+        if (_reconstruction && m.frame >= 0 && m.frame < m.sortedViewIds.length) {
+            if (m.syncSelected) {
+                _reconstruction.selectedViewId = m.sortedViewIds[m.frame];
+            } else {
+                _reconstruction.pickedViewId = m.sortedViewIds[m.frame];
+            }
+        }
+    }
+
     // Sequence player model:
     // - ordered set of viewpoints
     // - current frame
@@ -50,14 +60,17 @@ FloatingPane {
         property var viewpoints: currentCameraInit ? currentCameraInit.attribute('viewpoints').value : undefined
         property var sortedViewIds: viewpoints ? sequence(viewpoints) : []
         property int frame: 0
+        property bool syncSelected: true
         property bool playing: false
         property bool repeat: false
         property real fps: 1
 
         onFrameChanged: {
-            if (_reconstruction && frame >= 0 && frame < sortedViewIds.length) {
-                _reconstruction.selectedViewId = sortedViewIds[frame];
-            }
+            updateReconstructionView();
+        }
+
+        onSyncSelectedChanged: {
+            updateReconstructionView();
         }
     }
 
@@ -177,6 +190,10 @@ FloatingPane {
 
             onValueChanged: {
                 m.frame = value;
+            }
+
+            onPressedChanged: {
+                m.syncSelected = !pressed;
             }
 
             Connections {

--- a/meshroom/ui/qml/Viewer/SequencePlayer.qml
+++ b/meshroom/ui/qml/Viewer/SequencePlayer.qml
@@ -43,13 +43,23 @@ FloatingPane {
         interval: 1000 / fps
 
         onTriggered: {
-            viewSlider.value = viewSlider.value + 1;
+            viewSlider.value += 1;
         }
     }
     
     RowLayout {
 
         anchors.fill: parent
+
+        Button {
+            id: prevButton
+
+            text: "prev"
+
+            onClicked: {
+                viewSlider.value -= 1;
+            }
+        }
 
         Button {
             id: playButton
@@ -66,7 +76,16 @@ FloatingPane {
                     timer.running = false;
                 }
             }
+        }
 
+        Button {
+            id: nextButton
+
+            text: "next"
+
+            onClicked: {
+                viewSlider.value += 1;
+            }
         }
     
         Slider {
@@ -87,9 +106,6 @@ FloatingPane {
                     _reconstruction.selectedViewId = m.sortedViewIds[idx];
                 }
             }
-
         }
-
     }
-
 }

--- a/meshroom/ui/qml/Viewer/Viewer2D.qml
+++ b/meshroom/ui/qml/Viewer/Viewer2D.qml
@@ -35,8 +35,9 @@ FocusScope {
             // Read from the reconstruction object
             if (_reconstruction) {
                 let vp = getViewpoint(_reconstruction.selectedViewId);
-                let metadata = vp ? vp.childAttribute("metadata").value : "";
-                return JSON.parse(metadata);
+                if (vp) {
+                    return JSON.parse(vp.childAttribute("metadata").value);
+                }
             }
             return {};
         }

--- a/meshroom/ui/qml/Viewer/Viewer2D.qml
+++ b/meshroom/ui/qml/Viewer/Viewer2D.qml
@@ -270,6 +270,9 @@ FocusScope {
     }
 
     function buildOrderedSequence(path_template) {
+        // Resolve the path template on the sequence of viewpoints
+        // ordered by path
+
         let objs = []
         for (let i = 0; i < _reconstruction.viewpoints.count; i++) {
             objs.push(_reconstruction.viewpoints.at(i));
@@ -285,6 +288,8 @@ FocusScope {
     }
 
     function getSequence() {
+        // Entry point for getting the current image sequence
+
         if (useExternal) {
             return [];
         }
@@ -1344,6 +1349,7 @@ FocusScope {
                     id: sequencePlayer
                     anchors.margins: 0
                     Layout.fillWidth: true
+                    sortedViewIds: (root.enableSequencePlayer && _reconstruction && _reconstruction.viewpoints.count > 0) ? buildOrderedSequence("<VIEW_ID>") : []
                     viewer: floatImageViewerLoader.status === Loader.Ready ? floatImageViewerLoader.item : null
                     visible: root.enableSequencePlayer
                     enabled: root.enableSequencePlayer

--- a/meshroom/ui/qml/Viewer/Viewer2D.qml
+++ b/meshroom/ui/qml/Viewer/Viewer2D.qml
@@ -201,7 +201,7 @@ FocusScope {
             return sourceExternal;
         }
         if (_reconstruction && (!displayedNode || outputAttribute.name == "gallery")) {
-            return Filepath.stringToUrl(getViewpointAttribute("path",_reconstruction.selectedViewId));
+            return Filepath.stringToUrl(getViewpointAttribute("path",_reconstruction.pickedViewId));
         }
 
         var viewId = -1;

--- a/meshroom/ui/qml/Viewer/Viewer2D.qml
+++ b/meshroom/ui/qml/Viewer/Viewer2D.qml
@@ -435,7 +435,7 @@ FocusScope {
                                 'canBeHovered': false,
                                 'idView': Qt.binding(function() { return (_reconstruction ? _reconstruction.selectedViewId : -1); }),
                                 'cropFisheye': false,
-                                'sequence': Qt.binding(function() { return ((_reconstruction && _reconstruction.viewpoints) ? _reconstruction.allImagePaths() : []) }),
+                                'sequence': Qt.binding(function() { return ((_reconstruction && _reconstruction.viewpoints.count > 0) ? _reconstruction.allImagePaths() : []) }),
                                 'useSequence': Qt.binding(function() { return !useExternal && _reconstruction && (!displayedNode || outputAttribute.name == "gallery"); })
                                 })
                           } else {

--- a/meshroom/ui/qml/Viewer/Viewer2D.qml
+++ b/meshroom/ui/qml/Viewer/Viewer2D.qml
@@ -434,7 +434,8 @@ FocusScope {
                                 'surface.msfmData': Qt.binding(function() { return (msfmDataLoader.status === Loader.Ready && msfmDataLoader.item != null && msfmDataLoader.item.status === 2) ? msfmDataLoader.item : null; }),
                                 'canBeHovered': false,
                                 'idView': Qt.binding(function() { return (_reconstruction ? _reconstruction.selectedViewId : -1); }),
-                                'cropFisheye': false
+                                'cropFisheye': false,
+                                'sequence': Qt.binding(function() { return ((_reconstruction && _reconstruction.viewpoints) ? _reconstruction.allImagePaths() : []) })
                                 })
                           } else {
                                 // Force the unload (instead of using Component.onCompleted to load it once and for all) is necessary since Qt 5.14
@@ -1301,6 +1302,7 @@ FocusScope {
                     id: sequencePlayer
                     anchors.margins: 0
                     Layout.fillWidth: true
+                    viewer: floatImageViewerLoader.status === Loader.Ready ? floatImageViewerLoader.item : null
                 }
             }
         }

--- a/meshroom/ui/qml/Viewer/Viewer2D.qml
+++ b/meshroom/ui/qml/Viewer/Viewer2D.qml
@@ -417,9 +417,8 @@ FocusScope {
 
                     onActiveChanged: {
                         if (active) {
-                            // instantiate and initialize a FeaturesViewer component dynamically using Loader.setSource
+                            // instantiate and initialize a FLoatImage component dynamically using Loader.setSource
                             // Note: It does not work to use previously created component, so we re-create it with setSource.
-                            // floatViewerComp.createObject(floatImageViewerLoader, {
                             setSource("FloatImage.qml", {
                                 'source':  Qt.binding(function() { return getImageFile(); }),
                                 'gamma': Qt.binding(function() { return hdrImageToolbar.gammaValue; }),

--- a/meshroom/ui/qml/Viewer/Viewer2D.qml
+++ b/meshroom/ui/qml/Viewer/Viewer2D.qml
@@ -26,6 +26,7 @@ FocusScope {
     property var activeNodeFisheye: _reconstruction ? _reconstruction.activeNodes.get("PanoramaInit").node : null
     property bool cropFisheye : activeNodeFisheye ? activeNodeFisheye.attribute("useFisheye").value : false
     property bool enable8bitViewer: enable8bitViewerAction.checked
+    property bool enableSequencePlayer: enableSequencePlayerAction.checked
 
     QtObject {
         id: m
@@ -435,8 +436,8 @@ FocusScope {
                                 'canBeHovered': false,
                                 'idView': Qt.binding(function() { return (_reconstruction ? _reconstruction.selectedViewId : -1); }),
                                 'cropFisheye': false,
-                                'sequence': Qt.binding(function() { return ((_reconstruction && _reconstruction.viewpoints.count > 0) ? _reconstruction.allImagePaths() : []) }),
-                                'useSequence': Qt.binding(function() { return !useExternal && _reconstruction && (!displayedNode || outputAttribute.name == "gallery"); })
+                                'sequence': Qt.binding(function() { return ((root.enableSequencePlayer && _reconstruction && _reconstruction.viewpoints.count > 0) ? _reconstruction.allImagePaths() : []) }),
+                                'useSequence': Qt.binding(function() { return root.enableSequencePlayer && !useExternal && _reconstruction && (!displayedNode || outputAttribute.name == "gallery"); })
                                 })
                           } else {
                                 // Force the unload (instead of using Component.onCompleted to load it once and for all) is necessary since Qt 5.14
@@ -1304,6 +1305,8 @@ FocusScope {
                     anchors.margins: 0
                     Layout.fillWidth: true
                     viewer: floatImageViewerLoader.status === Loader.Ready ? floatImageViewerLoader.item : null
+                    visible: root.enableSequencePlayer
+                    enabled: root.enableSequencePlayer
                 }
             }
         }

--- a/meshroom/ui/qml/Viewer/Viewer2D.qml
+++ b/meshroom/ui/qml/Viewer/Viewer2D.qml
@@ -435,7 +435,8 @@ FocusScope {
                                 'canBeHovered': false,
                                 'idView': Qt.binding(function() { return (_reconstruction ? _reconstruction.selectedViewId : -1); }),
                                 'cropFisheye': false,
-                                'sequence': Qt.binding(function() { return ((_reconstruction && _reconstruction.viewpoints) ? _reconstruction.allImagePaths() : []) })
+                                'sequence': Qt.binding(function() { return ((_reconstruction && _reconstruction.viewpoints) ? _reconstruction.allImagePaths() : []) }),
+                                'useSequence': Qt.binding(function() { return !useExternal && _reconstruction && (!displayedNode || outputAttribute.name == "gallery"); })
                                 })
                           } else {
                                 // Force the unload (instead of using Component.onCompleted to load it once and for all) is necessary since Qt 5.14

--- a/meshroom/ui/qml/Viewer/Viewer2D.qml
+++ b/meshroom/ui/qml/Viewer/Viewer2D.qml
@@ -1296,6 +1296,10 @@ FocusScope {
 
                     }
                 }
+
+                FloatingPane {
+                    SequencePlayer {}
+                }
             }
         }
     }

--- a/meshroom/ui/qml/Viewer/Viewer2D.qml
+++ b/meshroom/ui/qml/Viewer/Viewer2D.qml
@@ -1297,8 +1297,10 @@ FocusScope {
                     }
                 }
 
-                FloatingPane {
-                    SequencePlayer {}
+                SequencePlayer {
+                    id: sequencePlayer
+                    anchors.margins: 0
+                    Layout.fillWidth: true
                 }
             }
         }

--- a/meshroom/ui/qml/WorkspaceView.qml
+++ b/meshroom/ui/qml/WorkspaceView.qml
@@ -146,6 +146,12 @@ Item {
                             checkable: true
                             checked: MeshroomApp.default8bitViewerEnabled
                         }
+                        Action {
+                            id: enableSequencePlayerAction
+                            text: "Enable Sequence Player"
+                            checkable: true
+                            checked: false
+                        }
                     }
                 }
             }

--- a/meshroom/ui/reconstruction.py
+++ b/meshroom/ui/reconstruction.py
@@ -696,6 +696,7 @@ class Reconstruction(UIGraph):
         self.sfmAugmented.emit(first, last)
         return sfm[0], sfm[-1]
 
+    @Slot(result="QVariantList")
     def allImagePaths(self):
         """ Get all image paths in the reconstruction. """
         return [vp.path.value for node in self._cameraInits for vp in node.viewpoints.value]

--- a/meshroom/ui/reconstruction.py
+++ b/meshroom/ui/reconstruction.py
@@ -441,6 +441,7 @@ class Reconstruction(UIGraph):
         self._solvedIntrinsics = None
         self._selectedViewId = None
         self._selectedViewpoint = None
+        self._pickedViewId = None
         self._liveSfmManager = LiveSfmManager(self)
 
         self._workerThreads = ThreadPool(processes=1)
@@ -1067,6 +1068,7 @@ class Reconstruction(UIGraph):
         if viewId == self._selectedViewId:
             return
         self._selectedViewId = viewId
+        self.setPickedViewId(viewId)
         vp = None
         if self.viewpoints:
             vp = next((v for v in self.viewpoints if str(v.viewId.value) == self._selectedViewId), None)
@@ -1078,6 +1080,12 @@ class Reconstruction(UIGraph):
             # Reconstruction has ownership of Viewpoint object - destroy it when not needed anymore
             self._selectedViewpoint.deleteLater()
         self._selectedViewpoint = ViewpointWrapper(viewpointAttribute, self) if viewpointAttribute else None
+
+    def setPickedViewId(self, viewId):
+        if viewId == self._pickedViewId:
+            return
+        self._pickedViewId = viewId
+        self.pickedViewIdChanged.emit()
 
     def reconstructedCamerasCount(self):
         """ Get the number of reconstructed cameras in the current context. """
@@ -1124,6 +1132,8 @@ class Reconstruction(UIGraph):
     selectedViewIdChanged = Signal()
     selectedViewId = Property(str, lambda self: self._selectedViewId, setSelectedViewId, notify=selectedViewIdChanged)
     selectedViewpoint = Property(ViewpointWrapper, lambda self: self._selectedViewpoint, notify=selectedViewIdChanged)
+    pickedViewIdChanged = Signal()
+    pickedViewId = Property(str, lambda self: self._pickedViewId, setPickedViewId, notify=pickedViewIdChanged)
 
     sfmChanged = Signal()
     sfm = Property(QObject, getSfm, setSfm, notify=sfmChanged)


### PR DESCRIPTION
## Description

This PR introduces a new UI element in the 2D viewer: an image sequence player.
This player allows user to navigate smoothly between viewpoints and provides playback functionnalities.

For performance and interactivity purposes, this feature relies on a newly introduces image sequence cache in QtAliceVision: https://github.com/alicevision/QtAliceVision/pull/36

![sequence_player](https://user-images.githubusercontent.com/70104194/234343000-6b49f0f1-fc37-44d8-beab-69dc38c94f17.PNG)

## Features list

- `SequencePlayer` component with :
  - slider to scroll through viewpoints
  - play/pause functionnalities
  - cached regions indicator in background
- new `pickedViewId` concept in `reconstruction` subordinated to `selectedViewId` to allow only partial UI updates
- bug fix in the float image viewer: avoid black image when a new image is being loaded

