### PR TITLE
[nodes] Remove limits on outliers for brackets detection

### DIFF
--- a/meshroom/nodes/aliceVision/LdrToHdrCalibration.py
+++ b/meshroom/nodes/aliceVision/LdrToHdrCalibration.py
@@ -267,9 +267,4 @@ Calibrate LDR to HDR response curve from samples.
             else:
                 bestTuple = bracketSizes.most_common(1)[0]
                 bestBracketSize = bestTuple[0]
-                bestCount = bestTuple[1]
-                total = bestBracketSize * bestCount
-                if total >= len(inputs) - 2:
-                    node.nbBrackets.value = bestBracketSize
-                else:
-                    node.nbBrackets.value = 0
+                node.nbBrackets.value = bestBracketSize

--- a/meshroom/nodes/aliceVision/LdrToHdrMerge.py
+++ b/meshroom/nodes/aliceVision/LdrToHdrMerge.py
@@ -353,12 +353,7 @@ Merge LDR images into HDR images.
             else:
                 bestTuple = bracketSizes.most_common(1)[0]
                 bestBracketSize = bestTuple[0]
-                bestCount = bestTuple[1]
-                total = bestBracketSize * bestCount
-                if total >= len(inputs) - 2:
-                    node.nbBrackets.value = bestBracketSize
-                else:
-                    node.nbBrackets.value = 0
+                node.nbBrackets.value = bestBracketSize
 
     def processChunk(self, chunk):
         # Trick to avoid sending --nbBrackets to the command line when the bracket detection is automatic.

--- a/meshroom/nodes/aliceVision/LdrToHdrSampling.py
+++ b/meshroom/nodes/aliceVision/LdrToHdrSampling.py
@@ -288,9 +288,4 @@ Sample pixels from Low range images for HDR creation.
             else:
                 bestTuple = bracketSizes.most_common(1)[0]
                 bestBracketSize = bestTuple[0]
-                bestCount = bestTuple[1]
-                total = bestBracketSize * bestCount
-                if total >= len(inputs) - 2:
-                    node.nbBrackets.value = bestBracketSize
-                else:
-                    node.nbBrackets.value = 0
+                node.nbBrackets.value = bestBracketSize


### PR DESCRIPTION
This PR removes brackets limits on Meshroom when managing outliers. The limit of two outliers at most does not exist anymore.

Related to https://github.com/alicevision/AliceVision/pull/1491.