### PR TITLE
[core] Add brackets option for GroupAttribute

### DIFF
--- a/meshroom/core/attribute.py
+++ b/meshroom/core/attribute.py
@@ -581,9 +581,19 @@ class GroupAttribute(Attribute):
             return {name: attr.getPrimitiveValue(exportDefault=exportDefault) for name, attr in self._value.items() if not attr.isDefault}
 
     def getValueStr(self):
+        # add brackets if requested
+        strBegin = ''
+        strEnd = ''
+        if self.attributeDesc.brackets is not None:
+            if len(self.attributeDesc.brackets) == 2:
+                strBegin = self.attributeDesc.brackets[0]
+                strEnd = self.attributeDesc.brackets[1]
+            else:
+                raise AttributeError("Incorrect brackets on GroupAttribute: {}".format(self.attributeDesc.brackets))
+            
         # sort values based on child attributes group description order
         sortedSubValues = [self._value.get(attr.name).getValueStr() for attr in self.attributeDesc.groupDesc]
-        return self.attributeDesc.joinChar.join(sortedSubValues)
+        return strBegin + self.attributeDesc.joinChar.join(sortedSubValues) + strEnd
 
     def updateInternals(self):
         super(GroupAttribute, self).updateInternals()

--- a/meshroom/core/desc.py
+++ b/meshroom/core/desc.py
@@ -112,12 +112,13 @@ class ListAttribute(Attribute):
 
 class GroupAttribute(Attribute):
     """ A macro Attribute composed of several Attributes """
-    def __init__(self, groupDesc, name, label, description, group='allParams', advanced=False, semantic='', enabled=True, joinChar=' '):
+    def __init__(self, groupDesc, name, label, description, group='allParams', advanced=False, semantic='', enabled=True, joinChar=' ', brackets=None):
         """
         :param groupDesc: the description of the Attributes composing this group
         """
         self._groupDesc = groupDesc
         self._joinChar = joinChar
+        self._brackets = brackets
         super(GroupAttribute, self).__init__(name=name, label=label, description=description, value={}, uid=(), group=group, advanced=advanced, semantic=semantic, enabled=enabled)
 
     groupDesc = Property(Variant, lambda self: self._groupDesc, constant=True)
@@ -198,6 +199,7 @@ class GroupAttribute(Attribute):
 
     uid = Property(Variant, retrieveChildrenUids, constant=True)
     joinChar = Property(str, lambda self: self._joinChar, constant=True)
+    brackets = Property(str, lambda self: self._brackets, constant=True)
 
 
 class Param(Attribute):


### PR DESCRIPTION
## Description

Add brackets option for GroupAttribute command line value. Brackets option is a two chars string or None. 
If specified the GroupAttribute command line value is encapsulated between the two chars. (e.g. '[]')
