### PR TITLE
[Utils] `getTimeStr`: Round up the number of minutes correctly

### DIFF
--- a/meshroom/ui/qml/Controls/TextFileViewer.qml
+++ b/meshroom/ui/qml/Controls/TextFileViewer.qml
@@ -226,7 +226,7 @@ Item {
                             anchors.fill: parent
                         }
                         enabled: logLine.duration > 0
-                        ToolTip.text: "Elapsed time: " + Format.getTimeStr(logLine.duration)
+                        ToolTip.text: "Elapsed time: " + Format.sec2timeStr(logLine.duration)
                         ToolTip.visible: mouseArea.containsMouse
                     }
 

--- a/meshroom/ui/qml/GraphEditor/NodeEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/NodeEditor.qml
@@ -34,7 +34,7 @@ Panel {
         else {
             timer.stop()
             if (node !== null && (node.isFinishedOrRunning() || globalStatus == "ERROR")) {
-                computationInfo.text = Format.getTimeStr(node.elapsedTime)
+                computationInfo.text = Format.sec2timeStr(node.elapsedTime)
             }
             else{
                 computationInfo.text =  ""
@@ -57,7 +57,7 @@ Panel {
                         nodeStartDateTime = new Date(node.getStartDateTime()).getTime()
                     }
                     var now = new Date().getTime()
-                    parent.text = Format.getTimeStr((now-nodeStartDateTime)/1000)
+                    parent.text = Format.sec2timeStr((now-nodeStartDateTime)/1000)
                 }
             }
             padding: 2
@@ -75,7 +75,7 @@ Panel {
                 if (node !== null && (node.isFinishedOrRunning() || (node.isSubmittedOrRunning() && node.elapsedTime > 0))) {
                     var longestChunkTime = getLongestChunkTime(node.chunks)
                     if (longestChunkTime > 0)
-                        return "Longest chunk: " + Format.getTimeStr(longestChunkTime) + " (" + node.chunks.count + " chunks)"
+                        return "Longest chunk: " + Format.sec2timeStr(longestChunkTime) + " (" + node.chunks.count + " chunks)"
                     else
                         return ""
                 } else {

--- a/meshroom/ui/qml/GraphEditor/NodeStatistics.qml
+++ b/meshroom/ui/qml/GraphEditor/NodeStatistics.qml
@@ -50,12 +50,12 @@ FocusScope {
             KeyValue {
                 key: "Time"
                 property real time: node.elapsedTime
-                value: time > 0.0 ? Format.sec2time(time) : "-"
+                value: time > 0.0 ? Format.sec2timecode(time) : "-"
             }
             KeyValue {
                 key: "Cumulated Time"
                 property real time: node.recursiveElapsedTime
-                value: time > 0.0 ? Format.sec2time(time) : "-"
+                value: time > 0.0 ? Format.sec2timecode(time) : "-"
             }
         }
     }

--- a/meshroom/ui/qml/Utils/format.js
+++ b/meshroom/ui/qml/Utils/format.js
@@ -14,40 +14,57 @@ function plainToHtml(t) {
     return escaped.replace(/\n/g, '<br>') // replace line breaks
 }
 
-function sec2time(time) {
-    var pad = function(num, size) { return ('000' + num).slice(size * -1) },
-    hours = Math.floor(time / 60 / 60),
-    minutes = Math.floor(time / 60) % 60,
-    seconds = Math.floor(time - minutes * 60);
-
-    return pad(hours, 2) + ':' + pad(minutes, 2) + ':' + pad(seconds, 2)
+function divmod(x, y) {
+    // Perform the division and get the quotient
+    const quotient = Math.floor(x / y);
+    // Compute the remainder
+    const remainder = x % y;
+    return [quotient, remainder];
 }
 
-function getTimeStr(elapsed)
-{
-    if (elapsed <= 0)
-        return ""
+function sec2timeHMS(totalSeconds) {
+    const [totalMinutes, seconds] = divmod(totalSeconds, 60.0)
+    const [hours, minutes] = divmod(totalMinutes, 60.0)
 
-    var hours = 0
-    var min = 0
-    var finalTime = ""
+    return {
+        hours: hours,
+        minutes: minutes,
+        seconds: seconds
+    };
+}
 
-    if (elapsed > 3600) {
-        hours = Math.floor(elapsed / 3600)
-        elapsed = elapsed - (hours * 3600)
-        finalTime += hours + "h"
-    }
-    if (elapsed > 60) {
-        min = Math.floor(elapsed / 60)
-        elapsed = elapsed - (min * 60)
-        finalTime += min + "m"
-    }
-    if (hours === 0 && min === 0) {
-        // Millisecond precision for execution times below 1 min
-        finalTime += Number(elapsed.toLocaleString(Qt.locale('en-US'))) + "s"
+function sec2timecode(timeSeconds) {
+    var pad = function(num, size) { return ('000' + num).slice(size * -1) }
+    var timeObj = sec2timeHMS(Math.round(timeSeconds))
+    var timeStr = pad(timeObj.hours, 2) + ':' + pad(timeObj.minutes, 2) + ':' + pad(timeObj.seconds, 2)
+    return timeStr
+}
+
+function sec2timeStr(timeSeconds) {
+    // Need to decide the rounding precision first
+    // to propagate the right values
+    if(timeSeconds >= 60.0) {
+        timeSeconds = Math.round(timeSeconds)
     } else {
-        finalTime += Math.round(elapsed) + "s"
+        timeSeconds = parseFloat(timeSeconds.toFixed(2))
     }
-
-    return finalTime
+    var timeObj = sec2timeHMS(timeSeconds)
+    var timeStr = ""
+    if(timeObj.hours > 0) {
+        timeStr += timeObj.hours + "h"
+    }
+    if(timeObj.hours > 0 || timeObj.minutes > 0) {
+        timeStr += timeObj.minutes + "m"
+    }
+    if(timeObj.hours === 0) {
+        // seconds only matter if the elapsed time is less than 1 hour
+        if(timeObj.minutes === 0) {
+            // If less than a minute, keep millisecond precision
+            timeStr += timeObj.seconds.toFixed(2) + "s"
+        } else {
+            // If more than a minute, do not need more precision than seconds
+            timeStr += Math.round(timeObj.seconds) + "s"
+        }
+    }
+    return timeStr
 }


### PR DESCRIPTION
## Description

When getting times such as 359.5, the previous version of `getTimeStr` was returning "5m60s" instead of "6m0s" because the number of minutes was first computed, and the remaining seconds were rounded up and used as such. In some cases, rounding up those remaining seconds may lead to a full minute, which should be handled.

After minutes have been computed, we now check that the rounded up remainder does not correspond to a full minute before moving to the seconds.