### PR TITLE
[ui] Viewer2D: various orientation fixes

### DIFF
--- a/meshroom/ui/qml/Viewer/CircleGizmo.qml
+++ b/meshroom/ui/qml/Viewer/CircleGizmo.qml
@@ -5,7 +5,7 @@ Item {
 
     property bool readOnly: false
 
-    signal moved()
+    signal moved(real xoffset, real yoffset)
     signal incrementRadius(real radiusOffset)
 
     // Circle
@@ -37,6 +37,45 @@ Item {
             width: parent.border.width * 0.5
             height: parent.height * 0.2
         }
+
+        Loader {
+            anchors.fill: parent
+            active: !root.readOnly
+
+            sourceComponent: MouseArea {
+                id: mArea
+                anchors.fill: parent
+                cursorShape: root.readOnly ? Qt.ArrowCursor : (controlModifierEnabled ? Qt.SizeBDiagCursor : (pressed ? Qt.ClosedHandCursor : Qt.OpenHandCursor))
+                propagateComposedEvents: true
+
+                property bool controlModifierEnabled: false
+                onPositionChanged: {
+                    mArea.controlModifierEnabled = (mouse.modifiers & Qt.ControlModifier)
+                    mouse.accepted = false;
+                }
+                acceptedButtons: Qt.LeftButton
+                hoverEnabled: true
+                drag.target: circle
+
+                drag.onActiveChanged: {
+                    if(!drag.active) {
+                        root.moved(circle.x - (root.width - circle.width) / 2, circle.y - (root.height - circle.height) / 2);
+                    }
+                }
+                onPressed: {
+                    forceActiveFocus();
+                }
+                onWheel: {
+                    mArea.controlModifierEnabled = (wheel.modifiers & Qt.ControlModifier)
+                    if (wheel.modifiers & Qt.ControlModifier) {
+                        root.incrementRadius(wheel.angleDelta.y / 120.0);
+                        wheel.accepted = true;
+                    } else {
+                        wheel.accepted = false;
+                    }
+                }
+            }
+        }
     }
     property alias circleRadius: circle.radius
     property alias circleBorder: circle.border
@@ -54,43 +93,4 @@ Item {
         height: 500
     }
     */
-
-    Loader {
-        anchors.fill: parent
-        active: !root.readOnly
-
-        sourceComponent: MouseArea {
-            id: mArea
-            anchors.fill: parent
-            cursorShape: root.readOnly ? Qt.ArrowCursor : (controlModifierEnabled ? Qt.SizeBDiagCursor : (pressed ? Qt.ClosedHandCursor : Qt.OpenHandCursor))
-            propagateComposedEvents: true
-
-            property bool controlModifierEnabled: false
-            onPositionChanged: {
-                mArea.controlModifierEnabled = (mouse.modifiers & Qt.ControlModifier)
-                mouse.accepted = false;
-            }
-            acceptedButtons: Qt.LeftButton
-            hoverEnabled: true
-            drag.target: root
-
-            drag.onActiveChanged: {
-                if(!drag.active) {
-                    moved();
-                }
-            }
-            onPressed: {
-                forceActiveFocus();
-            }
-            onWheel: {
-                mArea.controlModifierEnabled = (wheel.modifiers & Qt.ControlModifier)
-                if (wheel.modifiers & Qt.ControlModifier) {
-                    incrementRadius(wheel.angleDelta.y / 120.0);
-                    wheel.accepted = true;
-                } else {
-                    wheel.accepted = false;
-                }
-            }
-        }
-    }
 }

--- a/meshroom/ui/qml/Viewer/CircleGizmo.qml
+++ b/meshroom/ui/qml/Viewer/CircleGizmo.qml
@@ -1,6 +1,6 @@
 import QtQuick 2.15
 
