### PR TITLE
[bin] Fix all the scripts that had errors

### DIFF
--- a/bin/meshroom_statistics
+++ b/bin/meshroom_statistics
@@ -3,7 +3,8 @@ import argparse
 import os
 import sys
 from pprint import pprint
-from collections import Iterable, defaultdict
+from collections import defaultdict
+from collections.abc import Iterable
 
 from meshroom.core import graph as pg
 
@@ -15,11 +16,11 @@ def addPlots(curves, title, fileObj):
     import matplotlib.pyplot as plt, mpld3
 
     fig = plt.figure()
-    ax = fig.add_subplot(111, axisbg='#EEEEEE')
+    ax = fig.add_subplot(111, facecolor='#EEEEEE')
     ax.grid(color='white', linestyle='solid')
 
     for curveName, curve in curves:
-        if not isinstance(curve[0], pg.basestring):
+        if not isinstance(curve[0], str):
             ax.plot(curve, label=curveName)
     ax.legend()
     # plt.ylim(0, 100)

--- a/bin/meshroom_status
+++ b/bin/meshroom_status
@@ -42,11 +42,10 @@ if args.node:
 else:
     startNodes = None
     if args.toNode:
-        startNodes = [graph.nodes(args.toNode)]
+        startNodes = [graph.findNode(args.toNode)]
     nodes, edges = graph.dfsOnFinish(startNodes=startNodes)
     for node in nodes:
         for chunk in node.chunks:
             print('{}: {}'.format(chunk.name, chunk.status.status.name))
     if args.verbose:
         pprint([n.status.toDict() for n in nodes])
-

--- a/bin/meshroom_submit
+++ b/bin/meshroom_submit
@@ -11,7 +11,6 @@ parser.add_argument('meshroomFile', metavar='MESHROOMFILE.mg', type=str,
                     help='Filepath to a graph file.')
 parser.add_argument('--toNode', metavar='NODE_NAME', type=str,
                     help='Process the node with its dependencies.')
-
 parser.add_argument('--submitter',
                     type=str,
                     default='SimpleFarm',
@@ -23,4 +22,4 @@ parser.add_argument("--submitLabel",
 
 args = parser.parse_args()
 
-meshroom.core.graph.submit(args.save, args.submitter, toNode=toNodes, submitLabel=args.submitLabel)
+meshroom.core.graph.submit(args.meshroomFile, args.submitter, toNode=args.toNode, submitLabel=args.submitLabel)

--- a/meshroom/core/stats.py
+++ b/meshroom/core/stats.py
@@ -257,8 +257,8 @@ class Statistics:
         version = d.get('fileVersion', 0.0)
         if version != self.fileVersion:
             logging.debug('Statistics: file version was {} and the current version is {}.'.format(version, self.fileVersion))
-        self.computer = {}
-        self.process = {}
+        self.computer = ComputerStatistics()
+        self.process = ProcStatistics()
         self.times = []
         try:
             self.computer.fromDict(d.get('computer', {}))


### PR DESCRIPTION
## Description

This PR fixes errors on different Meshroom scripts that thus could not be run, or crashed when some specific arguments were set. More specifically, it targets:
- `meshroom_submit`: 
  - The input argument containing the path of the project file to submit was never used to call the core.graph's "submit" method;
  - Instead, two invalid arguments were used;
- `meshroom_status`: The `--toNode` option caused errors when retrieving the list of nodes up to `toNode`;
- `meshroom_statistics`: 
  - The script was still performing Python 2-imports;
  - It relied on a method in the core.stats module that was broken: when reading the `statistics` file, the computer and process statistics where initialized to empty dictionaries instead of `ComputerStatistics` and `ProcStatistics` objects, meaning the file was read but its content was never stored;
  - It used an outdated version of the Matplotlib API.

## Features list

- [x] Properly initialize the `ComputerStatistics` and `ProcStatistics` objects when reading a `statistics` file;
- [x] Fix all the errors when running `meshroom_submit`, `meshroom_status` and `meshroom_statistics`. 
