### PR TITLE
AttributeEditor: Flag attributes with invalid values

### DIFF
--- a/meshroom/core/attribute.py
+++ b/meshroom/core/attribute.py
@@ -62,6 +62,7 @@ class Attribute(BaseObject):
         self._value = copy.copy(attributeDesc.value)
         self._label = attributeDesc.label
         self._enabled = True
+        self._validValue = True
 
         # invalidation value for output attributes
         self._invalidationValue = ""
@@ -146,6 +147,24 @@ class Attribute(BaseObject):
     def getUidIgnoreValue(self):
         """ Value for which the attribute should be ignored during the UID computation. """
         return self.attributeDesc.uidIgnoreValue
+
+    def getValidValue(self):
+        """
+        Get the status of _validValue:
+            - If it is a function, execute it and return the result
+            - Otherwise, simply return its value
+        """
+        if isinstance(self.desc.validValue, types.FunctionType):
+            try:
+                return self.desc.validValue(self.node)
+            except Exception:
+                return True
+        return self._validValue
+
+    def setValidValue(self, value):
+        if self._validValue == value:
+            return
+        self._validValue = value
 
     def _get_value(self):
         if self.isLink:
@@ -338,6 +357,8 @@ class Attribute(BaseObject):
     enabledChanged = Signal()
     enabled = Property(bool, getEnabled, setEnabled, notify=enabledChanged)
     uidIgnoreValue = Property(Variant, getUidIgnoreValue, constant=True)
+    validValueChanged = Signal()
+    validValue = Property(bool, getValidValue, setValidValue, notify=validValueChanged)
 
 
 def raiseIfLink(func):

--- a/meshroom/core/desc.py
+++ b/meshroom/core/desc.py
@@ -14,7 +14,8 @@ class Attribute(BaseObject):
     """
     """
 
-    def __init__(self, name, label, description, value, advanced, semantic, uid, group, enabled, uidIgnoreValue=None):
+    def __init__(self, name, label, description, value, advanced, semantic, uid, group, enabled, uidIgnoreValue=None,
+                 validValue=True, errorMessage=""):
         super(Attribute, self).__init__()
         self._name = name
         self._label = label
@@ -26,6 +27,8 @@ class Attribute(BaseObject):
         self._enabled = enabled
         self._semantic = semantic
         self._uidIgnoreValue = uidIgnoreValue
+        self._validValue = validValue
+        self._errorMessage = errorMessage
 
     name = Property(str, lambda self: self._name, constant=True)
     label = Property(str, lambda self: self._label, constant=True)
@@ -37,6 +40,8 @@ class Attribute(BaseObject):
     enabled = Property(Variant, lambda self: self._enabled, constant=True)
     semantic = Property(str, lambda self: self._semantic, constant=True)
     uidIgnoreValue = Property(Variant, lambda self: self._uidIgnoreValue, constant=True)
+    validValue = Property(Variant, lambda self: self._validValue, constant=True)
+    errorMessage = Property(str, lambda self: self._errorMessage, constant=True)
     type = Property(str, lambda self: self.__class__.__name__, constant=True)
 
     def validateValue(self, value):
@@ -205,9 +210,9 @@ class GroupAttribute(Attribute):
 class Param(Attribute):
     """
     """
-    def __init__(self, name, label, description, value, uid, group, advanced, semantic, enabled, uidIgnoreValue=None):
+    def __init__(self, name, label, description, value, uid, group, advanced, semantic, enabled, uidIgnoreValue=None, validValue=True, errorMessage=""):
         super(Param, self).__init__(name=name, label=label, description=description, value=value, uid=uid, group=group, advanced=advanced, semantic=semantic, enabled=enabled,
-            uidIgnoreValue=uidIgnoreValue)
+            uidIgnoreValue=uidIgnoreValue, validValue=validValue, errorMessage=errorMessage)
 
 
 class File(Attribute):
@@ -253,9 +258,10 @@ class BoolParam(Param):
 class IntParam(Param):
     """
     """
-    def __init__(self, name, label, description, value, range, uid, group='allParams', advanced=False, semantic='', enabled=True):
+    def __init__(self, name, label, description, value, range, uid, group='allParams', advanced=False, semantic='', enabled=True, validValue=True, errorMessage=""):
         self._range = range