-Rectangle {
+Item {
     id: root
 
     property bool readOnly: false
@@ -8,11 +8,38 @@ Rectangle {
     signal moved()
     signal incrementRadius(real radiusOffset)
 
-    width: radius * 2
-    height: width
-    color: "transparent"
-    border.width: 5
-    border.color: readOnly ? "green" : "yellow"
+    // Circle
+    property real circleX: 0.
+    property real circleY: 0.
+    Rectangle {
+        id: circle
+
+        width: radius * 2
+        height: width
+
+        x: circleX + (root.width - width) / 2
+        y: circleY + (root.height - height) / 2
+
+        color: "transparent"
+        border.width: 5
+        border.color: readOnly ? "green" : "yellow"
+
+        // Cross to visualize the circle center
+        Rectangle {
+            color: parent.border.color
+            anchors.centerIn: parent
+            width: parent.width * 0.2
+            height: parent.border.width * 0.5
+        }
+        Rectangle {
+            color: parent.border.color
+            anchors.centerIn: parent
+            width: parent.border.width * 0.5
+            height: parent.height * 0.2
+        }
+    }
+    property alias circleRadius: circle.radius
+    property alias circleBorder: circle.border
 
     /*
     // visualize top-left corner for debugging purpose
@@ -27,37 +54,6 @@ Rectangle {
         height: 500
     }
     */
-    // Cross to visualize the circle center
-    Rectangle {
-        color: parent.border.color
-        anchors.centerIn: parent
-        width: parent.width * 0.2
-        height: parent.border.width * 0.5
-    }
-    Rectangle {
-        color: parent.border.color
-        anchors.centerIn: parent
-        width: parent.border.width * 0.5
-        height: parent.height * 0.2
-    }
-
-    Behavior on x {
-        NumberAnimation {
-            duration: 100
-        }
-    }
-
-    Behavior on y {
-        NumberAnimation {
-            duration: 100
-        }
-    }
-
-    Behavior on radius {
-        NumberAnimation {
-            duration: 100
-        }
-    }
 
     Loader {
         anchors.fill: parent

--- a/meshroom/ui/qml/Viewer/ColorCheckerEntity.qml
+++ b/meshroom/ui/qml/Viewer/ColorCheckerEntity.qml
@@ -31,8 +31,7 @@ Item {
     }
 
 
-    function transform(matrix) {
-        var m = matrix
+    function applyTransform(m) {
         transformation.matrix = Qt.matrix4x4(
                 m[0][0], m[0][1],  0, m[0][2],
                 m[1][0], m[1][1],  0, m[1][2],

--- a/meshroom/ui/qml/Viewer/ColorCheckerViewer.qml
+++ b/meshroom/ui/qml/Viewer/ColorCheckerViewer.qml
@@ -5,7 +5,6 @@ Item {
 
     property url source: undefined
     property var json: null
-    property var image: null
     property var viewpoint: null
     property real zoom: 1.0
 
@@ -15,10 +14,6 @@ Item {
     readonly property real ccheckerSizeX: 1675.0
     readonly property real ccheckerSizeY: 1125.0
 
-    // offset the cchecker top left corner to match the image top left corner
-    x: -image.width / 2 + ccheckerSizeX / 2
-    y: -image.height / 2 + ccheckerSizeY / 2
-
     property var ccheckers: []
     property int selectedCChecker: -1
 
@@ -26,7 +21,6 @@ Item {
     onSourceChanged: { readSourceFile(); }
     onViewpointChanged: { loadCCheckers(); }
     property var updatePane: null
-
 
     function getColors() {
         if (ccheckers[selectedCChecker] === undefined)
@@ -79,11 +73,13 @@ Item {
                 var cpt = Qt.createComponent("ColorCheckerEntity.qml");
 
                 var obj = cpt.createObject(root, {
+                    x: ccheckerSizeX / 2,
+                    y: ccheckerSizeY / 2,
                     sizeX: root.ccheckerSizeX,
                     sizeY: root.ccheckerSizeY,
                     colors: root.json.checkers[i].colors
                 });
-                obj.transform(root.json.checkers[i].transform);
+                obj.applyTransform(root.json.checkers[i].transform);
                 ccheckers.push(obj);
                 selectedCChecker = ccheckers.length-1;
                 break;
@@ -98,5 +94,4 @@ Item {
         ccheckers = [];
         selectedCChecker = -1;
     }
-
 }

--- a/meshroom/ui/qml/Viewer/Viewer2D.qml
+++ b/meshroom/ui/qml/Viewer/Viewer2D.qml
@@ -611,17 +611,21 @@ FocusScope {
                     active: (displayFisheyeCircleLoader.checked && activeNode)
 
                     sourceComponent: CircleGizmo {
+                        width: imgContainer.width
+                        height: imgContainer.height
+
                         property bool useAuto: activeNode.attribute("estimateFisheyeCircle").value
                         readOnly: useAuto
                         visible: (!useAuto) || activeNode.isComputed
                         property real userFisheyeRadius: activeNode.attribute("fisheyeRadius").value
                         property variant fisheyeAutoParams: _reconstruction.getAutoFisheyeCircle(activeNode)
 
-                        x: useAuto ? fisheyeAutoParams.x : activeNode.attribute("fisheyeCenterOffset.fisheyeCenterOffset_x").value
-                        y: useAuto ? fisheyeAutoParams.y : activeNode.attribute("fisheyeCenterOffset.fisheyeCenterOffset_y").value
-                        radius: useAuto ? fisheyeAutoParams.z : ((imgContainer.image ? Math.min(imgContainer.image.width, imgContainer.image.height) : 1.0) * 0.5 * (userFisheyeRadius * 0.01))
+                        circleX: useAuto ? fisheyeAutoParams.x : activeNode.attribute("fisheyeCenterOffset.fisheyeCenterOffset_x").value
+                        circleY: useAuto ? fisheyeAutoParams.y : activeNode.attribute("fisheyeCenterOffset.fisheyeCenterOffset_y").value
 
-                        border.width: Math.max(1, (3.0 / imgContainer.scale))
+                        circleRadius: useAuto ? fisheyeAutoParams.z : ((imgContainer.image ? Math.min(imgContainer.image.width, imgContainer.image.height) : 1.0) * 0.5 * (userFisheyeRadius * 0.01))
+
+                        circleBorder.width: Math.max(1, (3.0 / imgContainer.scale))
                         onMoved: {
                             if(!useAuto)
                             {
@@ -661,9 +665,9 @@ FocusScope {
                         readOnly: false
                         x: activeNode.attribute("sphereCenter.x").value
                         y: activeNode.attribute("sphereCenter.y").value
-                        radius: activeNode.attribute("sphereRadius").value
+                        circleRadius: activeNode.attribute("sphereRadius").value
 
-                        border.width: Math.max(1, (3.0 / imgContainer.scale))
+                        circleBorder.width: Math.max(1, (3.0 / imgContainer.scale))
                         onMoved: {
                             _reconstruction.setAttribute(
                                 activeNode.attribute("sphereCenter"),

--- a/meshroom/ui/qml/Viewer/Viewer2D.qml
+++ b/meshroom/ui/qml/Viewer/Viewer2D.qml
@@ -631,7 +631,7 @@ FocusScope {
                             {
                                 _reconstruction.setAttribute(
                                     activeNode.attribute("fisheyeCenterOffset"),
-                                    JSON.stringify([x, y])
+                                    JSON.stringify([xoffset, yoffset])
                                 );
                             }
                         }
@@ -667,7 +667,7 @@ FocusScope {
                         onMoved: {
                             _reconstruction.setAttribute(
                                 activeNode.attribute("sphereCenter"),
-                                JSON.stringify([x, y])
+                                JSON.stringify([xoffset, yoffset])
                             );
                         }
                         onIncrementRadius: {

--- a/meshroom/ui/qml/Viewer/Viewer2D.qml
+++ b/meshroom/ui/qml/Viewer/Viewer2D.qml
@@ -645,26 +645,22 @@ FocusScope {
                 }
 
                 // LightingCalibration: display circle
-                // note: use a Loader to evaluate if a PanoramaInit node exist and displayFisheyeCircle checked at runtime
-                Loader {
+                ExifOrientedViewer {
                     anchors.centerIn: parent
+                    orientationTag: imgContainer.orientationTag
+                    xOrigin: imgContainer.width / 2
+                    yOrigin: imgContainer.height / 2
                     property var activeNode: _reconstruction.activeNodes.get("SphereDetection").node
                     active: (displayLightingCircleLoader.checked && activeNode)
 
-                    // handle rotation/position based on available metadata
-                    rotation: {
-                        var orientation = m.imgMetadata ? m.imgMetadata["Orientation"] : 0
-                        switch(orientation) {
-                            case "6": return 90;
-                            case "8": return -90;
-                            default: return 0;
-                        }
-                    }
-
                     sourceComponent: CircleGizmo {
+                        width: imgContainer.width
+                        height: imgContainer.height
+
                         readOnly: false
-                        x: activeNode.attribute("sphereCenter.x").value
-                        y: activeNode.attribute("sphereCenter.y").value
+
+                        circleX: activeNode.attribute("sphereCenter.x").value
+                        circleY: activeNode.attribute("sphereCenter.y").value
                         circleRadius: activeNode.attribute("sphereRadius").value
 
                         circleBorder.width: Math.max(1, (3.0 / imgContainer.scale))

--- a/meshroom/ui/qml/Viewer/Viewer2D.qml
+++ b/meshroom/ui/qml/Viewer/Viewer2D.qml
@@ -678,17 +678,21 @@ FocusScope {
 
                 // ColorCheckerViewer: display color checker detection results
                 // note: use a Loader to evaluate if a ColorCheckerDetection node exist and displayColorChecker checked at runtime
-                Loader {
+                ExifOrientedViewer {
                     id: colorCheckerViewerLoader
                     anchors.centerIn: parent
+                    orientationTag: imgContainer.orientationTag
+                    xOrigin: imgContainer.width / 2
+                    yOrigin: imgContainer.height / 2
                     property var activeNode: _reconstruction ? _reconstruction.activeNodes.get("ColorCheckerDetection").node : null
                     active: (displayColorCheckerViewerLoader.checked && activeNode)
 
-
                     sourceComponent: ColorCheckerViewer {
+                        width: imgContainer.width
+                        height: imgContainer.height
+
                         visible: activeNode.isComputed && json !== undefined && imgContainer.image.status === Image.Ready
                         source: Filepath.stringToUrl(activeNode.attribute("outputData").value)
-                        image: imgContainer.image
                         viewpoint: _reconstruction.selectedViewpoint
                         zoom: imgContainer.scale
 


### PR DESCRIPTION
## Description

In the 2D viewer, several widgets were not positioned properly when the exif orientation of the selected view was non-trivial: 
- color checker viewer
- fisheye circle viewer
- sphere detection viewer

This PR fixes these problems by making sure these widgets are parented to a QML Item with the proper size and location.