### PR TITLE
Add a template for the HDR fusion

### DIFF
--- a/meshroom/nodes/aliceVision/LdrToHdrMerge.py
+++ b/meshroom/nodes/aliceVision/LdrToHdrMerge.py
@@ -1,4 +1,4 @@
-__version__ = "4.0"
+__version__ = "4.1"
 
 import json
 
@@ -209,6 +209,14 @@ Merge LDR images into HDR images.
     ]
 
     outputs = [
+        desc.File(
+            name='outputFolder',
+            label='Output Folder',
+            description='Path to the folder containing the merged HDR images.',
+            value=desc.Node.internalFolder,
+            uid=[],
+            group='',  # do not export on the command line
+        ),
         desc.File(
             name='outSfMData',
             label='SfMData File',

--- a/meshroom/pipelines/cameraTracking.mg
+++ b/meshroom/pipelines/cameraTracking.mg
@@ -6,7 +6,7 @@
         "template": true,
         "nodesVersions": {
             "ExportAnimatedCamera": "2.0",
-            "Publish": "1.2",
+            "Publish": "1.3",
             "StructureFromMotion": "3.0",
             "FeatureExtraction": "1.1",
             "FeatureMatching": "2.0",

--- a/meshroom/pipelines/hdrFusion.mg
+++ b/meshroom/pipelines/hdrFusion.mg
@@ -1,0 +1,88 @@
+{
+    "header": {
+        "nodesVersions": {
+            "Publish": "1.3",
+            "LdrToHdrSampling": "4.0",
+            "LdrToHdrMerge": "4.1",
+            "LdrToHdrCalibration": "3.0",
+            "CameraInit": "9.0"
+        },
+        "releaseVersion": "2023.2.0-develop",
+        "fileVersion": "1.1",
+        "template": true
+    },
+    "graph": {
+        "LdrToHdrMerge_1": {
+            "nodeType": "LdrToHdrMerge",
+            "position": [
+                600,
+                0
+            ],
+            "inputs": {
+                "input": "{LdrToHdrCalibration_1.input}",
+                "response": "{LdrToHdrCalibration_1.response}",
+                "userNbBrackets": "{LdrToHdrCalibration_1.userNbBrackets}",
+                "byPass": "{LdrToHdrCalibration_1.byPass}",
+                "channelQuantizationPower": "{LdrToHdrCalibration_1.channelQuantizationPower}",
+                "workingColorSpace": "{LdrToHdrCalibration_1.workingColorSpace}"
+            }
+        },
+        "LdrToHdrCalibration_1": {
+            "nodeType": "LdrToHdrCalibration",
+            "position": [
+                400,
+                0
+            ],
+            "inputs": {
+                "input": "{LdrToHdrSampling_1.input}",
+                "samples": "{LdrToHdrSampling_1.output}",
+                "userNbBrackets": "{LdrToHdrSampling_1.userNbBrackets}",
+                "byPass": "{LdrToHdrSampling_1.byPass}",
+                "calibrationMethod": "{LdrToHdrSampling_1.calibrationMethod}",
+                "channelQuantizationPower": "{LdrToHdrSampling_1.channelQuantizationPower}",
+                "workingColorSpace": "{LdrToHdrSampling_1.workingColorSpace}"
+            }
+        },
+        "LdrToHdrSampling_1": {
+            "nodeType": "LdrToHdrSampling",
+            "position": [
+                200,
+                0
+            ],
+            "inputs": {
+                "input": "{CameraInit_1.output}"
+            }
+        },
+        "CameraInit_1": {
+            "nodeType": "CameraInit",
+            "position": [
+                0,
+                0
+            ],
+            "inputs": {
+                "allowedCameraModels": [
+                    "pinhole",
+                    "radial1",
+                    "radial3",
+                    "brown",
+                    "fisheye1",
+                    "3deanamorphic4",
+                    "3deradial4",
+                    "3declassicld"
+                ]
+            }
+        },
+        "Publish_1": {
+            "nodeType": "Publish",
+            "position": [
+                800,
+                0
+            ],
+            "inputs": {
+                "inputFiles": [
+                    "{LdrToHdrMerge_1.outputFolder}"
+                ]
+            }
+        }
+    }
+}

--- a/meshroom/pipelines/panoramaFisheyeHdr.mg
+++ b/meshroom/pipelines/panoramaFisheyeHdr.mg
@@ -5,7 +5,7 @@
             "PanoramaSeams": "2.0", 
             "FeatureMatching": "2.0", 
             "PanoramaCompositing": "2.0", 
-            "LdrToHdrMerge": "4.0", 
+            "LdrToHdrMerge": "4.1",
             "LdrToHdrSampling": "4.0", 
             "LdrToHdrCalibration": "3.0", 
             "PanoramaEstimation": "1.0", 
@@ -17,7 +17,7 @@
             "FeatureExtraction": "1.1", 
             "PanoramaPrepareImages": "1.1", 
             "PanoramaWarping": "1.0",
-            "Publish": "1.2"
+            "Publish": "1.3"
         }, 
         "releaseVersion": "2023.1.0",
         "fileVersion": "1.1", 

--- a/meshroom/pipelines/panoramaHdr.mg
+++ b/meshroom/pipelines/panoramaHdr.mg
@@ -5,7 +5,7 @@
             "PanoramaSeams": "2.0", 
             "FeatureMatching": "2.0", 
             "PanoramaCompositing": "2.0", 
-            "LdrToHdrMerge": "4.0", 
+            "LdrToHdrMerge": "4.1",
             "LdrToHdrSampling": "4.0", 
             "LdrToHdrCalibration": "3.0", 
             "PanoramaEstimation": "1.0", 
@@ -17,7 +17,7 @@
             "FeatureExtraction": "1.1", 
             "PanoramaPrepareImages": "1.1", 
             "PanoramaWarping": "1.0",
-            "Publish": "1.2"
+            "Publish": "1.3"
         }, 
         "releaseVersion": "2023.1.0",
         "fileVersion": "1.1", 

--- a/meshroom/pipelines/photogrammetry.mg
+++ b/meshroom/pipelines/photogrammetry.mg
@@ -16,7 +16,7 @@
             "FeatureExtraction": "1.1", 
             "Meshing": "7.0", 
             "DepthMapFilter": "3.0",
-            "Publish": "1.2"
+            "Publish": "1.3"
         }
     }, 
     "graph": {

--- a/meshroom/pipelines/photogrammetryAndCameraTracking.mg
+++ b/meshroom/pipelines/photogrammetryAndCameraTracking.mg
@@ -5,7 +5,7 @@
         "fileVersion": "1.1",
         "template": true,
         "nodesVersions": {
-            "Publish": "1.2",
+            "Publish": "1.3",
             "StructureFromMotion": "3.0",
             "FeatureExtraction": "1.1",
             "FeatureMatching": "2.0",

--- a/meshroom/pipelines/photogrammetryDraft.mg
+++ b/meshroom/pipelines/photogrammetryDraft.mg
@@ -9,7 +9,7 @@
             "ImageMatching": "2.0", 
             "FeatureExtraction": "1.1", 
             "Meshing": "7.0",
-            "Publish": "1.2"
+            "Publish": "1.3"
         }, 
         "releaseVersion": "2023.1.0",
         "fileVersion": "1.1", 


### PR DESCRIPTION
## Description

This PR adds a new template to perform a stand-alone HDR fusion, which used to be only available in the HDR panorama templates.

As the `LdrToHdrMerge` node's only output was an SfMData file, its output folder is now exposed so that results of the fusion are available. 

The `Publish` node's support for inputs has also been extended to folders: if a folder is provided in the list of inputs, its content will be recursively published to the output folder.  

## Features list

- [x] Add support of folders for the inputs of the `Publish` node;
- [x] Expose the output folder of the `LdrToHdrMerge` node;
- [x] Add a new template dedicated to the HDR fusion. 
