### PR TITLE
[core] Only update the running chunk to `STOPPED` when stopping computations

### DIFF
--- a/meshroom/core/node.py
+++ b/meshroom/core/node.py
@@ -429,7 +429,11 @@ class NodeChunk(BaseObject):
         self.upgradeStatusTo(Status.SUCCESS)
 
     def stopProcess(self):
-        self.upgradeStatusTo(Status.STOPPED)
+        if not self.isExtern():
+            if self._status.status == Status.RUNNING:
+                self.upgradeStatusTo(Status.STOPPED)
+            elif self._status.status == Status.SUBMITTED:
+                self.upgradeStatusTo(Status.NONE)
         self.node.nodeDesc.stopProcess(self)
 
     def isExtern(self):
@@ -942,8 +946,7 @@ class BaseNode(BaseObject):
     def stopComputation(self):
         """ Stop the computation of this node. """
         for chunk in self._chunks.values():
-            if not chunk.isExtern():
-                chunk.stopProcess()
+            chunk.stopProcess()
 
     def getGlobalStatus(self):
         """


### PR DESCRIPTION
## Description

When stopping the local computations of the graph with the "Stop" button, the status of the chunks that have already been updated to `SUCCESS` is preserved, and the submitted chunks are reset. However, when stopping the computation of a specific node with the "Stop Computation" option, all the chunks are updated to `STOPPED` independently from their previous status.

This PR ensures that chunks of a node that are already in the `SUCCESS` state will not be updated when stopping the computations, and those that are `SUBMITTED` but not `RUNNING` will be reset to `NONE`; only the `RUNNING` chunk will be updated to `STOPPED`.