### PR TITLE
tolerant bracket size selection

### DIFF
--- a/meshroom/nodes/aliceVision/LdrToHdrCalibration.py
+++ b/meshroom/nodes/aliceVision/LdrToHdrCalibration.py
@@ -1,6 +1,7 @@
 __version__ = "3.0"
 
 import json
+from collections import Counter
 
 from meshroom.core import desc
 
@@ -229,7 +230,7 @@ Calibrate LDR to HDR response curve from samples.
         exposureGroups.append(exposures)
 
         exposures = None
-        bracketSizes = set()
+        bracketSizes = Counter()
         if len(exposureGroups) == 1:
             if len(set(exposureGroups[0])) == 1:
                 # Single exposure and multiple views
@@ -239,8 +240,16 @@ Calibrate LDR to HDR response curve from samples.
                 node.nbBrackets.value = len(exposureGroups[0])
         else:
             for expGroup in exposureGroups:
-                bracketSizes.add(len(expGroup))
-            if len(bracketSizes) == 1:
-                node.nbBrackets.value = bracketSizes.pop()
-            else:
+                bracketSizes[len(expGroup)] += 1
+
+            if len(bracketSizes) == 0:
                 node.nbBrackets.value = 0
+            else:
+                bestTuple = bracketSizes.most_common(1)[0]
+                bestBracketSize = bestTuple[0]
+                bestCount = bestTuple[1]
+                total = bestBracketSize * bestCount
+                if len(inputs) - total < 2:
+                    node.nbBrackets.value = bestBracketSize
+                else:
+                    node.nbBrackets.value = 0

--- a/meshroom/nodes/aliceVision/LdrToHdrMerge.py
+++ b/meshroom/nodes/aliceVision/LdrToHdrMerge.py
@@ -1,6 +1,7 @@
 __version__ = "4.1"
 
 import json
+from collections import Counter
 
 from meshroom.core import desc
 
@@ -321,7 +322,7 @@ Merge LDR images into HDR images.
         exposureGroups.append(exposures)
 
         exposures = None
-        bracketSizes = set()
+        bracketSizes = Counter()
         if len(exposureGroups) == 1:
             if len(set(exposureGroups[0])) == 1:
                 # Single exposure and multiple views
@@ -331,8 +332,16 @@ Merge LDR images into HDR images.
                 node.nbBrackets.value = len(exposureGroups[0])
         else:
             for expGroup in exposureGroups:
-                bracketSizes.add(len(expGroup))
-            if len(bracketSizes) == 1:
-                node.nbBrackets.value = bracketSizes.pop()
-            else:
+                bracketSizes[len(expGroup)] += 1
+
+            if len(bracketSizes) == 0:
                 node.nbBrackets.value = 0
+            else:
+                bestTuple = bracketSizes.most_common(1)[0]
+                bestBracketSize = bestTuple[0]
+                bestCount = bestTuple[1]
+                total = bestBracketSize * bestCount
+                if len(inputs) - total < 2:
+                    node.nbBrackets.value = bestBracketSize
+                else:
+                    node.nbBrackets.value = 0

--- a/meshroom/nodes/aliceVision/LdrToHdrMerge.py
+++ b/meshroom/nodes/aliceVision/LdrToHdrMerge.py
@@ -1,6 +1,7 @@
 __version__ = "4.1"
 
 import json
+import os
 from collections import Counter
 
 from meshroom.core import desc
@@ -305,19 +306,31 @@ Merge LDR images into HDR images.
         prevFnumber = 0.0
         prevShutterSpeed = 0.0
         prevIso = 0.0
+        prevPath = None  # Stores the dirname of the previous parsed image
+        newGroup = False  # True if a new exposure group needs to be created (useful when there are several datasets)
         for path, exp in inputs:
-            # A new group is created if the current image's exposure level is larger than the previous image's, or if there
-            # were any changes in the ISO or aperture value.
+            # If the dirname of the previous image and the dirname of the current image do not match, this means that the
+            # dataset that is being parsed has changed. A new group needs to be created but will fail to be detected in the
+            # next "if" statement if the new dataset's exposure levels are different. Setting "newGroup" to True prevents this
+            # from happening.
+            if prevPath is not None and prevPath != os.path.dirname(path):
+                newGroup = True
+
+            # A new group is created if the current image's exposure level is larger than the previous image's, if there
+            # were any changes in the ISO or aperture value, or if a new dataset has been detected with the path.
             # Since the input images are ordered, the shutter speed should always be decreasing, so a shutter speed larger
             # than the previous one indicates the start of a new exposure group.
             fnumber, shutterSpeed, iso = exp
             if exposures:
                 prevFnumber, prevShutterSpeed, prevIso = exposures[-1]
-            if exposures and len(exposures) > 1 and (fnumber != prevFnumber or shutterSpeed > prevShutterSpeed or iso != prevIso):
+            if exposures and len(exposures) > 1 and (fnumber != prevFnumber or shutterSpeed > prevShutterSpeed or iso != prevIso) or newGroup:
                 exposureGroups.append(exposures)
                 exposures = [exp]
             else:
                 exposures.append(exp)
