### PR TITLE
[bin] meshroom_batch: support multiple init nodes

### DIFF
--- a/bin/meshroom_batch
+++ b/bin/meshroom_batch
@@ -3,6 +3,8 @@ import argparse
 import os
 import sys
 import distutils.util
+import json
+import re
 
 import meshroom
 meshroom.setupEnvironment()
@@ -14,11 +16,11 @@ import logging
 
 
 parser = argparse.ArgumentParser(description='Launch the full photogrammetry or Panorama HDR pipeline.')
-parser.add_argument('-i', '--input', metavar='SFM/FOLDERS/IMAGES', type=str, nargs='*',
+parser.add_argument('-i', '--input', metavar='NODEINSTANCE:SFM/FOLDERS/IMAGES;...', type=str, nargs='*',
                     default=[],
                     help='Input folder containing images or folders of images or file (.sfm or .json) '
                          'with images paths and optionally predefined camera intrinsics.')
-parser.add_argument('-I', '--inputRecursive', metavar='FOLDERS/IMAGES', type=str, nargs='*',
+parser.add_argument('-I', '--inputRecursive', metavar='NODEINSTANCE:FOLDERS/IMAGES;...', type=str, nargs='*',
                     default=[],
                     help='Input folders containing all images recursively.')
 
@@ -90,21 +92,6 @@ logStringToPython = {
 if args.verbose:
     logging.getLogger().setLevel(logStringToPython[args.verbose])
 
-
-def getInitNode(g):
-    """
-    Helper function to get the Init node in the graph 'g' and raise an exception if there is no or
-    multiple candidates.
-    """
-    nodes = g.findInitNodes()
-    if len(nodes) == 0:
-        raise RuntimeError("meshroom_batch requires an Init node in the pipeline.")
-    elif len(nodes) > 1:
-        raise RuntimeError("meshroom_batch requires exactly one Init node in the pipeline, {} found: {}"
-                           .format(len(nodes), str(nodes)))
-    return nodes[0]
-
-
 if not args.input and not args.inputRecursive:
     print('Nothing to compute. You need to set --input or --inputRecursive.')
     sys.exit(1)
@@ -120,9 +107,38 @@ with multiview.GraphModification(graph):
         # custom pipeline
         graph.load(args.pipeline, setupProjectFile=False, publishOutputs=True if args.output else False)
 
-    # get init node and initialize it
-    initNode = getInitNode(graph)
-    initNode.nodeDesc.initialize(initNode, args.input, args.inputRecursive)
+    # get inputs for each init node
+    mapInput = {}
+    for inp in args.input:
+        inputGroup = inp.split(':')
+        if len(inputGroup) != 2:
+            print('Syntax error in input argument')
+            sys.exit(1)
+        nodeName = inputGroup[0]
+        nodeInputs = inputGroup[1].split(';')
+        mapInput[nodeName] = nodeInputs
+    
+    # get recursive inputs for each init node
+    mapInputRecursive = {}
+    for inp in args.inputRecursive:
+        inputGroup = inp.split(':')
+        if len(inputGroup) != 2:
+            print('Syntax error in inputRecursive argument')
+            sys.exit(1)
+        nodeName = inputGroup[0]
+        nodeInputs = inputGroup[1].split(';')
+        mapInputRecursive[nodeName] = nodeInputs
+
+    # get init nodes and initialize them
+    initNodes = graph.findInitNodes()
+    for initNode in initNodes:
+        nodeName = initNode.getName()
+        inp = mapInput.get(nodeName)
+        inpRec = mapInputRecursive.get(nodeName)
+        if not inp and not inpRec:
+            print(f'Nothing to compute for node {nodeName}.')
+            sys.exit(1)
+        initNode.nodeDesc.initialize(initNode, inp, inpRec)
 
     if not graph.canComputeLeaves:
         raise RuntimeError("Graph cannot be computed. Check for compatibility issues.")
@@ -142,7 +158,6 @@ with multiview.GraphModification(graph):
             raise RuntimeError("meshroom_batch requires a pipeline graph with at least one Publish node, none found.")
 
     if args.overrides:
-        import json
         with open(args.overrides, 'r', encoding='utf-8', errors='ignore') as f:
             data = json.load(f)
             for nodeName, overrides in data.items():
@@ -151,7 +166,6 @@ with multiview.GraphModification(graph):
 
     if args.paramOverrides:
         print("\n")
-        import re
         reExtract = re.compile('(\w+)([:.])(\w[\w.]*)=(.*)')
         for p in args.paramOverrides:
             result = reExtract.match(p)

--- a/bin/meshroom_batch
+++ b/bin/meshroom_batch
@@ -106,31 +106,43 @@ with multiview.GraphModification(graph):
     else:
         # custom pipeline
         graph.load(args.pipeline, setupProjectFile=False, publishOutputs=True if args.output else False)
+    
+    # get init nodes
+    initNodes = graph.findInitNodes()
+    uniqueInitNode = (len(initNodes) == 1)
 
-    # get inputs for each init node
+    # parse inputs for each init node
     mapInput = {}
     for inp in args.input:
         inputGroup = inp.split(':')
-        if len(inputGroup) != 2:
+        nodeName = None
+        if len(inputGroup) == 1 and uniqueInitNode:
+            nodeName = initNodes[0].getName()
+        elif len(inputGroup) == 2:
+            nodeName = inputGroup[0]
+        else:
             print('Syntax error in input argument')
             sys.exit(1)
-        nodeName = inputGroup[0]
-        nodeInputs = inputGroup[1].split(';')
+        nodeInputs = inputGroup[-1].split(';')
         mapInput[nodeName] = nodeInputs
     
-    # get recursive inputs for each init node
+    # parse recursive inputs for each init node
     mapInputRecursive = {}
     for inp in args.inputRecursive:
         inputGroup = inp.split(':')
-        if len(inputGroup) != 2:
+        nodeName = None
+        if len(inputGroup) == 1 and uniqueInitNode:
+            nodeName = initNodes[0].getName()
+        elif len(inputGroup) == 2:
+            nodeName = inputGroup[0]
+        else:
             print('Syntax error in inputRecursive argument')
             sys.exit(1)
         nodeName = inputGroup[0]
-        nodeInputs = inputGroup[1].split(';')
+        nodeInputs = inputGroup[-1].split(';')
         mapInputRecursive[nodeName] = nodeInputs
 
-    # get init nodes and initialize them
-    initNodes = graph.findInitNodes()
+    # feed inputs and recursive inputs to init nodes
     for initNode in initNodes:
         nodeName = initNode.getName()
         inp = mapInput.get(nodeName)

--- a/bin/meshroom_batch
+++ b/bin/meshroom_batch
@@ -50,11 +50,6 @@ parser.add_argument('--save', metavar='FILE', type=str, required=False,
 parser.add_argument('--compute', metavar='<yes/no>', type=lambda x: bool(distutils.util.strtobool(x)), default=True, required=False,
                     help='You can set it to <no/false/0> to disable the computation.')
 
-parser.add_argument('--scale', type=int, default=-1,
-                    choices=[-1, 1, 2, 4, 8, 16],
-                    help='Downscale factor override for DepthMap estimation. '
-                         'By default (-1): use pipeline default value.')
-
 parser.add_argument('--toNode', metavar='NODE', type=str, nargs='*',
                     default=None,
                     help='Process the node(s) with its dependencies.')
@@ -189,11 +184,6 @@ with multiview.GraphModification(graph):
             else:
                 raise ValueError('Invalid param override: ' + str(p))
         print("\n")
-
-    # setup DepthMap downscaling
-    if args.scale > 0:
-        for node in graph.nodesOfType('DepthMap'):
-            node.downscale.value = args.scale
 
     # setup cache directory
     graph.cacheDir = args.cache if args.cache else meshroom.core.defaultCacheFolder

--- a/bin/meshroom_batch
+++ b/bin/meshroom_batch
@@ -107,40 +107,32 @@ with multiview.GraphModification(graph):
         # custom pipeline
         graph.load(args.pipeline, setupProjectFile=False, publishOutputs=True if args.output else False)
     
+    def parseInputs(inputs, uniqueInitNode):
+        """Utility method for parsing the input and inputRecursive arguments."""
+        mapInputs = {}
+        for inp in inputs:
+            inputGroup = inp.split(':')
+            nodeName = None
+            if len(inputGroup) == 1 and uniqueInitNode:
+                nodeName = uniqueInitNode.getName()
+            elif len(inputGroup) == 2:
+                nodeName = inputGroup[0]
+            else:
+                print('Syntax error in input argument')
+                sys.exit(1)
+            nodeInputs = inputGroup[-1].split(';')
+            mapInputs[nodeName] = nodeInputs
+        return mapInputs
+    
     # get init nodes
     initNodes = graph.findInitNodes()
-    uniqueInitNode = (len(initNodes) == 1)
+    uniqueInitNode = initNodes[0] if (len(initNodes) == 1) else None
 
     # parse inputs for each init node
-    mapInput = {}
-    for inp in args.input:
-        inputGroup = inp.split(':')
-        nodeName = None
-        if len(inputGroup) == 1 and uniqueInitNode:
-            nodeName = initNodes[0].getName()
-        elif len(inputGroup) == 2:
-            nodeName = inputGroup[0]
-        else:
-            print('Syntax error in input argument')
-            sys.exit(1)
-        nodeInputs = inputGroup[-1].split(';')
-        mapInput[nodeName] = nodeInputs
+    mapInput = parseInputs(args.input, uniqueInitNode)
     
     # parse recursive inputs for each init node
-    mapInputRecursive = {}
-    for inp in args.inputRecursive:
-        inputGroup = inp.split(':')
-        nodeName = None
-        if len(inputGroup) == 1 and uniqueInitNode:
-            nodeName = initNodes[0].getName()
-        elif len(inputGroup) == 2:
-            nodeName = inputGroup[0]
-        else:
-            print('Syntax error in inputRecursive argument')
-            sys.exit(1)
-        nodeName = inputGroup[0]
-        nodeInputs = inputGroup[-1].split(';')
-        mapInputRecursive[nodeName] = nodeInputs
+    mapInputRecursive = parseInputs(args.inputRecursive, uniqueInitNode)
 
     # feed inputs and recursive inputs to init nodes
     for initNode in initNodes:


### PR DESCRIPTION
## Description

Modify `meshroom_batch` command line to support pipelines with multiple init nodes, such as the `cameraTracking` pipeline.

The `--input` and `--inputRecursive` arguments syntax used to be `input1 input2 input3 ...` (each input being either an image, a folder or a SfMData file), now it is `NodeAName:input1;input2;input3 NodeBName:input4`.

For example with a `cameraTracking` pipeline where the shot to track is in a folder named `/path/to/my/shot` and the distortion grid is just one image named `distogrid.exr` the command line would be:
```
meshroom_batch -i CameraInit_1:/path/to/my/shot CameraInit_2:distogrid.exr -p cameraTracking
```

When the pipeline used has only one init node (most common use case) there is no need to specify the `NodeName:` part:
```
meshroom_batch -i /some/images;/more/images -p photogrammetry
```

## Note

The `--scale` argument has been removed since it was redundant.