### PR TITLE
[ui] GraphEditor: Minor UI changes

### DIFF
--- a/meshroom/core/node.py
+++ b/meshroom/core/node.py
@@ -521,6 +521,9 @@ class BaseNode(BaseObject):
     def getName(self):
         return self._name
 
+    def getDefaultLabel(self):
+        return self.nameToLabel(self._name)
+
     def getLabel(self):
         """
         Returns:
@@ -530,7 +533,7 @@ class BaseNode(BaseObject):
             label = self.internalAttribute("label").value.strip()
             if label:
                 return label
-        return self.nameToLabel(self._name)
+        return self.getDefaultLabel()
 
     def getColor(self):
         """
@@ -1151,6 +1154,7 @@ class BaseNode(BaseObject):
 
 
     name = Property(str, getName, constant=True)
+    defaultLabel = Property(str, getDefaultLabel, constant=True)
     nodeType = Property(str, nodeType.fget, constant=True)
     documentation = Property(str, getDocumentation, constant=True)
     positionChanged = Signal()

--- a/meshroom/ui/qml/GraphEditor/ChunksListView.qml
+++ b/meshroom/ui/qml/GraphEditor/ChunksListView.qml
@@ -80,7 +80,7 @@ ColumnLayout {
             id: chunkDelegate
             property var chunk: object
             text: index
-            width: parent.width
+            width: parent ? parent.width : 0
             leftPadding: 8
             onClicked: {
                 chunksLV.forceActiveFocus()

--- a/meshroom/ui/qml/GraphEditor/CompatibilityManager.qml
+++ b/meshroom/ui/qml/GraphEditor/CompatibilityManager.qml
@@ -78,7 +78,7 @@ MessageDialog {
                 background: Rectangle { color: Qt.darker(parent.palette.window, 1.15) }
                 RowLayout {
                     width: parent.width
-                    Label { text: "Node"; Layout.preferredWidth: 130; font.bold: true }
+                    Label { text: "Node"; Layout.preferredWidth: 150; font.bold: true }
                     Label { text: "Issue"; Layout.fillWidth: true; font.bold: true }
                     Label { text: "Upgradable"; font.bold: true }
                 }
@@ -93,8 +93,8 @@ MessageDialog {
                 anchors.horizontalCenter: parent != null ? parent.horizontalCenter : undefined
 
                 Label {
-                    Layout.preferredWidth: 130
-                    text: compatibilityNodeDelegate.node ? compatibilityNodeDelegate.node.nodeType : ""
+                    Layout.preferredWidth: 150
+                    text: compatibilityNodeDelegate.node ? compatibilityNodeDelegate.node.defaultLabel : ""
                 }
                 Label {
                     Layout.fillWidth: true

--- a/meshroom/ui/qml/GraphEditor/NodeEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/NodeEditor.qml
@@ -21,7 +21,7 @@ Panel {
     signal attributeDoubleClicked(var mouse, var attribute)
     signal upgradeRequest()
 
-    title: "Node" + (node !== null ? " - <b>" + node.label + "</b>" : "")
+    title: "Node" + (node !== null ? " - <b>" + node.label + "</b>" + (node.label !== node.defaultLabel ? " (" + node.defaultLabel + ")" : "") : "")
     icon: MaterialLabel { text: MaterialIcons.tune }
 
     headerBar: RowLayout {


### PR DESCRIPTION
## Description

This PR introduces some minor UI changes in the Graph Editor:
- If a node has a custom label (set through the "Notes" tab), the default label of the node is now displayed next to the custom one in the Node Editor. The goal is to be able to quickly identify the type of nodes that have custom labels, as these labels may not be explicit. The default label is always composed of the node's type and a unique index (e.g. `CameraInit2`).
- When compatibility issues are raised on nodes, their default label is displayed in the Compatibility Manager instead of their type. For graphs that have multiple nodes of the same type, this allows to clearly identify the compatibility issue that's been raised for each node. The width of the "Node" column has also been increased to ensure that there is no overlapping between the "Node" and "Issue" columns when a default label is longer than usual.
- The existence of the `parent` object is checked before using it to set the width of the chunks in the Chunks List View. This prevents QML warnings. 

## Features list

- [x] Add a node's default label next to its custom one in the Node Editor;
- [x] Use a node's default label rather than its type in the "Node" column of the Compatibility Manager;
- [x] Fix QML warning with Chunks List View.
