### PR TITLE
[pipelines] add ImageSegmentation node to tracking pipelines

### DIFF
--- a/meshroom/pipelines/cameraTracking.mg
+++ b/meshroom/pipelines/cameraTracking.mg
@@ -5,30 +5,31 @@
         "fileVersion": "1.1",
         "template": true,
         "nodesVersions": {
-            "DepthMap": "4.0",
-            "PrepareDenseScene": "3.0",
-            "Publish": "1.3",
-            "KeyframeSelection": "4.1",
-            "SfMTransfer": "2.1",
-            "ApplyCalibration": "1.0",
-            "ImageMatchingMultiSfM": "1.0",
-            "DepthMapFilter": "3.0",
-            "Texturing": "6.0",
-            "ImageMatching": "2.0",
-            "MeshFiltering": "3.0",
-            "FeatureMatching": "2.0",
-            "ScenePreview": "1.0",
-            "SfMTriangulation": "1.0",
-            "CheckerboardDetection": "1.0",
-            "ConvertSfMFormat": "2.0",
-            "CameraInit": "9.0",
-            "StructureFromMotion": "3.1",
             "MeshDecimate": "1.0",
-            "ExportAnimatedCamera": "2.0",
-            "DistortionCalibration": "3.0",
-            "Meshing": "7.0",
+            "Texturing": "6.0",
             "ExportDistortion": "1.0",
-            "FeatureExtraction": "1.3"
+            "CameraInit": "9.0",
+            "ImageMatchingMultiSfM": "1.0",
+            "StructureFromMotion": "3.1",
+            "FeatureExtraction": "1.3",
+            "ApplyCalibration": "1.0",
+            "SfMTriangulation": "1.0",
+            "Publish": "1.3",
+            "DepthMap": "4.0",
+            "DistortionCalibration": "3.0",
+            "DepthMapFilter": "3.0",
+            "ImageSegmentation": "1.0",
+            "CheckerboardDetection": "1.0",
+            "ScenePreview": "1.0",
+            "Meshing": "7.0",
+            "PrepareDenseScene": "3.0",
+            "ImageMatching": "2.0",
+            "KeyframeSelection": "4.1",
+            "ConvertSfMFormat": "2.0",
+            "ExportAnimatedCamera": "2.0",
+            "FeatureMatching": "2.0",
+            "SfMTransfer": "2.1",
+            "MeshFiltering": "3.0"
         }
     },
     "graph": {
@@ -78,7 +79,10 @@
                 200
             ],
             "inputs": {
-                "input": "{ApplyCalibration_1.output}"
+                "input": "{ApplyCalibration_1.output}",
+                "masksFolder": "{ImageSegmentation_1.output}",
+                "maskExtension": "exr",
+                "maskInvert": true
             },
             "internalInputs": {
                 "color": "#575963"
@@ -484,6 +488,19 @@
             "internalInputs": {
                 "label": "FeatureMatchingFramesToKeyframes",
                 "color": "#80766f"
+            }
+        },
+        "ImageSegmentation_1": {
+            "nodeType": "ImageSegmentation",
+            "position": [
+                3,
+                200
+            ],
+            "inputs": {
+                "input": "{CameraInit_1.output}"
+            },
+            "internalInputs": {
+                "color": "#575963"
             }
         }
     }

--- a/meshroom/pipelines/cameraTracking.mg
+++ b/meshroom/pipelines/cameraTracking.mg
@@ -493,7 +493,7 @@
         "ImageSegmentation_1": {
             "nodeType": "ImageSegmentation",
             "position": [
-                3,
+                0,
                 200
             ],
             "inputs": {

--- a/meshroom/pipelines/photogrammetryAndCameraTracking.mg
+++ b/meshroom/pipelines/photogrammetryAndCameraTracking.mg
@@ -5,28 +5,29 @@
         "fileVersion": "1.1",
         "template": true,
         "nodesVersions": {
-            "FeatureMatching": "2.0",
-            "ConvertSfMFormat": "2.0",
-            "PrepareDenseScene": "3.0",
-            "Meshing": "7.0",
-            "KeyframeSelection": "4.1",
-            "FeatureExtraction": "1.3",
-            "MeshFiltering": "3.0",
-            "DepthMap": "4.0",
-            "ImageMatching": "2.0",
-            "DistortionCalibration": "3.0",
+            "MeshDecimate": "1.0",
             "Texturing": "6.0",
-            "DepthMapFilter": "3.0",
-            "CameraInit": "9.0",
-            "ScenePreview": "1.0",
-            "StructureFromMotion": "3.1",
             "ExportDistortion": "1.0",
+            "CameraInit": "9.0",
+            "ImageMatchingMultiSfM": "1.0",
+            "StructureFromMotion": "3.1",
+            "FeatureExtraction": "1.3",
             "ApplyCalibration": "1.0",
             "Publish": "1.3",
+            "DepthMap": "4.0",
+            "DistortionCalibration": "3.0",
+            "DepthMapFilter": "3.0",
+            "ImageSegmentation": "1.0",
+            "CheckerboardDetection": "1.0",
+            "ScenePreview": "1.0",
+            "Meshing": "7.0",
+            "PrepareDenseScene": "3.0",
+            "ImageMatching": "2.0",
+            "KeyframeSelection": "4.1",
+            "ConvertSfMFormat": "2.0",
             "ExportAnimatedCamera": "2.0",
-            "MeshDecimate": "1.0",
-            "ImageMatchingMultiSfM": "1.0",
-            "CheckerboardDetection": "1.0"
+            "FeatureMatching": "2.0",
+            "MeshFiltering": "3.0"
         }
     },
     "graph": {
@@ -49,7 +50,10 @@
                 200
             ],
             "inputs": {
-                "input": "{ApplyCalibration_1.output}"
+                "input": "{ApplyCalibration_1.output}",
+                "masksFolder": "{ImageSegmentation_1.output}",
+                "maskExtension": "exr",
+                "maskInvert": true
             },
             "internalInputs": {
                 "color": "#575963"
@@ -557,6 +561,19 @@
                 "featuresFolders": "{ImageMatchingMultiSfM_2.featuresFolders}",
                 "imagePairsList": "{ImageMatchingMultiSfM_2.output}",
                 "describerTypes": "{FeatureExtraction_1.describerTypes}"
+            },
+            "internalInputs": {
+                "color": "#575963"
+            }
+        },
+        "ImageSegmentation_1": {
+            "nodeType": "ImageSegmentation",
+            "position": [
+                6,
+                203
+            ],
+            "inputs": {
+                "input": "{CameraInit_1.output}"
             },
             "internalInputs": {
                 "color": "#575963"

--- a/meshroom/pipelines/photogrammetryAndCameraTracking.mg
+++ b/meshroom/pipelines/photogrammetryAndCameraTracking.mg
@@ -569,8 +569,8 @@
         "ImageSegmentation_1": {
             "nodeType": "ImageSegmentation",
             "position": [
-                6,
-                203
+                0,
+                200
             ],
             "inputs": {
                 "input": "{CameraInit_1.output}"


### PR DESCRIPTION
## Description

Add `ImageSegmentation` node to tracking pipelines: `Camera Tracking` and `Photogrammetry and Camera Tracking`.

By default only one class is used for segmentation: `person`.