### PR TITLE
[Viewer3D] Bind the display status of the resection groups to QtAliceVision

### DIFF
--- a/meshroom/ui/qml/Viewer3D/MediaLoader.qml
+++ b/meshroom/ui/qml/Viewer3D/MediaLoader.qml
@@ -100,7 +100,8 @@ import Utils 1.0
                                                'pointSize': Qt.binding(function() { return 0.01 * Viewer3DSettings.pointSize }),
                                                'locatorScale': Qt.binding(function() { return Viewer3DSettings.cameraScale }),
                                                'cameraPickingEnabled': Qt.binding(function() { return root.enabled }),
-                                               'resectionId': Qt.binding(function() { return Viewer3DSettings.resectionId })
+                                               'resectionId': Qt.binding(function() { return Viewer3DSettings.resectionId }),
+                                               'displayResections': Qt.binding(function() { return Viewer3DSettings.displayResectionIds })
                                            });
 
                 obj.statusChanged.connect(function() {

--- a/meshroom/ui/qml/Viewer3D/SfmDataLoader.qml
+++ b/meshroom/ui/qml/Viewer3D/SfmDataLoader.qml
@@ -45,6 +45,7 @@ SfmDataEntity {
         for (var i = 0; i < root.cameras.length; i++) {
             var cam = root.cameras[i]
             var resectionId = cam.resectionId
+            // 4294967295 = UINT_MAX, which might occur if the value is undefined on the C++ side
             if (resectionId === undefined || resectionId === 4294967295)
                 continue
             if (resectionId > maxResectionId)
@@ -60,6 +61,7 @@ SfmDataEntity {
         for (var i = 0; i < root.cameras.length; i++) {
             var cam = root.cameras[i]
             var resectionId = cam.resectionId
+            // 4294967295 = UINT_MAX, which might occur if the value is undefined on the C++ side
             if (resectionId === undefined || resectionId === 4294967295)
                 continue
             arr[resectionId] = arr[resectionId] + 1


### PR DESCRIPTION
## Description

This PR binds the status of the `displayResectionIds` boolean (true if the slider to display the resection groups is enabled, false otherwise) to QtAliceVision's `SfmDataEntity` object. This allows to only display or hide cameras based on their resection groups if the user has enabled that option. 

Relates to alicevision/QtAliceVision/pull/59.