### PR TITLE
Add option to keep input filename in imageSegmentation

### DIFF
--- a/meshroom/nodes/aliceVision/ImageSegmentation.py
+++ b/meshroom/nodes/aliceVision/ImageSegmentation.py
@@ -1,4 +1,4 @@
-__version__ = "1.0"
+__version__ = "1.2"
 
 from meshroom.core import desc
 

--- a/meshroom/nodes/aliceVision/ImageSegmentation.py
+++ b/meshroom/nodes/aliceVision/ImageSegmentation.py
@@ -69,7 +69,7 @@ Generate a mask with segmented labels for each pixel.
             label="Keep Filename",
             description="Keep Input Filename",
             value=False,
-            uid=[],
+            uid=[0],
         ),
         desc.ChoiceParam(
             name="verboseLevel",

--- a/meshroom/nodes/aliceVision/ImageSegmentation.py
+++ b/meshroom/nodes/aliceVision/ImageSegmentation.py
@@ -64,6 +64,13 @@ Generate a mask with segmented labels for each pixel.
             value=True,
             uid=[],
         ),
+        desc.BoolParam(
+            name="keepFilename",
+            label="Keep Filename",
+            description="Keep Input Filename",
+            value=False,
+            uid=[],
+        ),
         desc.ChoiceParam(
             name="verboseLevel",
             label="Verbose Level",

--- a/meshroom/pipelines/cameraTracking.mg
+++ b/meshroom/pipelines/cameraTracking.mg
@@ -1,7 +1,7 @@
 {
     "header": {
         "pipelineVersion": "2.2",
-        "releaseVersion": "2023.3.0",
+        "releaseVersion": "2024.1.0-develop",
         "fileVersion": "1.1",
         "template": true,
         "nodesVersions": {
@@ -13,7 +13,7 @@
             "ExportDistortion": "1.0",
             "Texturing": "6.0",
             "ConvertSfMFormat": "2.0",
-            "ImageSegmentation": "1.0",
+            "ImageSegmentation": "1.2",
             "PrepareDenseScene": "3.1",
             "KeyframeSelection": "5.0",
             "ExportAnimatedCamera": "2.0",

--- a/meshroom/pipelines/cameraTrackingWithoutCalibration.mg
+++ b/meshroom/pipelines/cameraTrackingWithoutCalibration.mg
@@ -1,7 +1,7 @@
 {
     "header": {
         "pipelineVersion": "2.2",
-        "releaseVersion": "2023.3.0",
+        "releaseVersion": "2024.1.0-develop",
         "fileVersion": "1.1",
         "template": true,
         "nodesVersions": {
@@ -12,7 +12,7 @@
             "DepthMap": "5.0",
             "Texturing": "6.0",
             "ConvertSfMFormat": "2.0",
-            "ImageSegmentation": "1.0",
+            "ImageSegmentation": "1.2",
             "PrepareDenseScene": "3.1",
             "KeyframeSelection": "5.0",
             "ExportAnimatedCamera": "2.0",

--- a/meshroom/pipelines/nodalCameraTracking.mg
+++ b/meshroom/pipelines/nodalCameraTracking.mg
@@ -12,7 +12,7 @@
             "RelativePoseEstimating": "1.0",
             "ExportAnimatedCamera": "2.0",
             "ConvertSfMFormat": "2.0",
-            "ImageSegmentation": "1.0",
+            "ImageSegmentation": "1.2",
             "NodalSfM": "1.0",
             "ExportDistortion": "1.0",
             "CameraInit": "9.0",

--- a/meshroom/pipelines/nodalCameraTrackingWithoutCalibration.mg
+++ b/meshroom/pipelines/nodalCameraTrackingWithoutCalibration.mg
@@ -1,12 +1,12 @@
 {
     "header": {
         "pipelineVersion": "2.2",
-        "releaseVersion": "2023.3.0",
+        "releaseVersion": "2024.1.0-develop",
         "fileVersion": "1.1",
         "template": true,
         "nodesVersions": {
             "TracksBuilding": "1.0",
-            "ImageSegmentation": "1.0",
+            "ImageSegmentation": "1.2",
             "FeatureExtraction": "1.3",
             "ScenePreview": "2.0",
             "ImageMatching": "2.0",

--- a/meshroom/pipelines/photogrammetryAndCameraTracking.mg
+++ b/meshroom/pipelines/photogrammetryAndCameraTracking.mg
@@ -1,7 +1,7 @@
 {
     "header": {
         "pipelineVersion": "2.2",
-        "releaseVersion": "2023.3.0",
+        "releaseVersion": "2024.1.0-develop",
         "fileVersion": "1.1",
         "template": true,
         "nodesVersions": {
@@ -13,7 +13,7 @@
             "DepthMap": "5.0",
             "Texturing": "6.0",
             "ConvertSfMFormat": "2.0",
-            "ImageSegmentation": "1.0",
+            "ImageSegmentation": "1.2",
             "PrepareDenseScene": "3.1",
             "KeyframeSelection": "5.0",
             "ExportAnimatedCamera": "2.0",


### PR DESCRIPTION
<!-- Checklist before submission:

 - I have read the [contribution guidelines](../CONTRIBUTING.md).
 - I have updated the documentation, if applicable.
 - I have ensured that the change is tested somewhere.
 - I have followed the prevailing code style (for history readability and limit conflicts for maintainance).

-->
## Description

This PR add an option avoiding the replacement of the input filename with the viewID in the imageSegmentation node.

Related AliceVision pull request: https://github.com/alicevision/AliceVision/pull/1636

## Features list

<!--
- [ ] Feature one. Fix #XXX
- [ ] Improve something else
- [ ] Connect to #3 (to declare link to issues without closing it when the PR is merged).
- [X] Add "X" when it is done.
-->


## Implementation remarks


<!--
Explain main implementation choices.
It is also the right place to ask for feedback and help when you hesitate on the implementation.
-->
