### PR TITLE
[ui] Preserve last `CameraInit` index when updating the CameraInits list

### DIFF
--- a/meshroom/ui/qml/ImageGallery/ImageGallery.qml
+++ b/meshroom/ui/qml/ImageGallery/ImageGallery.qml
@@ -35,6 +35,14 @@ Panel {
     title: "Image Gallery"
     implicitWidth: (root.defaultCellSize + 2) * 2
 
+    Connections {
+        target: _reconstruction
+
+        function onCameraInitChanged() {
+            nodesCB.currentIndex = root.cameraInitIndex
+        }
+    }
+
     QtObject {
         id: m
         property variant currentCameraInit: _reconstruction && _reconstruction.tempCameraInit ? _reconstruction.tempCameraInit : root.cameraInit

--- a/meshroom/ui/reconstruction.py
+++ b/meshroom/ui/reconstruction.py
@@ -573,7 +573,12 @@ class Reconstruction(UIGraph):
         if set(self._cameraInits.objectList()) == set(cameraInits):
             return
         self._cameraInits.setObjectList(cameraInits)
-        self.cameraInit = cameraInits[0] if cameraInits else None
+
+        if self.cameraInit is None or self.cameraInit not in cameraInits:
+            self.cameraInit = cameraInits[0] if cameraInits else None
+
+        # Manually emit the signal to ensure the active CameraInit index is always up-to-date in the UI
+        self.cameraInitChanged.emit()
 
     def getCameraInitIndex(self):
         if not self._cameraInit:


### PR DESCRIPTION
## Description

Prior to this PR, when a `CameraInit` node was added to or removed from the list of `CameraInit` nodes, the active `CameraInit` was always reset to the first one in the list, independently from its previous value. This meant that whenever a `CameraInit` node was added to or removed from the graph while the Image Gallery was displaying a `CameraInit` node that was not the first one in the list, the Image Gallery was automatically updated to display the first `CameraInit` node without any intervention from the user, as shown below:
<div align="center"><img src="https://github.com/alicevision/Meshroom/assets/11963329/d6f9da48-33cc-41ed-8e0b-e122ce4f79ac" height=500 /></div>

This pull request changes that behaviour by only modifying the active `CameraInit` node if no `CameraInit` node has been assigned yet, or if the active `CameraInit` node does not exist anymore (meaning it has been removed).

This requires to emit the `cameraInitChanged()` signal every single time the list of existing `CameraInit` nodes is modified even if the active one remains the same, and to connect it to the ImageGallery in order to ensure the index from the combo box always corresponds to the currently active `CameraInit` node. Indeed, when the list of CameraInits is updated, the
model for the combo box is reset, and it needs to be re-updated with the correct non-default value.
<div align="center"><img src="https://github.com/alicevision/Meshroom/assets/11963329/13fd1c3a-234b-4f21-ae05-1df60e27332e" height=500 /></div>
