### PR TITLE
[nodes] HDR Fusion: Fix bracket detection

### DIFF
--- a/meshroom/nodes/aliceVision/LdrToHdrCalibration.py
+++ b/meshroom/nodes/aliceVision/LdrToHdrCalibration.py
@@ -238,7 +238,7 @@ Calibrate LDR to HDR response curve from samples.
             fnumber, shutterSpeed, iso = exp
             if exposures:
                 prevFnumber, prevShutterSpeed, prevIso = exposures[-1]
-            if exposures and len(exposures) > 1 and (fnumber != prevFnumber or shutterSpeed > prevShutterSpeed or iso != prevIso) or newGroup:
+            if exposures and len(exposures) > 1 and (fnumber > prevFnumber or shutterSpeed > prevShutterSpeed or iso < prevIso) or newGroup:
                 exposureGroups.append(exposures)
                 exposures = [exp]
             else:
@@ -273,5 +273,4 @@ Calibrate LDR to HDR response curve from samples.
                         bestTuple = tuple if tuple[0] > bestTuple[0] else bestTuple
 
                 bestBracketSize = bestTuple[0]
-                bestCount = bestTuple[1]
                 node.nbBrackets.value = bestBracketSize

--- a/meshroom/nodes/aliceVision/LdrToHdrMerge.py
+++ b/meshroom/nodes/aliceVision/LdrToHdrMerge.py
@@ -324,7 +324,7 @@ Merge LDR images into HDR images.
             fnumber, shutterSpeed, iso = exp
             if exposures:
                 prevFnumber, prevShutterSpeed, prevIso = exposures[-1]
-            if exposures and len(exposures) > 1 and (fnumber != prevFnumber or shutterSpeed > prevShutterSpeed or iso != prevIso) or newGroup:
+            if exposures and len(exposures) > 1 and (fnumber > prevFnumber or shutterSpeed > prevShutterSpeed or iso < prevIso) or newGroup:
                 exposureGroups.append(exposures)
                 exposures = [exp]
             else:
@@ -359,7 +359,6 @@ Merge LDR images into HDR images.
                         bestTuple = tuple if tuple[0] > bestTuple[0] else bestTuple
 
                 bestBracketSize = bestTuple[0]
-                bestCount = bestTuple[1]
                 node.nbBrackets.value = bestBracketSize
 
     def processChunk(self, chunk):

--- a/meshroom/nodes/aliceVision/LdrToHdrSampling.py
+++ b/meshroom/nodes/aliceVision/LdrToHdrSampling.py
@@ -264,7 +264,7 @@ Sample pixels from Low range images for HDR creation.
             fnumber, shutterSpeed, iso = exp
             if exposures:
                 prevFnumber, prevShutterSpeed, prevIso = exposures[-1]
-            if exposures and len(exposures) > 1 and (fnumber != prevFnumber or shutterSpeed > prevShutterSpeed or iso != prevIso) or newGroup:
+            if exposures and len(exposures) > 1 and (fnumber > prevFnumber or shutterSpeed > prevShutterSpeed or iso < prevIso) or newGroup:
                 exposureGroups.append(exposures)
                 exposures = [exp]
             else:


### PR DESCRIPTION
## Description

Prior to this PR, only the shutter speed was compared between two images to determine whether they belonged to the same group. The fnumber and ISO were assumed to be fixed within a group, which is not always true, and differs from what is done on the AliceVision's side.

We now also check that the ISO is either constant or increasing and that the fnumber is either constant or decreasing to determine that an image belongs to the current exposure group.