### PR TITLE
[ui] Display an icon on nodes that have viewable outputs

### DIFF
--- a/meshroom/core/node.py
+++ b/meshroom/core/node.py
@@ -1123,6 +1123,12 @@ class BaseNode(BaseObject):
         return (self.locked and self.getGlobalStatus() == Status.SUBMITTED and
                 self.globalExecMode == "LOCAL" and self.statusInThisSession())
 
+    def hasImageOutputAttribute(self):
+        for attr in self._attributes:
+            if attr.enabled and attr.isOutput and attr.desc.semantic == "image":
+                return True
+        return False
+
 
     name = Property(str, getName, constant=True)
     nodeType = Property(str, nodeType.fget, constant=True)
@@ -1165,6 +1171,8 @@ class BaseNode(BaseObject):
     duplicates = Property(Variant, lambda self: self._duplicates, constant=True)
     hasDuplicatesChanged = Signal()
     hasDuplicates = Property(bool, lambda self: self._hasDuplicates, notify=hasDuplicatesChanged)
+    # When output attributes will be able to switch between enabled/disabled, the property should have a notifying
+    hasImageOutput = Property(bool, hasImageOutputAttribute, constant=True)
 
     outputAttrEnabledChanged = Signal()
 

--- a/meshroom/core/node.py
+++ b/meshroom/core/node.py
@@ -1171,10 +1171,9 @@ class BaseNode(BaseObject):
     duplicates = Property(Variant, lambda self: self._duplicates, constant=True)
     hasDuplicatesChanged = Signal()
     hasDuplicates = Property(bool, lambda self: self._hasDuplicates, notify=hasDuplicatesChanged)
-    # When output attributes will be able to switch between enabled/disabled, the property should have a notifying
-    hasImageOutput = Property(bool, hasImageOutputAttribute, constant=True)
 
     outputAttrEnabledChanged = Signal()
+    hasImageOutput = Property(bool, hasImageOutputAttribute, notify=outputAttrEnabledChanged)
 
 
 class Node(BaseNode):

--- a/meshroom/ui/qml/GraphEditor/Node.qml
+++ b/meshroom/ui/qml/GraphEditor/Node.qml
@@ -305,6 +305,36 @@ Item {
                                     hoverEnabled: true
                                 }
                             }
+
+                            MaterialLabel {
+                                id: nodeImageOutput
+                                visible: node.hasImageOutput && ["SUCCESS"].includes(node.globalStatus) && node.chunks.count > 0
+                                text: MaterialIcons.visibility
+                                padding: 2
+                                font.pointSize: 7
+
+                                ToolTip {
+                                    id: nodeImageOutputTooltip
+                                    parent: header
+                                    visible: nodeImageOutputMA.containsMouse && nodeImageOutput.visible
+                                    text: "This node has at least one output that can be loaded in the 2D Viewer.\n" +
+                                          "Double-clicking on this node will load it in the 2D Viewer."
+                                    implicitWidth: 500
+                                    delay: 300
+
+                                    // Relative position for the tooltip to ensure we won't get stuck in a case where it starts appearing over the mouse's
+                                    // position because it's a bit long and cutting off the hovering of the mouse area (which leads to the tooltip beginning
+                                    // to appear and immediately disappearing, over and over again)
+                                    x: implicitWidth / 2.5
+                                }
+
+                                MouseArea {
+                                    // If the node header is hovered, comments may be displayed
+                                    id: nodeImageOutputMA
+                                    anchors.fill: parent
+                                    hoverEnabled: true
+                                }
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
## Description

This PR adds an icon on nodes with outputs that can be visualised with the 2D Viewer (following #1776). 

When a node has been computed, if it has at least one viewable output, an icon appears next to its name with a tooltip indicating that it can be loaded by double-clicking it.

<div align="center"><img src="https://github.com/alicevision/Meshroom/assets/11963329/6819c506-ecb1-4c50-9c0d-c53a7c22f089" /></div>
