### PR TITLE
Correctly delete thread pools when exiting Meshroom with Python 3.9

### DIFF
--- a/meshroom/ui/components/thumbnail.py
+++ b/meshroom/ui/components/thumbnail.py
@@ -62,6 +62,10 @@ class ThumbnailCache(QObject):
     cleaningThread = None
     workerThreads = ThreadPool(processes=3)
 
+    def __del__(self):
+        self.workerThreads.terminate()
+        self.workerThreads.join()
+
     @staticmethod
     def initialize():
         """Initialize static fields in cache class and cache directory on disk."""

--- a/meshroom/ui/graph.py
+++ b/meshroom/ui/graph.py
@@ -48,6 +48,10 @@ class FilesModTimePollerThread(QObject):
         else:
             self._filePollerRefresh = PollerRefreshStatus.DISABLED
 
+    def __del__(self):
+        self._threadPool.terminate()
+        self._threadPool.join()
+
     def start(self, files=None):
         """ Start polling thread.
 

--- a/meshroom/ui/reconstruction.py
+++ b/meshroom/ui/reconstruction.py
@@ -452,6 +452,10 @@ class Reconstruction(UIGraph):
 
         self.setDefaultPipeline(defaultPipeline)
 
+    def __del__(self):
+        self._workerThreads.terminate()
+        self._workerThreads.join()
+
     def clear(self):
         self.clearActiveNodes()
         super(Reconstruction, self).clear()


### PR DESCRIPTION
Fix the error about threadpool deletion when Meshroom exits: this fixes the "OSError: [Errno 9] Bad file descriptor" that occurs when Python 3.9 is used. 