### PR TITLE
[build] Remove references to QmlAlembic in the build process

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,8 +8,7 @@ endif()
 set(ALICEVISION_ROOT "$ENV{ALICEVISION_ROOT}" CACHE STRING "AliceVision root dir")
 set(QT_DIR "$ENV{QT_DIR}" CACHE STRING "Qt root directory")
 
-option(MR_BUILD_QMLALEMBIC "Enable building of qmlAlembic plugin" ON)
-option(MR_BUILD_QTALICEVISION "Enable building of qtAliceVision plugin" ON)
+option(MR_BUILD_QTALICEVISION "Enable building of QtAliceVision plugin" ON)
 
 if(CMAKE_BUILD_TYPE MATCHES Release)
     message(STATUS "Force CMAKE_INSTALL_DO_STRIP in Release")
@@ -36,31 +35,16 @@ include(GNUInstallDirs)
 
 # message(STATUS "QT_CMAKE_FLAGS: ${QT_CMAKE_FLAGS}")
 
-if(MR_BUILD_QMLALEMBIC)
-set(QMLALEMBIC_TARGET qmlAlembic)
-ExternalProject_Add(${QMLALEMBIC_TARGET}
-      GIT_REPOSITORY https://github.com/alicevision/qmlAlembic
-      GIT_TAG develop
-      PREFIX ${BUILD_DIR}
-      BUILD_IN_SOURCE 0
-      BUILD_ALWAYS 0
-      SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/qmlAlembic
-      BINARY_DIR ${BUILD_DIR}/qmlAlembic_build
-      INSTALL_DIR ${CMAKE_INSTALL_PREFIX}
-      CONFIGURE_COMMAND ${CMAKE_COMMAND} ${CMAKE_CORE_BUILD_FLAGS} ${ALEMBIC_CMAKE_FLAGS} -DCMAKE_PREFIX_PATH:PATH=${QT_DIR} -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR> <SOURCE_DIR>
-      )
-endif()
-
 if(MR_BUILD_QTALICEVISION)
-set(QTALICEVISION_TARGET qtAliceVision)
+set(QTALICEVISION_TARGET QtAliceVision)
 ExternalProject_Add(${QTALICEVISION_TARGET}
-      GIT_REPOSITORY https://github.com/alicevision/qtAliceVision
+      GIT_REPOSITORY https://github.com/alicevision/QtAliceVision
       GIT_TAG develop
       PREFIX ${BUILD_DIR}
       BUILD_IN_SOURCE 0
       BUILD_ALWAYS 0
-      SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/qtAliceVision
-      BINARY_DIR ${BUILD_DIR}/qtAliceVision_build
+      SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/QtAliceVision
+      BINARY_DIR ${BUILD_DIR}/QtAliceVision_build
       INSTALL_DIR ${CMAKE_INSTALL_PREFIX}
       CONFIGURE_COMMAND ${CMAKE_COMMAND} ${CMAKE_CORE_BUILD_FLAGS} ${ALEMBIC_CMAKE_FLAGS} -DCMAKE_PREFIX_PATH:PATH=${QT_DIR}$<SEMICOLON>${ALICEVISION_ROOT} -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR> <SOURCE_DIR>
       )

