### PR TITLE
[nodes] ScenePreview: use base image name for naming output

### DIFF
--- a/meshroom/nodes/blender/ScenePreview.py
+++ b/meshroom/nodes/blender/ScenePreview.py
@@ -131,7 +131,7 @@ One frame per viewpoint will be rendered, and the undistorted views can optional
             label='Frames',
             description='Frames rendered in Blender',
             semantic='image',
-            value=desc.Node.internalFolder + '<VIEW_ID>.jpg',
+            value=desc.Node.internalFolder + '<FILENAME>_preview.jpg',
             uid=[],
             group='',
         ),

--- a/meshroom/nodes/blender/scripts/preview.py
+++ b/meshroom/nodes/blender/scripts/preview.py
@@ -138,7 +138,9 @@ def initCompositing():
 def setupRender(view, intrinsic, pose, outputDir):
     '''Setup rendering in Blender for a given view.'''
     setupCamera(intrinsic, pose)
-    bpy.context.scene.render.filepath = os.path.abspath(outputDir + '/' + view['viewId'] + '.jpg')
+
+    baseImgName = os.path.splitext(os.path.basename(view['path']))[0]
+    bpy.context.scene.render.filepath = os.path.abspath(outputDir + '/' + baseImgName + '_preview.jpg')
 
 
 def setupBackground(view, folderUndistorted):


### PR DESCRIPTION
## Description

The `ScenePreview` node was using `viewIds` to name its output images, which breaks sequence order and makes it difficult to compare with the initial images.

In this PR we change the output naming process and use the base images names instead.