### PR TITLE
[Viewer] Viewer: Fix various issues with the 2D Viewer

### DIFF
--- a/meshroom/ui/qml/Viewer/PanoramaViewer.qml
+++ b/meshroom/ui/qml/Viewer/PanoramaViewer.qml
@@ -290,7 +290,7 @@ AliceVision.PanoramaViewer {
                         'canBeHovered': true,
                         'useSequence': false
                     })
-                    imageLoaded = Qt.binding(function() { return repeater.itemAt(index).item.status === Image.Ready ? true : false })
+                    imageLoaded = Qt.binding(function() { return repeater.itemAt(index).item.imageStatus === Image.Ready ? true : false })
                 }
 
             }

--- a/meshroom/ui/qml/Viewer/SequencePlayer.qml
+++ b/meshroom/ui/qml/Viewer/SequencePlayer.qml
@@ -87,7 +87,7 @@ FloatingPane {
         interval: 1000 / m.fps
 
         onTriggered: {
-            if (viewer.status !== Image.Ready) {
+            if (viewer.imageStatus !== Image.Ready) {
                 // Wait for current image to be displayed before switching to next image
                 return;
             }

--- a/meshroom/ui/qml/Viewer/Viewer2D.qml
+++ b/meshroom/ui/qml/Viewer/Viewer2D.qml
@@ -681,7 +681,7 @@ FocusScope {
                         width: imgContainer.width
                         height: imgContainer.height
 
-                        visible: activeNode.isComputed && json !== undefined && imgContainer.image.status === Image.Ready
+                        visible: activeNode.isComputed && json !== undefined && imgContainer.image.imageStatus === Image.Ready
                         source: Filepath.stringToUrl(activeNode.attribute("outputData").value)
                         viewpoint: _reconstruction.selectedViewpoint
                         zoom: imgContainer.scale

--- a/meshroom/ui/qml/Viewer/Viewer2D.qml
+++ b/meshroom/ui/qml/Viewer/Viewer2D.qml
@@ -372,7 +372,7 @@ FocusScope {
 
             colorRGBA: {
                 if (!floatImageViewerLoader.item ||
-                    floatImageViewerLoader.item.status !== Image.Ready) {
+                    floatImageViewerLoader.item.imageStatus !== Image.Ready) {
                     return null
                 }
                 if (floatImageViewerLoader.item.containsMouse === false) {

--- a/meshroom/ui/qml/Viewer/Viewer2D.qml
+++ b/meshroom/ui/qml/Viewer/Viewer2D.qml
@@ -1140,7 +1140,7 @@ FocusScope {
                             }
 
                             ToolTip.text: activeNode ? "Panorama Viewer " + activeNode.label : "Panorama Viewer"
-                            text: MaterialIcons.panorama_sphere
+                            text: MaterialIcons.panorama_photosphere
                             font.pointSize: 16
                             padding: 0
                             Layout.minimumWidth: 0

--- a/meshroom/ui/qml/Viewer/Viewer2D.qml
+++ b/meshroom/ui/qml/Viewer/Viewer2D.qml
@@ -750,7 +750,7 @@ FocusScope {
                     Layout.fillWidth: true
                     Layout.fillHeight: false
                     Layout.preferredHeight: childrenRect.height
-                    visible: floatImageViewerLoader.item.imageStatus === Image.Error
+                    visible: floatImageViewerLoader.item !== null && floatImageViewerLoader.item.imageStatus === Image.Error
                     Layout.alignment: Qt.AlignHCenter
 
                     RowLayout {
@@ -759,16 +759,19 @@ FocusScope {
                         Label {
                             font.pointSize: 8
                             text: {
-                                switch (floatImageViewerLoader.item.status) {
-                                    case 2:  // AliceVision.FloatImageViewer.EStatus.OUTDATED_LOADING
-                                        return "Outdated Loading"
-                                    case 3:  // AliceVision.FloatImageViewer.EStatus.MISSING_FILE
-                                        return "Missing File"
-                                    case 4:  // AliceVision.FloatImageViewer.EStatus.ERROR
-                                        return "Error"
-                                    default:
-                                        return ""
+                                if (floatImageViewerLoader.item !== null) {
+                                    switch (floatImageViewerLoader.item.status) {
+                                        case 2:  // AliceVision.FloatImageViewer.EStatus.OUTDATED_LOADING
+                                            return "Outdated Loading"
+                                        case 3:  // AliceVision.FloatImageViewer.EStatus.MISSING_FILE
+                                            return "Missing File"
+                                        case 4:  // AliceVision.FloatImageViewer.EStatus.ERROR
+                                            return "Error"
+                                        default:
+                                            return ""
+                                    }
                                 }
+                                return ""
                             }
                             horizontalAlignment: Text.AlignHCenter
                             verticalAlignment: Text.AlignVCenter

--- a/meshroom/ui/qml/Viewer/Viewer2D.qml
+++ b/meshroom/ui/qml/Viewer/Viewer2D.qml
@@ -74,7 +74,7 @@ FocusScope {
         if (!imgContainer.image)
             return ""
         var res = ""
-        if (imgContainer.image.status === Image.Loading) {
+        if (imgContainer.image.imageStatus === Image.Loading) {
             res += " Image"
         }
         if (mfeaturesLoader.status === Loader.Ready) {
@@ -1389,7 +1389,7 @@ FocusScope {
         Component.onCompleted: {
             running = Qt.binding(function() {
                 return (root.usePanoramaViewer === true && imgContainer.image && imgContainer.image.allImagesLoaded === false)
-                       || (imgContainer.image && imgContainer.image.status === Image.Loading)
+                       || (imgContainer.image && imgContainer.image.imageStatus === Image.Loading)
             })
         }
         // disable the visibility when unused to avoid stealing the mouseEvent to the image color picker

--- a/meshroom/ui/qml/Viewer/Viewer2D.qml
+++ b/meshroom/ui/qml/Viewer/Viewer2D.qml
@@ -1044,7 +1044,7 @@ FocusScope {
 
                         // zoom label
                         MLabel {
-                            text: ((imgContainer.image && (imgContainer.image.status === Image.Ready)) ? imgContainer.scale.toFixed(2) : "1.00") + "x"
+                            text: ((imgContainer.image && (imgContainer.image.imageStatus === Image.Ready)) ? imgContainer.scale.toFixed(2) : "1.00") + "x"
                             MouseArea {
                                 anchors.fill: parent
                                 acceptedButtons: Qt.LeftButton | Qt.RightButton


### PR DESCRIPTION
## Description

This PR fixes the following issues:
- [x] An issue introduced with https://github.com/alicevision/Meshroom/pull/2250 that disabled the 2D viewer's color picker.
- [x] An issue introduced with https://github.com/alicevision/Meshroom/pull/2250 that never updated the loading status of the Panorama Viewer.
- [x] A MaterialIcon that was not displayed anymore for the Panorama Viewer as its name had been updated by https://github.com/alicevision/Meshroom/pull/2247.
- [x] Several QML warnings that appeared when trying to access the Float Image Viewer's item status without checking if it existed beforehand (introduced with #2250).
- [x] An issue introduced with https://github.com/alicevision/Meshroom/pull/2250 that prevented the Sequence Player from updating the image currently displayed in the viewer.
- [x] An issue introduced with https://github.com/alicevision/Meshroom/pull/2250 that blocked any update of the resolution label.
- [x] An issue introduced with https://github.com/alicevision/Meshroom/pull/2250 that caused the "loading" icon to never be displayed when updating the image in the 2D viewer. This specific problem also requires https://github.com/alicevision/QtAliceVision/pull/64 to be fixed.