### PR TITLE
sfm bootstraping

### DIFF
--- a/meshroom/nodes/aliceVision/RelativePoseEstimating.py
+++ b/meshroom/nodes/aliceVision/RelativePoseEstimating.py
@@ -15,10 +15,10 @@ class RelativePoseEstimating(desc.AVCommandLineNode):
 
     inputs = [
         desc.File(
-            name='input',
-            label='SfMData',
-            description='SfMData file.',
-            value='',
+            name="input",
+            label="SfMData",
+            description="SfMData file.",
+            value="",
             uid=[0],
         ),
         desc.ListAttribute(
@@ -34,28 +34,28 @@ class RelativePoseEstimating(desc.AVCommandLineNode):
             description="Folder(s) containing the extracted features and descriptors."
         ),
         desc.File(
-            name='tracksFilename',
-            label='Tracks file',
-            description='Tracks file.',
-            value='',
+            name="tracksFilename",
+            label="Tracks File",
+            description="Tracks file.",
+            value="",
             uid=[0],
         ),
         desc.ChoiceParam(
-            name='describerTypes',
-            label='Describer Types',
-            description='Describer types used to describe an image.',
-            value=['dspsift'],
-            values=['sift', 'sift_float', 'sift_upright', 'dspsift', 'akaze', 'akaze_liop', 'akaze_mldb', 'cctag3', 'cctag4', 'sift_ocv', 'akaze_ocv', 'tag16h5'],
+            name="describerTypes",
+            label="Describer Types",
+            description="Describer types used to describe an image.",
+            value=["dspsift"],
+            values=["sift", "sift_float", "sift_upright", "dspsift", "akaze", "akaze_liop", "akaze_mldb", "cctag3", "cctag4", "sift_ocv", "akaze_ocv", "tag16h5"],
             exclusive=False,
             uid=[0],
-            joinChar=',',
+            joinChar=",",
         ),
         desc.ChoiceParam(
-            name='verboseLevel',
-            label='Verbose Level',
-            description='Verbosity level (fatal, error, warning, info, debug, trace).',
-            value='info',
-            values=['fatal', 'error', 'warning', 'info', 'debug', 'trace'],
+            name="verboseLevel",
+            label="Verbose Level",
+            description="Verbosity level (fatal, error, warning, info, debug, trace).",
+            value="info",
+            values=["fatal", "error", "warning", "info", "debug", "trace"],
             exclusive=True,
             uid=[],
         )
@@ -63,9 +63,9 @@ class RelativePoseEstimating(desc.AVCommandLineNode):
 
     outputs = [
         desc.File(
-            name='output',
-            label='Pairs Infos',
-            description='Path to the output Pairs info files directory',
+            name="output",
+            label="Pairs Info",
+            description="Path to the output Pairs info files directory.",
             value=desc.Node.internalFolder,
             uid=[],
         )

--- a/meshroom/nodes/aliceVision/RelativePoseEstimating.py
+++ b/meshroom/nodes/aliceVision/RelativePoseEstimating.py
@@ -1,0 +1,72 @@
+__version__ = "1.0"
+
+from meshroom.core import desc
+
+class RelativePoseEstimating(desc.AVCommandLineNode):
+    commandLine = 'aliceVision_relativePoseEstimating {allParams}'
+    size = desc.DynamicNodeSize('input')
+    
+    parallelization = desc.Parallelization(blockSize=25)
+    commandLineRange = '--rangeStart {rangeStart} --rangeSize {rangeBlockSize}'
+
+    category = 'Sparse Reconstruction'
+    documentation = '''
+'''
+
+    inputs = [
+        desc.File(
+            name='input',
+            label='SfMData',
+            description='SfMData file.',
+            value='',
+            uid=[0],
+        ),
+        desc.ListAttribute(
+            elementDesc=desc.File(
+                name="featuresFolder",
+                label="Features Folder",
+                description="",
+                value="",
+                uid=[0],
+            ),
+            name="featuresFolders",
+            label="Features Folders",
+            description="Folder(s) containing the extracted features and descriptors."
+        ),
+        desc.File(
+            name='tracksFilename',
+            label='Tracks file',
+            description='Tracks file.',
+            value='',
+            uid=[0],
+        ),
+        desc.ChoiceParam(
+            name='describerTypes',
+            label='Describer Types',
+            description='Describer types used to describe an image.',
+            value=['dspsift'],
+            values=['sift', 'sift_float', 'sift_upright', 'dspsift', 'akaze', 'akaze_liop', 'akaze_mldb', 'cctag3', 'cctag4', 'sift_ocv', 'akaze_ocv', 'tag16h5'],
+            exclusive=False,
+            uid=[0],
+            joinChar=',',
+        ),
+        desc.ChoiceParam(
+            name='verboseLevel',
+            label='Verbose Level',
+            description='Verbosity level (fatal, error, warning, info, debug, trace).',
+            value='info',
+            values=['fatal', 'error', 'warning', 'info', 'debug', 'trace'],
+            exclusive=True,
+            uid=[],
+        )
+    ]
+
+    outputs = [
+        desc.File(
+            name='output',
+            label='Pairs Infos',
+            description='Path to the output Pairs info files directory',
+            value=desc.Node.internalFolder,
+            uid=[],
+        )
+    ]

--- a/meshroom/nodes/aliceVision/SfmBootstraping.py
+++ b/meshroom/nodes/aliceVision/SfmBootstraping.py
@@ -1,0 +1,77 @@
+__version__ = "1.0"
+
+from meshroom.core import desc
+
+
+class SfMBootStraping(desc.AVCommandLineNode):
+    commandLine = 'aliceVision_sfmBootstraping {allParams}'
+    size = desc.DynamicNodeSize('input')
+
+    category = 'Sparse Reconstruction'
+    documentation = '''
+'''
+
+    inputs = [
+        desc.File(
+            name='input',
+            label='SfMData',
+            description='SfMData file.',
+            value='',
+            uid=[0],
+        ),
+        desc.ListAttribute(
+            elementDesc=desc.File(
+                name="featuresFolder",
+                label="Features Folder",
+                description="",
+                value="",
+                uid=[0],
+            ),
+            name="featuresFolders",
+            label="Features Folders",
+            description="Folder(s) containing the extracted features and descriptors."
+        ),
+        desc.File(
+            name='tracksFilename',
+            label='Tracks file',
+            description='Tracks file.',
+            value='',
+            uid=[0],
+        ),
+        desc.File(
+            name='pairs',
+            label='Pairs file',
+            description='Information on pairs.',
+            value='',
+            uid=[0],
+        ),
+        desc.ChoiceParam(
+            name='describerTypes',
+            label='Describer Types',
+            description='Describer types used to describe an image.',
+            value=['dspsift'],
+            values=['sift', 'sift_float', 'sift_upright', 'dspsift', 'akaze', 'akaze_liop', 'akaze_mldb', 'cctag3', 'cctag4', 'sift_ocv', 'akaze_ocv', 'tag16h5'],
+            exclusive=False,
+            uid=[0],
+            joinChar=',',
+        ),
+        desc.ChoiceParam(
+            name='verboseLevel',
+            label='Verbose Level',
+            description='Verbosity level (fatal, error, warning, info, debug, trace).',
+            value='info',
+            values=['fatal', 'error', 'warning', 'info', 'debug', 'trace'],
+            exclusive=True,
+            uid=[],
+        )
+    ]
+
+    outputs = [
+        desc.File(
+            name='output',
+            label='SfMData',
+            description='Path to the output sfmdata file',
+            value=desc.Node.internalFolder + 'sfm.json',
+            uid=[],
+        )
+    ]

--- a/meshroom/nodes/aliceVision/SfmBootstraping.py
+++ b/meshroom/nodes/aliceVision/SfmBootstraping.py
@@ -13,10 +13,10 @@ class SfMBootStraping(desc.AVCommandLineNode):
 
     inputs = [
         desc.File(
-            name='input',
-            label='SfMData',
-            description='SfMData file.',
-            value='',
+            name="input",
+            label="SfMData",
+            description="SfMData file.",
+            value="",
             uid=[0],
         ),
         desc.ListAttribute(
@@ -32,35 +32,35 @@ class SfMBootStraping(desc.AVCommandLineNode):
             description="Folder(s) containing the extracted features and descriptors."
         ),
         desc.File(
-            name='tracksFilename',
-            label='Tracks file',
-            description='Tracks file.',
-            value='',
+            name="tracksFilename",
+            label="Tracks File",
+            description="Tracks file.",
+            value="",
             uid=[0],
         ),
         desc.File(
-            name='pairs',
-            label='Pairs file',
-            description='Information on pairs.',
-            value='',
+            name="pairs",
+            label="Pairs File",
+            description="Information on pairs.",
+            value="",
             uid=[0],
         ),
         desc.ChoiceParam(
-            name='describerTypes',
-            label='Describer Types',
-            description='Describer types used to describe an image.',
-            value=['dspsift'],
-            values=['sift', 'sift_float', 'sift_upright', 'dspsift', 'akaze', 'akaze_liop', 'akaze_mldb', 'cctag3', 'cctag4', 'sift_ocv', 'akaze_ocv', 'tag16h5'],
+            name="describerTypes",
+            label="Describer Types",
+            description="Describer types used to describe an image.",
+            value=["dspsift"],
+            values=["sift", "sift_float", "sift_upright", "dspsift", "akaze", "akaze_liop", "akaze_mldb", "cctag3", "cctag4", "sift_ocv", "akaze_ocv", "tag16h5"],
             exclusive=False,
             uid=[0],
-            joinChar=',',
+            joinChar=",",
         ),
         desc.ChoiceParam(
-            name='verboseLevel',
-            label='Verbose Level',
-            description='Verbosity level (fatal, error, warning, info, debug, trace).',
-            value='info',
-            values=['fatal', 'error', 'warning', 'info', 'debug', 'trace'],
+            name="verboseLevel",
+            label="Verbose Level",
+            description="Verbosity level (fatal, error, warning, info, debug, trace).",
+            value="info",
+            values=["fatal", "error", "warning", "info", "debug", "trace"],
             exclusive=True,
             uid=[],
         )
@@ -68,10 +68,10 @@ class SfMBootStraping(desc.AVCommandLineNode):
 
     outputs = [
         desc.File(
-            name='output',
-            label='SfMData',
-            description='Path to the output sfmdata file',
-            value=desc.Node.internalFolder + 'sfm.json',
+            name="output",
+            label="SfMData",
+            description="Path to the output SfMData file.",
+            value=desc.Node.internalFolder + "sfm.json",
             uid=[],
         )
     ]


### PR DESCRIPTION
SFM bootstraping ;

Incremental SFM needs to be bootstraped with an initial set of views.

This app choose the initial pair as currently done in ReconstructionEngine_sequential but as a standalone application.

Once the pair is chosen, it generate the associated point cloud and the SfmData as required for the rest of the pipeline.

See https://github.com/alicevision/AliceVision/pull/1432