### PR TITLE
[ui] ImageGallery: Reset viewpoints and intrinsics when removing all the images

### DIFF
--- a/meshroom/ui/qml/ImageGallery/ImageGallery.qml
+++ b/meshroom/ui/qml/ImageGallery/ImageGallery.qml
@@ -29,6 +29,7 @@ Panel {
     property bool readOnly: false
 
     signal removeImageRequest(var attribute)
+    signal allViewpointsCleared()
     signal filesDropped(var drop, var augmentSfm)
 
     title: "Image Gallery"
@@ -51,7 +52,7 @@ Panel {
     }
 
     property variant parsedIntrinsic
-    property int numberOfIntrinsics : m.intrinsics ? m.intrinsics.count : 0
+    property int numberOfIntrinsics: m.intrinsics ? m.intrinsics.count : 0
     onNumberOfIntrinsicsChanged: {
         parseIntr()
     }
@@ -280,8 +281,12 @@ Panel {
                     }
 
                     function sendRemoveRequest() {
-                        if(!readOnly)
+                        if (!readOnly) {
                             removeImageRequest(object)
+                            // If the last image has been removed, make sure the viewpoints and intrinsics are reset
+                            if (m.viewpoints.count === 0)
+                                allViewpointsCleared()
+                        }
                     }
 
                     onRemoveRequest: sendRemoveRequest()

--- a/meshroom/ui/qml/WorkspaceView.qml
+++ b/meshroom/ui/qml/WorkspaceView.qml
@@ -80,6 +80,7 @@ Item {
                 tempCameraInit: reconstruction ? reconstruction.tempCameraInit : null
                 cameraInitIndex: reconstruction ? reconstruction.cameraInitIndex : -1
                 onRemoveImageRequest: reconstruction.removeAttribute(attribute)
+                onAllViewpointsCleared: { reconstruction.clearImages(); reconstruction.selectedViewId = "-1" }
                 onFilesDropped: reconstruction.handleFilesDrop(drop, augmentSfm ? null : cameraInit)
             }
             LiveSfmView {


### PR DESCRIPTION
## Description

This PR fixes an issue that occurred when all the images from the Gallery were manually removed one by one (either with the "Del" key or the "Remove" option): the list of viewpoints was emptied as expected (but never reset) but the list of intrinsics was never modified (neither emptied nor reset). This could cause errors later on, when re-filling the Gallery with new images that were unrelated to the remaining intrinsics.

When the list of viewpoints is now emptied, both the list of viewpoints and the list of intrinsics are reset, in the same fashion as when "Clear Images" is called.


## Features list

- [x] Reset the lists of viewpoints and intrinsics when the last image of the active group is removed manually from the Gallery.
