### PR TITLE
[blender] apply masks to scene preview

### DIFF
--- a/meshroom/nodes/blender/ScenePreview.py
+++ b/meshroom/nodes/blender/ScenePreview.py
@@ -1,4 +1,4 @@
-__version__ = "1.0"
+__version__ = "2.0"
 
 from meshroom.core import desc
 import os.path
@@ -65,6 +65,21 @@ One frame per viewpoint will be rendered, and the undistorted views can optional
             value="",
             uid=[0],
             enabled=lambda node: node.useBackground.value,
+        ),
+        desc.BoolParam(
+            name="useMasks",
+            label="Use Masks",
+            description="Apply mask to the rendered geometry.",
+            value=True,
+            uid=[0],
+        ),
+        desc.File(
+            name="masks",
+            label="Masks",
+            description="Folder containing the masks.",
+            value="",
+            uid=[0],
+            enabled=lambda node: node.useMasks.value,
         ),
         desc.GroupAttribute(
             name="pointCloudParams",

--- a/meshroom/nodes/blender/ScenePreview.py
+++ b/meshroom/nodes/blender/ScenePreview.py
@@ -68,7 +68,7 @@ One frame per viewpoint will be rendered, and the undistorted views can optional
         ),
         desc.BoolParam(
             name="useMasks",
-            label="Use Masks",
+            label="Apply Masks",
             description="Apply mask to the rendered geometry.",
             value=True,
             uid=[0],

--- a/meshroom/pipelines/cameraTracking.mg
+++ b/meshroom/pipelines/cameraTracking.mg
@@ -5,31 +5,31 @@
         "fileVersion": "1.1",
         "template": true,
         "nodesVersions": {
-            "ExportDistortion": "1.0",
-            "FeatureExtraction": "1.3",
-            "DepthMap": "4.0",
-            "Texturing": "6.0",
             "ImageSegmentation": "1.0",
             "ApplyCalibration": "1.0",
-            "ScenePreview": "1.0",
             "MeshDecimate": "1.0",
-            "KeyframeSelection": "5.0",
             "PrepareDenseScene": "3.1",
+            "MeshFiltering": "3.0",
             "SfMTransfer": "2.1",
             "Publish": "1.3",
-            "MeshFiltering": "3.0",
             "DepthMapFilter": "3.0",
             "Meshing": "7.0",
             "ImageMatchingMultiSfM": "1.0",
+            "ScenePreview": "2.0",
             "FeatureMatching": "2.0",
             "CameraInit": "9.0",
             "ImageMatching": "2.0",
             "CheckerboardDetection": "1.0",
             "ConvertSfMFormat": "2.0",
             "SfMTriangulation": "1.0",
+            "KeyframeSelection": "5.0",
             "StructureFromMotion": "3.1",
             "ExportAnimatedCamera": "2.0",
-            "DistortionCalibration": "3.0"
+            "DistortionCalibration": "3.0",
+            "ExportDistortion": "1.0",
+            "FeatureExtraction": "1.3",
+            "DepthMap": "4.0",
+            "Texturing": "6.0"
         }
     },
     "graph": {
@@ -363,7 +363,8 @@
             "inputs": {
                 "cameras": "{ConvertSfMFormat_1.output}",
                 "model": "{MeshDecimate_1.output}",
-                "undistortedImages": "{ExportAnimatedCamera_1.outputUndistorted}"
+                "undistortedImages": "{ExportAnimatedCamera_1.outputUndistorted}",
+                "masks": "{ImageSegmentation_1.output}"
             },
             "internalInputs": {
                 "color": "#4c594c"

--- a/meshroom/pipelines/photogrammetryAndCameraTracking.mg
+++ b/meshroom/pipelines/photogrammetryAndCameraTracking.mg
@@ -5,29 +5,29 @@
         "fileVersion": "1.1",
         "template": true,
         "nodesVersions": {
-            "ExportDistortion": "1.0",
-            "FeatureExtraction": "1.3",
-            "DepthMap": "4.0",
-            "Texturing": "6.0",
             "ImageSegmentation": "1.0",
             "ApplyCalibration": "1.0",
-            "ScenePreview": "1.0",
             "MeshDecimate": "1.0",
-            "KeyframeSelection": "5.0",
             "PrepareDenseScene": "3.1",
             "Publish": "1.3",
             "MeshFiltering": "3.0",
             "DepthMapFilter": "3.0",
             "Meshing": "7.0",
             "ImageMatchingMultiSfM": "1.0",
+            "ScenePreview": "2.0",
             "FeatureMatching": "2.0",
             "CameraInit": "9.0",
             "ImageMatching": "2.0",
             "CheckerboardDetection": "1.0",
             "ConvertSfMFormat": "2.0",
+            "KeyframeSelection": "5.0",
             "StructureFromMotion": "3.1",
             "ExportAnimatedCamera": "2.0",
-            "DistortionCalibration": "3.0"
+            "DistortionCalibration": "3.0",
+            "ExportDistortion": "1.0",
+            "FeatureExtraction": "1.3",
+            "DepthMap": "4.0",
+            "Texturing": "6.0"
         }
     },
     "graph": {
@@ -240,7 +240,8 @@
             "inputs": {
                 "cameras": "{ConvertSfMFormat_1.output}",
                 "model": "{MeshDecimate_1.output}",
-                "undistortedImages": "{ExportAnimatedCamera_1.outputUndistorted}"
+                "undistortedImages": "{ExportAnimatedCamera_1.outputUndistorted}",
+                "masks": "{ImageSegmentation_1.output}"
             },
             "internalInputs": {
                 "color": "#4c594c"


### PR DESCRIPTION
## Description

Use segmentation masks in ScenePreview node: this will avoid rendering geometry on top of moving characters, cars, etc.

## Features

- [x] use masks in Blender compositing graph configured in preview script
- [x] update ScenePreview attributes
- [x] connect ImageSegmentation to ScenePreview in tracking pipelines