### PR TITLE
[nodes] HDR Fusion: Do not send `nbBrackets` parameter to the command line when the bracket detection is automatic

### DIFF
--- a/meshroom/nodes/aliceVision/LdrToHdrCalibration.py
+++ b/meshroom/nodes/aliceVision/LdrToHdrCalibration.py
@@ -69,6 +69,7 @@ Calibrate LDR to HDR response curve from samples.
             value=0,
             range=(0, 10, 1),
             uid=[0],
+            group="bracketsParams"
         ),
         desc.BoolParam(
             name="byPass",
@@ -163,6 +164,12 @@ Calibrate LDR to HDR response curve from samples.
     def processChunk(self, chunk):
         if chunk.node.nbBrackets.value == 1:
             return
+        # Trick to avoid sending --nbBrackets to the command line when the bracket detection is automatic.
+        # Otherwise, the AliceVision executable has no way of determining whether the bracket detection was automatic
+        # or if it was hard-set by the user.
+        self.commandLine = "aliceVision_LdrToHdrCalibration {allParams}"
+        if chunk.node.userNbBrackets.value == chunk.node.nbBrackets.value:
+            self.commandLine += "{bracketsParams}"
         super(LdrToHdrCalibration, self).processChunk(chunk)
 
     @classmethod

--- a/meshroom/nodes/aliceVision/LdrToHdrMerge.py
+++ b/meshroom/nodes/aliceVision/LdrToHdrMerge.py
@@ -68,6 +68,7 @@ Merge LDR images into HDR images.
             value=0,
             range=(0, 10, 1),
             uid=[0],
+            group="bracketsParams"
         ),
         desc.BoolParam(
             name="offsetRefBracketIndexEnabled",
@@ -358,3 +359,12 @@ Merge LDR images into HDR images.
                     node.nbBrackets.value = bestBracketSize
                 else:
                     node.nbBrackets.value = 0
+
+    def processChunk(self, chunk):
+        # Trick to avoid sending --nbBrackets to the command line when the bracket detection is automatic.
+        # Otherwise, the AliceVision executable has no way of determining whether the bracket detection was automatic
+        # or if it was hard-set by the user.
+        self.commandLine = "aliceVision_LdrToHdrMerge {allParams}"
+        if chunk.node.userNbBrackets.value == chunk.node.nbBrackets.value:
+            self.commandLine += "{bracketsParams}"
+        super(LdrToHdrMerge, self).processChunk(chunk)

--- a/meshroom/nodes/aliceVision/LdrToHdrSampling.py
+++ b/meshroom/nodes/aliceVision/LdrToHdrSampling.py
@@ -79,6 +79,7 @@ Sample pixels from Low range images for HDR creation.
             value=0,
             range=(0, 10, 1),
             uid=[0],
+            group="bracketsParams"
         ),
         desc.BoolParam(
             name="byPass",
@@ -184,6 +185,12 @@ Sample pixels from Low range images for HDR creation.
     def processChunk(self, chunk):
         if chunk.node.nbBrackets.value == 1:
             return
+        # Trick to avoid sending --nbBrackets to the command line when the bracket detection is automatic.
+        # Otherwise, the AliceVision executable has no way of determining whether the bracket detection was automatic
+        # or if it was hard-set by the user.
+        self.commandLine = "aliceVision_LdrToHdrSampling {allParams}"
+        if chunk.node.userNbBrackets.value == chunk.node.nbBrackets.value:
+            self.commandLine += "{bracketsParams}"
         super(LdrToHdrSampling, self).processChunk(chunk)
 
     @classmethod


### PR DESCRIPTION
## Description

This PR updates the command line for the HDR Fusion nodes (`LdrToHdrSampling`, `LdrToHdrCalibration` and `LdrToHdrMerge`) with or without the `nbBrackets` parameters depending on whether the number of brackets is detected automatically or provided by the user. 

If the user provides it, it is added to the command line as `--nbBrackets x`. If the detection is automatic, the `nbBrackets` parameter is not part of the command line, and the brackets will be automatically detected on the AliceVision side. 

The goal is to be able to distinguish, from the AliceVision side, cases where the number of brackets is determined automatically or set by the user; up until now, Meshroom always sent a fixed number of brackets (either automatically detected or provided by the user), without any way to distinguish where it came from.

The number of brackets that is displayed in the Image Gallery remains unchanged, and the automatic detection will still occur if needed.

## Implementation remarks

The `nbBrackets` parameter is excluded from the "allParams" group, withdrawing it by default from the command line. When the chunks are being processed, the command line is updated with it if the number of brackets has been provided by the user. If it has not, the command line is reset (at every iteration) to ensure that there are no `--nbBrackets` leftovers when we are switching between the automatic bracket detection and the manually-specified brackets number.

Rather than dynamically modifying the command line, the `nbBrackets` and `userNbBrackets` logic could be reversed for this to be done automatically. This however involves a lot of code modification that needs to be carried out throughout all the HDR Fusion nodes, and will thus be the focus of an ulterior pull request.   