### PR TITLE
[ui] ImageGallery: Add "Remove All Images" menu to clear all images

### DIFF
--- a/meshroom/ui/commands.py
+++ b/meshroom/ui/commands.py
@@ -356,13 +356,13 @@ class ListAttributeRemoveCommand(GraphCommand):
         listAttribute.insert(self.index, self.value)
 
 
-class ClearImagesCommand(GraphCommand):
+class RemoveImagesCommand(GraphCommand):
     def __init__(self, graph, cameraInitNodes, parent=None):
-        super(ClearImagesCommand, self).__init__(graph, parent)
+        super(RemoveImagesCommand, self).__init__(graph, parent)
         self.cameraInits = cameraInitNodes
         self.viewpoints = { cameraInit.name: cameraInit.attribute("viewpoints").getExportValue() for cameraInit in self.cameraInits }
         self.intrinsics = { cameraInit.name: cameraInit.attribute("intrinsics").getExportValue() for cameraInit in self.cameraInits }
-        self.title = "Clear{}Images".format(" " if len(self.cameraInits) == 1 else " All ")
+        self.title = "Remove{}Images".format(" " if len(self.cameraInits) == 1 else " All ")
         self.setText(self.title)
 
     def redoImpl(self):

--- a/meshroom/ui/graph.py
+++ b/meshroom/ui/graph.py
@@ -813,14 +813,14 @@ class UIGraph(QObject):
         self.push(commands.ListAttributeRemoveCommand(self._graph, attribute))
 
     @Slot()
-    def clearImages(self):
-        with self.groupedGraphModification("Clear Images"):
-            self.push(commands.ClearImagesCommand(self._graph, [self.cameraInit]))
+    def removeAllImages(self):
+        with self.groupedGraphModification("Remove All Images"):
+            self.push(commands.RemoveImagesCommand(self._graph, [self.cameraInit]))
 
     @Slot()
-    def clearAllImages(self):
-        with self.groupedGraphModification("Clear All Images"):
-            self.push(commands.ClearImagesCommand(self._graph, list(self.cameraInits)))
+    def removeImagesFromAllGroups(self):
+        with self.groupedGraphModification("Remove Images From All CameraInit Nodes"):
+            self.push(commands.RemoveImagesCommand(self._graph, list(self.cameraInits)))
 
     @Slot(Node)
     def appendSelection(self, node):

