### PR TITLE
[ui] Don't load a node's output in the 3DViewer if it has no 3D output

### DIFF
--- a/meshroom/ui/qml/main.qml
+++ b/meshroom/ui/qml/main.qml
@@ -995,7 +995,7 @@ ApplicationWindow {
                 }
 
                 function viewIn3D(attribute, mouse) {
-                    if(!panel3dViewer)
+                    if(!panel3dViewer || !attribute.node.has3DOutput)
                         return false;
                     var loaded = panel3dViewer.viewer3D.view(attribute);
                     // solo media if Control modifier was held


### PR DESCRIPTION
## Description

Prior to this PR and following #2208, any file whose extension is `.json`,  `.sfm` or `.abc` could be loaded in the 3D viewer. Double-clicking on a node that had an output with one of these extensions, even if it was not a 3D output, led to the node being loaded in the 3D viewer.

For example, double-clicking the `CameraInit` node, which has `.sfm` outputs but no 3D output, resulted in it being added to the list of entries of the Inspector3D. 

This PR ensures that no node will be loaded in the 3D viewer upon being double-clicked unless it has a 3D output, which is indicated by an icon next to the node's name in the Graph Editor. Only `.abc` outputs are considered to be valid 3D outputs.

Any `.json`, `.sfm` and `.abc` can still be dropped in the 3D viewer, and the `SfmDataLoader` will load it if it is valid.

This relates to https://github.com/alicevision/QtAliceVision/pull/49.
