### PR TITLE
[bin] meshroom_batch: Save graph once it has been all set up and resolved

### DIFF
--- a/bin/meshroom_batch
+++ b/bin/meshroom_batch
@@ -180,9 +180,9 @@ with multiview.GraphModification(graph):
     # setup cache directory
     graph.cacheDir = args.cache if args.cache else meshroom.core.defaultCacheFolder
 
-    if args.save:
-        graph.save(args.save, setupProjectFile=not bool(args.cache))
-        print('File successfully saved: "{}"'.format(args.save))
+if args.save:
+    graph.save(args.save, setupProjectFile=not bool(args.cache))
+    print('File successfully saved: "{}"'.format(args.save))
 
 if not args.output:
     print('No output set, results will be available in the cache folder: "{}"'.format(graph.cacheDir))


### PR DESCRIPTION
## Description

This PR fixes an issue in `meshroom_batch` which led its executions with the `--submit` argument to fail with the following key errors:
```
Invalid expression with missing key on "CameraInit_1.output" with value "{cache}/{nodeType}/{uid0}/cameraInit.sfm".
Error: 'uid0'
KeyError: 'uid0'
```

In order to prevent this, if the `--save` argument has been provided, the graph should be saved outside of the `GraphModificatioǹ event, once it has been set up entirely and resolved. If it is saved within the `GraphModification`, UIDs are not yet available when it is written on disk, so the dictonaries that should be filled with them are empty.

This does not cause any issue for the rest of the execution of `meshroom_batch` if the graph is to be computed locally, since the UIDs will be computed right after (but they still will never be written in the project file). 

However, when submitting the graph to a renderfarm, the project file is loaded again. If it does not contain any UID:
 - All the nodes will present the `UidConflict` compatibility issue;
 - Key errors will be raised when trying to apply the links between nodes since they contain direct references to UIDs, which cannot be resolved as they are not present in the project file.