### PR TITLE
[nodes] StructureFromMotion: Automatic alignment of the 3D reconstruction

### DIFF
--- a/meshroom/nodes/aliceVision/StructureFromMotion.py
+++ b/meshroom/nodes/aliceVision/StructureFromMotion.py
@@ -350,8 +350,11 @@ It iterates like that, adding cameras and triangulating new 2D features into 3D 
         ),
         desc.BoolParam(
             name="useAutoTransform",
-            label="Automatically align result",
-            description="Enable/Disable automatic alignment of result.",
+            label="Automatic Alignment",
+            description="Enable/Disable automatic alignment of the 3D reconstruction.\n"
+                        "Determines scene orientation from the cameras' X axis,\n"
+                        "determines north and scale from GPS information if available,\n"
+                        "and defines ground level from the point cloud.",
             value=True,
             uid=[0],
         ),

--- a/meshroom/nodes/aliceVision/StructureFromMotion.py
+++ b/meshroom/nodes/aliceVision/StructureFromMotion.py
@@ -1,4 +1,4 @@
-__version__ = "3.2"
+__version__ = "3.3"
 
 from meshroom.core import desc
 
@@ -345,6 +345,13 @@ It iterates like that, adding cameras and triangulating new 2D features into 3D 
             name="computeStructureColor",
             label="Compute Structure Color",
             description="Enable/Disable color computation of every 3D point.",
+            value=True,
+            uid=[0],
+        ),
+        desc.BoolParam(
+            name="useAutoTransform",
+            label="Automatically align result",
+            description="Enable/Disable automatic alignment of result.",
             value=True,
             uid=[0],
         ),


### PR DESCRIPTION
Enable automatic alignment at the of the structure from motion result.
"Determines scene orientation from the cameras' X axis, determines north and scale from GPS information if available, and defines ground level from the point cloud."

See https://github.com/alicevision/AliceVision/pull/1546