### PR TITLE
Input color space setting

### DIFF
--- a/meshroom/nodes/aliceVision/ImageProcessing.py
+++ b/meshroom/nodes/aliceVision/ImageProcessing.py
@@ -463,6 +463,15 @@ Convert or apply filtering to the input images.
             uid=[0],
         ),
         desc.ChoiceParam(
+            name="inputColorSpace",
+            label="Input Color Space",
+            description="Allows you to force the color space of the input image.",
+            value="AUTO",
+            values=["AUTO", "sRGB", "rec709", "Linear", "ACES2065-1", "ACEScg", "no_conversion"],
+            exclusive=True,
+            uid=[0],
+        ),
+        desc.ChoiceParam(
             name="outputColorSpace",
             label="Output Color Space",
             description="Allows you to choose the color space of the output image.",


### PR DESCRIPTION

<!-- Checklist before submission:

 - I have read the [contribution guidelines](../CONTRIBUTING.md).
 - I have updated the documentation, if applicable.
 - I have ensured that the change is tested somewhere.
 - I have followed the prevailing code style (for history readability and limit conflicts for maintainance).

-->
## Description

Add a choice param in the imageProcessing node to force the color space of the input images. Default value set to AUTO. In that case, the input color space is extracted from the metadata as it is implemented in the current version.

## Features list

<!--
- [ ] Feature one. Fix #XXX
- [ ] Improve something else
- [ ] Connect to #3 (to declare link to issues without closing it when the PR is merged).
- [X] Add "X" when it is done.
-->


## Implementation remarks


<!--
Explain main implementation choices.
It is also the right place to ask for feedback and help when you hesitate on the implementation.
-->
