### PR TITLE
[ui] ImageGallery: Use commands to set SfM attributes through the Image Gallery

### DIFF
--- a/meshroom/ui/qml/ImageGallery/ImageDelegate.qml
+++ b/meshroom/ui/qml/ImageGallery/ImageDelegate.qml
@@ -82,7 +82,7 @@ Item {
                 text: "Define As Center Image"
                 property var activeNode: _reconstruction ? _reconstruction.activeNodes.get("SfMTransform").node : null
                 enabled: !root.readOnly && _viewpoint.viewId != -1 && _reconstruction && activeNode
-                onClicked: activeNode.attribute("transformation").value = _viewpoint.viewId.toString()
+                onClicked: _reconstruction.setAttribute(activeNode.attribute("transformation"), _viewpoint.viewId.toString())
             }
             Menu {
                 id: sfmSetPairMenu
@@ -92,12 +92,12 @@ Item {
 
                 MenuItem {
                     text: "A"
-                    onClicked: sfmSetPairMenu.activeNode.attribute("initialPairA").value = _viewpoint.viewId.toString()
+                    onClicked: _reconstruction.setAttribute(sfmSetPairMenu.activeNode.attribute("initialPairA"), _viewpoint.viewId.toString())
                 }
 
                 MenuItem {
                     text: "B"
-                    onClicked: sfmSetPairMenu.activeNode.attribute("initialPairB").value = _viewpoint.viewId.toString()
+                    onClicked: _reconstruction.setAttribute(sfmSetPairMenu.activeNode.attribute("initialPairB"), _viewpoint.viewId.toString())
                 }
             }
         }


### PR DESCRIPTION
## Description

Some attributes of the `StructureFromMotion` and `SfMTransform` nodes can be set directly through the Image Gallery with the right-click menu. Prior to this PR, setting these attributes through the Image Gallery was directly modifying them without adding the changes to the stack of commands, meaning they could not be undone. 

This PR fixes that by using the "setAttribute" command to modify these attributes, which correctly adds them to the stack and allows to undo them with Ctrl-Z.

