### PR TITLE
[pipelines] Enable `Keep Filename` for all `ImageSegmentation` nodes in templates

### DIFF
--- a/meshroom/pipelines/cameraTracking.mg
+++ b/meshroom/pipelines/cameraTracking.mg
@@ -5,31 +5,31 @@
         "fileVersion": "1.1",
         "template": true,
         "nodesVersions": {
-            "ScenePreview": "2.0",
+            "ExportAnimatedCamera": "2.0",
+            "Texturing": "6.0",
+            "ImageMatching": "2.0",
             "Publish": "1.3",
             "MeshFiltering": "3.0",
-            "DepthMapFilter": "4.0",
-            "DepthMap": "5.0",
-            "ExportDistortion": "1.0",
-            "Texturing": "6.0",
-            "ConvertSfMFormat": "2.0",
-            "ImageSegmentation": "1.2",
-            "PrepareDenseScene": "3.1",
-            "KeyframeSelection": "5.0",
-            "ExportAnimatedCamera": "2.0",
-            "CheckerboardDetection": "1.0",
-            "DistortionCalibration": "3.0",
-            "FeatureExtraction": "1.3",
-            "FeatureMatching": "2.0",
-            "Meshing": "7.0",
-            "CameraInit": "9.0",
-            "ImageMatchingMultiSfM": "1.0",
             "MeshDecimate": "1.0",
+            "DepthMapFilter": "4.0",
+            "ExportDistortion": "1.0",
+            "PrepareDenseScene": "3.1",
+            "ImageMatchingMultiSfM": "1.0",
+            "Meshing": "7.0",
+            "KeyframeSelection": "5.0",
+            "CheckerboardDetection": "1.0",
+            "ApplyCalibration": "1.0",
+            "ConvertSfMFormat": "2.0",
+            "DepthMap": "5.0",
             "SfMTransfer": "2.1",
             "StructureFromMotion": "3.3",
+            "DistortionCalibration": "3.0",
             "SfMTriangulation": "1.0",
-            "ImageMatching": "2.0",
-            "ApplyCalibration": "1.0"
+            "FeatureMatching": "2.0",
+            "ScenePreview": "2.0",
+            "ImageSegmentation": "1.2",
+            "FeatureExtraction": "1.3",
+            "CameraInit": "9.0"
         }
     },
     "graph": {
@@ -426,7 +426,8 @@
             ],
             "inputs": {
                 "input": "{CameraInit_1.output}",
-                "maskInvert": true
+                "maskInvert": true,
+                "keepFilename": true
             },
             "internalInputs": {
                 "color": "#575963"

--- a/meshroom/pipelines/cameraTrackingWithoutCalibration.mg
+++ b/meshroom/pipelines/cameraTrackingWithoutCalibration.mg
@@ -5,28 +5,28 @@
         "fileVersion": "1.1",
         "template": true,
         "nodesVersions": {
-            "ScenePreview": "2.0",
+            "ExportAnimatedCamera": "2.0",
+            "Texturing": "6.0",
+            "ImageMatching": "2.0",
             "Publish": "1.3",
             "MeshFiltering": "3.0",
-            "DepthMapFilter": "4.0",
-            "DepthMap": "5.0",
-            "Texturing": "6.0",
-            "ConvertSfMFormat": "2.0",
-            "ImageSegmentation": "1.2",
-            "PrepareDenseScene": "3.1",
-            "KeyframeSelection": "5.0",
-            "ExportAnimatedCamera": "2.0",
-            "FeatureExtraction": "1.3",
-            "FeatureMatching": "2.0",
-            "Meshing": "7.0",
-            "CameraInit": "9.0",
-            "ImageMatchingMultiSfM": "1.0",
             "MeshDecimate": "1.0",
+            "DepthMapFilter": "4.0",
+            "PrepareDenseScene": "3.1",
+            "ImageMatchingMultiSfM": "1.0",
+            "Meshing": "7.0",
+            "KeyframeSelection": "5.0",
+            "ApplyCalibration": "1.0",
+            "ConvertSfMFormat": "2.0",
+            "DepthMap": "5.0",
             "SfMTransfer": "2.1",
             "StructureFromMotion": "3.3",
             "SfMTriangulation": "1.0",
-            "ImageMatching": "2.0",
-            "ApplyCalibration": "1.0"
+            "FeatureMatching": "2.0",
+            "ScenePreview": "2.0",
+            "ImageSegmentation": "1.2",
+            "FeatureExtraction": "1.3",
+            "CameraInit": "9.0"
         }
     },
     "graph": {
@@ -380,7 +380,8 @@
             ],
             "inputs": {
                 "input": "{CameraInit_1.output}",
-                "maskInvert": true
+                "maskInvert": true,
+                "keepFilename": true
             },
             "internalInputs": {
                 "color": "#575963"

--- a/meshroom/pipelines/nodalCameraTracking.mg
+++ b/meshroom/pipelines/nodalCameraTracking.mg
@@ -5,22 +5,22 @@
         "fileVersion": "1.1",
         "template": true,
         "nodesVersions": {
-            "DistortionCalibration": "3.0",
-            "FeatureExtraction": "1.3",
-            "ScenePreview": "2.0",
             "FeatureMatching": "2.0",
-            "RelativePoseEstimating": "1.0",
-            "ExportAnimatedCamera": "2.0",
-            "ConvertSfMFormat": "2.0",
-            "ImageSegmentation": "1.2",
-            "NodalSfM": "1.0",
             "ExportDistortion": "1.0",
-            "CameraInit": "9.0",
+            "ExportAnimatedCamera": "2.0",
+            "ScenePreview": "2.0",
+            "ConvertSfMFormat": "2.0",
             "CheckerboardDetection": "1.0",
-            "ImageMatching": "2.0",
-            "TracksBuilding": "1.0",
             "ApplyCalibration": "1.0",
-            "Publish": "1.3"
+            "ImageMatching": "2.0",
+            "CameraInit": "9.0",
+            "Publish": "1.3",
+            "DistortionCalibration": "3.0",
+            "ImageSegmentation": "1.2",
+            "RelativePoseEstimating": "1.0",
+            "FeatureExtraction": "1.3",
+            "NodalSfM": "1.0",
+            "TracksBuilding": "1.0"
         }
     },
     "graph": {
@@ -203,7 +203,8 @@
             ],
             "inputs": {
                 "input": "{CameraInit_1.output}",
-                "maskInvert": true
+                "maskInvert": true,
+                "keepFilename": true
             },
             "internalInputs": {
                 "color": "#80766f"

--- a/meshroom/pipelines/nodalCameraTrackingWithoutCalibration.mg
+++ b/meshroom/pipelines/nodalCameraTrackingWithoutCalibration.mg
@@ -5,18 +5,18 @@
         "fileVersion": "1.1",
         "template": true,
         "nodesVersions": {
-            "TracksBuilding": "1.0",
-            "ImageSegmentation": "1.2",
-            "FeatureExtraction": "1.3",
+            "FeatureMatching": "2.0",
+            "ExportAnimatedCamera": "2.0",
             "ScenePreview": "2.0",
+            "ConvertSfMFormat": "2.0",
             "ImageMatching": "2.0",
             "CameraInit": "9.0",
-            "NodalSfM": "1.0",
-            "ConvertSfMFormat": "2.0",
             "Publish": "1.3",
-            "ExportAnimatedCamera": "2.0",
-            "FeatureMatching": "2.0",
-            "RelativePoseEstimating": "1.0"
+            "ImageSegmentation": "1.2",
+            "RelativePoseEstimating": "1.0",
+            "FeatureExtraction": "1.3",
+            "NodalSfM": "1.0",
+            "TracksBuilding": "1.0"
         }
     },
     "graph": {
@@ -198,7 +198,8 @@
             ],
             "inputs": {
                 "input": "{CameraInit_1.output}",
-                "maskInvert": true
+                "maskInvert": true,
+                "keepFilename": true
             },
             "internalInputs": {
                 "color": "#80766f"

--- a/meshroom/pipelines/photogrammetryAndCameraTracking.mg
+++ b/meshroom/pipelines/photogrammetryAndCameraTracking.mg
@@ -5,29 +5,29 @@
         "fileVersion": "1.1",
         "template": true,
         "nodesVersions": {
-            "ScenePreview": "2.0",
+            "ExportAnimatedCamera": "2.0",
+            "Texturing": "6.0",
+            "ImageMatching": "2.0",
             "Publish": "1.3",
             "MeshFiltering": "3.0",
+            "MeshDecimate": "1.0",
             "DepthMapFilter": "4.0",
             "ExportDistortion": "1.0",
-            "DepthMap": "5.0",
-            "Texturing": "6.0",
-            "ConvertSfMFormat": "2.0",
-            "ImageSegmentation": "1.2",
             "PrepareDenseScene": "3.1",
-            "KeyframeSelection": "5.0",
-            "ExportAnimatedCamera": "2.0",
-            "CheckerboardDetection": "1.0",
-            "DistortionCalibration": "3.0",
-            "FeatureExtraction": "1.3",
-            "FeatureMatching": "2.0",
-            "Meshing": "7.0",
-            "CameraInit": "9.0",
             "ImageMatchingMultiSfM": "1.0",
-            "MeshDecimate": "1.0",
+            "Meshing": "7.0",
+            "KeyframeSelection": "5.0",
+            "CheckerboardDetection": "1.0",
+            "ApplyCalibration": "1.0",
+            "ConvertSfMFormat": "2.0",
+            "DepthMap": "5.0",
             "StructureFromMotion": "3.3",
-            "ImageMatching": "2.0",
-            "ApplyCalibration": "1.0"
+            "DistortionCalibration": "3.0",
+            "FeatureMatching": "2.0",
+            "ScenePreview": "2.0",
+            "ImageSegmentation": "1.2",
+            "FeatureExtraction": "1.3",
+            "CameraInit": "9.0"
         }
     },
     "graph": {
@@ -301,7 +301,8 @@
             ],
             "inputs": {
                 "input": "{CameraInit_1.output}",
-                "maskInvert": true
+                "maskInvert": true,
+                "keepFilename": true
             },
             "internalInputs": {
                 "color": "#575963"


### PR DESCRIPTION
## Description

Following #2288, this PR enables the `Keep Filename` option for all the `ImageSegmentation` nodes that are in the templates. The targeted templates are:
- Camera Tracking
- Camera Tracking without Calibration
- Nodal Camera Tracking
- Nodal Camera Tracking without Calibration
- Photogrammetry & Camera Tracking