--- a/meshroom/ui/qml/ImageGallery/ImageDelegate.qml
+++ b/meshroom/ui/qml/ImageGallery/ImageDelegate.qml
@@ -20,6 +20,7 @@ Item {
 
     signal pressed(var mouse)
     signal removeRequest()
+    signal removeAllImagesRequest()
 
     default property alias children: imageMA.children
 
@@ -77,6 +78,11 @@ Item {
                 text: "Remove"
                 enabled: !root.readOnly
                 onClicked: removeRequest()
+            }
+            MenuItem {
+                text: "Remove All Images"
+                enabled: !root.readOnly
+                onClicked: removeAllImagesRequest()
             }
             MenuItem {
                 text: "Define As Center Image"

--- a/meshroom/ui/qml/ImageGallery/ImageGallery.qml
+++ b/meshroom/ui/qml/ImageGallery/ImageGallery.qml
@@ -290,7 +290,7 @@ Panel {
                     }
 
                     function removeAllImages() {
-                        _reconstruction.clearImages()
+                        _reconstruction.removeAllImages()
                         _reconstruction.selectedViewId = "-1"
                     }
 

--- a/meshroom/ui/qml/ImageGallery/ImageGallery.qml
+++ b/meshroom/ui/qml/ImageGallery/ImageGallery.qml
@@ -289,8 +289,22 @@ Panel {
                         }
                     }
 
+                    function removeAllImages() {
+                        _reconstruction.clearImages()
+                        _reconstruction.selectedViewId = "-1"
+                    }
+
                     onRemoveRequest: sendRemoveRequest()
-                    Keys.onDeletePressed: sendRemoveRequest()
+                    Keys.onPressed: (event) => {
+                        if (event.key === Qt.Key_Delete && event.modifiers === Qt.ShiftModifier) {
+                            removeAllImages()
+                        } else if (event.key === Qt.Key_Delete) {
+                            sendRemoveRequest()
+                        }
+                    }
+                    onRemoveAllImagesRequest: {
+                        removeAllImages()
+                    }
 
                     RowLayout {
                         anchors.top: parent.top

--- a/meshroom/ui/qml/WorkspaceView.qml
+++ b/meshroom/ui/qml/WorkspaceView.qml
@@ -79,7 +79,7 @@ Item {
                 tempCameraInit: reconstruction ? reconstruction.tempCameraInit : null
                 cameraInitIndex: reconstruction ? reconstruction.cameraInitIndex : -1
                 onRemoveImageRequest: reconstruction.removeAttribute(attribute)
-                onAllViewpointsCleared: { reconstruction.clearImages(); reconstruction.selectedViewId = "-1" }
+                onAllViewpointsCleared: { reconstruction.removeAllImages(); reconstruction.selectedViewId = "-1" }
                 onFilesDropped: reconstruction.handleFilesDrop(drop, augmentSfm ? null : cameraInit)
             }
             LiveSfmView {

--- a/meshroom/ui/qml/main.qml
+++ b/meshroom/ui/qml/main.qml
@@ -477,21 +477,21 @@ ApplicationWindow {
     }
 
     Action {
-        id: clearImagesAction
-        property string tooltip: "Clear images for the current CameraInit group"
-        text: "Clear Images"
+        id: removeAllImagesAction
+        property string tooltip: "Remove all the images from the current CameraInit group"
+        text: "Remove All Images"
         onTriggered: {
-            _reconstruction.clearImages()
+            _reconstruction.removeAllImages()
             _reconstruction.selectedViewId = "-1"
         }
     }
 
     Action {
-        id: clearAllImagesAction
-        property string tooltip: "Clear all the images for all the CameraInit groups"
-        text: "Clear All Images"
+        id: removeImagesFromAllGroupsAction
+        property string tooltip: "Remove all the images from all the CameraInit groups"
+        text: "Remove Images From All CameraInit Nodes"
         onTriggered: {
-            _reconstruction.clearAllImages()
+            _reconstruction.removeImagesFromAllGroups()
             _reconstruction.selectedViewId = "-1"
         }
     }
@@ -723,15 +723,16 @@ ApplicationWindow {
             }
 
             MenuItem {
-                action: clearImagesAction
+                action: removeAllImagesAction
                 ToolTip.visible: hovered
-                ToolTip.text: clearImagesAction.tooltip
+                ToolTip.text: removeAllImagesAction.tooltip
             }
 
             MenuSeparator { }
             Menu {
                 id: advancedMenu
                 title: "Advanced"
+                implicitWidth: 300
 
                 Action {
                     id: saveAsTemplateAction
@@ -768,9 +769,9 @@ ApplicationWindow {
                 }
 
                 MenuItem {
-                    action: clearAllImagesAction
+                    action: removeImagesFromAllGroupsAction
                     ToolTip.visible: hovered
-                    ToolTip.text: clearAllImagesAction.tooltip
+                    ToolTip.text: removeImagesFromAllGroupsAction.tooltip
                 }
             }
             MenuSeparator { }


### PR DESCRIPTION
## Description

In addition to the existing "Remove" menu action in the Image Gallery that deletes the currently selected image, this PR adds a "Remove All Images" menu action that performs the same action as "Clear Images" from the "File" menu.

The `Del` key was used as a shortcut to remove the currently selected image when the Image Gallery has the focus, `Shift+Del` can now also be used to remove all the images at once.

<div align=center><img src="https://github.com/alicevision/Meshroom/assets/11963329/082aa304-5aba-4f0f-b891-29a5e3bffd41" height=400 /></div>
