### PR TITLE
[UI] fix resize of horizontal splitview

### DIFF
--- a/meshroom/ui/qml/WorkspaceView.qml
+++ b/meshroom/ui/qml/WorkspaceView.qml
@@ -66,7 +66,6 @@ Item {
 
         Controls1.SplitView {
             orientation: Qt.Vertical
-            Layout.fillWidth: true
             Layout.fillHeight: true
             implicitWidth: Math.round(parent.width * 0.2)
             Layout.minimumWidth: imageGallery.defaultCellSize
@@ -182,7 +181,6 @@ Item {
             Layout.minimumWidth: 20
             Layout.minimumHeight: 80
             Layout.fillHeight: true
-            Layout.fillWidth: true
             implicitWidth: Math.round(parent.width * 0.45)
 
             Loader {
@@ -199,7 +197,7 @@ Item {
             Panel {
                 id: panel3dViewer
                 title: "3D Viewer"
-  
+
                 property alias viewer3D: c_viewer3D
 
                 Controls1.SplitView {


### PR DESCRIPTION
When dragging the border between 3D Viewer and 2D Viewer:

- previous behavior: the Image Gallery is resized instead of the 2D Viewer

![before](https://github.com/alicevision/Meshroom/assets/72821992/d58fa78a-1604-4598-82d3-c2926a1089ff)

- new behavior: the 2D Viewer is resized

![after](https://github.com/alicevision/Meshroom/assets/72821992/32d301ef-32a7-49ba-8e6e-829e8ac3ff66)
