### PR TITLE
[nodes] HDR Fusion: Correctly detect the number of brackets when there are several intrinsics

### DIFF
--- a/meshroom/nodes/aliceVision/LdrToHdrMerge.py
+++ b/meshroom/nodes/aliceVision/LdrToHdrMerge.py
@@ -260,33 +260,31 @@ Merge LDR images into HDR images.
         if not isinstance(node.nodeDesc, cls):
             raise ValueError("Node {} is not an instance of type {}".format(node, cls))
         # TODO: use Node version for this test
-        if 'userNbBrackets' not in node.getAttributes().keys():
+        if "userNbBrackets" not in node.getAttributes().keys():
             # Old version of the node
             return
         if node.userNbBrackets.value != 0:
             node.nbBrackets.value = node.userNbBrackets.value
             return
-        # logging.info("[LDRToHDR] Update start: version:" + str(node.packageVersion))
         cameraInitOutput = node.input.getLinkParam(recursive=True)
         if not cameraInitOutput:
             node.nbBrackets.value = 0
             return
-        if not cameraInitOutput.node.hasAttribute('viewpoints'):
-            if cameraInitOutput.node.hasAttribute('input'):
+        if not cameraInitOutput.node.hasAttribute("viewpoints"):
+            if cameraInitOutput.node.hasAttribute("input"):
                 cameraInitOutput = cameraInitOutput.node.input.getLinkParam(recursive=True)
-        if cameraInitOutput and cameraInitOutput.node and cameraInitOutput.node.hasAttribute('viewpoints'):
+        if cameraInitOutput and cameraInitOutput.node and cameraInitOutput.node.hasAttribute("viewpoints"):
             viewpoints = cameraInitOutput.node.viewpoints.value
         else:
             # No connected CameraInit
             node.nbBrackets.value = 0
             return
 
-        # logging.info("[LDRToHDR] Update start: nb viewpoints:" + str(len(viewpoints)))
         inputs = []
         for viewpoint in viewpoints:
             jsonMetadata = viewpoint.metadata.value
             if not jsonMetadata:
-                # no metadata, we cannot found the number of brackets
+                # no metadata, we cannot find the number of brackets
                 node.nbBrackets.value = 0
                 return
             d = json.loads(jsonMetadata)
@@ -298,18 +296,30 @@ Merge LDR images into HDR images.
                 # We assume that there is no multi-bracketing, so nothing to do.
                 node.nbBrackets.value = 1
                 return
-            inputs.append((viewpoint.path.value, (fnumber, shutterSpeed, iso)))
+            inputs.append((viewpoint.path.value, (float(fnumber), float(shutterSpeed), float(iso))))
         inputs.sort()
 
         exposureGroups = []
         exposures = []
+        prevFnumber = 0.0
+        prevShutterSpeed = 0.0
+        prevIso = 0.0
         for path, exp in inputs:
-            if exposures and exp != exposures[-1] and exp == exposures[0]:
+            # A new group is created if the current image's exposure level is larger than the previous image's, or if there
+            # were any changes in the ISO or aperture value.
+            # Since the input images are ordered, the shutter speed should always be decreasing, so a shutter speed larger
+            # than the previous one indicates the start of a new exposure group.
+            fnumber, shutterSpeed, iso = exp
+            if exposures:
+                prevFnumber, prevShutterSpeed, prevIso = exposures[-1]
+            if exposures and len(exposures) > 1 and (fnumber != prevFnumber or shutterSpeed > prevShutterSpeed or iso != prevIso):
                 exposureGroups.append(exposures)
                 exposures = [exp]
             else:
                 exposures.append(exp)
+
         exposureGroups.append(exposures)
+
         exposures = None
         bracketSizes = set()
         if len(exposureGroups) == 1:
@@ -324,8 +334,5 @@ Merge LDR images into HDR images.
                 bracketSizes.add(len(expGroup))
             if len(bracketSizes) == 1:
                 node.nbBrackets.value = bracketSizes.pop()
-                # logging.info("[LDRToHDR] nb bracket size:" + str(node.nbBrackets.value))
             else:
                 node.nbBrackets.value = 0
-        # logging.info("[LDRToHDR] Update end")
-

--- a/meshroom/nodes/aliceVision/LdrToHdrSampling.py
+++ b/meshroom/nodes/aliceVision/LdrToHdrSampling.py
@@ -189,33 +189,31 @@ Sample pixels from Low range images for HDR creation.
         if not isinstance(node.nodeDesc, cls):
             raise ValueError("Node {} is not an instance of type {}".format(node, cls))
         # TODO: use Node version for this test
