### PR TITLE
[doc] RELEASING: Add example command to generate the release note

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -25,6 +25,9 @@ Tags
    - Create branch from develop: "rcMAJOR.MINOR"
    - Modify version in code, version status to RELEASE (meshroom/__init__.py)
    - Create Release note (using https://github.com/cbentejac/github-generate-release-note)
+     - ```
+	   ./github-generate-release-note.py -o alicevision -r Meshroom -m "Meshroom MAJOR.MINOR.PATCH" --highlights major-feature --label-include bugfix,ci,scope:doc,scope:build -s updated-asc
+	   ```
    - PR to develop: "Release MAJOR.MINOR"
  - Build
    - Build docker & push to dockerhub


### PR DESCRIPTION
## Description

## Description

This PR adds an example of the command to use to generate the release note.

```
./github-generate-release-note.py -o alicevision -r Meshroom -m "Meshroom MAJOR.MINOR.PATCH" --highlights major-feature --label-include bugfix,ci,scope:doc,scope:build -s updated-asc
```
generates a list of all the closed pull requests for the milestone MAJOR.MINOR.PATCH with:
- a "Main features" section (`highlights`) containing all the PRs tagged with the label `major-feature`;
- an "Other improvements" section that contains all the PRs that are not tagged with the labels used in `label-include`;
- a section (`label-include`) that includes all the PRs tagged with labels `bugfix`, `ci`, `scope:doc`, `scope:build`.

All the pull requests are sorted with the "least recently updated" setting.