-        super(IntParam, self).__init__(name=name, label=label, description=description, value=value, uid=uid, group=group, advanced=advanced, semantic=semantic, enabled=enabled)
+        super(IntParam, self).__init__(name=name, label=label, description=description, value=value, uid=uid, group=group, advanced=advanced, semantic=semantic, enabled=enabled,
+            validValue=validValue, errorMessage=errorMessage)
 
     def validateValue(self, value):
         # handle unsigned int values that are translated to int by shiboken and may overflow
@@ -275,9 +281,10 @@ class IntParam(Param):
 class FloatParam(Param):
     """
     """
-    def __init__(self, name, label, description, value, range, uid, group='allParams', advanced=False, semantic='', enabled=True):
+    def __init__(self, name, label, description, value, range, uid, group='allParams', advanced=False, semantic='', enabled=True, validValue=True, errorMessage=""):
         self._range = range
-        super(FloatParam, self).__init__(name=name, label=label, description=description, value=value, uid=uid, group=group, advanced=advanced, semantic=semantic, enabled=enabled)
+        super(FloatParam, self).__init__(name=name, label=label, description=description, value=value, uid=uid, group=group, advanced=advanced, semantic=semantic, enabled=enabled,
+            validValue=validValue, errorMessage=errorMessage)
 
     def validateValue(self, value):
         try:
@@ -334,9 +341,9 @@ class ChoiceParam(Param):
 class StringParam(Param):
     """
     """
-    def __init__(self, name, label, description, value, uid, group='allParams', advanced=False, semantic='', enabled=True, uidIgnoreValue=None):
+    def __init__(self, name, label, description, value, uid, group='allParams', advanced=False, semantic='', enabled=True, uidIgnoreValue=None, validValue=True, errorMessage=""):
         super(StringParam, self).__init__(name=name, label=label, description=description, value=value, uid=uid, group=group, advanced=advanced, semantic=semantic, enabled=enabled,
-            uidIgnoreValue=uidIgnoreValue)
+            uidIgnoreValue=uidIgnoreValue, validValue=validValue, errorMessage=errorMessage)
 
     def validateValue(self, value):
         if not isinstance(value, str):

--- a/meshroom/nodes/aliceVision/LdrToHdrCalibration.py
+++ b/meshroom/nodes/aliceVision/LdrToHdrCalibration.py
@@ -70,7 +70,7 @@ Calibrate LDR to HDR response curve from samples.
                         "It is detected automatically from input Viewpoints metadata if 'userNbBrackets' is 0,\n"
                         "else it is equal to 'userNbBrackets'.",
             value=0,
-            range=(0, 10, 1),
+            range=(0, 15, 1),
             uid=[0],
             group="bracketsParams"
         ),

--- a/meshroom/nodes/aliceVision/LdrToHdrCalibration.py
+++ b/meshroom/nodes/aliceVision/LdrToHdrCalibration.py
@@ -60,6 +60,8 @@ Calibrate LDR to HDR response curve from samples.
             range=(0, 15, 1),
             uid=[],
             group="user",  # not used directly on the command line
