### PR TITLE
[nodes] Masking: Handle file extensions for masks and mask inversion for `ImageSegmentation`

### DIFF
--- a/meshroom/nodes/aliceVision/ImageSegmentation.py
+++ b/meshroom/nodes/aliceVision/ImageSegmentation.py
@@ -23,7 +23,6 @@ Generate a mask with segmented labels for each pixel.
             value="",
             uid=[0],
         ),
-
         desc.File(
             name="modelPath",
             label="Segmentation Model",
@@ -31,7 +30,6 @@ Generate a mask with segmented labels for each pixel.
             value="${ALICEVISION_SEMANTIC_SEGMENTATION_MODEL}",
             uid=[0]
         ),
-
         desc.ChoiceParam(
             name="validClasses",
             label="Classes",
@@ -52,7 +50,13 @@ Generate a mask with segmented labels for each pixel.
             exclusive=False,
             uid=[0],
         ),
-
+        desc.BoolParam(
+            name="maskInvert",
+            label="Invert Masks",
+            description="Invert mask values. If selected, the pixels corresponding to the mask will be set to 0 instead of 255.",
+            value=False,
+            uid=[0],
+        ),
         desc.ChoiceParam(
             name="verboseLevel",
             label="Verbose Level",

--- a/meshroom/nodes/aliceVision/MeshMasking.py
+++ b/meshroom/nodes/aliceVision/MeshMasking.py
@@ -1,4 +1,4 @@
-__version__ = "1.0"
+__version__ = "1.1"
 
 from meshroom.core import desc
 
@@ -46,6 +46,15 @@ Decimate triangles based on image masks.
             name="masksFolders",
             label="Masks Folders",
             description="Use masks from specific folder(s). Filename should be the same or the image UID.",
+        ),
+        desc.ChoiceParam(
+            name="maskExtension",
+            label="Mask Extension",
+            description="File extension for the masks to use.",
+            value="png",
+            values=["exr", "jpg", "png"],
+            exclusive=True,
+            uid=[0]
         ),
         desc.IntParam(
             name="threshold",

--- a/meshroom/nodes/aliceVision/PrepareDenseScene.py
+++ b/meshroom/nodes/aliceVision/PrepareDenseScene.py
@@ -1,4 +1,4 @@
-__version__ = "3.0"
+__version__ = "3.1"
 
 from meshroom.core import desc
 
@@ -45,6 +45,15 @@ This node export undistorted images so the depth map and texturing can be comput
             name="masksFolders",
             label="Masks Folders",
             description="Use masks from specific folder(s). Filename should be the same or the image UID.",
+        ),
+        desc.ChoiceParam(
+            name="maskExtension",
+            label="Mask Extension",
+            description="File extension for the masks to use.",
+            value="png",
+            values=["exr", "jpg", "png"],
+            exclusive=True,
+            uid=[0]
         ),
         desc.ChoiceParam(
             name="outputFileType",

--- a/meshroom/pipelines/cameraTracking.mg
+++ b/meshroom/pipelines/cameraTracking.mg
@@ -5,31 +5,31 @@
         "fileVersion": "1.1",
         "template": true,
         "nodesVersions": {
-            "MeshDecimate": "1.0",
-            "Texturing": "6.0",
-            "ExportDistortion": "1.0",
-            "CameraInit": "9.0",
-            "ImageMatchingMultiSfM": "1.0",
-            "StructureFromMotion": "3.1",
-            "FeatureExtraction": "1.3",
-            "ApplyCalibration": "1.0",
-            "SfMTriangulation": "1.0",
-            "Publish": "1.3",
             "DepthMap": "4.0",
-            "DistortionCalibration": "3.0",
-            "DepthMapFilter": "3.0",
-            "ImageSegmentation": "1.0",
-            "CheckerboardDetection": "1.0",
-            "ScenePreview": "1.0",
-            "Meshing": "7.0",
-            "PrepareDenseScene": "3.0",
-            "ImageMatching": "2.0",
+            "SfMTriangulation": "1.0",
+            "StructureFromMotion": "3.1",
+            "ApplyCalibration": "1.0",
+            "Texturing": "6.0",
+            "PrepareDenseScene": "3.1",
             "KeyframeSelection": "4.1",
+            "ScenePreview": "1.0",
+            "DepthMapFilter": "3.0",
+            "MeshDecimate": "1.0",
+            "MeshFiltering": "3.0",
+            "SfMTransfer": "2.1",
+            "Publish": "1.3",
+            "ImageMatchingMultiSfM": "1.0",
+            "FeatureMatching": "2.0",
+            "Meshing": "7.0",
+            "CameraInit": "9.0",
+            "ImageMatching": "2.0",
+            "CheckerboardDetection": "1.0",
             "ConvertSfMFormat": "2.0",
             "ExportAnimatedCamera": "2.0",
-            "FeatureMatching": "2.0",
-            "SfMTransfer": "2.1",
-            "MeshFiltering": "3.0"
+            "DistortionCalibration": "3.0",
+            "ExportDistortion": "1.0",
+            "FeatureExtraction": "1.3",
+            "ImageSegmentation": "1.0"
         }
     },
     "graph": {
@@ -81,8 +81,7 @@
             "inputs": {
                 "input": "{ApplyCalibration_1.output}",
                 "masksFolder": "{ImageSegmentation_1.output}",
-                "maskExtension": "exr",
-                "maskInvert": true
+                "maskExtension": "exr"
             },
             "internalInputs": {
                 "color": "#575963"
@@ -193,7 +192,11 @@
                 0
             ],
             "inputs": {
-                "input": "{SfMTriangulation_1.output}"
+                "input": "{SfMTriangulation_1.output}",
+                "masksFolders": [
+                    "{ImageSegmentation_1.output}"
+                ],
+                "maskExtension": "exr"
             },
             "internalInputs": {
                 "color": "#3f3138"
@@ -407,6 +410,20 @@
                 "color": "#80766f"
             }
         },
