### PR TITLE
Support pixel aspect ratio (no UI)

### DIFF
--- a/meshroom/nodes/aliceVision/CameraInit.py
+++ b/meshroom/nodes/aliceVision/CameraInit.py
@@ -449,7 +449,7 @@ The needed metadata are:
                     view['metadata'] = json.loads(view['metadata'])
 
             sfmData = {
-                "version": [1, 2, 2],
+                "version": [1, 2, 5],
                 "views": views + newViews,
                 "intrinsics": intrinsics,
                 "featureFolder": "",

--- a/meshroom/nodes/blender/scripts/preview.py
+++ b/meshroom/nodes/blender/scripts/preview.py
@@ -91,6 +91,7 @@ def setupCamera(intrinsic, pose):
 
     bpy.context.scene.render.resolution_x = int(intrinsic['width'])
     bpy.context.scene.render.resolution_y = int(intrinsic['height'])
+    bpy.context.scene.render.pixel_aspect_x = float(intrinsic['pixelRatio'])
 
     camData.sensor_width = float(intrinsic['sensorWidth'])
     camData.lens = float(intrinsic['focalLength'])


### PR DESCRIPTION
## Description

Full support of pixel aspect ratio in all the tools used for camera tracking.

related AliceVision PR: https://github.com/alicevision/AliceVision/pull/1448

This PR is **NOT** about supporting non-trivial pixel aspect ratio in the UI.

## Important

The SfMData file version was increased to `1.2.5` and this change impacts the `viewpoints.sfm` file generated when importing images in Meshroom.