### PR TITLE
[blender] preview: use cycles render engine

### DIFF
--- a/meshroom/nodes/blender/scripts/preview.py
+++ b/meshroom/nodes/blender/scripts/preview.py
@@ -116,6 +116,11 @@ def initScene():
     bpy.data.objects.remove(bpy.data.objects['Light'])
     # Set output format
     bpy.context.scene.render.image_settings.file_format = 'JPEG'
+    # Setup rendering engine
+    bpy.context.scene.render.engine = 'CYCLES'
+    bpy.context.scene.cycles.samples = 1
+    bpy.context.scene.cycles.use_adaptative_sampling = False
+    bpy.context.scene.cycles.use_denoising = False
 
 
 def initCompositing():


### PR DESCRIPTION
## Description

Use the `CYCLES` render engine in the `ScenePreview` node script to support farm rendering.