### PR TITLE
[core] Detect and handle UID conflicts when loading a graph

### DIFF
--- a/meshroom/core/graph.py
+++ b/meshroom/core/graph.py
@@ -243,7 +243,7 @@ class Graph(BaseObject):
     @Slot(str)
     def load(self, filepath, setupProjectFile=True, importProject=False, publishOutputs=False):
         """
-        Load a meshroom graph ".mg" file.
+        Load a Meshroom graph ".mg" file.
 
         Args:
             filepath: project filepath to load
@@ -308,7 +308,38 @@ class Graph(BaseObject):
                 # Note: needs to be done at the end as it will trigger an updateInternals.
                 self._setFilepath(filepath)
 
+            # By this point, the graph has been fully loaded and an updateInternals has been triggered, so all the nodes'
+            # links have been resolved and their UID computations are all complete.
+            # It is now possible to check whether the UIDs stored in the graph file for each node correspond to the ones
+            # that were computed.
+            if not isTemplate:  # UIDs are not stored in templates
+                self._evaluateUidConflicts(graphData)
+                self._applyExpr()
+
         return True
+
+    def _evaluateUidConflicts(self, data):
+        """
+        Compare the UIDs of all the nodes in the graph with the UID that is expected in the graph file. If there
+        are mismatches, the nodes with the unexpected UID are replaced with "UidConflict" compatibility nodes.
+
+        Args:
+            data (dict): the dictionary containing all the nodes to import and their data
+        """
+        for nodeName, nodeData in sorted(data.items(), key=lambda x: self.getNodeIndexFromName(x[0])):
+            node = self.node(nodeName)
+            # If the node is a CompatibilityNode, its UID is not available and there is no need to check it
+            if isinstance(node, CompatibilityNode):
+                continue
+
+            savedUid = nodeData.get("uids", "").get("0", "")  # Node's UID from the graph file
+            graphUid = node._uids.get(0)  # Node's UID from the graph itself
+            if savedUid != graphUid and graphUid is not None:
+                # Different UIDs, remove the existing node from the graph and replace it with a CompatibilityNode
+                logging.debug("UID conflict detected for {}".format(nodeName))
+                self.removeNode(nodeName)
+                n = nodeFactory(nodeData, nodeName, template=False, uidConflict=True)
+                self._addNode(n, nodeName)
 
     def updateImportedProject(self, data):
         """

--- a/meshroom/core/node.py
+++ b/meshroom/core/node.py
@@ -1579,7 +1579,7 @@ class CompatibilityNode(BaseNode):
     issueDetails = Property(str, issueDetails.fget, constant=True)
 
 
-def nodeFactory(nodeDict, name=None, template=False):
+def nodeFactory(nodeDict, name=None, template=False, uidConflict=False):
     """
     Create a node instance by deserializing the given node data.
     If the serialized data matches the corresponding node type description, a Node instance is created.
@@ -1588,6 +1588,8 @@ def nodeFactory(nodeDict, name=None, template=False):
     Args:
         nodeDict (dict): the serialization of the node
         name (str): (optional) the node's name
+        template (bool): (optional) true if the node is part of a template, false otherwise
+        uidConflict (bool): (optional) true if a UID conflict has been detected externally on that node
 
     Returns:
         BaseNode: the created node
@@ -1616,7 +1618,10 @@ def nodeFactory(nodeDict, name=None, template=False):
         # unknown node type
         compatibilityIssue = CompatibilityIssue.UnknownNodeType
 
-    if nodeDesc:
+    if uidConflict:
+        compatibilityIssue = CompatibilityIssue.UidConflict
+
+    if nodeDesc and not uidConflict:  # if uidConflict, there is no need to look for another compatibility issue
         # compare serialized node version with current node version
         currentNodeVersion = meshroom.core.nodeVersion(nodeDesc)
         # if both versions are available, check for incompatibility in major version

--- a/meshroom/core/node.py
+++ b/meshroom/core/node.py
@@ -1487,6 +1487,8 @@ class CompatibilityNode(BaseNode):
             )
         elif self.issue == CompatibilityIssue.DescriptionConflict:
             return "Node attributes do not match node description."
+        elif self.issue == CompatibilityIssue.UidConflict:
+            return "Node UID differs from the expected one."
         else:
             return "Unknown error."
 

--- a/meshroom/ui/qml/GraphEditor/CompatibilityManager.qml
+++ b/meshroom/ui/qml/GraphEditor/CompatibilityManager.qml
@@ -16,7 +16,7 @@ MessageDialog {
     // alias to underlying compatibilityNodes model
     readonly property var nodesModel: uigraph ? uigraph.graph.compatibilityNodes : undefined
     // the total number of compatibility issues
-    readonly property int issueCount: (nodesModel != undefined) ? nodesModel.count : 0
+    readonly property int issueCount: (nodesModel !== undefined && nodesModel !== null) ? nodesModel.count : 0
     // the number of CompatibilityNodes that can be upgraded
     readonly property int upgradableCount: {
         var count = 0
@@ -113,7 +113,7 @@ MessageDialog {
 
         Label {
             id: questionLabel
-            text: upgradableCount ? "Upgrade all possible nodes to current version ?"
+            text: upgradableCount ? "Upgrade all possible nodes to current version?"
                                   : "Those nodes can't be upgraded, remove them manually if needed."
         }
     }


### PR DESCRIPTION
## Description

This PR relates to #2038, which invalidates all the nodes in all the existing graphs by changing the way UIDs are computed. Without it, all nodes will be invalidated silently, without letting the user know why or giving them the chance to still use their computed data before doing the upgrade.

With this PR, UID conflicts - differences between the UIDs that are saved in a project file and the UIDs that are computed in the graph once all the links have been resolved - are detected and handled like any other compatibility issue, meaning they can be solved with the Compatibility Manager.

When a project file is loaded, the graph is built normally (compatibility issues on nodes' versions and descriptions are raised as usual) and then evaluated to check for UID conflicts. If a node presents a UID conflict, it is removed from the graph and replaced with a Compatibility node that has a `UidConflict` compatibility issue.


## Features list

- [x] Add a message for the `UidConflict` compatibility issue;
- [x] Detect UID conflicts and create the corresponding Compatibility nodes.


## Implementation remarks

The comparison between the nodes' actual UIDs and the expected one cannot be performed while the graph is being built, as there is no way to compute accurate UIDs until the links for all the nodes have been resolved. It is necessary to build the graph and resolve all the links first before performing the comparison, and replacing nodes that present UID conflicts.

Nodes from templates are excluded from the comparison since no UID is saved in template files. Nodes that were created in the graph as Compatibility nodes (with versions or descriptions compatibility issues) are also ignored, since the UID of Compatibility nodes are not resolved.