### PR TITLE
ImageSegmentation: add an option to choose between cpu and gpu

### DIFF
--- a/meshroom/nodes/aliceVision/ImageSegmentation.py
+++ b/meshroom/nodes/aliceVision/ImageSegmentation.py
@@ -57,6 +57,13 @@ Generate a mask with segmented labels for each pixel.
             value=False,
             uid=[0],
         ),
+        desc.BoolParam(
+            name="useGpu",
+            label="Use GPU",
+            description="Use GPU for computation if available",
+            value=True,
+            uid=[],
+        ),
         desc.ChoiceParam(
             name="verboseLevel",
             label="Verbose Level",


### PR DESCRIPTION
Add an option in image segmentation to use GPU (or CPU if disabled).

related to https://github.com/alicevision/AliceVision/pull/1618