### PR TITLE
Use the correct response file to display the graph of the Camera Response Function

### DIFF
--- a/meshroom/nodes/aliceVision/LdrToHdrCalibration.py
+++ b/meshroom/nodes/aliceVision/LdrToHdrCalibration.py
@@ -1,4 +1,4 @@
-__version__ = "3.0"
+__version__ = "3.1"
 
 import json
 import math
@@ -161,7 +161,7 @@ Calibrate LDR to HDR response curve from samples.
             name="response",
             label="Response File",
             description="Path to the output response file.",
-            value=desc.Node.internalFolder + "response.csv",
+            value=desc.Node.internalFolder + "response_<INTRINSIC_ID>.csv",
             uid=[],
         )
     ]

--- a/meshroom/pipelines/hdrFusion.mg
+++ b/meshroom/pipelines/hdrFusion.mg
@@ -3,11 +3,11 @@
         "nodesVersions": {
             "CameraInit": "9.0",
             "LdrToHdrMerge": "4.1",
-            "LdrToHdrCalibration": "3.0",
+            "LdrToHdrCalibration": "3.1",
             "LdrToHdrSampling": "4.0",
             "Publish": "1.3"
         },
-        "releaseVersion": "2023.3.0",
+        "releaseVersion": "2024.1.0-develop",
         "fileVersion": "1.1",
         "template": true
     },

--- a/meshroom/pipelines/panoramaFisheyeHdr.mg
+++ b/meshroom/pipelines/panoramaFisheyeHdr.mg
@@ -9,7 +9,7 @@
             "PanoramaPostProcessing": "2.0",
             "SfMTransform": "3.1",
             "PanoramaWarping": "1.1",
-            "LdrToHdrCalibration": "3.0",
+            "LdrToHdrCalibration": "3.1",
             "LdrToHdrSampling": "4.0",
             "PanoramaCompositing": "2.0",
             "Publish": "1.3",
@@ -19,7 +19,7 @@
             "ImageMatching": "2.0",
             "PanoramaEstimation": "1.0"
         },
-        "releaseVersion": "2023.3.0",
+        "releaseVersion": "2024.1.0-develop",
         "fileVersion": "1.1",
         "template": true
     },

--- a/meshroom/pipelines/panoramaHdr.mg
+++ b/meshroom/pipelines/panoramaHdr.mg
@@ -9,7 +9,7 @@
             "PanoramaPostProcessing": "2.0",
             "SfMTransform": "3.1",
             "PanoramaWarping": "1.1",
-            "LdrToHdrCalibration": "3.0",
+            "LdrToHdrCalibration": "3.1",
             "LdrToHdrSampling": "4.0",
             "PanoramaCompositing": "2.0",
             "Publish": "1.3",
@@ -19,7 +19,7 @@
             "ImageMatching": "2.0",
             "PanoramaEstimation": "1.0"
         },
-        "releaseVersion": "2023.3.0",
+        "releaseVersion": "2024.1.0-develop",
         "fileVersion": "1.1",
         "template": true
     },

--- a/meshroom/ui/qml/Viewer/CameraResponseGraph.qml
+++ b/meshroom/ui/qml/Viewer/CameraResponseGraph.qml
@@ -14,7 +14,7 @@ import DataObjects 1.0
 FloatingPane {
     id: root
 
-    property var ldrHdrCalibrationNode: null
+    property var responsePath: null
     property color textColor: Colors.sysPalette.text
 
     clip: true
@@ -22,8 +22,7 @@ FloatingPane {
 
     CsvData {
         id: csvData
-        property bool hasAttr: (ldrHdrCalibrationNode && ldrHdrCalibrationNode.hasAttribute("response"))
-        filepath: hasAttr ? ldrHdrCalibrationNode.attribute("response").value : ""
+        filepath: responsePath
     }
 
     // To avoid interaction with components in background

--- a/meshroom/ui/qml/Viewer/Viewer2D.qml
+++ b/meshroom/ui/qml/Viewer/Viewer2D.qml
@@ -1019,14 +1019,13 @@ FocusScope {
 
                         property var activeNode: _reconstruction ? _reconstruction.activeNodes.get('LdrToHdrCalibration').node : null
                         property var isEnabled: displayLdrHdrCalibrationGraph.checked && activeNode && activeNode.isComputed
-                        // active: isEnabled
-                        // Setting "active" from true to false creates a crash on linux with Qt 5.14.2.
-                        // As a workaround, we clear the CameraResponseGraph with an empty node
-                        // and hide the loader content.
-                        visible: isEnabled
+                        active: isEnabled
+
+                        property var path: activeNode && activeNode.hasAttribute("response") ? activeNode.attribute("response").value : ""
+                        property var vp: _reconstruction ? getViewpoint(_reconstruction.selectedViewId) : null
 
                         sourceComponent: CameraResponseGraph {
-                            ldrHdrCalibrationNode: isEnabled ? activeNode : null
+                            responsePath: resolve(path, vp)
                         }
                     }
                 }


### PR DESCRIPTION
## Description

Following the changes introduced by https://github.com/alicevision/AliceVision/pull/1484, the response file is not always named "response.csv" anymore, but is instead named "response_{INTRINSIC_ID}.csv".

This PR updates the corresponding output attribute in the `LdrToHdrCalibration` node by adding the intrinsic ID, which is never fixed beforehand, to the string of the response file's path. 

Since the intrinsic ID must be resolved, the way the CSV file is provided to the Camera Response Graph widget is also modified: instead of providing the `LdrToHdrCalibration` node to the Camera Response Graph and retrieving the path of the response file within the widget, the path is retrieved and resolved before activating the Camera Response Graph, and is then passed as a parameter to the component.


## Features list

- [x] Add the intrinsic ID to the name of the output response CSV file to match with what is generated by the AliceVision `LdrToHdrCalibration` program.
- [x] Provide the resolved response file path to the Camera Response Graph instead of having the widget trying to retrieve it.