### PR TITLE
[Viewer3D] Connect any change of the selected view ID to the SfmDataLoader

### DIFF
--- a/meshroom/ui/qml/Viewer3D/MediaLoader.qml
+++ b/meshroom/ui/qml/Viewer3D/MediaLoader.qml
@@ -117,6 +117,12 @@ import Utils 1.0
                     resectionId = Viewer3DSettings.resectionIdCount
                     root.status = obj.status;
                 })
+
+                obj.cameraSelected.connect(
+                    function(viewId) {
+                        obj.selectedViewId = viewId
+                    }
+                )
             }
         }
     }

--- a/meshroom/ui/qml/Viewer3D/SfmDataLoader.qml
+++ b/meshroom/ui/qml/Viewer3D/SfmDataLoader.qml
@@ -17,6 +17,13 @@ SfmDataEntity {
 
     signal cameraSelected(var viewId)
 
+    Connections {
+        target: _reconstruction
+        function onSelectedViewIdChanged() {
+            root.cameraSelected(_reconstruction.selectedViewId)
+        }
+    }
+
     function spawnCameraSelectors() {
         var validCameras = 0;
         // spawn camera selector for each camera


### PR DESCRIPTION
## Description

This PR connects the `selectedViewId` property from the `Reconstruction` object to the `selectedViewId` property of the `SfmDataLoader` object: any change of the currently selected view ID, either by selecting another image in the Image Gallery or by clicking on a camera in the 3D Viewer, will be propagated to QtAliceVision.

This relates to https://github.com/alicevision/QtAliceVision/pull/52.