### PR TITLE
[nodes] ImageSegmentation: Support loading masks in 2D Viewer if they are named after the input images

### DIFF
--- a/meshroom/nodes/aliceVision/ImageSegmentation.py
+++ b/meshroom/nodes/aliceVision/ImageSegmentation.py
@@ -95,7 +95,7 @@ Generate a mask with segmented labels for each pixel.
             label="Masks",
             description="Generated segmentation masks.",
             semantic="image",
-            value=desc.Node.internalFolder + "<VIEW_ID>.exr",
+            value=lambda attr: desc.Node.internalFolder + "<VIEW_ID>.exr" if not attr.node.keepFilename.value else desc.Node.internalFolder + "<FILENAME>.exr",
             group="",
             uid=[],
         ),


### PR DESCRIPTION
## Description

Up until #2288, the `ImageSegmentation` node's outputs were named based on the original image's view ID. They can now also be named directly after the input image.

When loading an `ImageSegmentation` node in the 2D Viewer, it should thus have the correct name of the generated masks.