### PR TITLE
Set `ALICEVISION_SEMANTIC_SEGMENTATION_MODEL` variable during the initialisation

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -14,12 +14,15 @@ Provided in AliceVision source tree: {ALICEVISION_REPOSITORY}/src/aliceVision/se
 It can be downloaded [here](https://gitlab.com/alicevision/trainedVocabularyTreeData/raw/master/vlfeat_K80L3.SIFT.tree).
 * sphere detection model (optional): for the automated sphere detection in stereo photometry.
 It can be downloaded [here](https://gitlab.com/alicevision/SphereDetectionModel/-/raw/main/sphereDetection_Mask-RCNN.onnx).
+* semantic segmentation model (optional): for the semantic segmentation of objects.
+It can be downloaded [here](https://gitlab.com/alicevision/semanticSegmentationModel/-/raw/main/fcn_resnet50.onnx).
 
 Environment variables must be set for Meshroom to find those files:
 ```
 ALICEVISION_SENSOR_DB=/path/to/database
 ALICEVISION_VOCTREE=/path/to/voctree
 ALICEVISION_SPHERE_DETECTION_MODEL=/path/to/detection/model
+ALICEVISION_SEMANTIC_SEGMENTATION_MODEL=/path/to/segmentation/model
 ALICEVISION_ROOT=/path/to/AliceVision/install/directory
 ```
 

--- a/meshroom/__init__.py
+++ b/meshroom/__init__.py
@@ -121,6 +121,7 @@ def setupEnvironment(backend=Backend.STANDALONE):
         sensorDBPath = os.path.join(aliceVisionShareDir, "cameraSensors.db")
         voctreePath = os.path.join(aliceVisionShareDir, "vlfeat_K80L3.SIFT.tree")
         sphereDetectionModel = os.path.join(aliceVisionShareDir, "sphereDetection_Mask-RCNN.onnx")
+        semanticSegmentationModel = os.path.join(aliceVisionShareDir, "fcn_resnet50.onnx")
 
         env = {
             'PATH': aliceVisionBinDir,
@@ -136,7 +137,8 @@ def setupEnvironment(backend=Backend.STANDALONE):
             "ALICEVISION_ROOT": aliceVisionDir,
             "ALICEVISION_SENSOR_DB": sensorDBPath,
             "ALICEVISION_VOCTREE": voctreePath,
-            "ALICEVISION_SPHERE_DETECTION_MODEL": sphereDetectionModel
+            "ALICEVISION_SPHERE_DETECTION_MODEL": sphereDetectionModel,
+            "ALICEVISION_SEMANTIC_SEGMENTATION_MODEL": semanticSegmentationModel
         }
 
         for key, value in variables.items():


### PR DESCRIPTION
## Description

The `ALICEVISION_SEMANTIC_SEGMENTATION_MODEL` variable needs to be declared and set using the installation path. If it is not, no node using it will be able to work unless the users set this environment variable on their own.

Additionally, the `INSTALL.md` file is completed with a link to download the semantic segmentation model and how to set the `ALICEVISION_SEMANTIC_SEGMENTATION_MODEL` variable. 

This PR relates to https://github.com/alicevision/AliceVision/pull/1481.