### PR TITLE
[pipelines] PhotogAndCamTrack: Update matching mode to "Exhaustive"

### DIFF
--- a/meshroom/pipelines/photogrammetryAndCameraTracking.mg
+++ b/meshroom/pipelines/photogrammetryAndCameraTracking.mg
@@ -488,7 +488,7 @@
                 "featuresFolders": [
                     "{FeatureExtraction_1.output}"
                 ],
-                "method": "VocabularyTree",
+                "method": "Exhaustive",
                 "matchingMode": "a/b"
             },
             "internalInputs": {


### PR DESCRIPTION
## Description

This PR updates the matching method from the `ImageMatchingMultiSfm` node (matching between the photog and the keyframes) to `Exhaustive`.