### PR TITLE
[nodes] StereoPhotometry: Fix some labels and descriptions

### DIFF
--- a/meshroom/nodes/aliceVision/LightingCalibration.py
+++ b/meshroom/nodes/aliceVision/LightingCalibration.py
@@ -15,14 +15,14 @@ Can also be used to calibrate a lighting dome (RTI type).
         desc.File(
             name='inputPath',
             label='SfMData',
-            description='Input file. Could be SfMData file or folder.',
+            description='Input SfMData file.',
             value='',
             uid=[0]
         ),
         desc.File(
             name='inputJSON',
             label='Sphere Detection File',
-            description='Input JSON file containing spheres centers and radius.',
+            description='Input JSON file containing sphere centers and radiuses.',
             value='',
             uid=[0]
         ),

--- a/meshroom/nodes/aliceVision/SphereDetection.py
+++ b/meshroom/nodes/aliceVision/SphereDetection.py
@@ -84,8 +84,8 @@ Spheres can be automatically detected or manually defined in the interface.
     outputs = [
         desc.File(
             name='output',
-            label='Light File Folder',
-            description='Light information will be written here.',
+            label='Output Folder',
+            description='Sphere detection information will be written here.',
             value=desc.Node.internalFolder,
             uid=[]
         )


### PR DESCRIPTION
## Description

Related AliceVision pull request: https://github.com/alicevision/AliceVision/pull/1452

This PR fixes the label and description for the output folder of the `SphereDetection` node, as well as some parameters' description in the `LightingCalibration` node.
