### PR TITLE
[ui] SequencePlayer: minor adjustments (fps, icon, play)

### DIFF
--- a/meshroom/ui/qml/Viewer/SequencePlayer.qml
+++ b/meshroom/ui/qml/Viewer/SequencePlayer.qml
@@ -43,7 +43,7 @@ FloatingPane {
         property bool syncSelected: true
         property bool playing: false
         property bool repeat: false
-        property real fps: 1
+        property real fps: 24
 
         onFrameChanged: {
             updateReconstructionView();
@@ -231,6 +231,7 @@ FloatingPane {
                 from: 1
                 to: 60
                 stepSize: 1
+                value: m.fps
 
                 onValueChanged: {
                     m.fps = value;

--- a/meshroom/ui/qml/Viewer/SequencePlayer.qml
+++ b/meshroom/ui/qml/Viewer/SequencePlayer.qml
@@ -244,7 +244,7 @@ FloatingPane {
 
             checkable: true
             checked: false
-            text: MaterialIcons.replay
+            text: MaterialIcons.repeat
             ToolTip.text: "Repeat"
 
             onCheckedChanged: {

--- a/meshroom/ui/qml/Viewer/SequencePlayer.qml
+++ b/meshroom/ui/qml/Viewer/SequencePlayer.qml
@@ -55,7 +55,11 @@ FloatingPane {
 
         onPlayingChanged: {
             syncSelected = !playing;
-            viewer.playback(m.playing);
+            if(playing && (frame + 1 >= sortedViewIds.length))
+            {
+                frame = 0;
+            }
+            viewer.playback(playing);
         }
     }
 


### PR DESCRIPTION
## Description

Default value for FPS is now 24
Update icon to use "repeat" (instead of "replay")
When launching "play" on the last frame, restart from the beginning instead of doing nothing.

