### PR TITLE
[docker] Fix link to download `libassimpsceneimport.so` in Docker images

### DIFF
--- a/docker/build-centos.sh
+++ b/docker/build-centos.sh
@@ -26,7 +26,7 @@ test -f dl/qt.run || \
 
 # Download a prebuilt assimp importer to address https://bugreports.qt.io/browse/QTBUG-88821
 test -f dl/libassimpsceneimport.so || \
-        wget --no-check-certificate "https://gdirect.cc/d/bBomG&type=1" -O "dl/libassimpsceneimport.so"
+        wget --no-check-certificate "https://drive.google.com/uc?export=download&id=1cTU7xrOsLI6ICgRSYz_t9E1lsrNF1kBB" -O "dl/libassimpsceneimport.so"
 
 
 # DEPENDENCIES

--- a/docker/build-ubuntu.sh
+++ b/docker/build-ubuntu.sh
@@ -18,7 +18,7 @@ test -f dl/qt.run || \
 
 # Download a prebuilt assimp importer to address https://bugreports.qt.io/browse/QTBUG-88821
 test -f dl/libassimpsceneimport.so || \
-        wget --no-check-certificate "https://gdirect.cc/d/bBomG&type=1" -O "dl/libassimpsceneimport.so"
+        wget --no-check-certificate "https://drive.google.com/uc?export=download&id=1cTU7xrOsLI6ICgRSYz_t9E1lsrNF1kBB" -O "dl/libassimpsceneimport.so"
 
 # DEPENDENCIES
 docker build \


### PR DESCRIPTION
## Description

The links allowing to download the `libassimpsceneimport.so` file have expired. This PR replaces them with new working links. 