### PR TITLE
[nodes] CameraInit: check allowedCameraModels validity

### DIFF
--- a/meshroom/nodes/aliceVision/CameraInit.py
+++ b/meshroom/nodes/aliceVision/CameraInit.py
@@ -247,6 +247,8 @@ The needed metadata are:
             exclusive=False,
             uid=[],
             joinChar=",",
+            validValue=lambda node: len(node.allowedCameraModels.value),
+            errorMessage="Need at least one allowed camera model.",
             advanced=True,
         ),
         desc.ChoiceParam(


### PR DESCRIPTION
Display an error on the param if the value is invalid.
