### PR TITLE
Disable pyramid export for fisheye

### DIFF
--- a/meshroom/pipelines/panoramaFisheyeHdr.mg
+++ b/meshroom/pipelines/panoramaFisheyeHdr.mg
@@ -157,7 +157,7 @@
             "inputs": {
                 "inputPanorama": "{PanoramaMerging_1.outputPanorama}",
                 "fillHoles": true,
-                "exportLevels": true
+                "exportLevels": false
             }
         },
         "PanoramaPrepareImages_1": {


### PR DESCRIPTION
Disable export of pyramid for panorama fisheye in the default pipeline