+        "ImageSegmentation_1": {
+            "nodeType": "ImageSegmentation",
+            "position": [
+                0,
+                200
+            ],
+            "inputs": {
+                "input": "{CameraInit_1.output}",
+                "maskInvert": true
+            },
+            "internalInputs": {
+                "color": "#575963"
+            }
+        },
         "StructureFromMotion_2": {
             "nodeType": "StructureFromMotion",
             "position": [
@@ -488,19 +505,6 @@
             "internalInputs": {
                 "label": "FeatureMatchingFramesToKeyframes",
                 "color": "#80766f"
-            }
-        },
-        "ImageSegmentation_1": {
-            "nodeType": "ImageSegmentation",
-            "position": [
-                0,
-                200
-            ],
-            "inputs": {
-                "input": "{CameraInit_1.output}"
-            },
-            "internalInputs": {
-                "color": "#575963"
             }
         }
     }

--- a/meshroom/pipelines/photogrammetryAndCameraTracking.mg
+++ b/meshroom/pipelines/photogrammetryAndCameraTracking.mg
@@ -5,29 +5,29 @@
         "fileVersion": "1.1",
         "template": true,
         "nodesVersions": {
-            "MeshDecimate": "1.0",
-            "Texturing": "6.0",
-            "ExportDistortion": "1.0",
-            "CameraInit": "9.0",
-            "ImageMatchingMultiSfM": "1.0",
-            "StructureFromMotion": "3.1",
-            "FeatureExtraction": "1.3",
-            "ApplyCalibration": "1.0",
-            "Publish": "1.3",
             "DepthMap": "4.0",
-            "DistortionCalibration": "3.0",
-            "DepthMapFilter": "3.0",
-            "ImageSegmentation": "1.0",
-            "CheckerboardDetection": "1.0",
-            "ScenePreview": "1.0",
-            "Meshing": "7.0",
-            "PrepareDenseScene": "3.0",
-            "ImageMatching": "2.0",
+            "StructureFromMotion": "3.1",
+            "ApplyCalibration": "1.0",
+            "Texturing": "6.0",
+            "PrepareDenseScene": "3.1",
             "KeyframeSelection": "4.1",
+            "ScenePreview": "1.0",
+            "DepthMapFilter": "3.0",
+            "MeshDecimate": "1.0",
+            "MeshFiltering": "3.0",
+            "Publish": "1.3",
+            "ImageMatchingMultiSfM": "1.0",
+            "FeatureMatching": "2.0",
+            "Meshing": "7.0",
+            "CameraInit": "9.0",
+            "ImageMatching": "2.0",
+            "CheckerboardDetection": "1.0",
             "ConvertSfMFormat": "2.0",
             "ExportAnimatedCamera": "2.0",
-            "FeatureMatching": "2.0",
-            "MeshFiltering": "3.0"
+            "DistortionCalibration": "3.0",
+            "ExportDistortion": "1.0",
+            "FeatureExtraction": "1.3",
+            "ImageSegmentation": "1.0"
         }
     },
     "graph": {
@@ -52,8 +52,7 @@
             "inputs": {
                 "input": "{ApplyCalibration_1.output}",
                 "masksFolder": "{ImageSegmentation_1.output}",
-                "maskExtension": "exr",
-                "maskInvert": true
+                "maskExtension": "exr"
             },
             "internalInputs": {
                 "color": "#575963"
@@ -286,6 +285,20 @@
             "internalInputs": {
                 "comment": "Estimate cameras parameters for the complete camera tracking sequence.",
                 "color": "#80766f"
+            }
+        },
+        "ImageSegmentation_1": {
+            "nodeType": "ImageSegmentation",
+            "position": [
+                0,
+                200
+            ],
+            "inputs": {
+                "input": "{CameraInit_1.output}",
+                "maskInvert": true
+            },
+            "internalInputs": {
+                "color": "#575963"
             }
         },
         "StructureFromMotion_2": {
@@ -561,19 +574,6 @@
                 "featuresFolders": "{ImageMatchingMultiSfM_2.featuresFolders}",
                 "imagePairsList": "{ImageMatchingMultiSfM_2.output}",
                 "describerTypes": "{FeatureExtraction_1.describerTypes}"
-            },
-            "internalInputs": {
-                "color": "#575963"
-            }
-        },
-        "ImageSegmentation_1": {
-            "nodeType": "ImageSegmentation",
-            "position": [
-                0,
-                200
-            ],
-            "inputs": {
-                "input": "{CameraInit_1.output}"
             },
             "internalInputs": {
                 "color": "#575963"


### PR DESCRIPTION
## Description

This PR reflects the changes made in alicevision/AliceVision#1517 to handle other file extensions than "png" for masks and to invert mask values in the `ImageSegmentation` node. 

Additionally, the "Camera Tracking" and "Camera Tracking and Photogrammetry" templates are updated as follows:
- The `maskInvert` attribute of the `ImageSegmentation` node is enabled;
- The `maskInvert` attribute of the `FeatureExtraction` node is disabled;
- For the "Camera Tracking" pipeline, the (inverted) output of the `ImageSegmentation` node is connected to the `PrepareDenseScene`'s input.


## Features list

- [x] The `MeshMasking` and `PrepareDenseScene` nodes now have `maskExtension` parameters;
- [x] The `ImageSegmentation` node now has an `maskInvert` parameter to invert the output masks' values;
- [x] The "Camera Tracking" and "Camera Tracking and Photogrammetry" templates are updated.