### PR TITLE
KeyframeSelection: Add new parameter value to disable the export of keyframes

### DIFF
--- a/meshroom/nodes/aliceVision/KeyframeSelection.py
+++ b/meshroom/nodes/aliceVision/KeyframeSelection.py
@@ -1,4 +1,4 @@
-__version__ = "4.0"
+__version__ = "4.1"
 
 import os
 from meshroom.core import desc
@@ -212,14 +212,17 @@ You can extract frames at regular interval by configuring only the min/maxFrameS
                         "If the selected keyframes are at index [15, 294, 825], they will be written as [00000.exr, 00001.exr, 00002.exr] with this\n"
                         "option enabled instead of [00015.exr, 00294.exr, 00825.exr].",
             value=False,
+            enabled=lambda node: node.outputExtension.value != "none",
             uid=[0]
         ),
         desc.ChoiceParam(
             name="outputExtension",
             label="Keyframes File Extension",
-            description="File extension of the written keyframes.",
-            value="jpg",
-            values=["exr", "jpg", "png"],
+            description="File extension of the written keyframes.\n"
+                        "If 'none' is selected, no keyframe will be written on disk.\n"
+                        "For input videos, 'none' should not be used since the written keyframes are used to generate the output SfMData file.",
+            value="none",
+            values=["none", "exr", "jpg", "png"],
             exclusive=True,
             uid=[0],
         ),

--- a/meshroom/pipelines/cameraTracking.mg
+++ b/meshroom/pipelines/cameraTracking.mg
@@ -13,7 +13,7 @@
             "DepthMapFilter": "3.0",
             "DistortionCalibration": "3.0",
             "PrepareDenseScene": "3.0",
-            "KeyframeSelection": "4.0",
+            "KeyframeSelection": "4.1",
             "Publish": "1.3",
             "StructureFromMotion": "3.1",
             "CheckerboardDetection": "1.0",


### PR DESCRIPTION
## Description

Related AliceVision pull request: https://github.com/alicevision/AliceVision/pull/1454

This PR adds the support of the `none` value for the `outputExtension` parameter in the `KeyframeSelection` node, and sets it as the default value. Setting `outputExtension` to `none` disables the export of the selected keyframes, meaning that only the SfMData files will be written on disk as outputs of the `KeyframeSelection` node. 

The description of the parameter is updated accordingly and mentions that it should not be used with video inputs, as this would lead to no output at all.