### PR TITLE
Set `ALICEVISION_SPHERE_DETECTION_MODEL` variable during the initialisation

### DIFF
--- a/meshroom/__init__.py
+++ b/meshroom/__init__.py
@@ -120,6 +120,7 @@ def setupEnvironment(backend=Backend.STANDALONE):
         qtPluginsDir = os.path.join(rootDir, "qtPlugins")
         sensorDBPath = os.path.join(aliceVisionShareDir, "cameraSensors.db")
         voctreePath = os.path.join(aliceVisionShareDir, "vlfeat_K80L3.SIFT.tree")
+        sphereDetectionModel = os.path.join(aliceVisionShareDir, "sphereDetection_Mask-RCNN.onnx")
 
         env = {
             'PATH': aliceVisionBinDir,
@@ -134,7 +135,8 @@ def setupEnvironment(backend=Backend.STANDALONE):
         variables = {
             "ALICEVISION_ROOT": aliceVisionDir,
             "ALICEVISION_SENSOR_DB": sensorDBPath,
-            "ALICEVISION_VOCTREE": voctreePath
+            "ALICEVISION_VOCTREE": voctreePath,
+            "ALICEVISION_SPHERE_DETECTION_MODEL": sphereDetectionModel
         }
 
         for key, value in variables.items():


### PR DESCRIPTION
## Description

The `ALICEVISION_SPHERE_DETECTION` variable needs to be declared and set using the installation path. If it is not, no node using it will be able to work unless the users set this environment variable on their own.

This relates to #2067 and should have been a part of it.