### PR TITLE
[Viewer] Display error labels when an image cannot be loaded

### DIFF
--- a/meshroom/ui/qml/Viewer/FloatImage.qml
+++ b/meshroom/ui/qml/Viewer/FloatImage.qml
@@ -15,16 +15,19 @@ AliceVision.FloatImageViewer {
     height: sourceSize.height
     visible: true
 
-    // paintedWidth / paintedHeight / status for compatibility with standard Image
+    // paintedWidth / paintedHeight / imageStatus for compatibility with standard Image
     property int paintedWidth: sourceSize.width
     property int paintedHeight: sourceSize.height
-    property var status: {
-        if (root.loading)
-            return Image.Loading;
-        else if ((root.source === "") ||
-                 (root.sourceSize.height <= 0) ||
-                 (root.sourceSize.width <= 0))
+    property var imageStatus: {
+        if (root.status === AliceVision.FloatImageViewer.EStatus.LOADING) {
+            return Image.Loading
+        } else if (root.status === AliceVision.FloatImageViewer.EStatus.ERROR ||
+                   root.status === AliceVision.FloatImageViewer.EStatus.MISSING_FILE ||
+                   root.status === AliceVision.FloatImageViewer.EStatus.OUTDATED_LOADING) {
+            return Image.Error
+        } else if ((root.source === "") || (root.sourceSize.height <= 0) || (root.sourceSize.width <= 0)) {
             return Image.Null
+        }
 
         return Image.Ready
     }

--- a/meshroom/ui/qml/Viewer/Viewer2D.qml
+++ b/meshroom/ui/qml/Viewer/Viewer2D.qml
@@ -463,11 +463,11 @@ FocusScope {
                                 'gamma': Qt.binding(function() { return hdrImageToolbar.gammaValue }),
                                 'gain': Qt.binding(function() { return hdrImageToolbar.gainValue }),
                                 'channelModeString': Qt.binding(function() { return hdrImageToolbar.channelModeValue }),
-                                'isPrincipalPointsDisplayed' : Qt.binding(function() { return lensDistortionImageToolbar.displayPrincipalPoint }),
-                                'surface.displayGrid' :  Qt.binding(function() { return lensDistortionImageToolbar.visible && lensDistortionImageToolbar.displayGrid }),
-                                'surface.gridOpacity' : Qt.binding(function() { return lensDistortionImageToolbar.opacityValue }),
-                                'surface.gridColor' : Qt.binding(function() { return lensDistortionImageToolbar.color }),
-                                'surface.subdivisions' : Qt.binding(function() { return root.useFloatImageViewer ? 1 : lensDistortionImageToolbar.subdivisionsValue }),
+                                'isPrincipalPointsDisplayed': Qt.binding(function() { return lensDistortionImageToolbar.displayPrincipalPoint }),
+                                'surface.displayGrid':  Qt.binding(function() { return lensDistortionImageToolbar.visible && lensDistortionImageToolbar.displayGrid }),
+                                'surface.gridOpacity': Qt.binding(function() { return lensDistortionImageToolbar.opacityValue }),
+                                'surface.gridColor': Qt.binding(function() { return lensDistortionImageToolbar.color }),
+                                'surface.subdivisions': Qt.binding(function() { return root.useFloatImageViewer ? 1 : lensDistortionImageToolbar.subdivisionsValue }),
                                 'viewerTypeString': Qt.binding(function() { return displayLensDistortionViewer.checked ? "distortion" : "hdr" }),
                                 'sfmRequired': Qt.binding(function() { return displayLensDistortionViewer.checked ? true : false }),
                                 'surface.msfmData': Qt.binding(function() { return (msfmDataLoader.status === Loader.Ready && msfmDataLoader.item != null && msfmDataLoader.item.status === 2) ? msfmDataLoader.item : null }),
@@ -476,7 +476,7 @@ FocusScope {
                                 'cropFisheye': false,
                                 'sequence': Qt.binding(function() { return ((root.enableSequencePlayer && _reconstruction && _reconstruction.viewpoints.count > 0) ? getSequence() : []) }),
                                 'targetSize': Qt.binding(function() { return floatImageViewerLoader.targetSize }),
-                                'useSequence': Qt.binding(function() { return root.enableSequencePlayer && !useExternal && _reconstruction }),
+                                'useSequence': Qt.binding(function() { return root.enableSequencePlayer && !useExternal && _reconstruction })
                                 })
                           } else {
                                 // Forcing the unload (instead of using Component.onCompleted to load it once and for all) is necessary since Qt 5.14
@@ -745,6 +745,39 @@ FocusScope {
                         }
                     }
                 }
+
+                FloatingPane {
+                    Layout.fillWidth: true
+                    Layout.fillHeight: false
+                    Layout.preferredHeight: childrenRect.height
+                    visible: floatImageViewerLoader.item.imageStatus === Image.Error
+                    Layout.alignment: Qt.AlignHCenter
+
+                    RowLayout {
+                        anchors.fill: parent
+
+                        Label {
+                            font.pointSize: 8
+                            text: {
+                                switch (floatImageViewerLoader.item.status) {
+                                    case 2:  // AliceVision.FloatImageViewer.EStatus.OUTDATED_LOADING
+                                        return "Outdated Loading"
+                                    case 3:  // AliceVision.FloatImageViewer.EStatus.MISSING_FILE
+                                        return "Missing File"
+                                    case 4:  // AliceVision.FloatImageViewer.EStatus.ERROR
+                                        return "Error"
+                                    default:
+                                        return ""
+                                }
+                            }
+                            horizontalAlignment: Text.AlignHCenter
+                            verticalAlignment: Text.AlignVCenter
+                            Layout.fillWidth: true
+                            Layout.alignment: Qt.AlignHCenter
+                        }
+                    }
+                }
+
                 Item {
                     id: imgPlaceholder
                     Layout.fillWidth: true


### PR DESCRIPTION
## Description

When an image cannot be loaded in the 2D Viewer, for example when visualizing the output of a node while an image whose viewpoint does not correspond to any output image is selected in the Image Gallery, the viewer remained in a loading state. The only way to get out of it was to try and load another image successfully. 

This PR stops displaying a loading icon as soon as it has been detected that the image could not be loaded, basing itself on the FloatImageViewer's global status, which is updated in QtAliceVision: the viewer is cleared and the error message corresponding to the global status is displayed (in the case described above: "Missing File").

<div align="center"><img src="https://github.com/alicevision/Meshroom/assets/11963329/5aeb57a5-f307-4d39-ad25-01febb8c0565" width=600 /></div>

This relates to alicevision/QtAliceVision#57.
