### PR TITLE
[core] Stats: Retrieve and set the GPU name if it is found

### DIFF
--- a/meshroom/core/stats.py
+++ b/meshroom/core/stats.py
@@ -97,6 +97,11 @@ class ComputerStatistics:
             gpuTree = smiTree.find('gpu')
 
             try:
+                self.gpuName = gpuTree.find('product_name').text
+            except Exception as e:
+                logging.debug('Failed to get gpuName: "{}".'.format(str(e)))
+                pass
+            try:
                 gpuMemoryUsed = gpuTree.find('fb_memory_usage').find('used').text.split(" ")[0]
                 self._addKV('gpuMemoryUsed', gpuMemoryUsed)
             except Exception as e:
@@ -105,6 +110,7 @@ class ComputerStatistics:
             try:
                 self.gpuMemoryTotal = gpuTree.find('fb_memory_usage').find('total').text.split(" ")[0]
             except Exception as e:
+                logging.debug('Failed to get gpuMemoryTotal: "{}".'.format(str(e)))
                 pass
             try:
                 gpuUsed = gpuTree.find('utilization').find('gpu_util').text.split(" ")[0]


### PR DESCRIPTION
## Description

This PR fixes an issue that occured whenever a GPU was found and its name and total memory size were expected to be displayed in the "Statistics" tab: the memory size was correctly shown, but the name remained empty.

<div align="center">
<img src="https://i.gyazo.com/dbd934fc2d7058a358e6409d87519022.png" width=400 />
</div>

This stemmed from the parsing of the XML tree that is obtained with the `nvidia-smi -q -x` command: the memory-related information was correctly parsed, but the name of the GPU was never retrieved. The name of the GPU is now retrieved and saved alongside the rest of the information, which automatically fixes the display in the "Statistics" tab:

<div align="center"><img src="https://i.gyazo.com/3c03fbf09d643b47a26e1f601a6f6aef.png" width=400 />
</div>