### PR TITLE
[nodes] ExportDistortion: Option to export lens grid undistorted

### DIFF
--- a/meshroom/nodes/aliceVision/ExportDistortion.py
+++ b/meshroom/nodes/aliceVision/ExportDistortion.py
@@ -7,7 +7,8 @@ class ExportDistortion(desc.AVCommandLineNode):
 
     category = 'Export'
     documentation = '''
-Export the distortion model and parameters of cameras in a SfM scene.
+Export the lens distortion model as Nuke node and STMaps.
+It also allows to export an undistorted image of the lens grids for validation.
 '''
 
     inputs = [
@@ -16,6 +17,28 @@ Export the distortion model and parameters of cameras in a SfM scene.
             label="Input SfMData",
             description="Input SfMData file.",
             value="",
+            uid=[0],
+        ),
+        desc.BoolParam(
+            name="exportNukeNode",
+            label="Export Nuke Node",
+            description="Export Nuke LensDistortion node as nuke file.\n"
+                        "Only supports 3DEqualizer/3DE4 Anamorphic lens model.",
+            value=True,
+            uid=[0],
+        ),
+        desc.BoolParam(
+            name="exportLensGridsUndistorted",
+            label="Export Lens Grids Undistorted",
+            description="Export the lens grids undistorted for validation.",
+            value=True,
+            uid=[0],
+        ),
+        desc.BoolParam(
+            name="exportSTMaps",
+            label="Export STMaps",
+            description="Export STMaps for distortion and undistortion.",
+            value=True,
             uid=[0],
         ),
     ]
@@ -29,29 +52,42 @@ Export the distortion model and parameters of cameras in a SfM scene.
             uid=[],
         ),
         desc.File(
-            name="distoStMap",
+            name="distortionNukeNode",
+            label="Distortion Nuke Node",
+            description="Calibrated distortion ST map.",
+            value=desc.Node.internalFolder + "nukeLensDistortion_<INTRINSIC_ID>.nk",
+            group="",  # do not export on the command line
+            uid=[],
+            enabled=lambda node: node.exportNukeNode.value,
+        ),
+        desc.File(
+            name="lensGridsUndistorted",
+            label="Undistorted Lens Grids",
+            description="Undistorted lens grids for validation",
+            semantic="image",
+            value=desc.Node.internalFolder + "lensgrid_<VIEW_ID>_undistort.exr",
+            group="",  # do not export on the command line
+            uid=[],
+            enabled=lambda node: node.exportLensGridsUndistorted.value,
+        ),
+        desc.File(
+            name="distortionStMap",
             label="Distortion ST Map",
             description="Calibrated distortion ST map.",
             semantic="image",
-            value=desc.Node.internalFolder + "<INTRINSIC_ID>_distort.exr",
+            value=desc.Node.internalFolder + "stmap_<INTRINSIC_ID>_distort.exr",
             group="",  # do not export on the command line
             uid=[],
+            enabled=lambda node: node.exportSTMaps.value,
         ),
         desc.File(
-            name="undistoStMap",
+            name="undistortionStMap",
             label="Undistortion ST Map",
             description="Calibrated undistortion ST map.",
             semantic="image",
-            value=desc.Node.internalFolder + "<INTRINSIC_ID>_undistort.exr",
+            value=desc.Node.internalFolder + "stmap_<INTRINSIC_ID>_undistort.exr",
             group="",  # do not export on the command line
             uid=[],
-        ),
-        desc.BoolParam(
-            name="exportUndistortedGrids",
-            label="Export undistorted lens grids",
-            description="Undistort the lens grids and save as images",
-            value=True,
-            uid=[0],
-            advanced=True,
+            enabled=lambda node: node.exportSTMaps.value,
         ),
     ]

--- a/meshroom/nodes/aliceVision/ExportDistortion.py
+++ b/meshroom/nodes/aliceVision/ExportDistortion.py
@@ -46,4 +46,12 @@ Export the distortion model and parameters of cameras in a SfM scene.
             group="",  # do not export on the command line
             uid=[],
         ),
+        desc.BoolParam(
+            name="exportUndistortedGrids",
+            label="Export undistorted lens grids",
+            description="Undistort the lens grids and save as images",
+            value=True,
+            uid=[0],
+            advanced=True,
+        ),
     ]


### PR DESCRIPTION
Add an option to ExportDistortion to undistort input lens grids and save the result as an EXR image

See https://github.com/alicevision/AliceVision/pull/1630