--- a/COPYING.md
+++ b/COPYING.md
@@ -12,7 +12,7 @@ Meshroom is licensed under the [MPL2 license](LICENSE-MPL2.md).
 
  * __Python__  
    [https://www.python.org](https://www.python.org)  
-   Copyright (c) 2001-2018 Python Software Foundation  
+   Copyright (c) 2001-2018 Python Software Foundation.  
    Distributed under the [PSFL V2 license](https://www.python.org/download/releases/2.7/license/).
 
  * __Qt/PySide2__  
@@ -20,7 +20,7 @@ Meshroom is licensed under the [MPL2 license](LICENSE-MPL2.md).
    Copyright (C) 2018 The Qt Company Ltd and other contributors.  
    Distributed under the [LGPL V3 license](https://opensource.org/licenses/LGPL-3.0).
 
- * __qmlAlembic__  
-   [https://github.com/alicevision/qmlAlembic](https://github.com/alicevision/qmlAlembic)  
+ * __QtAliceVision__  
+   [https://github.com/alicevision/QtAliceVision](https://github.com/alicevision/QtAliceVision)  
    Copyright (c) 2018 AliceVision contributors.  
    Distributed under the [MPL2 license](https://opensource.org/licenses/MPL-2.0).

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -47,23 +47,19 @@ It can either be taken from an older version, or directly downloaded from here:
 and then copied into PySide's installation folder, in `plugins/sceneparsers`.
 
 
-### Qt Plugins
-Additional Qt plugins can be built to extend Meshroom UI features. They can be found on separate repositories,
-though they might get better integration in the future.
-Note that they are optional but highly recommended.
-
-#### [QmlAlembic](https://github.com/alicevision/qmlAlembic)
-Adds support for Alembic file loading in Meshroom's 3D viewport. Allows to visualize sparse reconstruction results
-(point cloud and cameras).
-```
-QML2_IMPORT_PATH=/path/to/qmlAlembic/install/qml
-```
+### Qt Plugin
+An additional Qt plugin can be built to extend Meshroom UI features. It can be found on a separate repository,
+though it might get better integration in the future.
+Note that it is optional but highly recommended.
 
 #### [QtAliceVision](https://github.com/alicevision/QtAliceVision)
-Use AliceVision to load and visualize intermediate reconstruction files and OpenImageIO as backend to read RAW/EXR images.
+It uses AliceVision to load and visualize intermediate reconstruction files and OpenImageIO as backend to read RAW/EXR images.
+It also adds support for Alembic file loading in Meshroom's 3D viewport, which allows to visualize sparse reconstruction results
+(point clouds and cameras).
+
 ```
-QML2_IMPORT_PATH=/path/to/qtAliceVision/install/qml
-QT_PLUGIN_PATH=/path/to/qtAliceVision/install
+QML2_IMPORT_PATH=/path/to/QtAliceVision/install/qml
+QT_PLUGIN_PATH=/path/to/QtAliceVision/install
 ```
 
 

--- a/docker/Dockerfile_centos
+++ b/docker/Dockerfile_centos
@@ -24,8 +24,7 @@ WORKDIR ${MESHROOM_BUILD}
 # Build Meshroom plugins
 RUN cmake "${MESHROOM_DEV}" -DCMAKE_PREFIX_PATH="${AV_INSTALL}" -DALICEVISION_ROOT="${AV_INSTALL}" -DCMAKE_INSTALL_PREFIX="${MESHROOM_BUNDLE}/qtPlugins"
 
-RUN make "-j$(nproc)" qmlAlembic
-RUN make "-j$(nproc)" qtAliceVision
+RUN make "-j$(nproc)" QtAliceVision
 RUN make "-j$(nproc)" && \
     rm -rf "${MESHROOM_BUILD}" "${MESHROOM_DEV}" \
            ${MESHROOM_BUNDLE}/aliceVision/share/doc \

--- a/docker/Dockerfile_ubuntu
+++ b/docker/Dockerfile_ubuntu
@@ -42,8 +42,7 @@ WORKDIR ${MESHROOM_BUILD}
 
 # Build Meshroom plugins
 RUN cmake "${MESHROOM_DEV}" -DALICEVISION_ROOT="${AV_INSTALL}" -DCMAKE_INSTALL_PREFIX="${MESHROOM_BUNDLE}/qtPlugins"
-RUN make "-j$(nproc)" qmlAlembic
-RUN make "-j$(nproc)" qtAliceVision
+RUN make "-j$(nproc)" QtAliceVision
 RUN make "-j$(nproc)" && \
 	rm -rf "${MESHROOM_BUILD}" "${MESHROOM_DEV}" \
 		${MESHROOM_BUNDLE}/aliceVision/share/doc \

--- a/docker/Dockerfile_ubuntu_deps
+++ b/docker/Dockerfile_ubuntu_deps
@@ -13,7 +13,7 @@ ENV MESHROOM_DEV=/opt/Meshroom \
     QT_CI_LOGIN=alicevisionjunk@gmail.com \
     QT_CI_P=azerty1.
 
-# Workaround for qmlAlembic/qtAliceVision builds: fuse lib/lib64 folders
+# Workaround for QtAliceVision builds: fuse lib/lib64 folders
 #RUN ln -s ${AV_INSTALL}/lib ${AV_INSTALL}/lib64
 
 # Install libs needed by Qt


### PR DESCRIPTION
## Description

Following https://github.com/alicevision/QtAliceVision/pull/38 which merged QmlAlembic into QtAliceVision, this PR removes all the references to QmlAlembic from the documentation and the Dockerfiles.

QtAliceVision is now referred to as the only existing plugin for Meshroom, and is the only one to be built in Meshroom's Dockerfiles. 