### PR TITLE
[ui] Check for the existence of the `poses` key in SfM JSON files before accessing it

### DIFF
--- a/meshroom/ui/reconstruction.py
+++ b/meshroom/ui/reconstruction.py
@@ -373,8 +373,9 @@ def parseSfMJsonFile(sfmJsonFile):
     for view in report['views']:
         views[view['viewId']] = view
 
-    for pose in report['poses']:
-        poses[pose['poseId']] = pose['pose']
+    if "poses" in report:
+        for pose in report['poses']:
+            poses[pose['poseId']] = pose['pose']
 
     for intrinsic in report['intrinsics']:
         intrinsics[intrinsic['intrinsicId']] = intrinsic


### PR DESCRIPTION
## Description

When parsing the input SfM JSON file of a project, there might be some instances where the `poses` key, unlike the `views` and `intrinsics` keys, does not exist. If that is the case, an unhandled exception is raised while connections are being made, which then causes issues for the lifetime of the Meshroom instance.

This PR checks that the `poses` key exists before trying to access it, which prevents raising unhandled exceptions while the active project is being set up.

