### PR TITLE
Add camera color spaces

### DIFF
--- a/meshroom/core/attribute.py
+++ b/meshroom/core/attribute.py
@@ -516,10 +516,10 @@ class ListAttribute(Attribute):
     def getValueStr(self, withQuotes=True):
         assert(isinstance(self.value, ListModel))
         if self.attributeDesc.joinChar == ' ':
-            return self.attributeDesc.joinChar.join([v.getValueStr(withQuotes=True) for v in self.value])
+            return self.attributeDesc.joinChar.join([v.getValueStr(withQuotes=withQuotes) for v in self.value])
         else:
             v = self.attributeDesc.joinChar.join([v.getValueStr(withQuotes=False) for v in self.value])
-            if v:
+            if withQuotes and v:
                 return '"{}"'.format(v)
             return v
 

--- a/meshroom/core/attribute.py
+++ b/meshroom/core/attribute.py
@@ -312,7 +312,7 @@ class Attribute(BaseObject):
             return Template(self.value).safe_substitute(os.environ)
         return self.value
 
-    def getValueStr(self):
+    def getValueStr(self, withQuotes=True):
         '''
         Return the value formatted as a string with quotes to deal with spaces.
         If it is a string, expressions will be evaluated.
@@ -325,11 +325,11 @@ class Attribute(BaseObject):
             # ensure value is a list as expected
             assert(isinstance(self.value, Sequence) and not isinstance(self.value, str))
             v = self.attributeDesc.joinChar.join(self.getEvalValue())
-            if v:
+            if withQuotes and v:
                 return '"{}"'.format(v)
             return v
         # String, File, single value Choice are based on strings and should includes quotes to deal with spaces
-        if isinstance(self.attributeDesc, (desc.StringParam, desc.File, desc.ChoiceParam)):
+        if withQuotes and isinstance(self.attributeDesc, (desc.StringParam, desc.File, desc.ChoiceParam)):
             return '"{}"'.format(self.getEvalValue())
         return str(self.getEvalValue())
 
@@ -513,9 +513,15 @@ class ListAttribute(Attribute):
         else:
             return [attr.getPrimitiveValue(exportDefault=exportDefault) for attr in self._value if not attr.isDefault]
 
-    def getValueStr(self):
+    def getValueStr(self, withQuotes=True):
         assert(isinstance(self.value, ListModel))
-        return self.attributeDesc.joinChar.join([v.getValueStr() for v in self.value])
+        if self.attributeDesc.joinChar == ' ':
+            return self.attributeDesc.joinChar.join([v.getValueStr(withQuotes=True) for v in self.value])
+        else:
+            v = self.attributeDesc.joinChar.join([v.getValueStr(withQuotes=False) for v in self.value])
+            if v:
+                return '"{}"'.format(v)
+            return v
 
     def updateInternals(self):
         super(ListAttribute, self).updateInternals()
@@ -631,7 +637,7 @@ class GroupAttribute(Attribute):
         else:
             return {name: attr.getPrimitiveValue(exportDefault=exportDefault) for name, attr in self._value.items() if not attr.isDefault}
 
-    def getValueStr(self):
+    def getValueStr(self, withQuotes=True):
         # add brackets if requested
         strBegin = ''
         strEnd = ''
@@ -641,10 +647,17 @@ class GroupAttribute(Attribute):
                 strEnd = self.attributeDesc.brackets[1]
             else:
                 raise AttributeError("Incorrect brackets on GroupAttribute: {}".format(self.attributeDesc.brackets))
-            
+        
+        # particular case when using space separator
+        spaceSep = self.attributeDesc.joinChar == ' '
+
         # sort values based on child attributes group description order
-        sortedSubValues = [self._value.get(attr.name).getValueStr() for attr in self.attributeDesc.groupDesc]
-        return strBegin + self.attributeDesc.joinChar.join(sortedSubValues) + strEnd
+        sortedSubValues = [self._value.get(attr.name).getValueStr(withQuotes=spaceSep) for attr in self.attributeDesc.groupDesc]
+        s = self.attributeDesc.joinChar.join(sortedSubValues)
+
+        if withQuotes and not spaceSep:
+            return '"{}{}{}"'.format(strBegin, s, strEnd)
+        return '{}{}{}'.format(strBegin, s, strEnd)
 
     def updateInternals(self):
         super(GroupAttribute, self).updateInternals()

--- a/meshroom/core/node.py
+++ b/meshroom/core/node.py
@@ -709,9 +709,10 @@ class BaseNode(BaseObject):
                 group = attr.attributeDesc.group(attr.node) if isinstance(attr.attributeDesc.group, types.FunctionType) else attr.attributeDesc.group
                 if group is not None:
                     # if there is a valid command line "group"
-                    v = attr.getValueStr()
+                    v = attr.getValueStr(withQuotes=True)
                     cmdVars[name] = '--{name} {value}'.format(name=name, value=v)
-                    cmdVars[name + 'Value'] = v
+                    # xxValue is exposed without quotes to allow to compose expressions
+                    cmdVars[name + 'Value'] = attr.getValueStr(withQuotes=False)
 
                     # List elements may give a fully empty string and will not be sent to the command line.
                     # String attributes will return only quotes if it is empty and thus will be send to the command line.
@@ -763,10 +764,11 @@ class BaseNode(BaseObject):
                 except ValueError as e:
                     logging.warning('Invalid expression value on "{nodeName}.{attrName}" with value "{defaultValue}".\nError: {err}'.format(nodeName=self.name, attrName=attr.name, defaultValue=defaultValue, err=str(e)))
 
-            v = attr.getValueStr()
+            v = attr.getValueStr(withQuotes=True)
 
             self._cmdVars[name] = '--{name} {value}'.format(name=name, value=v)
-            self._cmdVars[name + 'Value'] = v
+            # xxValue is exposed without quotes to allow to compose expressions
+            self._cmdVars[name + 'Value'] = attr.getValueStr(withQuotes=False)
 
             if v:
                 self._cmdVars[attr.attributeDesc.group] = self._cmdVars.get(attr.attributeDesc.group, '') + \

--- a/meshroom/core/node.py
+++ b/meshroom/core/node.py
@@ -711,8 +711,12 @@ class BaseNode(BaseObject):
                     # if there is a valid command line "group"
                     v = attr.getValueStr()
                     cmdVars[name] = '--{name} {value}'.format(name=name, value=v)
-                    cmdVars[name + 'Value'] = str(v)
+                    cmdVars[name + 'Value'] = v
 
+                    # List elements may give a fully empty string and will not be sent to the command line.
+                    # String attributes will return only quotes if it is empty and thus will be send to the command line.
+                    # But a List of string containing 1 element,
+                    # and this element is an empty string will also return quotes and will be send to the command line.
                     if v:
                         cmdVars[group] = cmdVars.get(group, '') + ' ' + cmdVars[name]
                 elif isinstance(attr, GroupAttribute):
@@ -762,7 +766,7 @@ class BaseNode(BaseObject):
             v = attr.getValueStr()
 
             self._cmdVars[name] = '--{name} {value}'.format(name=name, value=v)
-            self._cmdVars[name + 'Value'] = str(v)
+            self._cmdVars[name + 'Value'] = v
 
             if v:
                 self._cmdVars[attr.attributeDesc.group] = self._cmdVars.get(attr.attributeDesc.group, '') + \

--- a/meshroom/core/utils.py
+++ b/meshroom/core/utils.py
@@ -1,0 +1,5 @@
+COLORSPACES = ["AUTO", "sRGB", "rec709", "Linear", "ACES2065-1", "ACEScg", "Linear ARRI Wide Gamut 3",
+               "ARRI LogC3 (EI800)", "Linear ARRI Wide Gamut 4", "ARRI LogC4", "Linear BMD WideGamut Gen5",
+               "BMDFilm WideGamut Gen5", "CanonLog2 CinemaGamut D55", "CanonLog3 CinemaGamut D55",
+               "Linear CinemaGamut D55", "Linear V-Gamut", "V-Log V-Gamut", "Linear REDWideGamutRGB",
+               "Log3G10 REDWideGamutRGB", "Linear Venice S-Gamut3.Cine", "S-Log3 Venice S-Gamut3.Cine", "no_conversion"]

--- a/meshroom/nodes/aliceVision/FeatureExtraction.py
+++ b/meshroom/nodes/aliceVision/FeatureExtraction.py
@@ -1,6 +1,7 @@
 __version__ = "1.3"
 
 from meshroom.core import desc
+from meshroom.core.utils import COLORSPACES
 
 
 class FeatureExtraction(desc.AVCommandLineNode):
@@ -140,8 +141,8 @@ It is robust to motion-blur, depth-of-field, occlusion. Be careful to have enoug
                 name="workingColorSpace",
                 label="Working Color Space",
                 description="Allows you to choose the color space in which the data are processed.",
+                values=COLORSPACES,
                 value="sRGB",
-                values=["sRGB", "Linear", "ACES2065-1", "ACEScg", "no_conversion"],
                 exclusive=True,
                 uid=[0],
         ),

--- a/meshroom/nodes/aliceVision/ImageProcessing.py
+++ b/meshroom/nodes/aliceVision/ImageProcessing.py
@@ -1,6 +1,7 @@
 __version__ = "3.3"
 
 from meshroom.core import desc
+from meshroom.core.utils import COLORSPACES
 
 import os.path
 
@@ -497,8 +498,8 @@ Convert or apply filtering to the input images.
             name="inputColorSpace",
             label="Input Color Space",
             description="Allows you to force the color space of the input image.",
+            values=COLORSPACES,
             value="AUTO",
-            values=["AUTO", "sRGB", "rec709", "Linear", "ACES2065-1", "ACEScg", "no_conversion"],
             exclusive=True,
             uid=[0],
         ),
@@ -506,8 +507,8 @@ Convert or apply filtering to the input images.
             name="outputColorSpace",
             label="Output Color Space",
             description="Allows you to choose the color space of the output image.",
+            values=COLORSPACES,
             value="AUTO",
-            values=["AUTO", "sRGB", "rec709", "Linear", "ACES2065-1", "ACEScg", "no_conversion"],
             exclusive=True,
             uid=[0],
         ),
@@ -515,8 +516,8 @@ Convert or apply filtering to the input images.
             name="workingColorSpace",
             label="Working Color Space",
             description="Allows you to choose the color space in which the data are processed.",
+            values=COLORSPACES,
             value="Linear",
-            values=["sRGB", "rec709", "Linear", "ACES2065-1", "ACEScg", "no_conversion"],
             exclusive=True,
             uid=[0],
             enabled=lambda node: not node.applyDcpMetadata.value,

--- a/meshroom/nodes/aliceVision/LdrToHdrCalibration.py
+++ b/meshroom/nodes/aliceVision/LdrToHdrCalibration.py
@@ -6,6 +6,7 @@ import os
 from collections import Counter
 
 from meshroom.core import desc
+from meshroom.core.utils import COLORSPACES
 
 def findMetadata(d, keys, defaultValue):
     v = None
@@ -126,8 +127,8 @@ Calibrate LDR to HDR response curve from samples.
             label="Working Color Space",
             description="Color space in which the data are processed.\n"
                         "If 'auto' is selected, the working color space will be 'Linear' if RAW images are detected; otherwise, it will be set to 'sRGB'.",
-            value="auto",
-            values=["auto", "sRGB", "Linear", "ACES2065-1", "ACEScg"],
+            values=COLORSPACES,
+            value="AUTO",
             exclusive=True,
             uid=[],
             group="user",  # not used directly on the command line

--- a/meshroom/nodes/aliceVision/LdrToHdrMerge.py
+++ b/meshroom/nodes/aliceVision/LdrToHdrMerge.py
@@ -6,6 +6,7 @@ import math
 from collections import Counter
 
 from meshroom.core import desc
+from meshroom.core.utils import COLORSPACES
 
 def findMetadata(d, keys, defaultValue):
     v = None
@@ -169,8 +170,8 @@ Merge LDR images into HDR images.
             label="Working Color Space",
             description="Color space in which the data are processed.\n"
                         "If 'auto' is selected, the working color space will be 'Linear' if RAW images are detected; otherwise, it will be set to 'sRGB'.",
-            value="auto",
-            values=["auto", "sRGB", "Linear", "ACES2065-1", "ACEScg", "no_conversion"],
+            values=COLORSPACES,
+            value="AUTO",
             exclusive=True,
             uid=[0],
             enabled=lambda node: node.byPass.enabled and not node.byPass.value,

--- a/meshroom/nodes/aliceVision/LdrToHdrSampling.py
+++ b/meshroom/nodes/aliceVision/LdrToHdrSampling.py
@@ -6,6 +6,7 @@ import os
 from collections import Counter
 
 from meshroom.core import desc
+from meshroom.core.utils import COLORSPACES
 
 
 def findMetadata(d, keys, defaultValue):
@@ -126,8 +127,8 @@ Sample pixels from Low range images for HDR creation.
             label="Working Color Space",
             description="Color space in which the data are processed.\n"
                         "If 'auto' is selected, the working color space will be 'Linear' if RAW images are detected; otherwise, it will be set to 'sRGB'.",
-            value="auto",
-            values=["auto", "sRGB", "Linear", "ACES2065-1", "ACEScg", "no_conversion"],
+            values=COLORSPACES,
+            value="AUTO",
             exclusive=True,
             uid=[0],
             enabled=lambda node: node.byPass.enabled and not node.byPass.value,

--- a/meshroom/nodes/aliceVision/PanoramaPostProcessing.py
+++ b/meshroom/nodes/aliceVision/PanoramaPostProcessing.py
@@ -4,6 +4,7 @@ import json
 import os
 
 from meshroom.core import desc
+from meshroom.core.utils import COLORSPACES
 
 
 class PanoramaPostProcessing(desc.CommandLineNode):
@@ -58,8 +59,8 @@ Post process the panorama.
             name="outputColorSpace",
             label="Output Color Space",
             description="The color space of the output image.",
+            values=COLORSPACES,
             value="Linear",
-            values=["sRGB", "rec709", "Linear", "ACES2065-1", "ACEScg"],
             exclusive=True,
             uid=[0],
         ),

--- a/meshroom/nodes/aliceVision/PanoramaWarping.py
+++ b/meshroom/nodes/aliceVision/PanoramaWarping.py
@@ -4,6 +4,7 @@ import json
 import os
 
 from meshroom.core import desc
+from meshroom.core.utils import COLORSPACES
 
 
 class PanoramaWarping(desc.AVCommandLineNode):
@@ -69,8 +70,8 @@ Compute the image warping for each input image in the panorama coordinate system
             name="workingColorSpace",
             label="Working Color Space",
             description="Colorspace in which the panorama warping will be performed.",
+            values=COLORSPACES,
             value="Linear",
-            values=["Linear", "ACES2065-1", "ACEScg", "no_conversion"],
             exclusive=True,
             uid=[0],
         ),

--- a/meshroom/nodes/aliceVision/Texturing.py
+++ b/meshroom/nodes/aliceVision/Texturing.py
@@ -1,6 +1,7 @@
 __version__ = "6.0"
 
 from meshroom.core import desc, Version
+from meshroom.core.utils import COLORSPACES
 import logging
 
 
@@ -259,8 +260,8 @@ Many cameras are contributing to the low frequencies and only the best ones cont
             name="workingColorSpace",
             label="Working Color Space",
             description="Color space for the texturing internal computation (does not impact the output file color space).",
+            values=COLORSPACES,
             value="sRGB",
-            values=("sRGB", "Linear", "ACES2065-1", "ACEScg"),
             exclusive=True,
             uid=[0],
             advanced=True,
@@ -269,8 +270,8 @@ Many cameras are contributing to the low frequencies and only the best ones cont
             name="outputColorSpace",
             label="Output Color Space",
             description="Color space for the output texture files.",
+            values=COLORSPACES,
             value="AUTO",
-            values=("sRGB", "rec709", "Linear", "ACES2065-1", "ACEScg", "AUTO"),
             exclusive=True,
             uid=[0],
         ),

--- a/tests/test_nodeCommandLineFormatting.py
+++ b/tests/test_nodeCommandLineFormatting.py
@@ -29,34 +29,37 @@ def test_formatting_listOfFiles():
     n1.featuresFolders.resetValue()
     assert n1.featuresFolders.getValueStr() == ''
 
-    value = '"/non/existing/fileA" "/non/existing/with space/fileB"'
     n1.featuresFolders.extend(inputImages)
-    assert n1.featuresFolders.getValueStr() == value
+    assert n1.featuresFolders.getValueStr() == '"/non/existing/fileA" "/non/existing/with space/fileB"'
 
     n1._buildCmdVars()  # prepare vars for command line creation
     # and check some values
     name = 'featuresFolders'
-    assert n1._cmdVars[name + 'Value'] == value
+    assert n1._cmdVars[name + 'Value'] == '/non/existing/fileA /non/existing/with space/fileB'
 
 
 def test_formatting_strings():
     graph = Graph('')
     n1 = graph.addNewNode('ImageMatching')
     name = 'weights'
-    assert n1._cmdVars[name + 'Value'] == '""'  # Empty string should generate empty quotes
+    assert n1.weights.getValueStr() == '""'  # Empty string should generate empty quotes
+    assert n1._cmdVars[name + 'Value'] == ''
     name = 'method'
-    assert n1._cmdVars[name + 'Value'] == '"SequentialAndVocabularyTree"'
+    assert n1.method.getValueStr() == '"SequentialAndVocabularyTree"'
+    assert n1._cmdVars[name + 'Value'] == 'SequentialAndVocabularyTree'
 
     n2 = graph.addNewNode('ImageMatching')
     n2._buildCmdVars()  # prepare vars for command line creation
     name = 'featuresFolders'
-    assert n2._cmdVars[name + 'Value'] == ''  # Empty list should become fully empty
+    assert n2._cmdVars[name + 'Value'] == '', 'Empty list should become fully empty'
     n2.featuresFolders.extend('')
     n2._buildCmdVars()  # prepare vars for command line creation
-    assert n2._cmdVars[name + 'Value'] == '""'  # A list with one empty string should generate empty quotes
+    assert n2.featuresFolders.getValueStr() == '""', 'A list with one empty string should generate empty quotes'
+    assert n2._cmdVars[name + 'Value'] == '', 'The Value is always only the value, so empty here'
     n2.featuresFolders.extend('')
     n2._buildCmdVars()  # prepare vars for command line creation
-    assert n2._cmdVars[name + 'Value'] == '"" ""'  # A list with 2 empty strings should generate quotes
+    assert n2.featuresFolders.getValueStr() == '"" ""', 'A list with 2 empty strings should generate quotes'
+    assert n2._cmdVars[name + 'Value'] == ' ', 'The Value is always only the value, so 2 empty with the space separator in the middle'
 
 
 def test_formatting_groups():
@@ -64,9 +67,11 @@ def test_formatting_groups():
     n3 = graph.addNewNode('ImageProcessing')
     n3._buildCmdVars()  # prepare vars for command line creation
     name = 'sharpenFilter'
-    assert n3._cmdVars[name + 'Value'] == '"False:3:1.0:0.0"'
+    assert n3.sharpenFilter.getValueStr() == '"False:3:1.0:0.0"'
+    assert n3._cmdVars[name + 'Value'] == 'False:3:1.0:0.0', 'The Value is always only the value, so no quotes'
     name = 'fillHoles'
-    assert n3._cmdVars[name + 'Value'] == 'False'  # Booleans
+    assert n3._cmdVars[name + 'Value'] == 'False', 'Booleans'
     name = 'noiseFilter'
-    assert n3._cmdVars[name + 'Value'] == '"False:uniform:0.0:1.0:True"'
+    assert n3.noiseFilter.getValueStr() == '"False:uniform:0.0:1.0:True"'
+    assert n3._cmdVars[name + 'Value'] == 'False:uniform:0.0:1.0:True'
 

--- a/tests/test_nodeCommandLineFormatting.py
+++ b/tests/test_nodeCommandLineFormatting.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python
+# coding:utf-8
+import os
+import tempfile
+
+import meshroom.multiview
+from meshroom.core.graph import Graph
+from meshroom.core.node import Node
+
+
+def test_formatting_listOfFiles():
+    inputImages = ['/non/existing/fileA', '/non/existing/with space/fileB']
+
+    graph = Graph('')
+    n1 = graph.addNewNode('CameraInit')
+    n1.viewpoints.extend([{'path': image} for image in inputImages])
+    # viewId, poseId, path, intrinsicId, rigId, subPoseId, metadata
+    assert n1.viewpoints.getValueStr() == '-1 -1 "/non/existing/fileA" -1 -1 -1 "" -1 -1 "/non/existing/with space/fileB" -1 -1 -1 ""'
+
+    assert n1.allowedCameraModels.getValueStr() == '"pinhole,radial1,radial3,brown,fisheye4,fisheye1,3deanamorphic4,3deradial4,3declassicld"'
+
+    graph = Graph('')
+    n1 = graph.addNewNode('ImageMatching')
+    assert n1.featuresFolders.getValueStr() == ''
+
+    n1.featuresFolders.extend("single value with space")
+    assert n1.featuresFolders.getValueStr() == '"single value with space"'
+
+    n1.featuresFolders.resetValue()
+    assert n1.featuresFolders.getValueStr() == ''
+
+    value = '"/non/existing/fileA" "/non/existing/with space/fileB"'
+    n1.featuresFolders.extend(inputImages)
+    assert n1.featuresFolders.getValueStr() == value
+
+    n1._buildCmdVars()  # prepare vars for command line creation
+    # and check some values
+    name = 'featuresFolders'
+    assert n1._cmdVars[name + 'Value'] == value
+
+
+def test_formatting_strings():
+    graph = Graph('')
+    n1 = graph.addNewNode('ImageMatching')
+    name = 'weights'
+    assert n1._cmdVars[name + 'Value'] == '""'  # Empty string should generate empty quotes
+    name = 'method'
+    assert n1._cmdVars[name + 'Value'] == '"SequentialAndVocabularyTree"'
+
+    n2 = graph.addNewNode('ImageMatching')
+    n2._buildCmdVars()  # prepare vars for command line creation
+    name = 'featuresFolders'
+    assert n2._cmdVars[name + 'Value'] == ''  # Empty list should become fully empty
+    n2.featuresFolders.extend('')
+    n2._buildCmdVars()  # prepare vars for command line creation
+    assert n2._cmdVars[name + 'Value'] == '""'  # A list with one empty string should generate empty quotes
+    n2.featuresFolders.extend('')
+    n2._buildCmdVars()  # prepare vars for command line creation
+    assert n2._cmdVars[name + 'Value'] == '"" ""'  # A list with 2 empty strings should generate quotes
+
+
+def test_formatting_groups():
+    graph = Graph('')
+    n3 = graph.addNewNode('ImageProcessing')
+    n3._buildCmdVars()  # prepare vars for command line creation
+    name = 'sharpenFilter'
+    assert n3._cmdVars[name + 'Value'] == 'False:3:1.0:0.0'
+    name = 'fillHoles'
+    assert n3._cmdVars[name + 'Value'] == 'False'  # Booleans
+    name = 'noiseFilter'
+    assert n3._cmdVars[name + 'Value'] == 'False:"uniform":0.0:1.0:True'
+

--- a/tests/test_nodeCommandLineFormatting.py
+++ b/tests/test_nodeCommandLineFormatting.py
@@ -64,9 +64,9 @@ def test_formatting_groups():
     n3 = graph.addNewNode('ImageProcessing')
     n3._buildCmdVars()  # prepare vars for command line creation
     name = 'sharpenFilter'
-    assert n3._cmdVars[name + 'Value'] == 'False:3:1.0:0.0'
+    assert n3._cmdVars[name + 'Value'] == '"False:3:1.0:0.0"'
     name = 'fillHoles'
     assert n3._cmdVars[name + 'Value'] == 'False'  # Booleans
     name = 'noiseFilter'
-    assert n3._cmdVars[name + 'Value'] == 'False:"uniform":0.0:1.0:True'
+    assert n3._cmdVars[name + 'Value'] == '"False:uniform:0.0:1.0:True"'
 


### PR DESCRIPTION


<!-- Checklist before submission:

 - I have read the [contribution guidelines](../CONTRIBUTING.md).
 - I have updated the documentation, if applicable.
 - I have ensured that the change is tested somewhere.
 - I have followed the prevailing code style (for history readability and limit conflicts for maintainance).

-->
## Description

This PR adds native support of the following camera color spaces through an updated "ocio.config" file:

ARRI:
Linear ARRI Wide Gamut_3
ARRI LogC3 (EI800)
Linear ARRI Wide Gamut_4
ARRI LogC4

Black Magic:
Linear BMD Wide Gamut Gen5
BMD Film Wide Gamut Gen5

Canon:
CanonLog2 Cinema Gamut D55
CanonLog3 Cinema Gamut D55
Linear Cinema Gamut D55

Panasonic:
Linear V Gamut
V Log V Gamut

RED:
Linear RED Wide Gamut RGB
Log3G10 RED Wide Gamut RGB

Sony:
Linear Venice S Gamut3 Cine
S Log3 Venice S Gamut3 Cine

## Features list

<!--
- [ ] Feature one. Fix #XXX
- [ ] Improve something else
- [ ] Connect to #3 (to declare link to issues without closing it when the PR is merged).
- [X] Add "X" when it is done.
-->


## Implementation remarks


<!--
Explain main implementation choices.
It is also the right place to ask for feedback and help when you hesitate on the implementation.
-->
