### PR TITLE
Viewer2D: Dynamically update the list of viewable outputs

### DIFF
--- a/meshroom/core/node.py
+++ b/meshroom/core/node.py
@@ -1166,6 +1166,8 @@ class BaseNode(BaseObject):
     hasDuplicatesChanged = Signal()
     hasDuplicates = Property(bool, lambda self: self._hasDuplicates, notify=hasDuplicatesChanged)
 
+    outputAttrEnabledChanged = Signal()
+
 
 class Node(BaseNode):
     """
@@ -1192,6 +1194,8 @@ class Node(BaseNode):
 
         # List attributes per uid
         for attr in self._attributes:
+            if attr.isOutput and attr.desc.semantic == "image":
+                attr.enabledChanged.connect(self.outputAttrEnabledChanged)
             for uidIndex in attr.attributeDesc.uid:
                 self.attributesPerUid[uidIndex].add(attr)
 

--- a/meshroom/nodes/aliceVision/DepthMap.py
+++ b/meshroom/nodes/aliceVision/DepthMap.py
@@ -391,7 +391,7 @@ Use a downscale factor of one (full-resolution) only if the quality of the input
                 label='Export Depth Maps',
                 description='Export intermediate depth/similarity maps from the SGM and Refine steps.',
                 value=False,
-                uid=[],
+                uid=[0],
                 advanced=True,
             ),
             desc.BoolParam(
@@ -399,7 +399,7 @@ Use a downscale factor of one (full-resolution) only if the quality of the input
                 label='Export Volumes',
                 description='Export intermediate full similarity volumes from the SGM and Refine steps.',
                 value=False,
-                uid=[],
+                uid=[0],
                 advanced=True,
             ),
             desc.BoolParam(
@@ -407,7 +407,7 @@ Use a downscale factor of one (full-resolution) only if the quality of the input
                 label='Export Cross Volumes',
                 description='Export intermediate similarity cross volumes from the SGM and Refine steps.',
                 value=False,
-                uid=[],
+                uid=[0],
                 advanced=True,
             ),
             desc.BoolParam(
@@ -415,7 +415,7 @@ Use a downscale factor of one (full-resolution) only if the quality of the input
                 label='Export 9 Points',
                 description='Export intermediate volumes 9 points from the SGM and Refine steps in CSV files.',
                 value=False,
-                uid=[],
+                uid=[0],
                 advanced=True,
             ),
             desc.BoolParam(
@@ -423,7 +423,7 @@ Use a downscale factor of one (full-resolution) only if the quality of the input
                 label='Export Tile Pattern',
                 description='Export the bounding boxes of tiles volumes as meshes. This allows to visualize the depth map search areas.',
                 value=False,
-                uid=[],
+                uid=[0],
                 advanced=True,
             ),
         ]),

--- a/meshroom/nodes/aliceVision/DepthMap.py
+++ b/meshroom/nodes/aliceVision/DepthMap.py
@@ -483,7 +483,7 @@ Use a downscale factor of one (full-resolution) only if the quality of the input
             value=desc.Node.internalFolder + '<VIEW_ID>_tilePattern.obj',
             uid=[],
             group='', # do not export on the command line
-            # enabled=lambda node: node.intermediateResults.exportTilePattern.value,
+            enabled=lambda node: node.intermediateResults.exportTilePattern.value,
         ),
         desc.File(
             name='depthSgm',
@@ -493,7 +493,7 @@ Use a downscale factor of one (full-resolution) only if the quality of the input
             value=desc.Node.internalFolder + '<VIEW_ID>_depthMap_scale2_sgm.exr',
             uid=[],
             group='', # do not export on the command line
-            # enabled=lambda node: node.intermediateResults.exportIntermediateDepthSimMaps.value,
+            enabled=lambda node: node.intermediateResults.exportIntermediateDepthSimMaps.value,
         ),
         desc.File(
             name='depthSgmUpscaled',
@@ -503,7 +503,7 @@ Use a downscale factor of one (full-resolution) only if the quality of the input
             value=desc.Node.internalFolder + '<VIEW_ID>_depthMap_sgmUpscaled.exr',
             uid=[],
             group='', # do not export on the command line
-            # enabled=lambda node: node.intermediateResults.exportIntermediateDepthSimMaps.value,
+            enabled=lambda node: node.intermediateResults.exportIntermediateDepthSimMaps.value,
         ),
         desc.File(
             name='depthRefined',
@@ -513,6 +513,6 @@ Use a downscale factor of one (full-resolution) only if the quality of the input
             value=desc.Node.internalFolder + '<VIEW_ID>_depthMap_refinedFused.exr',
             uid=[],
             group='', # do not export on the command line
-            # enabled=lambda node: node.intermediateResults.exportIntermediateDepthSimMaps.value,
+            enabled=lambda node: node.intermediateResults.exportIntermediateDepthSimMaps.value,
         ),
     ]

--- a/meshroom/ui/qml/Viewer/Viewer2D.qml
+++ b/meshroom/ui/qml/Viewer/Viewer2D.qml
@@ -184,7 +184,7 @@ FocusScope {
         var hasImageOutputAttr = false;
         for (var i = 0; i < node.attributes.count; i++) {
             var attr = node.attributes.at(i);
-            if (attr.isOutput && attr.desc.semantic == "image") {
+            if (attr.isOutput && attr.desc.semantic === "image" && attr.enabled) {
                 hasImageOutputAttr = true;
                 break;
             }
@@ -280,7 +280,7 @@ FocusScope {
             // store attr name for output attributes that represent images
             for (var i = 0; i < displayedNode.attributes.count; i++) {
                 var attr = displayedNode.attributes.at(i);
-                if (attr.isOutput && attr.desc.semantic == "image") {
+                if (attr.isOutput && attr.desc.semantic === "image" && attr.enabled) {
                     names.push(attr.name);
                 }
             }
@@ -300,6 +300,10 @@ FocusScope {
         }
     }
 
+    Connections {
+        target: displayedNode
+        onOutputAttrEnabledChanged: tryLoadNode(displayedNode)
+    }
     // context menu
     property Component contextMenu: Menu {
         MenuItem {
@@ -1193,7 +1197,7 @@ FocusScope {
                             property var names: ["gallery"]
                             property string name: names[currentIndex]
 
-                            model: names.map(n => (n == "gallery") ? "Image Gallery" : displayedNode.attributes.get(n).label)
+                            model: names.map(n => (n === "gallery") ? "Image Gallery" : displayedNode.attributes.get(n).label)
                             enabled: count > 1
 
                             FontMetrics {


### PR DESCRIPTION
## Description

This PR splits from #1925 and keeps the dynamic update of the list of viewable outputs in the 2D Viewer: instead of displaying at all times the list of a node's viewable outputs independently from their current status (enabled or disabled), the 2D Viewer should only show the enabled outputs, and adding/removing them as soon as they get enabled/disabled.

Hiding (or showing) the connections of output attributes that get disabled (or enabled) will remain handled in #1925.

## Features list

- [x] Update the list of viewable outputs in the 2D Viewer depending on the loaded node's enabled outputs.
- [x] Uncomment the conditional `enabled` status of some `DepthMap`'s outputs. 