+            errorMessage="The set number of brackets is not a multiple of the number of input images.\n"
+                         "Errors will occur during the computation."
         ),
         desc.IntParam(
             name="nbBrackets",
@@ -181,13 +183,24 @@ Calibrate LDR to HDR response curve from samples.
         if "userNbBrackets" not in node.getAttributes().keys():
             # Old version of the node
             return
-        if node.userNbBrackets.value != 0:
-            node.nbBrackets.value = node.userNbBrackets.value
-            return
+        node.userNbBrackets.validValue = True  # Reset the status of "userNbBrackets"
+
         cameraInitOutput = node.input.getLinkParam(recursive=True)
         if not cameraInitOutput:
             node.nbBrackets.value = 0
             return
+        if node.userNbBrackets.value != 0:
+            # The number of brackets has been manually forced: check whether it is valid or not
+            if cameraInitOutput and cameraInitOutput.node and cameraInitOutput.node.hasAttribute("viewpoints"):
+                viewpoints = cameraInitOutput.node.viewpoints.value
+                # The number of brackets should be a multiple of the number of input images
+                if (len(viewpoints) % node.userNbBrackets.value != 0):
+                    node.userNbBrackets.validValue = False
+                else:
+                    node.userNbBrackets.validValue = True
+            node.nbBrackets.value = node.userNbBrackets.value
+            return
+
         if not cameraInitOutput.node.hasAttribute("viewpoints"):
             if cameraInitOutput.node.hasAttribute("input"):
                 cameraInitOutput = cameraInitOutput.node.input.getLinkParam(recursive=True)

--- a/meshroom/nodes/aliceVision/LdrToHdrMerge.py
+++ b/meshroom/nodes/aliceVision/LdrToHdrMerge.py
@@ -59,6 +59,8 @@ Merge LDR images into HDR images.
             range=(0, 15, 1),
             uid=[],
             group="user",  # not used directly on the command line
+            errorMessage="The set number of brackets is not a multiple of the number of input images.\n"
+                         "Errors will occur during the computation."
         ),
         desc.IntParam(
             name="nbBrackets",
@@ -267,13 +269,24 @@ Merge LDR images into HDR images.
         if "userNbBrackets" not in node.getAttributes().keys():
             # Old version of the node
             return
-        if node.userNbBrackets.value != 0:
-            node.nbBrackets.value = node.userNbBrackets.value
-            return
+        node.userNbBrackets.validValue = True  # Reset the status of "userNbBrackets"
+
         cameraInitOutput = node.input.getLinkParam(recursive=True)
         if not cameraInitOutput:
             node.nbBrackets.value = 0
             return
+        if node.userNbBrackets.value != 0:
+            # The number of brackets has been manually forced: check whether it is valid or not
+            if cameraInitOutput and cameraInitOutput.node and cameraInitOutput.node.hasAttribute("viewpoints"):
+                viewpoints = cameraInitOutput.node.viewpoints.value
+                # The number of brackets should be a multiple of the number of input images
+                if (len(viewpoints) % node.userNbBrackets.value != 0):
+                    node.userNbBrackets.validValue = False
+                else:
+                    node.userNbBrackets.validValue = True
+            node.nbBrackets.value = node.userNbBrackets.value
+            return
+
         if not cameraInitOutput.node.hasAttribute("viewpoints"):
             if cameraInitOutput.node.hasAttribute("input"):
                 cameraInitOutput = cameraInitOutput.node.input.getLinkParam(recursive=True)

--- a/meshroom/nodes/aliceVision/LdrToHdrMerge.py
+++ b/meshroom/nodes/aliceVision/LdrToHdrMerge.py
@@ -69,7 +69,7 @@ Merge LDR images into HDR images.
                         "It is detected automatically from input Viewpoints metadata if 'userNbBrackets'\n"
                         "is 0, else it is equal to 'userNbBrackets'.",
             value=0,
-            range=(0, 10, 1),
+            range=(0, 15, 1),
             uid=[0],
             group="bracketsParams"
         ),

--- a/meshroom/nodes/aliceVision/LdrToHdrSampling.py
+++ b/meshroom/nodes/aliceVision/LdrToHdrSampling.py
@@ -84,7 +84,7 @@ Sample pixels from Low range images for HDR creation.
                         "It is detected automatically from input Viewpoints metadata if 'userNbBrackets'\n"
                         "is 0, else it is equal to 'userNbBrackets'.",
             value=0,
-            range=(0, 10, 1),
+            range=(0, 15, 1),
             uid=[0],
             group="bracketsParams"
         ),

--- a/meshroom/nodes/aliceVision/LdrToHdrSampling.py
+++ b/meshroom/nodes/aliceVision/LdrToHdrSampling.py
@@ -74,6 +74,8 @@ Sample pixels from Low range images for HDR creation.
             range=(0, 15, 1),
             uid=[],
             group="user",  # not used directly on the command line
