### PR TITLE
[nodes] Blender: Rescale rendered images based on their pixel aspect ratio

### DIFF
--- a/meshroom/nodes/blender/scripts/preview.py
+++ b/meshroom/nodes/blender/scripts/preview.py
@@ -401,6 +401,7 @@ def main():
             finalImg = bpy.data.images.load(bpy.context.scene.render.filepath)
             finalImg.scale(int(bpy.context.scene.render.resolution_x * bpy.context.scene.render.pixel_aspect_x), bpy.context.scene.render.resolution_y)
             finalImg.save()
+            # clear image from memory
             bpy.data.images.remove(finalImg)
 
         # clear memory

--- a/meshroom/nodes/blender/scripts/preview.py
+++ b/meshroom/nodes/blender/scripts/preview.py
@@ -396,6 +396,13 @@ def main():
         setupRender(view, intrinsic, pose, args.output)
         bpy.ops.render.render(write_still=True)
 
+        # if the pixel aspect ratio is not 1, reload and rescale the rendered image
+        if bpy.context.scene.render.pixel_aspect_x != 1.0:
+            finalImg = bpy.data.images.load(bpy.context.scene.render.filepath)
+            finalImg.scale(int(bpy.context.scene.render.resolution_x * bpy.context.scene.render.pixel_aspect_x), bpy.context.scene.render.resolution_y)
+            finalImg.save()
+            bpy.data.images.remove(finalImg)
+
         # clear memory
         if img:
             bpy.data.images.remove(img)


### PR DESCRIPTION
## Description

This PR rescales images that are rendered by the `ScenePreview` node if the input images have a pixel aspect ratio that is different from 1. This prevents getting visualisation images that are squished and that have lost all the pixel aspect ratio-related information.