### PR TITLE
KeyframeSelection: Flag `outputExtension` attribute when it is set to "none" for video inputs

### DIFF
--- a/meshroom/core/attribute.py
+++ b/meshroom/core/attribute.py
@@ -196,6 +196,7 @@ class Attribute(BaseObject):
             self.requestNodeUpdate()
 
         self.valueChanged.emit()
+        self.validValueChanged.emit()
 
     def upgradeValue(self, exportedValue):
         self._set_value(exportedValue)

--- a/meshroom/core/desc.py
+++ b/meshroom/core/desc.py
@@ -303,13 +303,15 @@ class FloatParam(Param):
 class ChoiceParam(Param):
     """
     """
-    def __init__(self, name, label, description, value, values, exclusive, uid, group='allParams', joinChar=' ', advanced=False, semantic='', enabled=True):
+    def __init__(self, name, label, description, value, values, exclusive, uid, group='allParams', joinChar=' ', advanced=False, semantic='',
+                 enabled=True, validValue=True, errorMessage=""):
         assert values
         self._values = values
         self._exclusive = exclusive
         self._joinChar = joinChar
         self._valueType = type(self._values[0])  # cast to value type
-        super(ChoiceParam, self).__init__(name=name, label=label, description=description, value=value, uid=uid, group=group, advanced=advanced, semantic=semantic, enabled=enabled)
+        super(ChoiceParam, self).__init__(name=name, label=label, description=description, value=value, uid=uid, group=group, advanced=advanced,
+                                          semantic=semantic, enabled=enabled, validValue=validValue, errorMessage=errorMessage)
 
     def conformValue(self, val):
         """ Conform 'val' to the correct type and check for its validity """

--- a/meshroom/nodes/aliceVision/KeyframeSelection.py
+++ b/meshroom/nodes/aliceVision/KeyframeSelection.py
@@ -3,6 +3,9 @@ __version__ = "4.1"
 import os
 from meshroom.core import desc
 
+# List of supported video extensions (provided by OpenImageIO)
+videoExts = [".avi", ".mov", ".mp4", ".m4a", ".m4v", ".3gp", ".3g2", ".mj2", ".m4v", ".mpg"]
+
 class KeyframeSelectionNodeSize(desc.DynamicNodeSize):
     def computeSize(self, node):
         inputPathsSize = super(KeyframeSelectionNodeSize, self).computeSize(node)
@@ -273,6 +276,8 @@ You can extract frames at regular interval by configuring only the min/maxFrameS
             value="none",
             values=["none", "exr", "jpg", "png"],
             exclusive=True,
+            validValue=lambda node: not (any(ext in input.value.lower() for ext in videoExts for input in node.inputPaths.value) and node.outputExtension.value == "none"),
+            errorMessage="A video input has been provided. The output extension should be different from 'none'.",
             uid=[0],
         ),
         desc.ChoiceParam(


### PR DESCRIPTION
## Description

This PR follows #2141 and extends the `validValue` and `errorMessage` parameters to "Choice" attributes. It additionally ensures that the `validValueChanged` signal is emitted whenever the attribute's value is updated so it can be re-evaluated, even if `validValue` itself has not changed.

The `outputExtension` attribute from the `KeyframeSelection` node, which determines whether the selected keyframes should be written on disk (and the file extension they should be written on disk with), gets its `validValue` and `errorMessage` parameters to get flagged whenever a video input is part of the list of inputs while `outputExtension` is set to "none". Indeed, if it is set to "none" for video inputs, no frame will ever be written on disk and, as a consequence, no SfMData file will be written (since it needs a location of the frames on disk), meaning that whole score computation and keyframe selection process will have been done for nothing. 
