### PR TITLE
[ui] ImageGallery: Disable "Visualize HDR" button after clearing images

### DIFF
--- a/meshroom/ui/qml/ImageGallery/ImageGallery.qml
+++ b/meshroom/ui/qml/ImageGallery/ImageGallery.qml
@@ -781,7 +781,7 @@ Panel {
             iconText: MaterialIcons.filter
             label: activeNode ? activeNode.attribute("nbBrackets").value : ""
             visible: activeNode
-            enabled: activeNode && activeNode.isComputed
+            enabled: activeNode && activeNode.isComputed && (m.viewpoints ? m.viewpoints.count > 0 : false)
             property string nodeID: activeNode ? (activeNode.label + activeNode.isComputed) : ""
             onNodeIDChanged: {
                 if(checked) {


### PR DESCRIPTION
## Description

This PR fixes a minor UI issue in the Image Gallery related to the visualization of HDR images.

When all the images in the gallery are cleared using the "Clear Images" or "Clear All Images" menu action while the "Visualize HDR images" option is turned on, the gallery was correctly emptied and the viewer correctly reset but the button remained turned on even though there was nothing left to show.

As it was turned on (although with a "0" count), the gallery remained in read-only mode and no more image could be dropped until the button was manually clicked to be turned off. Even after that, it remained clickable instead of being disabled.
<div align="center"><img src="https://github.com/alicevision/Meshroom/assets/11963329/27660c2a-a1da-4f2f-ace0-f2ef78b533bd" height=300 /></div>

This PR ensures that the button gets disabled if the number of viewpoints is 0 (meaning the gallery is empty). That way, the button correctly reflects the current situation, and the gallery is ready to have images dropped. 
<div align="center"><img src="https://github.com/alicevision/Meshroom/assets/11963329/018b5e16-bddf-480b-9897-242a2f3a39dd" height=300 /></div>