+            errorMessage="The set number of brackets is not a multiple of the number of input images.\n"
+                         "Errors will occur during the computation."
         ),
         desc.IntParam(
             name="nbBrackets",
@@ -207,13 +209,24 @@ Sample pixels from Low range images for HDR creation.
             # Old version of the node
             return
         node.outliersNb = 0  # Reset the number of detected outliers
-        if node.userNbBrackets.value != 0:
-            node.nbBrackets.value = node.userNbBrackets.value
-            return
+        node.userNbBrackets.validValue = True  # Reset the status of "userNbBrackets"
+
         cameraInitOutput = node.input.getLinkParam(recursive=True)
         if not cameraInitOutput:
             node.nbBrackets.value = 0
             return
+        if node.userNbBrackets.value != 0:
+            # The number of brackets has been manually forced: check whether it is valid or not
+            if cameraInitOutput and cameraInitOutput.node and cameraInitOutput.node.hasAttribute("viewpoints"):
+                viewpoints = cameraInitOutput.node.viewpoints.value
+                # The number of brackets should be a multiple of the number of input images
+                if (len(viewpoints) % node.userNbBrackets.value != 0):
+                    node.userNbBrackets.validValue = False
+                else:
+                    node.userNbBrackets.validValue = True
+            node.nbBrackets.value = node.userNbBrackets.value
+            return
+
         if not cameraInitOutput.node.hasAttribute("viewpoints"):
             if cameraInitOutput.node.hasAttribute("input"):
                 cameraInitOutput = cameraInitOutput.node.input.getLinkParam(recursive=True)

--- a/meshroom/ui/qml/GraphEditor/AttributeItemDelegate.qml
+++ b/meshroom/ui/qml/GraphEditor/AttributeItemDelegate.qml
@@ -25,7 +25,6 @@ RowLayout {
 
     function updateAttributeLabel()
     {
-        errorLabel.visible = !attribute.validValue
         background.color = attribute.validValue ?  Qt.darker(palette.window, 1.1) : Qt.darker(Colors.red, 1.5)
 
         if (attribute.desc) {
@@ -48,21 +47,6 @@ RowLayout {
             spacing: 0
             width: parent.width
             height: parent.height
-
-            MaterialLabel {
-                id: errorLabel
-
-                text: MaterialIcons.dangerous
-                font.pointSize: 10
-                leftPadding: 5
-                visible: !object.validValue
-
-                MouseArea {
-                    id: errorLabelMA
-                    anchors.fill: parent
-                    hoverEnabled: true
-                }
-            }
 
             Label {
                 id: parameterLabel
@@ -87,7 +71,7 @@ RowLayout {
                         tooltip += "<b>" + object.desc.name + "</b><br>" + Format.plainToHtml(object.desc.description)
                         return tooltip
                     }
-                    visible: parameterMA.containsMouse || errorLabelMA.containsMouse
+                    visible: parameterMA.containsMouse
                     delay: 800
                 }
 

--- a/meshroom/ui/qml/MaterialIcons/MaterialIcons.qml
+++ b/meshroom/ui/qml/MaterialIcons/MaterialIcons.qml
@@ -244,6 +244,7 @@ QtObject {
     readonly property string crop_portrait: "\ue3c5"
     readonly property string crop_rotate: "\ue437"
     readonly property string crop_square: "\ue3c6"
+    readonly property string dangerous: "\ue99a"
     readonly property string dashboard: "\ue871"
     readonly property string data_usage: "\ue1af"
     readonly property string date_range: "\ue916"


### PR DESCRIPTION
## Description

This PR introduces two new parameters in the description of Int, Float and String attributes:
- `validValue`, which is true if the value of the attribute is not erroneous (i.e. valid for the type of the attribute but invalid in the
context of that specific attribute) and false otherwise. This holds a different significance than the "validateValue()" method, which only checks if the attribute's value is correct with respect to its type. For example, we could want an IntParam that flags any value that is not even: an odd integer value would successfully go through the "validateValue()" method, but would then be flagged as an invalid value at the attribute's level.
- `errorMessage`, an attribute-specific string that contains a message explaining why the attribute's `validValue` parameter might be set to false.

With these new parameters, attributes that have an invalid value will be flagged directly in the Attribute Editor as follows:
1. An icon indicating an error will be added next to the attribute's name.
2. The color of the label's background will change to red to clearly indicate that the current value is wrong.
3. If the attribute's error message has been filled, it will be displayed in its tooltip, right before its regular description.

Finally, this PR sets `validValue` and `errorMessage` in the HDR fusion nodes (`LdrToHdrSampling`, `LdrToHdrCalibration` and `LdrToHdrMerge`) for the `userNbBrackets` attribute so that any user-set bracket value that is not a multiple of the number of input images is flagged down. 

For example, if the user manually sets `userNbBrackets` to 3 when there are 28 input images, the attribute will immediately appear as invalid:
<div align="center"><img src="https://github.com/alicevision/Meshroom/assets/11963329/e77138c5-7ddf-4c45-9d60-61c6b3bda9d2" width=400 /></div>


## Features list

- [X] Add new `validValue` and `errorMessage` parameters to the description of Int, Float and String attributes;
- [X] Highlight attributes with invalid values in the Attribute Editor;
- [X] Display an attribute's error message along with its description in its tooltip if its value is invalid;
- [X] Flag the `userNbBrackets` attribute in the HDR Fusion nodes when its value is not a multiple of the number of input images.

