### PR TITLE
[ui] ImageGallery: Display the name of the active `CameraInit` group

### DIFF
--- a/meshroom/ui/qml/ImageGallery/ImageGallery.qml
+++ b/meshroom/ui/qml/ImageGallery/ImageGallery.qml
@@ -577,8 +577,14 @@ Panel {
 
             ToolButton {
                 text: MaterialIcons.navigate_before
+                property string previousGroupName: {
+                    if (root.cameraInits && root.cameraInitIndex - 1 >= 0) {
+                        return root.cameraInits.at(root.cameraInitIndex - 1).name
+                    }
+                    return ""
+                }
                 font.family: MaterialIcons.fontFamily
-                ToolTip.text: "Previous Group (Alt+Left)"
+                ToolTip.text: "Previous Group (Alt+Left): " + previousGroupName
                 ToolTip.visible: hovered
                 enabled: nodesCB.currentIndex > 0
                 onClicked: nodesCB.decrementCurrentIndex()
@@ -605,11 +611,29 @@ Panel {
             Label { text: "/ " + (root.cameraInits ? root.cameraInits.count : "Unknown") }
             ToolButton {
                 text: MaterialIcons.navigate_next
+                property string nextGroupName: {
+                    if (root.cameraInits && root.cameraInitIndex + 1 < root.cameraInits.count) {
+                        return root.cameraInits.at(root.cameraInitIndex + 1).name
+                    }
+                    return ""
+                }
                 font.family: MaterialIcons.fontFamily
-                ToolTip.text: "Next Group (Alt+Right)"
+                ToolTip.text: "Next Group (Alt+Right): " + nextGroupName
                 ToolTip.visible: hovered
                 enabled: root.cameraInits ? nodesCB.currentIndex < root.cameraInits.count - 1 : false
                 onClicked: nodesCB.incrementCurrentIndex()
+            }
+        }
+
+        RowLayout {
+            Layout.fillHeight: false
+            Layout.alignment: Qt.AlignHCenter
+            visible: root.cameraInits ? root.cameraInits.count > 1 : false
+
+            Label {
+                id: groupName
+                text: root.cameraInit ? root.cameraInit.name : ""
+                font.pointSize: 8
             }
         }
     }

--- a/meshroom/ui/qml/ImageGallery/ImageGallery.qml
+++ b/meshroom/ui/qml/ImageGallery/ImageGallery.qml
@@ -579,7 +579,7 @@ Panel {
                 text: MaterialIcons.navigate_before
                 property string previousGroupName: {
                     if (root.cameraInits && root.cameraInitIndex - 1 >= 0) {
-                        return root.cameraInits.at(root.cameraInitIndex - 1).name
+                        return root.cameraInits.at(root.cameraInitIndex - 1).label
                     }
                     return ""
                 }
@@ -613,7 +613,7 @@ Panel {
                 text: MaterialIcons.navigate_next
                 property string nextGroupName: {
                     if (root.cameraInits && root.cameraInitIndex + 1 < root.cameraInits.count) {
-                        return root.cameraInits.at(root.cameraInitIndex + 1).name
+                        return root.cameraInits.at(root.cameraInitIndex + 1).label
                     }
                     return ""
                 }
@@ -632,7 +632,7 @@ Panel {
 
             Label {
                 id: groupName
-                text: root.cameraInit ? root.cameraInit.name : ""
+                text: root.cameraInit ? root.cameraInit.label : ""
                 font.pointSize: 8
             }
         }


### PR DESCRIPTION
## Description

This PR adds the name of the currently active `CameraInit` group in the Image Gallery, right below the group selection area.

Additionally, it adds the name of the previous/next `CameraInit` group in the tooltip of the buttons used to switch between groups.
<div align="center"><img src="https://github.com/alicevision/Meshroom/assets/11963329/5b7f6c69-1ba3-4fba-af91-2e6459e043e4" /></div>