+
+            prevPath = os.path.dirname(path)
+            newGroup = False
 
         exposureGroups.append(exposures)
 
@@ -341,7 +354,7 @@ Merge LDR images into HDR images.
                 bestBracketSize = bestTuple[0]
                 bestCount = bestTuple[1]
                 total = bestBracketSize * bestCount
-                if len(inputs) - total < 2:
+                if total >= len(inputs) - 2:
                     node.nbBrackets.value = bestBracketSize
                 else:
                     node.nbBrackets.value = 0

--- a/meshroom/nodes/aliceVision/LdrToHdrSampling.py
+++ b/meshroom/nodes/aliceVision/LdrToHdrSampling.py
@@ -1,6 +1,7 @@
 __version__ = "4.0"
 
 import json
+from collections import Counter
 
 from meshroom.core import desc
 
@@ -250,7 +251,7 @@ Sample pixels from Low range images for HDR creation.
         exposureGroups.append(exposures)
 
         exposures = None
-        bracketSizes = set()
+        bracketSizes = Counter()
         if len(exposureGroups) == 1:
             if len(set(exposureGroups[0])) == 1:
                 # Single exposure and multiple views
@@ -260,8 +261,16 @@ Sample pixels from Low range images for HDR creation.
                 node.nbBrackets.value = len(exposureGroups[0])
         else:
             for expGroup in exposureGroups:
-                bracketSizes.add(len(expGroup))
-            if len(bracketSizes) == 1:
-                node.nbBrackets.value = bracketSizes.pop()
-            else:
+                bracketSizes[len(expGroup)] += 1
+
+            if len(bracketSizes) == 0:
                 node.nbBrackets.value = 0
+            else:
+                bestTuple = bracketSizes.most_common(1)[0]
+                bestBracketSize = bestTuple[0]
+                bestCount = bestTuple[1]
+                total = bestBracketSize * bestCount
+                if len(inputs) - total < 2:
+                    node.nbBrackets.value = bestBracketSize
+                else:
+                    node.nbBrackets.value = 0

--- a/meshroom/nodes/aliceVision/LdrToHdrSampling.py
+++ b/meshroom/nodes/aliceVision/LdrToHdrSampling.py
@@ -1,6 +1,7 @@
 __version__ = "4.0"
 
 import json
+import os
 from collections import Counter
 
 from meshroom.core import desc
@@ -234,19 +235,31 @@ Sample pixels from Low range images for HDR creation.
         prevFnumber = 0.0
         prevShutterSpeed = 0.0
         prevIso = 0.0
+        prevPath = None  # Stores the dirname of the previous parsed image
+        newGroup = False  # True if a new exposure group needs to be created (useful when there are several datasets)
         for path, exp in inputs:
-            # A new group is created if the current image's exposure level is larger than the previous image's, or if there
-            # were any changes in the ISO or aperture value.
+            # If the dirname of the previous image and the dirname of the current image do not match, this means that the
+            # dataset that is being parsed has changed. A new group needs to be created but will fail to be detected in the
+            # next "if" statement if the new dataset's exposure levels are different. Setting "newGroup" to True prevents this
+            # from happening.
+            if prevPath is not None and prevPath != os.path.dirname(path):
+                newGroup = True
+
+            # A new group is created if the current image's exposure level is larger than the previous image's, if there
+            # were any changes in the ISO or aperture value, or if a new dataset has been detected with the path.
             # Since the input images are ordered, the shutter speed should always be decreasing, so a shutter speed larger
             # than the previous one indicates the start of a new exposure group.
             fnumber, shutterSpeed, iso = exp
             if exposures:
                 prevFnumber, prevShutterSpeed, prevIso = exposures[-1]
-            if exposures and len(exposures) > 1 and (fnumber != prevFnumber or shutterSpeed > prevShutterSpeed or iso != prevIso):
+            if exposures and len(exposures) > 1 and (fnumber != prevFnumber or shutterSpeed > prevShutterSpeed or iso != prevIso) or newGroup:
                 exposureGroups.append(exposures)
                 exposures = [exp]
             else:
                 exposures.append(exp)
+
+            prevPath = os.path.dirname(path)
+            newGroup = False
 
         exposureGroups.append(exposures)
 
@@ -270,7 +283,7 @@ Sample pixels from Low range images for HDR creation.
                 bestBracketSize = bestTuple[0]
                 bestCount = bestTuple[1]
                 total = bestBracketSize * bestCount
-                if len(inputs) - total < 2:
+                if total >= len(inputs) - 2:
                     node.nbBrackets.value = bestBracketSize
                 else:
                     node.nbBrackets.value = 0


### PR DESCRIPTION
Bracket size selection is now tolerant to at most two spurious image in the images list.

rule : (Bracket size * countGroupsWithThisSize) >= totalImages - 2