-        if 'userNbBrackets' not in node.getAttributes().keys():
+        if "userNbBrackets" not in node.getAttributes().keys():
             # Old version of the node
             return
         if node.userNbBrackets.value != 0:
             node.nbBrackets.value = node.userNbBrackets.value
             return
-        # logging.info("[LDRToHDR] Update start: version:" + str(node.packageVersion))
         cameraInitOutput = node.input.getLinkParam(recursive=True)
         if not cameraInitOutput:
             node.nbBrackets.value = 0
             return
-        if not cameraInitOutput.node.hasAttribute('viewpoints'):
-            if cameraInitOutput.node.hasAttribute('input'):
+        if not cameraInitOutput.node.hasAttribute("viewpoints"):
+            if cameraInitOutput.node.hasAttribute("input"):
                 cameraInitOutput = cameraInitOutput.node.input.getLinkParam(recursive=True)
-        if cameraInitOutput and cameraInitOutput.node and cameraInitOutput.node.hasAttribute('viewpoints'):
+        if cameraInitOutput and cameraInitOutput.node and cameraInitOutput.node.hasAttribute("viewpoints"):
             viewpoints = cameraInitOutput.node.viewpoints.value
         else:
             # No connected CameraInit
             node.nbBrackets.value = 0
             return
 
-        # logging.info("[LDRToHDR] Update start: nb viewpoints:" + str(len(viewpoints)))
         inputs = []
         for viewpoint in viewpoints:
             jsonMetadata = viewpoint.metadata.value
             if not jsonMetadata:
-                # no metadata, we cannot found the number of brackets
+                # no metadata, we cannot find the number of brackets
                 node.nbBrackets.value = 0
                 return
             d = json.loads(jsonMetadata)
@@ -227,18 +225,30 @@ Sample pixels from Low range images for HDR creation.
                 # We assume that there is no multi-bracketing, so nothing to do.
                 node.nbBrackets.value = 1
                 return
-            inputs.append((viewpoint.path.value, (fnumber, shutterSpeed, iso)))
+            inputs.append((viewpoint.path.value, (float(fnumber), float(shutterSpeed), float(iso))))
         inputs.sort()
 
         exposureGroups = []
         exposures = []
+        prevFnumber = 0.0
+        prevShutterSpeed = 0.0
+        prevIso = 0.0
         for path, exp in inputs:
-            if exposures and exp != exposures[-1] and exp == exposures[0]:
+            # A new group is created if the current image's exposure level is larger than the previous image's, or if there
+            # were any changes in the ISO or aperture value.
+            # Since the input images are ordered, the shutter speed should always be decreasing, so a shutter speed larger
+            # than the previous one indicates the start of a new exposure group.
+            fnumber, shutterSpeed, iso = exp
+            if exposures:
+                prevFnumber, prevShutterSpeed, prevIso = exposures[-1]
+            if exposures and len(exposures) > 1 and (fnumber != prevFnumber or shutterSpeed > prevShutterSpeed or iso != prevIso):
                 exposureGroups.append(exposures)
                 exposures = [exp]
             else:
                 exposures.append(exp)
+
         exposureGroups.append(exposures)
+
         exposures = None
         bracketSizes = set()
         if len(exposureGroups) == 1:
@@ -253,8 +263,5 @@ Sample pixels from Low range images for HDR creation.
                 bracketSizes.add(len(expGroup))
             if len(bracketSizes) == 1:
                 node.nbBrackets.value = bracketSizes.pop()
-                # logging.info("[LDRToHDR] nb bracket size:" + str(node.nbBrackets.value))
             else:
                 node.nbBrackets.value = 0
-        # logging.info("[LDRToHDR] Update end")
-


### PR DESCRIPTION
## Description

This PR relates to https://github.com/alicevision/AliceVision/pull/1484.

The detection of the number of brackets used to only work in a case where there was a single dataset / a single camera intrinsics. If two datasets with the same number of brackets were provided, the detection was failing because we expected the exposure levels to be uniform across all the images.

If more than one dataset is provided, there is no guarantee that the exposure groups will be identical although the number of brackets is the same.

The inputs are however sorted, and the shutter speeds are expected to be decreasing, meaning that a shutter speed N superior to a shutter speed N-1 indicates a new group. In the same manner, ISO or aperture values that change from one input to the next one indicate a new group.

For the comparison between exposure levels to be valid, the aperture, shutter speed and ISO values need to be stored in tuples as floats instead of strings.

This method is used for the following nodes:
- `LdrToHdrSampling`
- `LdrToHdrCalibration`
- `LdrToHdrMerge`