### PR TITLE
QML: Fix minor coercion error and warning

### DIFF
--- a/meshroom/ui/qml/Utils/SortFilterDelegateModel.qml
+++ b/meshroom/ui/qml/Utils/SortFilterDelegateModel.qml
@@ -70,7 +70,7 @@ DelegateModel {
     function find(value, roleName) {
         for(var i = 0; i < filteredItems.count; ++i)
         {
-            if(modelData(filteredItems.get(i), roleName) === value)
+            if(modelData(filteredItems.get(i), roleName) == value)
                 return i
         }
         return -1

--- a/meshroom/ui/qml/Viewer/Viewer2D.qml
+++ b/meshroom/ui/qml/Viewer/Viewer2D.qml
@@ -294,7 +294,9 @@ FocusScope {
 
     Connections {
         target: displayedNode
-        onOutputAttrEnabledChanged: tryLoadNode(displayedNode)
+        function onOutputAttrEnabledChanged() {
+            tryLoadNode(displayedNode)
+        }
     }
     // context menu
     property Component contextMenu: Menu {


### PR DESCRIPTION
## Description

Following #1882, this PR fixes an issue related to type coercion in `SortFilterDelegateModel` which prevents the `find` method from ever matching with anything, as well as a warning caused by the deprecated use of implictly declared slots.  