### PR TITLE
[nodes] HDR Fusion: Select group with largest bracket number in case of equality

### DIFF
--- a/meshroom/nodes/aliceVision/LdrToHdrCalibration.py
+++ b/meshroom/nodes/aliceVision/LdrToHdrCalibration.py
@@ -265,6 +265,13 @@ Calibrate LDR to HDR response curve from samples.
             if len(bracketSizes) == 0:
                 node.nbBrackets.value = 0
             else:
-                bestTuple = bracketSizes.most_common(1)[0]
+                bestTuple = None
+                for tuple in bracketSizes.most_common():
+                    if bestTuple is None or tuple[1] > bestTuple[1]:
+                        bestTuple = tuple
+                    elif tuple[1] == bestTuple[1]:
+                        bestTuple = tuple if tuple[0] > bestTuple[0] else bestTuple
+
                 bestBracketSize = bestTuple[0]
+                bestCount = bestTuple[1]
                 node.nbBrackets.value = bestBracketSize

--- a/meshroom/nodes/aliceVision/LdrToHdrMerge.py
+++ b/meshroom/nodes/aliceVision/LdrToHdrMerge.py
@@ -351,8 +351,15 @@ Merge LDR images into HDR images.
             if len(bracketSizes) == 0:
                 node.nbBrackets.value = 0
             else:
-                bestTuple = bracketSizes.most_common(1)[0]
+                bestTuple = None
+                for tuple in bracketSizes.most_common():
+                    if bestTuple is None or tuple[1] > bestTuple[1]:
+                        bestTuple = tuple
+                    elif tuple[1] == bestTuple[1]:
+                        bestTuple = tuple if tuple[0] > bestTuple[0] else bestTuple
+
                 bestBracketSize = bestTuple[0]
+                bestCount = bestTuple[1]
                 node.nbBrackets.value = bestBracketSize
 
     def processChunk(self, chunk):

--- a/meshroom/nodes/aliceVision/LdrToHdrSampling.py
+++ b/meshroom/nodes/aliceVision/LdrToHdrSampling.py
@@ -291,7 +291,13 @@ Sample pixels from Low range images for HDR creation.
             if len(bracketSizes) == 0:
                 node.nbBrackets.value = 0
             else:
-                bestTuple = bracketSizes.most_common(1)[0]
+                bestTuple = None
+                for tuple in bracketSizes.most_common():
+                    if bestTuple is None or tuple[1] > bestTuple[1]:
+                        bestTuple = tuple
+                    elif tuple[1] == bestTuple[1]:
+                        bestTuple = tuple if tuple[0] > bestTuple[0] else bestTuple
+
                 bestBracketSize = bestTuple[0]
                 bestCount = bestTuple[1]
                 node.outliersNb = len(inputs) - (bestBracketSize * bestCount)  # Compute number of outliers


### PR DESCRIPTION
## Description

If there are several groups with different bracket numbers but identical counts (e.g. 3 groups with 7 brackets, and 3 groups with 3 brackets), select the groups with the largest bracket number (e.g. groups with 7 brackets instead of 3).

This reflects changes introduced with https://github.com/alicevision/AliceVision/pull/1493.
