### PR TITLE
[pipelines] Panorama: Enable "Minimal 2D Motion" for `FeatureMatching`

### DIFF
--- a/meshroom/pipelines/panoramaFisheyeHdr.mg
+++ b/meshroom/pipelines/panoramaFisheyeHdr.mg
@@ -1,23 +1,23 @@
 {
     "header": {
         "nodesVersions": {
-            "FeatureMatching": "2.0",
-            "PanoramaMerging": "1.0",
-            "PanoramaSeams": "2.0",
-            "CameraInit": "9.0",
-            "LdrToHdrMerge": "4.1",
-            "PanoramaPostProcessing": "2.0",
-            "SfMTransform": "3.1",
-            "PanoramaWarping": "1.1",
-            "LdrToHdrCalibration": "3.1",
-            "LdrToHdrSampling": "4.0",
-            "PanoramaCompositing": "2.0",
-            "Publish": "1.3",
-            "PanoramaPrepareImages": "1.1",
             "FeatureExtraction": "1.3",
-            "PanoramaInit": "2.0",
+            "PanoramaSeams": "2.0",
+            "PanoramaPostProcessing": "2.0",
+            "PanoramaWarping": "1.1",
+            "LdrToHdrMerge": "4.1",
+            "PanoramaMerging": "1.0",
+            "Publish": "1.3",
+            "PanoramaEstimation": "1.0",
+            "CameraInit": "9.0",
+            "LdrToHdrCalibration": "3.1",
             "ImageMatching": "2.0",
-            "PanoramaEstimation": "1.0"
+            "LdrToHdrSampling": "4.0",
+            "PanoramaPrepareImages": "1.1",
+            "FeatureMatching": "2.0",
+            "PanoramaCompositing": "2.0",
+            "SfMTransform": "3.1",
+            "PanoramaInit": "2.0"
         },
         "releaseVersion": "2024.1.0-develop",
         "fileVersion": "1.1",
@@ -227,7 +227,8 @@
                 "input": "{ImageMatching_1.input}",
                 "featuresFolders": "{ImageMatching_1.featuresFolders}",
                 "imagePairsList": "{ImageMatching_1.output}",
-                "describerTypes": "{FeatureExtraction_1.describerTypes}"
+                "describerTypes": "{FeatureExtraction_1.describerTypes}",
+                "minRequired2DMotion": 5.0
             }
         },
         "Publish_1": {

--- a/meshroom/pipelines/panoramaHdr.mg
+++ b/meshroom/pipelines/panoramaHdr.mg
@@ -1,23 +1,23 @@
 {
     "header": {
         "nodesVersions": {
-            "FeatureMatching": "2.0",
-            "PanoramaMerging": "1.0",
-            "PanoramaSeams": "2.0",
-            "CameraInit": "9.0",
-            "LdrToHdrMerge": "4.1",
-            "PanoramaPostProcessing": "2.0",
-            "SfMTransform": "3.1",
-            "PanoramaWarping": "1.1",
-            "LdrToHdrCalibration": "3.1",
-            "LdrToHdrSampling": "4.0",
-            "PanoramaCompositing": "2.0",
-            "Publish": "1.3",
-            "PanoramaPrepareImages": "1.1",
             "FeatureExtraction": "1.3",
-            "PanoramaInit": "2.0",
+            "PanoramaSeams": "2.0",
+            "PanoramaPostProcessing": "2.0",
+            "PanoramaWarping": "1.1",
+            "LdrToHdrMerge": "4.1",
+            "PanoramaMerging": "1.0",
+            "Publish": "1.3",
+            "PanoramaEstimation": "1.0",
+            "CameraInit": "9.0",
+            "LdrToHdrCalibration": "3.1",
             "ImageMatching": "2.0",
-            "PanoramaEstimation": "1.0"
+            "LdrToHdrSampling": "4.0",
+            "PanoramaPrepareImages": "1.1",
+            "FeatureMatching": "2.0",
+            "PanoramaCompositing": "2.0",
+            "SfMTransform": "3.1",
+            "PanoramaInit": "2.0"
         },
         "releaseVersion": "2024.1.0-develop",
         "fileVersion": "1.1",
@@ -222,7 +222,8 @@
                 "input": "{ImageMatching_1.input}",
                 "featuresFolders": "{ImageMatching_1.featuresFolders}",
                 "imagePairsList": "{ImageMatching_1.output}",
-                "describerTypes": "{FeatureExtraction_1.describerTypes}"
+                "describerTypes": "{FeatureExtraction_1.describerTypes}",
+                "minRequired2DMotion": 5.0
             }
         },
         "Publish_1": {


### PR DESCRIPTION
## Description

This PR updates the "Panorama HDR" and "Panorama Fisheye HDR" templates to set the "Minimal 2D Motion" parameter, which was disabled up to now, to 5.