### PR TITLE
[nodes] PanoramaPostProcessing: Add attributes to change the outputs' names

### DIFF
--- a/meshroom/nodes/aliceVision/PanoramaPostProcessing.py
+++ b/meshroom/nodes/aliceVision/PanoramaPostProcessing.py
@@ -83,6 +83,24 @@ Post process the panorama.
             uid=[0],
             enabled=lambda node: node.compressionMethod.value in ["dwaa", "dwab", "zip", "zips"]
         ),
+        desc.StringParam(
+            name="panoramaName",
+            label="Output Panorama Name",
+            description="Name of the output panorama.",
+            value="panorama.exr",
+            uid=[],
+            group=None,
+            advanced=True
+        ),
+        desc.StringParam(
+            name="previewName",
+            label="Panorama Preview Name",
+            description="Name of the preview of the output panorama.",
+            value="panoramaPreview.jpg",
+            uid=[],
+            group=None,
+            advanced=True,
+        ),
         desc.ChoiceParam(
             name="verboseLevel",
             label="Verbose Level",
@@ -100,7 +118,7 @@ Post process the panorama.
             label="Output Panorama",
             description="Generated panorama in EXR format.",
             semantic="image",
-            value=desc.Node.internalFolder + "panorama.exr",
+            value=lambda attr: desc.Node.internalFolder + attr.node.panoramaName.value,
             uid=[],
         ),
         desc.File(
@@ -108,14 +126,14 @@ Post process the panorama.
             label="Output Panorama Preview",
             description="Preview of the generated panorama in JPG format.",
             semantic="image",
-            value=desc.Node.internalFolder + "panoramaPreview.jpg",
+            value=lambda attr: desc.Node.internalFolder + attr.node.previewName.value,
             uid=[],
         ),
         desc.File(
             name="downscaledPanoramaLevels",
             label="Downscaled Panorama Levels",
             description="Downscaled versions of the generated panorama.",
-            value=desc.Node.internalFolder + "level_*.exr",
+            value=lambda attr: desc.Node.internalFolder + os.path.splitext(attr.node.panoramaName.value)[0] + "_level_*.exr",
             uid=[],
             group='',
         ),

--- a/meshroom/pipelines/panoramaFisheyeHdr.mg
+++ b/meshroom/pipelines/panoramaFisheyeHdr.mg
@@ -11,7 +11,7 @@
             "PanoramaPrepareImages": "1.1",
             "PanoramaInit": "2.0",
             "Publish": "1.3",
-            "PanoramaPostProcessing": "2.0",
+            "PanoramaPostProcessing": "2.1",
             "FeatureMatching": "2.0",
             "LdrToHdrSampling": "4.0",
             "PanoramaWarping": "1.1",

--- a/meshroom/pipelines/panoramaHdr.mg
+++ b/meshroom/pipelines/panoramaHdr.mg
@@ -11,7 +11,7 @@
             "PanoramaPrepareImages": "1.1",
             "PanoramaInit": "2.0",
             "Publish": "1.3",
-            "PanoramaPostProcessing": "2.0",
+            "PanoramaPostProcessing": "2.1",
             "FeatureMatching": "2.0",
             "LdrToHdrSampling": "4.0",
             "PanoramaWarping": "1.1",


### PR DESCRIPTION
## Description

This PR adds two new input String parameters to the `PanoramaPostProcessing` node to determine the name of the generated outputs. These attributes include:
- the name of the generated output panorama;
- the name of the generated output panorama preview.

These two attributes are not added to the command line, as their only purpose is to be used to set the names of the outputs at will. The base folder for these outputs remains the node's cache, only the name of the outputs themselves can be updated.

The `downscaledPanoramaLevels` output attribute is also updated following alicevision/AliceVision#1542, since the name of the downscaled levels is now a concatenation of the generated panorama's name, "_level_" and the size of the level.

As a consequence, the version of the `PanoramaPostProcessing` node is upgraded, and the templates using it are updated accordingly.
