### PR TITLE
[nodes] Use utilitary constants for common `ChoiceParams` lists of values

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,3 +1,5 @@
+# [nodes] Harmonize the use of trailing commas across all the nodes
+61a8dcd4e2878f80b2f320f2b1c3c9b41e999b82
 # [nodes] Clean-up: Harmonize nodes' descriptions
 f2d67706511954aa3e1c026ecc858beb8c08f938
 # [qml] Clean-up: Harmonize syntax across all files

--- a/meshroom/core/utils.py
+++ b/meshroom/core/utils.py
@@ -3,3 +3,13 @@ COLORSPACES = ["AUTO", "sRGB", "rec709", "Linear", "ACES2065-1", "ACEScg", "Line
                "BMDFilm WideGamut Gen5", "CanonLog2 CinemaGamut D55", "CanonLog3 CinemaGamut D55",
                "Linear CinemaGamut D55", "Linear V-Gamut", "V-Log V-Gamut", "Linear REDWideGamutRGB",
                "Log3G10 REDWideGamutRGB", "Linear Venice S-Gamut3.Cine", "S-Log3 Venice S-Gamut3.Cine", "no_conversion"]
+
+DESCRIBER_TYPES = ["sift", "sift_float", "sift_upright", "dspsift", "akaze", "akaze_liop", "akaze_mldb", "cctag3",
+                   "cctag4", "sift_ocv", "akaze_ocv", "tag16h5", "unknown"]
+
+EXR_STORAGE_DATA_TYPE = ["float", "half", "halfFinite", "auto"]
+
+RAW_COLOR_INTERPRETATION = ["None", "LibRawNoWhiteBalancing", "LibRawWhiteBalancing", "DCPLinearProcessing",
+                            "DCPMetadata", "Auto"]
+
+VERBOSE_LEVEL = ["fatal", "error", "warning", "info", "debug", "trace"]

--- a/meshroom/nodes/aliceVision/ApplyCalibration.py
+++ b/meshroom/nodes/aliceVision/ApplyCalibration.py
@@ -1,6 +1,7 @@
 __version__ = "1.0"
 
 from meshroom.core import desc
+from meshroom.core.utils import VERBOSE_LEVEL
 
 class ApplyCalibration(desc.AVCommandLineNode):
     commandLine = 'aliceVision_applyCalibration {allParams}'
@@ -30,8 +31,8 @@ Overwrite intrinsics with a calibrated intrinsic.
             name="verboseLevel",
             label="Verbose Level",
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
+            values=VERBOSE_LEVEL,
             value="info",
-            values=["fatal", "error", "warning", "info", "debug", "trace"],
             exclusive=True,
             uid=[],
         ),

--- a/meshroom/nodes/aliceVision/CameraCalibration.py
+++ b/meshroom/nodes/aliceVision/CameraCalibration.py
@@ -52,7 +52,7 @@ class CameraCalibration(desc.AVCommandLineNode):
                     range=(0, 10000, 1),
                     uid=[0],
                 ),
-            ]
+            ],
         ),
         desc.FloatParam(
             name="squareSize",

--- a/meshroom/nodes/aliceVision/CameraCalibration.py
+++ b/meshroom/nodes/aliceVision/CameraCalibration.py
@@ -1,6 +1,7 @@
 __version__ = "1.0"
 
 from meshroom.core import desc
+from meshroom.core.utils import VERBOSE_LEVEL
 
 
 class CameraCalibration(desc.AVCommandLineNode):
@@ -127,8 +128,8 @@ class CameraCalibration(desc.AVCommandLineNode):
             name="verboseLevel",
             label="Verbose Level",
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
+            values=VERBOSE_LEVEL,
             value="info",
-            values=["fatal", "error", "warning", "info", "debug", "trace"],
             exclusive=True,
             uid=[],
         ),

--- a/meshroom/nodes/aliceVision/CameraInit.py
+++ b/meshroom/nodes/aliceVision/CameraInit.py
@@ -8,6 +8,7 @@ import tempfile
 import logging
 
 from meshroom.core import desc, Version
+from meshroom.core.utils import RAW_COLOR_INTERPRETATION, VERBOSE_LEVEL
 from meshroom.multiview import FilesByType, findFilesByTypeInFolder
 
 Viewpoint = [
@@ -260,8 +261,8 @@ The needed metadata are:
                         " - LibRawWhiteBalancing: Use internal white balancing from libraw.\n"
                         " - DCPLinearProcessing: Use DCP color profile.\n"
                         " - DCPMetadata: Same as None with DCP info added in metadata.",
+            values=RAW_COLOR_INTERPRETATION,
             value="DCPLinearProcessing" if os.environ.get("ALICEVISION_COLOR_PROFILE_DB", "") else "LibRawWhiteBalancing",
-            values=["None", "LibRawNoWhiteBalancing", "LibRawWhiteBalancing", "DCPLinearProcessing", "DCPMetadata"],
             exclusive=True,
             uid=[0],
         ),
@@ -313,8 +314,8 @@ The needed metadata are:
             name="verboseLevel",
             label="Verbose Level",
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
+            values=VERBOSE_LEVEL,
             value="info",
-            values=["fatal", "error", "warning", "info", "debug", "trace"],
             exclusive=True,
             uid=[],
         ),

--- a/meshroom/nodes/aliceVision/CameraInit.py
+++ b/meshroom/nodes/aliceVision/CameraInit.py
@@ -12,38 +12,116 @@ from meshroom.core.utils import RAW_COLOR_INTERPRETATION, VERBOSE_LEVEL
 from meshroom.multiview import FilesByType, findFilesByTypeInFolder
 
 Viewpoint = [
-    desc.IntParam(name="viewId", label="ID", description="Image UID.", value=-1, uid=[0], range=None),
-    desc.IntParam(name="poseId", label="Pose ID", description="Pose ID.", value=-1, uid=[0], range=None),
-    desc.File(name="path", label="Image Path", description="Image filepath.", value="", uid=[0]),
-    desc.IntParam(name="intrinsicId", label="Intrinsic", description="Internal camera parameters.", value=-1, uid=[0], range=None),
-    desc.IntParam(name="rigId", label="Rig", description="Rig parameters.", value=-1, uid=[0], range=None),
-    desc.IntParam(name="subPoseId", label="Rig Sub-Pose", description="Rig sub-pose parameters.", value=-1, uid=[0], range=None),
-    desc.StringParam(name="metadata", label="Image Metadata",
-                     description="The configuration of the Viewpoints is based on the images' metadata.\n"
-                                 "The important ones are:\n"
-                                 " - Focal Length: the focal length in mm.\n"
-                                 " - Make and Model: this information allows to convert the focal in mm into a focal length in pixels using "
-                                 "an embedded sensor database.\n"
-                                 " - Serial Number: allows to uniquely identify a device so multiple devices with the same Make, Model can be "
-                                 "differentiated and their internal parameters are optimized separately.",
-                     value="", uid=[], advanced=True),
+    desc.IntParam(
+        name="viewId",
+        label="ID",
+        description="Image UID.",
+        value=-1,
+        uid=[0],
+        range=None,
+    ),
+    desc.IntParam(
+        name="poseId",
+        label="Pose ID",
+        description="Pose ID.",
+        value=-1,
+        uid=[0],
+        range=None,
+    ),
+    desc.File(
+        name="path",
+        label="Image Path",
+        description="Image filepath.",
+        value="",
+        uid=[0],
+    ),
+    desc.IntParam(
+        name="intrinsicId",
+        label="Intrinsic",
+        description="Internal camera parameters.",
+        value=-1,
+        uid=[0],
+        range=None,
+    ),
+    desc.IntParam(
+        name="rigId",
+        label="Rig",
+        description="Rig parameters.",
+        value=-1,
+        uid=[0],
+        range=None,
+    ),
+    desc.IntParam(
+        name="subPoseId",
+        label="Rig Sub-Pose",
+        description="Rig sub-pose parameters.",
+        value=-1,
+        uid=[0],
+        range=None,
+    ),
+    desc.StringParam(
+        name="metadata",
+        label="Image Metadata",
+        description="The configuration of the Viewpoints is based on the images' metadata.\n"
+                    "The important ones are:\n"
+                    " - Focal Length: the focal length in mm.\n"
+                    " - Make and Model: this information allows to convert the focal in mm into a focal length in pixels using "
+                    "an embedded sensor database.\n"
+                    " - Serial Number: allows to uniquely identify a device so multiple devices with the same Make, Model can be "
+                    "differentiated and their internal parameters are optimized separately.",
+        value="",
+        uid=[],
+        advanced=True,
+    ),
 ]
 
 Intrinsic = [
-    desc.IntParam(name="intrinsicId", label="ID", description="Intrinsic UID.", value=-1, uid=[0], range=None),
-    desc.FloatParam(name="initialFocalLength", label="Initial Focal Length",
-                    description="Initial guess on the focal length (in mm).\n"
-                                "When we have an initial value from EXIF, this value is not accurate but it cannot be wrong.\n"
-                                "So this value is used to limit the range of possible values in the optimization.\n"
-                                "If this value is set to -1, it will not be used and the focal length will not be bounded.",
-                    value=-1.0, uid=[0], range=None),
-    desc.FloatParam(name="focalLength", label="Focal Length", description="Known/calibrated focal length (in mm).", value=1000.0, uid=[0], range=(0.0, 10000.0, 1.0)),
-    desc.FloatParam(name="pixelRatio", label="Pixel Ratio", description="Ratio between the pixel width and the pixel height.", value=1.0, uid=[0], range=(0.0, 10.0, 0.1)),
-    desc.BoolParam(name="pixelRatioLocked", label="Pixel Ratio Locked",
-                   description="The pixel ratio value is locked for estimation.",
-                   value=True, uid=[0]),
-    desc.ChoiceParam(name="type", label="Camera Type",
-                     description="Mathematical model used to represent a camera:\n"
+    desc.IntParam(
+        name="intrinsicId",
+        label="ID",
+        description="Intrinsic UID.",
+        value=-1,
+        uid=[0],
+        range=None,
+    ),
+    desc.FloatParam(
+        name="initialFocalLength",
+        label="Initial Focal Length",
+        description="Initial guess on the focal length (in mm).\n"
+                    "When we have an initial value from EXIF, this value is not accurate but it cannot be wrong.\n"
+                    "So this value is used to limit the range of possible values in the optimization.\n"
+                    "If this value is set to -1, it will not be used and the focal length will not be bounded.",
+        value=-1.0,
+        uid=[0],
+        range=None,
+    ),
+    desc.FloatParam(
+        name="focalLength",
+        label="Focal Length",
+        description="Known/calibrated focal length (in mm).",
+        value=1000.0,
+        uid=[0],
+        range=(0.0, 10000.0, 1.0),
+    ),
+    desc.FloatParam(
+        name="pixelRatio",
+        label="Pixel Ratio",
+        description="Ratio between the pixel width and the pixel height.",
+        value=1.0,
+        uid=[0],
+        range=(0.0, 10.0, 0.1),
+    ),
+    desc.BoolParam(
+        name="pixelRatioLocked",
+        label="Pixel Ratio Locked",
+        description="The pixel ratio value is locked for estimation.",
+        value=True,
+        uid=[0],
+    ),
+    desc.ChoiceParam(
+        name="type",
+        label="Camera Type",
+        description="Mathematical model used to represent a camera:\n"
                      " - pinhole: Simplest projective camera model without optical distortion (focal and optical center).\n"
                      " - radial1: Pinhole camera with one radial distortion parameter.\n"
                      " - radial3: Pinhole camera with 3 radial distortion parameters.\n"
@@ -53,65 +131,154 @@ Intrinsic = [
                      " - 3deanamorphic4: Pinhole camera with 4 anamorphic distortion coefficients.\n"
                      " - 3declassicld: Pinhole camera with 10 anamorphic distortion coefficients.\n"
                      " - 3deradial4: Pinhole camera with 3DE radial4 model.\n",
-                     value="", values=["", "pinhole", "radial1", "radial3", "brown", "fisheye4", "equidistant_r3", "3deanamorphic4", "3declassicld", "3deradial4"], exclusive=True, uid=[0]),
-    desc.IntParam(name="width", label="Width", description="Image width.", value=0, uid=[0], range=(0, 10000, 1)),
-    desc.IntParam(name="height", label="Height", description="Image height.", value=0, uid=[0], range=(0, 10000, 1)),
-    desc.FloatParam(name="sensorWidth", label="Sensor Width", description="Sensor width (in mm).", value=36.0, uid=[0], range=(0.0, 1000.0, 1.0)),
-    desc.FloatParam(name="sensorHeight", label="Sensor Height", description="Sensor height (in mm).", value=24.0, uid=[0], range=(0.0, 1000.0, 1.0)),
-    desc.StringParam(name="serialNumber", label="Serial Number", description="Device serial number (Camera UID and Lens UID combined).", value="", uid=[0]),
-    desc.GroupAttribute(name="principalPoint", label="Principal Point", description="Position of the optical center in the image (i.e. the sensor surface).", groupDesc=[
-        desc.FloatParam(name="x", label="x", description="", value=0.0, uid=[0], range=(0.0, 10000.0, 1.0)),
-        desc.FloatParam(name="y", label="y", description="", value=0.0, uid=[0], range=(0.0, 10000.0, 1.0)),
-    ]),
-
-    desc.ChoiceParam(name="initializationMode", label="Initialization Mode",
-                     description="Defines how this intrinsic was initialized:\n"
-                                 " - calibrated: calibrated externally.\n"
-                                 " - estimated: estimated from metadata and/or sensor width.\n"
-                                 " - unknown: unknown camera parameters (can still have default value guess).\n"
-                                 " - none: not set.",
-                     values=("calibrated", "estimated", "unknown", "none"),
-                     value="none",
-                     exclusive=True,
-                     uid=[0],
+        value="",
+        values=["", "pinhole", "radial1", "radial3", "brown", "fisheye4", "equidistant_r3", "3deanamorphic4", "3declassicld", "3deradial4"],
+        exclusive=True,
+        uid=[0],
     ),
-
-    desc.ChoiceParam(name="distortionInitializationMode", label="Distortion Initialization Mode",
-                     description="Defines how the distortion model and parameters were initialized:\n"
-                                 " - calibrated: calibrated externally.\n"
-                                 " - estimated: estimated from a database of generic calibration.\n"
-                                 " - unknown: unknown camera parameters (can still have default value guess).\n"
-                                 " - none: not set.",
-                     values=("calibrated", "estimated", "unknown", "none"),
-                     value="none",
-                     exclusive=True,
-                     uid=[0],
+    desc.IntParam(
+        name="width",
+        label="Width",
+        description="Image width.",
+        value=0,
+        uid=[0],
+        range=(0, 10000, 1),
     ),
-
-    desc.ListAttribute(
-            name="distortionParams",
-            elementDesc=desc.FloatParam(name="p", label="", description="", value=0.0, uid=[0], range=(-0.1, 0.1, 0.01)),
-            label="Distortion Params",
-            description="Distortion parameters.",
+    desc.IntParam(
+        name="height",
+        label="Height",
+        description="Image height.",
+        value=0,
+        uid=[0],
+        range=(0, 10000, 1),
+    ),
+    desc.FloatParam(
+        name="sensorWidth",
+        label="Sensor Width",
+        description="Sensor width (in mm).",
+        value=36.0,
+        uid=[0],
+        range=(0.0, 1000.0, 1.0),
+    ),
+    desc.FloatParam(
+        name="sensorHeight",
+        label="Sensor Height",
+        description="Sensor height (in mm).",
+        value=24.0,
+        uid=[0],
+        range=(0.0, 1000.0, 1.0),
+    ),
+    desc.StringParam(
+        name="serialNumber",
+        label="Serial Number",
+        description="Device serial number (Camera UID and Lens UID combined).",
+        value="",
+        uid=[0],
     ),
     desc.GroupAttribute(
-            name="undistortionOffset",
-            label="Undistortion Offset",
-            description="Undistortion offset.",
-            groupDesc=[
-                desc.FloatParam(name="x", label="x", description="", value=0.0, uid=[0], range=(0.0, 10000.0, 1.0)),
-                desc.FloatParam(name="y", label="y", description="", value=0.0, uid=[0], range=(0.0, 10000.0, 1.0)),
-            ]
+        name="principalPoint",
+        label="Principal Point",
+        description="Position of the optical center in the image (i.e. the sensor surface).",
+        groupDesc=[
+            desc.FloatParam(
+                name="x",
+                label="x",
+                description="",
+                value=0.0,
+                uid=[0],
+                range=(0.0, 10000.0, 1.0),
+            ),
+            desc.FloatParam(
+                name="y",
+                label="y",
+                description="",
+                value=0.0,
+                uid=[0],
+                range=(0.0, 10000.0, 1.0),
+            ),
+        ],
+    ),
+    desc.ChoiceParam(
+        name="initializationMode",
+        label="Initialization Mode",
+        description="Defines how this intrinsic was initialized:\n"
+                    " - calibrated: calibrated externally.\n"
+                    " - estimated: estimated from metadata and/or sensor width.\n"
+                    " - unknown: unknown camera parameters (can still have default value guess).\n"
+                    " - none: not set.",
+        values=("calibrated", "estimated", "unknown", "none"),
+        value="none",
+        exclusive=True,
+        uid=[0],
+    ),
+    desc.ChoiceParam(
+        name="distortionInitializationMode",
+        label="Distortion Initialization Mode",
+        description="Defines how the distortion model and parameters were initialized:\n"
+                    " - calibrated: calibrated externally.\n"
+                    " - estimated: estimated from a database of generic calibration.\n"
+                    " - unknown: unknown camera parameters (can still have default value guess).\n"
+                    " - none: not set.",
+        values=("calibrated", "estimated", "unknown", "none"),
+        value="none",
+        exclusive=True,
+        uid=[0],
     ),
     desc.ListAttribute(
-            name="undistortionParams",
-            elementDesc=desc.FloatParam(name="p", label="", description="", value=0.0, uid=[0], range=(-0.1, 0.1, 0.01)),
-            label="Undistortion Params",
-            description="Undistortion parameters."
+        name="distortionParams",
+        elementDesc=desc.FloatParam(
+            name="p",
+            label="",
+            description="",
+            value=0.0,
+            uid=[0],
+            range=(-0.1, 0.1, 0.01),
+        ),
+        label="Distortion Params",
+        description="Distortion parameters.",
     ),
-    desc.BoolParam(name="locked", label="Locked",
-                   description="If the camera has been calibrated, the internal camera parameters (intrinsics) can be locked. It should improve robustness and speed-up the reconstruction.",
-                   value=False, uid=[0]
+    desc.GroupAttribute(
+        name="undistortionOffset",
+        label="Undistortion Offset",
+        description="Undistortion offset.",
+        groupDesc=[
+            desc.FloatParam(
+                name="x",
+                label="x",
+                description="",
+                value=0.0,
+                uid=[0],
+                range=(0.0, 10000.0, 1.0),
+            ),
+            desc.FloatParam(
+                name="y",
+                label="y",
+                description="",
+                value=0.0,
+                uid=[0],
+                range=(0.0, 10000.0, 1.0),
+            ),
+        ],
+    ),
+    desc.ListAttribute(
+        name="undistortionParams",
+        elementDesc=desc.FloatParam(
+            name="p",
+            label="",
+            description="",
+            value=0.0,
+            uid=[0],
+            range=(-0.1, 0.1, 0.01),
+        ),
+        label="Undistortion Params",
+        description="Undistortion parameters."
+    ),
+    desc.BoolParam(
+        name="locked",
+        label="Locked",
+        description="If the camera has been calibrated, the internal camera parameters (intrinsics) can be locked. It should improve robustness and speed-up the reconstruction.",
+        value=False,
+        uid=[0],
     ),
 ]
 
@@ -183,14 +350,24 @@ The needed metadata are:
     inputs = [
         desc.ListAttribute(
             name="viewpoints",
-            elementDesc=desc.GroupAttribute(name="viewpoint", label="Viewpoint", description="Viewpoint.", groupDesc=Viewpoint),
+            elementDesc=desc.GroupAttribute(
+                name="viewpoint",
+                label="Viewpoint",
+                description="Viewpoint.",
+                groupDesc=Viewpoint,
+            ),
             label="Viewpoints",
             description="Input viewpoints.",
             group="",
         ),
         desc.ListAttribute(
             name="intrinsics",
-            elementDesc=desc.GroupAttribute(name="intrinsic", label="Intrinsic", description="Intrinsic.", groupDesc=Intrinsic),
+            elementDesc=desc.GroupAttribute(
+                name="intrinsic",
+                label="Intrinsic",
+                description="Intrinsic.",
+                groupDesc=Intrinsic,
+            ),
             label="Intrinsics",
             description="Camera intrinsics.",
             group="",
@@ -243,8 +420,8 @@ The needed metadata are:
             name="allowedCameraModels",
             label="Allowed Camera Models",
             description="List of the camera models that can be attributed.",
-            value=["pinhole", "radial1", "radial3", "brown", "fisheye4", "fisheye1", "3deanamorphic4", "3deradial4", "3declassicld"],
             values=["pinhole", "radial1", "radial3", "brown", "fisheye4", "fisheye1", "3deanamorphic4", "3deradial4", "3declassicld"],
+            value=["pinhole", "radial1", "radial3", "brown", "fisheye4", "fisheye1", "3deanamorphic4", "3deradial4", "3declassicld"],
             exclusive=False,
             uid=[],
             joinChar=",",

--- a/meshroom/nodes/aliceVision/CameraLocalization.py
+++ b/meshroom/nodes/aliceVision/CameraLocalization.py
@@ -2,6 +2,7 @@ __version__ = "1.0"
 
 import os
 from meshroom.core import desc
+from meshroom.core.utils import DESCRIBER_TYPES, VERBOSE_LEVEL
 
 
 class CameraLocalization(desc.AVCommandLineNode):
@@ -44,8 +45,8 @@ class CameraLocalization(desc.AVCommandLineNode):
             name="matchDescTypes",
             label="Match Desc Types",
             description="Describer types to use for the matching.",
+            values=DESCRIBER_TYPES,
             value=["dspsift"],
-            values=["sift", "sift_float", "sift_upright", "dspsift", "akaze", "akaze_liop", "akaze_mldb", "cctag3", "cctag4", "sift_ocv", "akaze_ocv"],
             exclusive=False,
             uid=[0],
             joinChar=",",
@@ -210,8 +211,8 @@ class CameraLocalization(desc.AVCommandLineNode):
             name="verboseLevel",
             label="Verbose Level",
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
+            values=VERBOSE_LEVEL,
             value="info",
-            values=["fatal", "error", "warning", "info", "debug", "trace"],
             exclusive=True,
             uid=[],
         ),

--- a/meshroom/nodes/aliceVision/CameraRigCalibration.py
+++ b/meshroom/nodes/aliceVision/CameraRigCalibration.py
@@ -2,6 +2,7 @@ __version__ = "1.0"
 
 import os
 from meshroom.core import desc
+from meshroom.core.utils import DESCRIBER_TYPES, VERBOSE_LEVEL
 
 
 class CameraRigCalibration(desc.AVCommandLineNode):
@@ -52,8 +53,8 @@ class CameraRigCalibration(desc.AVCommandLineNode):
             name="matchDescTypes",
             label="Match Describer Types",
             description="The describer types to use for the matching.",
+            values=DESCRIBER_TYPES,
             value=["dspsift"],
-            values=["sift", "sift_float", "sift_upright", "dspsift", "akaze", "akaze_liop", "akaze_mldb", "cctag3", "cctag4", "sift_ocv", "akaze_ocv"],
             exclusive=False,
             uid=[0],
             joinChar=",",
@@ -169,8 +170,8 @@ class CameraRigCalibration(desc.AVCommandLineNode):
             name="verboseLevel",
             label="Verbose Level",
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
+            values=VERBOSE_LEVEL,
             value="info",
-            values=["fatal", "error", "warning", "info", "debug", "trace"],
             exclusive=True,
             uid=[],
         ),

--- a/meshroom/nodes/aliceVision/CameraRigLocalization.py
+++ b/meshroom/nodes/aliceVision/CameraRigLocalization.py
@@ -2,6 +2,7 @@ __version__ = "1.0"
 
 import os
 from meshroom.core import desc
+from meshroom.core.utils import DESCRIBER_TYPES, VERBOSE_LEVEL
 
 
 class CameraRigLocalization(desc.AVCommandLineNode):
@@ -51,8 +52,8 @@ class CameraRigLocalization(desc.AVCommandLineNode):
             name="matchDescTypes",
             label="Match Describer Types",
             description="The describer types to use for the matching.",
+            values=DESCRIBER_TYPES,
             value=["dspsift"],
-            values=["sift", "sift_float", "sift_upright", "dspsift", "akaze", "akaze_liop", "akaze_mldb", "cctag3", "cctag4", "sift_ocv", "akaze_ocv"],
             exclusive=False,
             uid=[0],
             joinChar=",",
@@ -176,8 +177,8 @@ class CameraRigLocalization(desc.AVCommandLineNode):
             name="verboseLevel",
             label="Verbose Level",
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
+            values=VERBOSE_LEVEL,
             value="info",
-            values=["fatal", "error", "warning", "info", "debug", "trace"],
             exclusive=True,
             uid=[],
         ),

--- a/meshroom/nodes/aliceVision/CheckerboardCalibration.py
+++ b/meshroom/nodes/aliceVision/CheckerboardCalibration.py
@@ -1,6 +1,7 @@
 __version__ = '1.0'
 
 from meshroom.core import desc
+from meshroom.core.utils import VERBOSE_LEVEL
 
 
 class CheckerboardCalibration(desc.AVCommandLineNode):
@@ -39,8 +40,8 @@ Estimate the camera intrinsics and extrinsincs on a set of checkerboard images.
             name="verboseLevel",
             label="Verbose Level",
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
+            values=VERBOSE_LEVEL,
             value="info",
-            values=["fatal", "error", "warning", "info", "debug", "trace"],
             exclusive=True,
             uid=[],
         ),

--- a/meshroom/nodes/aliceVision/CheckerboardDetection.py
+++ b/meshroom/nodes/aliceVision/CheckerboardDetection.py
@@ -1,6 +1,7 @@
 __version__ = "1.0"
 
 from meshroom.core import desc
+from meshroom.core.utils import VERBOSE_LEVEL
 
 
 class CheckerboardDetection(desc.AVCommandLineNode):
@@ -43,6 +44,15 @@ The detection method also supports nested calibration grids.
             description="Export debug images.",
             value=False,
             uid=[0],
+        ),
+        desc.ChoiceParam(
+            name="verboseLevel",
+            label="Verbose Level",
+            description="Verbosity level (fatal, error, warning, info, debug, trace).",
+            values=VERBOSE_LEVEL,
+            value="info",
+            exclusive=True,
+            uid=[],
         ),
     ]
 

--- a/meshroom/nodes/aliceVision/ColorCheckerCorrection.py
+++ b/meshroom/nodes/aliceVision/ColorCheckerCorrection.py
@@ -1,6 +1,7 @@
 __version__ = "1.0"
 
 from meshroom.core import desc
+from meshroom.core.utils import EXR_STORAGE_DATA_TYPE, VERBOSE_LEVEL
 
 import os.path
 
@@ -54,8 +55,8 @@ If multiple color charts are submitted, only the first one will be taken in acco
                         " - half: Use half float (16 bits per channel).\n"
                         " - halfFinite: Use half float, but clamp values to avoid non-finite values.\n"
                         " - auto: Use half float if all values can fit, else use full float.",
+            values=EXR_STORAGE_DATA_TYPE,
             value="float",
-            values=["float", "half", "halfFinite", "auto"],
             exclusive=True,
             uid=[0],
         ),
@@ -63,8 +64,8 @@ If multiple color charts are submitted, only the first one will be taken in acco
             name="verboseLevel",
             label="Verbose Level",
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
+            values=VERBOSE_LEVEL,
             value="info",
-            values=["fatal", "error", "warning", "info", "debug", "trace"],
             exclusive=True,
             uid=[],
         ),

--- a/meshroom/nodes/aliceVision/ColorCheckerDetection.py
+++ b/meshroom/nodes/aliceVision/ColorCheckerDetection.py
@@ -1,6 +1,7 @@
 __version__ = "1.0"
 
 from meshroom.core import desc
+from meshroom.core.utils import VERBOSE_LEVEL
 
 import os.path
 
@@ -55,8 +56,8 @@ Dev notes:
             name="verboseLevel",
             label="Verbose Level",
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
+            values=VERBOSE_LEVEL,
             value="info",
-            values=["fatal", "error", "warning", "info", "debug", "trace"],
             exclusive=True,
             uid=[],
         ),

--- a/meshroom/nodes/aliceVision/ConvertMesh.py
+++ b/meshroom/nodes/aliceVision/ConvertMesh.py
@@ -1,6 +1,7 @@
 __version__ = "1.0"
 
 from meshroom.core import desc
+from meshroom.core.utils import VERBOSE_LEVEL
 
 
 class ConvertMesh(desc.AVCommandLineNode):
@@ -31,8 +32,8 @@ class ConvertMesh(desc.AVCommandLineNode):
             name="verboseLevel",
             label="Verbose Level",
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
+            values=VERBOSE_LEVEL,
             value="info",
-            values=["fatal", "error", "warning", "info", "debug", "trace"],
             exclusive=True,
             uid=[],
         ),

--- a/meshroom/nodes/aliceVision/ConvertSfMFormat.py
+++ b/meshroom/nodes/aliceVision/ConvertSfMFormat.py
@@ -109,4 +109,3 @@ It can also be used to remove specific parts of from an SfM scene (like filter a
             uid=[],
         ),
     ]
-

--- a/meshroom/nodes/aliceVision/ConvertSfMFormat.py
+++ b/meshroom/nodes/aliceVision/ConvertSfMFormat.py
@@ -1,6 +1,7 @@
 __version__ = "2.0"
 
 from meshroom.core import desc
+from meshroom.core.utils import DESCRIBER_TYPES, VERBOSE_LEVEL
 
 
 class ConvertSfMFormat(desc.AVCommandLineNode):
@@ -35,8 +36,8 @@ It can also be used to remove specific parts of from an SfM scene (like filter a
             name="describerTypes",
             label="Describer Types",
             description="Describer types to keep.",
+            values=DESCRIBER_TYPES,
             value=["dspsift"],
-            values=["sift", "sift_float", "sift_upright", "dspsift", "akaze", "akaze_liop", "akaze_mldb", "cctag3", "cctag4", "sift_ocv", "akaze_ocv", "tag16h5", "unknown"],
             exclusive=False,
             uid=[0],
             joinChar=",",
@@ -92,8 +93,8 @@ It can also be used to remove specific parts of from an SfM scene (like filter a
             name="verboseLevel",
             label="Verbose Level",
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
+            values=VERBOSE_LEVEL,
             value="info",
-            values=["fatal", "error", "warning", "info", "debug", "trace"],
             exclusive=True,
             uid=[],
         ),

--- a/meshroom/nodes/aliceVision/DepthMap.py
+++ b/meshroom/nodes/aliceVision/DepthMap.py
@@ -74,40 +74,41 @@ Use a downscale factor of one (full-resolution) only if the quality of the input
             description="Tiles are used to split the computation into fixed buffers to fit the GPU best.",
             group=None,
             groupDesc=[
-            desc.IntParam(
-                name="tileBufferWidth",
-                label="Buffer Width",
-                description="Maximum tile buffer width.",
-                value=1024,
-                range=(-1, 2000, 10),
-                uid=[0],
-            ),
-            desc.IntParam(
-                name="tileBufferHeight",
-                label="Buffer Height",
-                description="Maximum tile buffer height.",
-                value=1024,
-                range=(-1, 2000, 10),
-                uid=[0],
-            ),
-            desc.IntParam(
-                name="tilePadding",
-                label="Padding",
-                description="Buffer padding for overlapping tiles.",
-                value=64,
-                range=(0, 500, 1),
-                uid=[0],
-            ),
-            desc.BoolParam(
-                name="autoAdjustSmallImage",
-                label="Auto Adjust Small Image",
-                description="Automatically adjust depth map parameters if images are smaller than one tile\n"
-                            "(maxTCamsPerTile = maxTCams, adjust step if needed).",
-                value=True,
-                uid=[0],
-                advanced=True,
-            ),
-        ]),
+                desc.IntParam(
+                    name="tileBufferWidth",
+                    label="Buffer Width",
+                    description="Maximum tile buffer width.",
+                    value=1024,
+                    range=(-1, 2000, 10),
+                    uid=[0],
+                ),
+                desc.IntParam(
+                    name="tileBufferHeight",
+                    label="Buffer Height",
+                    description="Maximum tile buffer height.",
+                    value=1024,
+                    range=(-1, 2000, 10),
+                    uid=[0],
+                ),
+                desc.IntParam(
+                    name="tilePadding",
+                    label="Padding",
+                    description="Buffer padding for overlapping tiles.",
+                    value=64,
+                    range=(0, 500, 1),
+                    uid=[0],
+                ),
+                desc.BoolParam(
+                    name="autoAdjustSmallImage",
+                    label="Auto Adjust Small Image",
+                    description="Automatically adjust depth map parameters if images are smaller than one tile\n"
+                                "(maxTCamsPerTile = maxTCams, adjust step if needed).",
+                    value=True,
+                    uid=[0],
+                    advanced=True,
+                ),
+            ],
+        ),
         desc.BoolParam(
             name="chooseTCamsPerTile",
             label="Choose Neighbour Cameras Per Tile",
@@ -277,7 +278,7 @@ Use a downscale factor of one (full-resolution) only if the quality of the input
                     value=False,
                     uid=[0],
                 ),
-            ]
+            ],
         ),
         desc.GroupAttribute(
             name="refine",
@@ -398,7 +399,7 @@ Use a downscale factor of one (full-resolution) only if the quality of the input
                     uid=[0],
                     enabled=lambda node: node.refine.refineEnabled.value,
                 ),
-            ]
+            ],
         ),
         desc.GroupAttribute(
             name="colorOptimization",
@@ -423,7 +424,7 @@ Use a downscale factor of one (full-resolution) only if the quality of the input
                     advanced=True,
                     enabled=lambda node: node.colorOptimization.colorOptimizationEnabled.value,
                 ),
-            ]
+            ],
         ),
         desc.GroupAttribute(
             name="customPatchPattern",
@@ -502,7 +503,7 @@ Use a downscale factor of one (full-resolution) only if the quality of the input
                                 range=(0.0, 1.0, 0.1),
                                 uid=[0],
                             ),
-                        ]
+                        ],
                     ),
                 ),
                 desc.BoolParam(
@@ -514,7 +515,7 @@ Use a downscale factor of one (full-resolution) only if the quality of the input
                     advanced=True,
                     enabled=lambda node: (node.customPatchPattern.sgmUseCustomPatchPattern.value or node.customPatchPattern.refineUseCustomPatchPattern.value),
                 ),
-            ]
+            ],
         ),
         desc.GroupAttribute(
             name="intermediateResults",
@@ -580,7 +581,7 @@ Use a downscale factor of one (full-resolution) only if the quality of the input
                     uid=[0],
                     advanced=True,
                 ),
-            ]
+            ],
         ),
         desc.IntParam(
             name="nbGPUs",

--- a/meshroom/nodes/aliceVision/DepthMap.py
+++ b/meshroom/nodes/aliceVision/DepthMap.py
@@ -1,6 +1,7 @@
 __version__ = "5.0"
 
 from meshroom.core import desc
+from meshroom.core.utils import VERBOSE_LEVEL
 
 
 class DepthMap(desc.AVCommandLineNode):
@@ -594,8 +595,8 @@ Use a downscale factor of one (full-resolution) only if the quality of the input
             name="verboseLevel",
             label="Verbose Level",
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
+            values=VERBOSE_LEVEL,
             value="info",
-            values=["fatal", "error", "warning", "info", "debug", "trace"],
             exclusive=True,
             uid=[],
         ),

--- a/meshroom/nodes/aliceVision/DepthMapFilter.py
+++ b/meshroom/nodes/aliceVision/DepthMapFilter.py
@@ -1,6 +1,7 @@
 __version__ = "4.0"
 
 from meshroom.core import desc
+from meshroom.core.utils import VERBOSE_LEVEL
 
 
 class DepthMapFilter(desc.AVCommandLineNode):
@@ -113,8 +114,8 @@ This allows to filter unstable points before starting the fusion of all depth ma
             name="verboseLevel",
             label="Verbose Level",
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
+            values=VERBOSE_LEVEL,
             value="info",
-            values=["fatal", "error", "warning", "info", "debug", "trace"],
             exclusive=True,
             uid=[],
         ),

--- a/meshroom/nodes/aliceVision/DistortionCalibration.py
+++ b/meshroom/nodes/aliceVision/DistortionCalibration.py
@@ -55,5 +55,5 @@ Calibration of a camera/lens couple distortion using a full screen checkerboard.
             description="Path to the output SfMData file.",
             value=desc.Node.internalFolder + "sfmData.sfm",
             uid=[],
-        )
+        ),
     ]

--- a/meshroom/nodes/aliceVision/DistortionCalibration.py
+++ b/meshroom/nodes/aliceVision/DistortionCalibration.py
@@ -1,6 +1,7 @@
 __version__ = '3.0'
 
 from meshroom.core import desc
+from meshroom.core.utils import VERBOSE_LEVEL
 
 
 class DistortionCalibration(desc.AVCommandLineNode):
@@ -40,8 +41,8 @@ Calibration of a camera/lens couple distortion using a full screen checkerboard.
             name="verboseLevel",
             label="Verbose Level",
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
+            values=VERBOSE_LEVEL,
             value="info",
-            values=["fatal", "error", "warning", "info", "debug", "trace"],
             exclusive=True,
             uid=[],
         ),

--- a/meshroom/nodes/aliceVision/ExportAnimatedCamera.py
+++ b/meshroom/nodes/aliceVision/ExportAnimatedCamera.py
@@ -1,6 +1,7 @@
 __version__ = "2.0"
 
 from meshroom.core import desc
+from meshroom.core.utils import VERBOSE_LEVEL
 
 
 class ExportAnimatedCamera(desc.AVCommandLineNode):
@@ -80,8 +81,8 @@ Based on the input image filenames, it will recognize the input video sequence t
             name="verboseLevel",
             label="Verbose Level",
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
+            values=VERBOSE_LEVEL,
             value="info",
-            values=["fatal", "error", "warning", "info", "debug", "trace"],
             exclusive=True,
             uid=[],
         ),

--- a/meshroom/nodes/aliceVision/ExportAnimatedCamera.py
+++ b/meshroom/nodes/aliceVision/ExportAnimatedCamera.py
@@ -113,4 +113,3 @@ Based on the input image filenames, it will recognize the input video sequence t
             uid=[],
         ),
     ]
-

--- a/meshroom/nodes/aliceVision/ExportColoredPointCloud.py
+++ b/meshroom/nodes/aliceVision/ExportColoredPointCloud.py
@@ -1,6 +1,7 @@
 __version__ = "1.0"
 
 from meshroom.core import desc
+from meshroom.core.utils import VERBOSE_LEVEL
 
 
 class ExportColoredPointCloud(desc.AVCommandLineNode):
@@ -22,8 +23,8 @@ class ExportColoredPointCloud(desc.AVCommandLineNode):
             name="verboseLevel",
             label="Verbose Level",
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
+            values=VERBOSE_LEVEL,
             value="info",
-            values=["fatal", "error", "warning", "info", "debug", "trace"],
             exclusive=True,
             uid=[],
         ),

--- a/meshroom/nodes/aliceVision/ExportDistortion.py
+++ b/meshroom/nodes/aliceVision/ExportDistortion.py
@@ -1,6 +1,7 @@
 __version__ = "1.0"
 
 from meshroom.core import desc
+from meshroom.core.utils import VERBOSE_LEVEL
 
 class ExportDistortion(desc.AVCommandLineNode):
     commandLine = 'aliceVision_exportDistortion {allParams}'
@@ -40,6 +41,15 @@ It also allows to export an undistorted image of the lens grids for validation.
             description="Export STMaps for distortion and undistortion.",
             value=True,
             uid=[0],
+        ),
+        desc.ChoiceParam(
+            name="verboseLevel",
+            label="Verbose Level",
+            description="Verbosity level (fatal, error, warning, info, debug, trace).",
+            values=VERBOSE_LEVEL,
+            value="info",
+            exclusive=True,
+            uid=[],
         ),
     ]
 

--- a/meshroom/nodes/aliceVision/ExportMatches.py
+++ b/meshroom/nodes/aliceVision/ExportMatches.py
@@ -40,7 +40,7 @@ class ExportMatches(desc.AVCommandLineNode):
             ),
             name="featuresFolders",
             label="Features Folders",
-            description="Folder(s) containing the extracted features and descriptors."
+            description="Folder(s) containing the extracted features and descriptors.",
         ),
         desc.ListAttribute(
             elementDesc=desc.File(
@@ -52,7 +52,7 @@ class ExportMatches(desc.AVCommandLineNode):
             ),
             name="matchesFolders",
             label="Matches Folders",
-            description="Folder(s) in which computed matches are stored."
+            description="Folder(s) in which computed matches are stored.",
         ),
         desc.ChoiceParam(
             name="verboseLevel",

--- a/meshroom/nodes/aliceVision/ExportMatches.py
+++ b/meshroom/nodes/aliceVision/ExportMatches.py
@@ -1,6 +1,7 @@
 __version__ = "1.1"
 
 from meshroom.core import desc
+from meshroom.core.utils import DESCRIBER_TYPES, VERBOSE_LEVEL
 
 
 class ExportMatches(desc.AVCommandLineNode):
@@ -23,8 +24,8 @@ class ExportMatches(desc.AVCommandLineNode):
             name="describerTypes",
             label="Describer Types",
             description="Describer types used to describe an image.",
+            values=DESCRIBER_TYPES,
             value=["dspsift"],
-            values=["sift", "sift_float", "sift_upright", "dspsift", "akaze", "akaze_liop", "akaze_mldb", "cctag3", "cctag4", "sift_ocv", "akaze_ocv"],
             exclusive=False,
             uid=[0],
             joinChar=",",
@@ -57,8 +58,8 @@ class ExportMatches(desc.AVCommandLineNode):
             name="verboseLevel",
             label="Verbose Level",
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
+            values=VERBOSE_LEVEL,
             value="info",
-            values=["fatal", "error", "warning", "info", "debug", "trace"],
             exclusive=True,
             uid=[],
         ),

--- a/meshroom/nodes/aliceVision/ExportMaya.py
+++ b/meshroom/nodes/aliceVision/ExportMaya.py
@@ -1,6 +1,7 @@
 __version__ = "1.0"
 
 from meshroom.core import desc
+from meshroom.core.utils import VERBOSE_LEVEL
 
 
 class ExportMaya(desc.AVCommandLineNode):
@@ -26,8 +27,8 @@ MeshroomMaya contains a user interface to browse all cameras.
             name="verboseLevel",
             label="Verbose Level",
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
+            values=VERBOSE_LEVEL,
             value="info",
-            values=["fatal", "error", "warning", "info", "debug", "trace"],
             exclusive=True,
             uid=[],
         ),

--- a/meshroom/nodes/aliceVision/FeatureExtraction.py
+++ b/meshroom/nodes/aliceVision/FeatureExtraction.py
@@ -138,13 +138,13 @@ It is robust to motion-blur, depth-of-field, occlusion. Be careful to have enoug
             uid=[0],
         ),
         desc.ChoiceParam(
-                name="workingColorSpace",
-                label="Working Color Space",
-                description="Allows you to choose the color space in which the data are processed.",
-                values=COLORSPACES,
-                value="sRGB",
-                exclusive=True,
-                uid=[0],
+            name="workingColorSpace",
+            label="Working Color Space",
+            description="Allows you to choose the color space in which the data are processed.",
+            values=COLORSPACES,
+            value="sRGB",
+            exclusive=True,
+            uid=[0],
         ),
         desc.BoolParam(
             name="forceCpuExtraction",
@@ -171,7 +171,7 @@ It is robust to motion-blur, depth-of-field, occlusion. Be careful to have enoug
             value="info",
             exclusive=True,
             uid=[],
-        )
+        ),
     ]
 
     outputs = [

--- a/meshroom/nodes/aliceVision/FeatureExtraction.py
+++ b/meshroom/nodes/aliceVision/FeatureExtraction.py
@@ -1,7 +1,7 @@
 __version__ = "1.3"
 
 from meshroom.core import desc
-from meshroom.core.utils import COLORSPACES
+from meshroom.core.utils import COLORSPACES, DESCRIBER_TYPES, VERBOSE_LEVEL
 
 
 class FeatureExtraction(desc.AVCommandLineNode):
@@ -66,8 +66,8 @@ It is robust to motion-blur, depth-of-field, occlusion. Be careful to have enoug
             name="describerTypes",
             label="Describer Types",
             description="Describer types used to describe an image.",
+            values=DESCRIBER_TYPES,
             value=["dspsift"],
-            values=["sift", "sift_float", "sift_upright", "dspsift", "akaze", "akaze_liop", "akaze_mldb", "cctag3", "cctag4", "sift_ocv", "akaze_ocv", "tag16h5"],
             exclusive=False,
             uid=[0],
             joinChar=",",
@@ -167,8 +167,8 @@ It is robust to motion-blur, depth-of-field, occlusion. Be careful to have enoug
             name="verboseLevel",
             label="Verbose Level",
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
+            values=VERBOSE_LEVEL,
             value="info",
-            values=["fatal", "error", "warning", "info", "debug", "trace"],
             exclusive=True,
             uid=[],
         )

--- a/meshroom/nodes/aliceVision/FeatureMatching.py
+++ b/meshroom/nodes/aliceVision/FeatureMatching.py
@@ -1,6 +1,7 @@
 __version__ = "2.0"
 
 from meshroom.core import desc
+from meshroom.core.utils import DESCRIBER_TYPES, VERBOSE_LEVEL
 
 
 class FeatureMatching(desc.AVCommandLineNode):
@@ -63,8 +64,8 @@ then it checks the number of features that validates this model and iterate thro
             name="describerTypes",
             label="Describer Types",
             description="Describer types used to describe an image.",
+            values=DESCRIBER_TYPES,
             value=["dspsift"],
-            values=["sift", "sift_float", "sift_upright", "dspsift", "akaze", "akaze_liop", "akaze_mldb", "cctag3", "cctag4", "sift_ocv", "akaze_ocv", "tag16h5"],
             exclusive=False,
             uid=[0],
             joinChar=",",
@@ -213,8 +214,8 @@ then it checks the number of features that validates this model and iterate thro
             name="verboseLevel",
             label="Verbose Level",
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
+            values=VERBOSE_LEVEL,
             value="info",
-            values=["fatal", "error", "warning", "info", "debug", "trace"],
             exclusive=True,
             uid=[],
         )

--- a/meshroom/nodes/aliceVision/FeatureMatching.py
+++ b/meshroom/nodes/aliceVision/FeatureMatching.py
@@ -51,7 +51,7 @@ then it checks the number of features that validates this model and iterate thro
             ),
             name="featuresFolders",
             label="Features Folders",
-            description="Folder(s) containing the extracted features and descriptors."
+            description="Folder(s) containing the extracted features and descriptors.",
         ),
         desc.File(
             name="imagePairsList",
@@ -208,7 +208,7 @@ then it checks the number of features that validates this model and iterate thro
             description="Expor debug files (svg, dot).",
             value=False,
             uid=[],
-            advanced=True
+            advanced=True,
         ),
         desc.ChoiceParam(
             name="verboseLevel",
@@ -218,7 +218,7 @@ then it checks the number of features that validates this model and iterate thro
             value="info",
             exclusive=True,
             uid=[],
-        )
+        ),
     ]
     outputs = [
         desc.File(

--- a/meshroom/nodes/aliceVision/FeatureRepeatability.py
+++ b/meshroom/nodes/aliceVision/FeatureRepeatability.py
@@ -120,7 +120,7 @@ Compare feature/descriptor matching repeatability on some dataset with known hom
             value="info",
             exclusive=True,
             uid=[],
-        )
+        ),
     ]
 
     outputs = [

--- a/meshroom/nodes/aliceVision/FeatureRepeatability.py
+++ b/meshroom/nodes/aliceVision/FeatureRepeatability.py
@@ -1,6 +1,7 @@
 __version__ = "1.1"
 
 from meshroom.core import desc
+from meshroom.core.utils import DESCRIBER_TYPES, VERBOSE_LEVEL
 
 
 class FeatureRepeatability(desc.AVCommandLineNode):
@@ -26,8 +27,8 @@ Compare feature/descriptor matching repeatability on some dataset with known hom
             name="describerTypes",
             label="Describer Types",
             description="Describer types used to describe an image.",
+            values=DESCRIBER_TYPES,
             value=["sift"],
-            values=["sift", "sift_float", "sift_upright", "dspsift", "akaze", "akaze_liop", "akaze_mldb", "cctag3", "cctag4", "sift_ocv", "akaze_ocv"],
             exclusive=False,
             uid=[0],
             joinChar=",",
@@ -115,8 +116,8 @@ Compare feature/descriptor matching repeatability on some dataset with known hom
             name="verboseLevel",
             label="Verbose Level",
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
+            values=VERBOSE_LEVEL,
             value="info",
-            values=["fatal", "error", "warning", "info", "debug", "trace"],
             exclusive=True,
             uid=[],
         )

--- a/meshroom/nodes/aliceVision/GlobalSfM.py
+++ b/meshroom/nodes/aliceVision/GlobalSfM.py
@@ -4,6 +4,7 @@ import json
 import os
 
 from meshroom.core import desc
+from meshroom.core.utils import DESCRIBER_TYPES, VERBOSE_LEVEL
 
 
 class GlobalSfM(desc.AVCommandLineNode):
@@ -52,9 +53,8 @@ It is known to be faster but less robust to challenging datasets than the Increm
             name="describerTypes",
             label="Describer Types",
             description="Describer types used to describe an image.",
+            values=DESCRIBER_TYPES,
             value=["dspsift"],
-            values=["sift", "sift_float", "sift_upright", "dspsift", "akaze", "akaze_liop", "akaze_mldb", "cctag3", "cctag4",
-                    "sift_ocv", "akaze_ocv"],
             exclusive=False,
             uid=[0],
             joinChar=",",
@@ -95,8 +95,8 @@ It is known to be faster but less robust to challenging datasets than the Increm
             name="verboseLevel",
             label="Verbose Level",
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
+            values=VERBOSE_LEVEL,
             value="info",
-            values=["fatal", "error", "warning", "info", "debug", "trace"],
             exclusive=True,
             uid=[],
         )

--- a/meshroom/nodes/aliceVision/GlobalSfM.py
+++ b/meshroom/nodes/aliceVision/GlobalSfM.py
@@ -35,7 +35,7 @@ It is known to be faster but less robust to challenging datasets than the Increm
             ),
             name="featuresFolders",
             label="Features Folders",
-            description="Folder(s) containing the extracted features."
+            description="Folder(s) containing the extracted features.",
         ),
         desc.ListAttribute(
             elementDesc=desc.File(
@@ -47,7 +47,7 @@ It is known to be faster but less robust to challenging datasets than the Increm
             ),
             name="matchesFolders",
             label="Matches Folders",
-            description="Folder(s) in which computed matches are stored."
+            description="Folder(s) in which computed matches are stored.",
         ),
         desc.ChoiceParam(
             name="describerTypes",
@@ -99,7 +99,7 @@ It is known to be faster but less robust to challenging datasets than the Increm
             value="info",
             exclusive=True,
             uid=[],
-        )
+        ),
     ]
 
     outputs = [

--- a/meshroom/nodes/aliceVision/ImageMasking.py
+++ b/meshroom/nodes/aliceVision/ImageMasking.py
@@ -48,7 +48,7 @@ class ImageMasking(desc.AVCommandLineNode):
                     semantic="color/hue",
                     value=0.33,
                     range=(0.0, 1.0, 0.01),
-                    uid=[0]
+                    uid=[0],
                 ),
                 desc.FloatParam(
                     name="hsvHueRange",
@@ -56,7 +56,7 @@ class ImageMasking(desc.AVCommandLineNode):
                     description="Tolerance around the hue value to isolate.",
                     value=0.1,
                     range=(0.0, 1.0, 0.01),
-                    uid=[0]
+                    uid=[0],
                 ),
                 desc.FloatParam(
                     name="hsvMinSaturation",
@@ -64,7 +64,7 @@ class ImageMasking(desc.AVCommandLineNode):
                     description="Hue is meaningless if saturation is low. Do not mask pixels below this threshold.",
                     value=0.3,
                     range=(0.0, 1.0, 0.01),
-                    uid=[0]
+                    uid=[0],
                 ),
                 desc.FloatParam(
                     name="hsvMaxSaturation",
@@ -72,7 +72,7 @@ class ImageMasking(desc.AVCommandLineNode):
                     description="Do not mask pixels above this threshold. It might be useful to mask white/black pixels.",
                     value=1.0,
                     range=(0.0, 1.0, 0.01),
-                    uid=[0]
+                    uid=[0],
                 ),
                 desc.FloatParam(
                     name="hsvMinValue",
@@ -80,7 +80,7 @@ class ImageMasking(desc.AVCommandLineNode):
                     description="Hue is meaningless if the value is low. Do not mask pixels below this threshold.",
                     value=0.3,
                     range=(0.0, 1.0, 0.01),
-                    uid=[0]
+                    uid=[0],
                 ),
                 desc.FloatParam(
                     name="hsvMaxValue",
@@ -88,9 +88,9 @@ class ImageMasking(desc.AVCommandLineNode):
                     description="Do not mask pixels above this threshold. It might be useful to mask white/black pixels.",
                     value=1.0,
                     range=(0.0, 1.0, 0.01),
-                    uid=[0]
+                    uid=[0],
                 ),
-            ]
+            ],
         ),
         desc.BoolParam(
             name="invert",
@@ -98,7 +98,7 @@ class ImageMasking(desc.AVCommandLineNode):
             description="If selected, the selected area is ignored.\n"
                         "If not, only the selected area is considered.",
             value=True,
-            uid=[0]
+            uid=[0],
         ),
         desc.IntParam(
             name="growRadius",
@@ -107,7 +107,7 @@ class ImageMasking(desc.AVCommandLineNode):
                         "It might be used to fill the holes: then use shrinkRadius to restore the initial coutours.",
             value=0,
             range=(0, 50, 1),
-            uid=[0]
+            uid=[0],
         ),
         desc.IntParam(
             name="shrinkRadius",
@@ -115,7 +115,7 @@ class ImageMasking(desc.AVCommandLineNode):
             description="Shrink the selected area.",
             value=0,
             range=(0, 50, 1),
-            uid=[0]
+            uid=[0],
         ),
         desc.File(
             name="depthMapFolder",
@@ -139,7 +139,7 @@ class ImageMasking(desc.AVCommandLineNode):
             value="info",
             exclusive=True,
             uid=[],
-        )
+        ),
     ]
 
     outputs = [

--- a/meshroom/nodes/aliceVision/ImageMasking.py
+++ b/meshroom/nodes/aliceVision/ImageMasking.py
@@ -1,6 +1,7 @@
 __version__ = "3.0"
 
 from meshroom.core import desc
+from meshroom.core.utils import VERBOSE_LEVEL
 
 
 class ImageMasking(desc.AVCommandLineNode):
@@ -134,8 +135,8 @@ class ImageMasking(desc.AVCommandLineNode):
             name="verboseLevel",
             label="Verbose Level",
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
+            values=VERBOSE_LEVEL,
             value="info",
-            values=["fatal", "error", "warning", "info", "debug", "trace"],
             exclusive=True,
             uid=[],
         )

--- a/meshroom/nodes/aliceVision/ImageMatching.py
+++ b/meshroom/nodes/aliceVision/ImageMatching.py
@@ -2,6 +2,7 @@ __version__ = "2.0"
 
 import os
 from meshroom.core import desc
+from meshroom.core.utils import VERBOSE_LEVEL
 
 
 class ImageMatching(desc.AVCommandLineNode):
@@ -133,8 +134,8 @@ If images have known poses, use frustum intersection else use VocabularuTree.
             name="verboseLevel",
             label="Verbose Level",
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
+            values=VERBOSE_LEVEL,
             value="info",
-            values=["fatal", "error", "warning", "info", "debug", "trace"],
             exclusive=True,
             uid=[],
         )

--- a/meshroom/nodes/aliceVision/ImageMatching.py
+++ b/meshroom/nodes/aliceVision/ImageMatching.py
@@ -52,7 +52,7 @@ If images have known poses, use frustum intersection else use VocabularuTree.
             ),
             name="featuresFolders",
             label="Features Folders",
-            description="Folder(s) containing the extracted features and descriptors."
+            description="Folder(s) containing the extracted features and descriptors.",
         ),
         desc.ChoiceParam(
             name="method",
@@ -138,7 +138,7 @@ If images have known poses, use frustum intersection else use VocabularuTree.
             value="info",
             exclusive=True,
             uid=[],
-        )
+        ),
     ]
 
     outputs = [

--- a/meshroom/nodes/aliceVision/ImageMatchingMultiSfM.py
+++ b/meshroom/nodes/aliceVision/ImageMatchingMultiSfM.py
@@ -2,6 +2,7 @@ __version__ = "1.0"
 
 import os
 from meshroom.core import desc
+from meshroom.core.utils import VERBOSE_LEVEL
 
 
 class ImageMatchingMultiSfM(desc.AVCommandLineNode):
@@ -136,8 +137,8 @@ Thanks to this node, the FeatureMatching node will only compute the matches betw
             name="verboseLevel",
             label="Verbose Level",
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
+            values=VERBOSE_LEVEL,
             value="info",
-            values=["fatal", "error", "warning", "info", "debug", "trace"],
             exclusive=True,
             uid=[],
         )

--- a/meshroom/nodes/aliceVision/ImageMatchingMultiSfM.py
+++ b/meshroom/nodes/aliceVision/ImageMatchingMultiSfM.py
@@ -44,7 +44,7 @@ Thanks to this node, the FeatureMatching node will only compute the matches betw
             ),
             name="featuresFolders",
             label="Features Folders",
-            description="Folder(s) containing the extracted features and descriptors."
+            description="Folder(s) containing the extracted features and descriptors.",
         ),
         desc.ChoiceParam(
             name="method",
@@ -141,7 +141,7 @@ Thanks to this node, the FeatureMatching node will only compute the matches betw
             value="info",
             exclusive=True,
             uid=[],
-        )
+        ),
     ]
 
     outputs = [

--- a/meshroom/nodes/aliceVision/ImageProcessing.py
+++ b/meshroom/nodes/aliceVision/ImageProcessing.py
@@ -172,9 +172,9 @@ Convert or apply filtering to the input images.
                     description="Chromatic aberration (fringing) correction if the model parameters are available in the metadata.",
                     value=False,
                     uid=[0],
-                    enabled=lambda node: node.lensCorrection.lensCorrectionEnabled.value
-                )
-            ]
+                    enabled=lambda node: node.lensCorrection.lensCorrectionEnabled.value,
+                ),
+            ],
         ),
         desc.FloatParam(
             name="scaleFactor",
@@ -264,7 +264,7 @@ Convert or apply filtering to the input images.
                     uid=[0],
                     enabled=lambda node: node.sharpenFilter.sharpenFilterEnabled.value,
                 ),
-            ]
+            ],
         ),
         desc.GroupAttribute(
             name="bilateralFilter",
@@ -307,7 +307,7 @@ Convert or apply filtering to the input images.
                     uid=[0],
                     enabled=lambda node: node.bilateralFilter.bilateralFilterEnabled.value,
                 ),
-            ]
+            ],
         ),
         desc.GroupAttribute(
             name="claheFilter",
@@ -341,7 +341,7 @@ Convert or apply filtering to the input images.
                     uid=[0],
                     enabled=lambda node: node.claheFilter.claheEnabled.value,
                 ),
-            ]
+            ],
         ),
         desc.GroupAttribute(
             name="noiseFilter",
@@ -402,7 +402,7 @@ Convert or apply filtering to the input images.
                     uid=[0],
                     enabled=lambda node: node.noiseFilter.noiseEnabled.value,
                 ),
-            ]
+            ],
         ),
         desc.GroupAttribute(
             name="nlmFilter",
@@ -459,7 +459,7 @@ Convert or apply filtering to the input images.
                     uid=[0],
                     enabled=lambda node: node.nlmFilter.nlmFilterEnabled.value,
                 ),
-            ]
+            ],
         ),
         desc.GroupAttribute(
             name="parFilter",
@@ -483,7 +483,7 @@ Convert or apply filtering to the input images.
                     uid=[0],
                     enabled=lambda node: node.parFilter.parEnabled.value,
                 ),
-            ]
+            ],
         ),
         desc.ChoiceParam(
             name="outputFormat",
@@ -522,7 +522,6 @@ Convert or apply filtering to the input images.
             uid=[0],
             enabled=lambda node: not node.applyDcpMetadata.value,
         ),
-        
         desc.ChoiceParam(
             name="rawColorInterpretation",
             label="RAW Color Interpretation",
@@ -532,7 +531,6 @@ Convert or apply filtering to the input images.
             exclusive=True,
             uid=[0],
         ),
-        
         desc.BoolParam(
             name="applyDcpMetadata",
             label="Apply DCP Metadata",
@@ -540,7 +538,6 @@ Convert or apply filtering to the input images.
             value=False,
             uid=[0],
         ),
-        
         desc.File(
             name="colorProfileDatabase",
             label="Color Profile Database",
@@ -549,7 +546,6 @@ Convert or apply filtering to the input images.
             uid=[],
             enabled=lambda node: (node.rawColorInterpretation.value == "DCPLinearProcessing") or (node.rawColorInterpretation.value == "DCPMetadata"),
         ),
-        
         desc.BoolParam(
             name="errorOnMissingColorProfile",
             label="Error On Missing DCP Color Profile",
@@ -558,7 +554,6 @@ Convert or apply filtering to the input images.
             uid=[0],
             enabled=lambda node: (node.rawColorInterpretation.value == "DCPLinearProcessing") or (node.rawColorInterpretation.value == "DCPMetadata"),
         ),
-        
         desc.BoolParam(
             name="useDCPColorMatrixOnly",
             label="Use DCP Color Matrix Only",
@@ -567,7 +562,6 @@ Convert or apply filtering to the input images.
             uid=[0],
             enabled=lambda node: (node.rawColorInterpretation.value == "DCPLinearProcessing") or (node.rawColorInterpretation.value == "DCPMetadata"),
         ),
-        
         desc.BoolParam(
             name="doWBAfterDemosaicing",
             label="WB After Demosaicing",
@@ -576,7 +570,6 @@ Convert or apply filtering to the input images.
             uid=[0],
             enabled=lambda node: (node.rawColorInterpretation.value == "DCPLinearProcessing") or (node.rawColorInterpretation.value == "DCPMetadata"),
         ),
-        
         desc.ChoiceParam(
             name="demosaicingAlgo",
             label="Demosaicing Algorithm",
@@ -586,7 +579,6 @@ Convert or apply filtering to the input images.
             exclusive=True,
             uid=[0],
         ),
-        
         desc.ChoiceParam(
             name="highlightMode",
             label="Highlight Mode",
@@ -600,7 +592,6 @@ Convert or apply filtering to the input images.
             exclusive=True,
             uid=[0],
         ),
-        
         desc.FloatParam(
             name="correlatedColorTemperature",
             label="Illuminant Color Temperature",
@@ -610,7 +601,6 @@ Convert or apply filtering to the input images.
             range=(-1.0, 10000.0, 1.0),
             uid=[0],
         ),
-
         desc.File(
             name="lensCorrectionProfileInfo",
             label="Lens Correction Profile Info",
@@ -618,7 +608,6 @@ Convert or apply filtering to the input images.
             value="${ALICEVISION_LENS_PROFILE_INFO}",
             uid=[],
         ),
-        
         desc.BoolParam(
             name="lensCorrectionProfileSearchIgnoreCameraModel",
             label="LCP Generic Search",
@@ -627,7 +616,6 @@ Convert or apply filtering to the input images.
             uid=[0],
             advanced=True,
         ),
-        
         desc.ChoiceParam(
             name="storageDataType",
             label="Storage Data Type For EXR Output",
@@ -641,7 +629,6 @@ Convert or apply filtering to the input images.
             exclusive=True,
             uid=[0],
         ),
-        
         desc.ChoiceParam(
             name="exrCompressionMethod",
             label="EXR Compression Method",
@@ -651,7 +638,6 @@ Convert or apply filtering to the input images.
             exclusive=True,
             uid=[0],
         ),
-        
         desc.IntParam(
             name="exrCompressionLevel",
             label="EXR Compression Level",
@@ -661,9 +647,8 @@ Convert or apply filtering to the input images.
             value=0,
             range=(0, 500, 1),
             uid=[0],
-            enabled=lambda node: node.exrCompressionMethod.value in ["dwaa", "dwab", "zip", "zips"]
+            enabled=lambda node: node.exrCompressionMethod.value in ["dwaa", "dwab", "zip", "zips"],
         ),
-
         desc.BoolParam(
             name="jpegCompress",
             label="JPEG Compress",
@@ -671,7 +656,6 @@ Convert or apply filtering to the input images.
             value=True,
             uid=[0],
         ),
-
         desc.IntParam(
             name="jpegQuality",
             label="JPEG Quality",
@@ -679,9 +663,8 @@ Convert or apply filtering to the input images.
             value=90,
             range=(0, 100, 1),
             uid=[0],
-            enabled=lambda node: node.jpegCompress.value
+            enabled=lambda node: node.jpegCompress.value,
         ),
-
         desc.ChoiceParam(
             name="verboseLevel",
             label="Verbose Level",
@@ -690,7 +673,7 @@ Convert or apply filtering to the input images.
             value="info",
             exclusive=True,
             uid=[],
-        )
+        ),
     ]
 
     outputs = [

--- a/meshroom/nodes/aliceVision/ImageProcessing.py
+++ b/meshroom/nodes/aliceVision/ImageProcessing.py
@@ -1,7 +1,7 @@
 __version__ = "3.3"
 
 from meshroom.core import desc
-from meshroom.core.utils import COLORSPACES
+from meshroom.core.utils import COLORSPACES, EXR_STORAGE_DATA_TYPE, RAW_COLOR_INTERPRETATION, VERBOSE_LEVEL
 
 import os.path
 
@@ -527,8 +527,8 @@ Convert or apply filtering to the input images.
             name="rawColorInterpretation",
             label="RAW Color Interpretation",
             description="Allows you to choose how RAW data are color processed.",
+            values=RAW_COLOR_INTERPRETATION,
             value="DCPLinearProcessing" if os.environ.get("ALICEVISION_COLOR_PROFILE_DB", "") else "LibRawWhiteBalancing",
-            values=["None", "LibRawNoWhiteBalancing", "LibRawWhiteBalancing", "DCPLinearProcessing", "DCPMetadata", "Auto"],
             exclusive=True,
             uid=[0],
         ),
@@ -636,8 +636,8 @@ Convert or apply filtering to the input images.
                         " - half: Use half float (16 bits per channel).\n"
                         " - halfFinite: Use half float, but clamp values to avoid non-finite values.\n"
                         " - auto: Use half float if all values can fit, else use full float.",
+            values=EXR_STORAGE_DATA_TYPE,
             value="float",
-            values=["float", "half", "halfFinite", "auto"],
             exclusive=True,
             uid=[0],
         ),
@@ -686,8 +686,8 @@ Convert or apply filtering to the input images.
             name="verboseLevel",
             label="Verbose Level",
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
+            values=VERBOSE_LEVEL,
             value="info",
-            values=["fatal", "error", "warning", "info", "debug", "trace"],
             exclusive=True,
             uid=[],
         )

--- a/meshroom/nodes/aliceVision/ImageSegmentation.py
+++ b/meshroom/nodes/aliceVision/ImageSegmentation.py
@@ -29,7 +29,7 @@ Generate a mask with segmented labels for each pixel.
             label="Segmentation Model",
             description="Weights file for the internal model.",
             value="${ALICEVISION_SEMANTIC_SEGMENTATION_MODEL}",
-            uid=[0]
+            uid=[0],
         ),
         desc.ChoiceParam(
             name="validClasses",
@@ -80,7 +80,7 @@ Generate a mask with segmented labels for each pixel.
             value="info",
             exclusive=True,
             uid=[],
-        )
+        ),
     ]
 
     outputs = [
@@ -101,4 +101,3 @@ Generate a mask with segmented labels for each pixel.
             uid=[],
         ),
     ]
-

--- a/meshroom/nodes/aliceVision/ImageSegmentation.py
+++ b/meshroom/nodes/aliceVision/ImageSegmentation.py
@@ -1,6 +1,7 @@
 __version__ = "1.2"
 
 from meshroom.core import desc
+from meshroom.core.utils import VERBOSE_LEVEL
 
 
 class ImageSegmentation(desc.AVCommandLineNode):
@@ -75,8 +76,8 @@ Generate a mask with segmented labels for each pixel.
             name="verboseLevel",
             label="Verbose Level",
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
+            values=VERBOSE_LEVEL,
             value="info",
-            values=["fatal", "error", "warning", "info", "debug", "trace"],
             exclusive=True,
             uid=[],
         )

--- a/meshroom/nodes/aliceVision/ImportE57.py
+++ b/meshroom/nodes/aliceVision/ImportE57.py
@@ -1,6 +1,7 @@
 __version__ = "1.0"
 
 from meshroom.core import desc
+from meshroom.core.utils import VERBOSE_LEVEL
 
 
 class ImportE57(desc.AVCommandLineNode):
@@ -37,8 +38,8 @@ Import an E57 file and generate an SfMData.
             name="verboseLevel",
             label="Verbose Level",
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
+            values=VERBOSE_LEVEL,
             value="info",
-            values=["fatal", "error", "warning", "info", "debug", "trace"],
             exclusive=True,
             uid=[],
         )

--- a/meshroom/nodes/aliceVision/ImportE57.py
+++ b/meshroom/nodes/aliceVision/ImportE57.py
@@ -24,7 +24,7 @@ Import an E57 file and generate an SfMData.
             ),
             name="input",
             label="Input Files",
-            description="Set of E57 files in the same reference frame."
+            description="Set of E57 files in the same reference frame.",
         ),
         desc.FloatParam(
             name="maxDensity",
@@ -32,7 +32,7 @@ Import an E57 file and generate an SfMData.
             description="Ensure no points has no neighbour closer than maxDensity meters.",
             value=0.01,
             range=(0.0, 0.2, 0.001),
-            uid=[0]
+            uid=[0],
         ),
         desc.ChoiceParam(
             name="verboseLevel",
@@ -42,7 +42,7 @@ Import an E57 file and generate an SfMData.
             value="info",
             exclusive=True,
             uid=[],
-        )
+        ),
     ]
 
     outputs = [

--- a/meshroom/nodes/aliceVision/ImportKnownPoses.py
+++ b/meshroom/nodes/aliceVision/ImportKnownPoses.py
@@ -35,7 +35,7 @@ class ImportKnownPoses(desc.AVCommandLineNode):
             value="info",
             exclusive=True,
             uid=[],
-        )
+        ),
     ]
 
     outputs = [

--- a/meshroom/nodes/aliceVision/ImportKnownPoses.py
+++ b/meshroom/nodes/aliceVision/ImportKnownPoses.py
@@ -1,6 +1,7 @@
 __version__ = "1.0"
 
 from meshroom.core import desc
+from meshroom.core.utils import VERBOSE_LEVEL
 
 
 class ImportKnownPoses(desc.AVCommandLineNode):
@@ -30,8 +31,8 @@ class ImportKnownPoses(desc.AVCommandLineNode):
             name="verboseLevel",
             label="Verbose Level",
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
+            values=VERBOSE_LEVEL,
             value="info",
-            values=["fatal", "error", "warning", "info", "debug", "trace"],
             exclusive=True,
             uid=[],
         )

--- a/meshroom/nodes/aliceVision/KeyframeSelection.py
+++ b/meshroom/nodes/aliceVision/KeyframeSelection.py
@@ -89,7 +89,7 @@ You can extract frames at regular interval by configuring only the min/maxFrameS
             ),
             name="brands",
             label="Brands",
-            description="Camera brands."
+            description="Camera brands.",
         ),
         desc.ListAttribute(
             elementDesc=desc.File(
@@ -101,7 +101,7 @@ You can extract frames at regular interval by configuring only the min/maxFrameS
             ),
             name="models",
             label="Models",
-            description="Camera models."
+            description="Camera models.",
         ),
         desc.ListAttribute(
             elementDesc=desc.FloatParam(
@@ -114,7 +114,7 @@ You can extract frames at regular interval by configuring only the min/maxFrameS
             ),
             name="mmFocals",
             label="Focals",
-            description="Focals in mm (will be used if not 0)."
+            description="Focals in mm (will be used if not 0).",
         ),
         desc.File(
             name="sensorDbPath",
@@ -135,7 +135,7 @@ You can extract frames at regular interval by configuring only the min/maxFrameS
             label="Masks",
             description="Masks (e.g. segmentation masks) used to exclude some parts of the frames from the score computations\n"
                         "for the smart keyframe selection.",
-            enabled=lambda node: node.selectionMethod.useSmartSelection.value
+            enabled=lambda node: node.selectionMethod.useSmartSelection.value,
         ),
         desc.GroupAttribute(
             name="selectionMethod",
@@ -150,7 +150,7 @@ You can extract frames at regular interval by configuring only the min/maxFrameS
                     label="Use Smart Keyframe Selection",
                     description="Use the smart keyframe selection.",
                     value=True,
-                    uid=[0]
+                    uid=[0],
                 ),
                 desc.GroupAttribute(
                     name="regularSelection",
@@ -167,7 +167,7 @@ You can extract frames at regular interval by configuring only the min/maxFrameS
                             value=12,
                             range=(1, 1000, 1),
                             uid=[0],
-                            enabled=lambda node: node.regularSelection.enabled
+                            enabled=lambda node: node.regularSelection.enabled,
                         ),
                         desc.IntParam(
                             name="maxFrameStep",
@@ -176,7 +176,7 @@ You can extract frames at regular interval by configuring only the min/maxFrameS
                             value=0,
                             range=(0, 1000, 1),
                             uid=[0],
-                            enabled=lambda node: node.regularSelection.enabled
+                            enabled=lambda node: node.regularSelection.enabled,
                         ),
                         desc.IntParam(
                             name="maxNbOutFrames",
@@ -187,7 +187,7 @@ You can extract frames at regular interval by configuring only the min/maxFrameS
                             value=0,
                             range=(0, 10000, 1),
                             uid=[0],
-                            enabled=lambda node: node.regularSelection.enabled
+                            enabled=lambda node: node.regularSelection.enabled,
                         ),
                     ],
                 ),
@@ -206,7 +206,7 @@ You can extract frames at regular interval by configuring only the min/maxFrameS
                             value=10.0,
                             range=(0.0, 100.0, 1.0),
                             uid=[0],
-                            enabled=lambda node: node.smartSelection.enabled
+                            enabled=lambda node: node.smartSelection.enabled,
                         ),
                         desc.IntParam(
                             name="minNbOutFrames",
@@ -215,7 +215,7 @@ You can extract frames at regular interval by configuring only the min/maxFrameS
                             value=10,
                             range=(1, 100, 1),
                             uid=[0],
-                            enabled=lambda node: node.smartSelection.enabled
+                            enabled=lambda node: node.smartSelection.enabled,
                         ),
                         desc.IntParam(
                             name="maxNbOutFrames",
@@ -224,7 +224,7 @@ You can extract frames at regular interval by configuring only the min/maxFrameS
                             value=2000,
                             range=(1, 10000, 1),
                             uid=[0],
-                            enabled=lambda node: node.smartSelection.enabled
+                            enabled=lambda node: node.smartSelection.enabled,
                         ),
                         desc.IntParam(
                             name="rescaledWidthSharpness",
@@ -235,7 +235,7 @@ You can extract frames at regular interval by configuring only the min/maxFrameS
                             range=(0, 4000, 1),
                             uid=[0],
                             enabled=lambda node: node.smartSelection.enabled,
-                            advanced=True
+                            advanced=True,
                         ),
                         desc.IntParam(
                             name="rescaledWidthFlow",
@@ -246,7 +246,7 @@ You can extract frames at regular interval by configuring only the min/maxFrameS
                             range=(0, 4000, 1),
                             uid=[0],
                             enabled=lambda node: node.smartSelection.enabled,
-                            advanced=True
+                            advanced=True,
                         ),
                         desc.IntParam(
                             name="sharpnessWindowSize",
@@ -256,7 +256,7 @@ You can extract frames at regular interval by configuring only the min/maxFrameS
                             range=(1, 10000, 1),
                             uid=[0],
                             enabled=lambda node: node.smartSelection.enabled,
-                            advanced=True
+                            advanced=True,
                         ),
                         desc.IntParam(
                             name="flowCellSize",
@@ -266,7 +266,7 @@ You can extract frames at regular interval by configuring only the min/maxFrameS
                             range=(10, 2000, 1),
                             uid=[0],
                             enabled=lambda node: node.smartSelection.enabled,
-                            advanced=True
+                            advanced=True,
                         ),
                         desc.IntParam(
                             name="minBlockSize",
@@ -278,11 +278,11 @@ You can extract frames at regular interval by configuring only the min/maxFrameS
                             range=(1, 1000, 1),
                             uid=[],
                             enabled=lambda node: node.smartSelection.enabled,
-                            advanced=True
-                        )
-                    ]
-                )
-            ]
+                            advanced=True,
+                        ),
+                    ],
+                ),
+            ],
         ),
         desc.BoolParam(
             name="renameKeyframes",
@@ -292,7 +292,7 @@ You can extract frames at regular interval by configuring only the min/maxFrameS
                         "option enabled instead of [00015.exr, 00294.exr, 00825.exr].",
             value=False,
             enabled=lambda node: node.outputExtension.value != "none",
-            uid=[0]
+            uid=[0],
         ),
         desc.ChoiceParam(
             name="outputExtension",
@@ -320,7 +320,7 @@ You can extract frames at regular interval by configuring only the min/maxFrameS
             exclusive=True,
             uid=[0],
             enabled=lambda node: node.outputExtension.value == "exr",
-            advanced=True
+            advanced=True,
         ),
         desc.GroupAttribute(
             name="debugOptions",
@@ -342,7 +342,7 @@ You can extract frames at regular interval by configuring only the min/maxFrameS
                             label="Export Scores To CSV",
                             description="Export the computed sharpness and optical flow scores to a CSV file.",
                             value=False,
-                            uid=[0]
+                            uid=[0],
                         ),
                         desc.StringParam(
                             name="csvFilename",
@@ -350,7 +350,7 @@ You can extract frames at regular interval by configuring only the min/maxFrameS
                             description="Name of the CSV file to export. It will be written in the node's output folder.",
                             value="scores.csv",
                             uid=[0],
-                            enabled=lambda node: node.debugOptions.debugScores.exportScores.value
+                            enabled=lambda node: node.debugOptions.debugScores.exportScores.value,
                         ),
                         desc.BoolParam(
                             name="exportSelectedFrames",
@@ -358,9 +358,9 @@ You can extract frames at regular interval by configuring only the min/maxFrameS
                             description="Add a column in the CSV file containing 1s for frames that were selected and 0s for those that were not.",
                             value=False,
                             uid=[0],
-                            enabled=lambda node: node.debugOptions.debugScores.exportScores.value
-                        )
-                    ]
+                            enabled=lambda node: node.debugOptions.debugScores.exportScores.value,
+                        ),
+                    ],
                 ),
                 desc.GroupAttribute(
                     name="opticalFlowVisualisation",
@@ -375,7 +375,7 @@ You can extract frames at regular interval by configuring only the min/maxFrameS
                             description="Export each frame's optical flow HSV visualisation as PNG images.",
                             value=False,
                             uid=[0],
-                            enabled=lambda node: node.debugOptions.opticalFlowVisualisation.enabled
+                            enabled=lambda node: node.debugOptions.opticalFlowVisualisation.enabled,
                         ),
                         desc.BoolParam(
                             name="flowVisualisationOnly",
@@ -384,9 +384,9 @@ You can extract frames at regular interval by configuring only the min/maxFrameS
                                         "If this option is selected, all the other options will be ignored.",
                             value=False,
                             uid=[0],
-                            enabled=lambda node: node.debugOptions.opticalFlowVisualisation.enabled
-                        )
-                    ]
+                            enabled=lambda node: node.debugOptions.opticalFlowVisualisation.enabled,
+                        ),
+                    ],
                 ),
                 desc.BoolParam(
                     name="skipSharpnessComputation",
@@ -394,7 +394,7 @@ You can extract frames at regular interval by configuring only the min/maxFrameS
                     description="Skip the sharpness score computation. A fixed score of 1.0 will be applied by default to all the frames.",
                     value=False,
                     uid=[0],
-                    enabled=lambda node: node.debugOptions.enabled
+                    enabled=lambda node: node.debugOptions.enabled,
                 ),
                 desc.BoolParam(
                     name="skipSelection",
@@ -402,9 +402,9 @@ You can extract frames at regular interval by configuring only the min/maxFrameS
                     description="Compute the sharpness and optical flow scores, but do not proceed to the frame selection.",
                     value=False,
                     uid=[0],
-                    enabled=lambda node: node.debugOptions.enabled
-                )
-            ]
+                    enabled=lambda node: node.debugOptions.enabled,
+                ),
+            ],
         ),
         desc.ChoiceParam(
             name="verboseLevel",
@@ -438,7 +438,7 @@ You can extract frames at regular interval by configuring only the min/maxFrameS
             description="Output SfMData file containing all the frames that were not selected as keyframes.\n"
                         "If the input contains videos, this file will not be written since all the frames that were not selected do not actually exist on disk.",
             value=desc.Node.internalFolder + "frames.sfm",
-            uid=[]
-        )
+            uid=[],
+        ),
     ]
 

--- a/meshroom/nodes/aliceVision/KeyframeSelection.py
+++ b/meshroom/nodes/aliceVision/KeyframeSelection.py
@@ -2,6 +2,7 @@ __version__ = "5.0"
 
 import os
 from meshroom.core import desc
+from meshroom.core.utils import EXR_STORAGE_DATA_TYPE, VERBOSE_LEVEL
 
 # List of supported video extensions (provided by OpenImageIO)
 videoExts = [".avi", ".mov", ".mp4", ".m4a", ".m4v", ".3gp", ".3g2", ".mj2", ".m4v", ".mpg"]
@@ -314,8 +315,8 @@ You can extract frames at regular interval by configuring only the min/maxFrameS
                         " - half: Use half float (16 bits per channel).\n"
                         " - halfFinite: Use half float, but clamp values to avoid non-finite values.\n"
                         " - auto: Use half float if all values can fit, else use full float.",
+            values=EXR_STORAGE_DATA_TYPE,
             value="float",
-            values=["float", "half", "halfFinite", "auto"],
             exclusive=True,
             uid=[0],
             enabled=lambda node: node.outputExtension.value == "exr",
@@ -409,8 +410,8 @@ You can extract frames at regular interval by configuring only the min/maxFrameS
             name="verboseLevel",
             label="Verbose Level",
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
+            values=VERBOSE_LEVEL,
             value="info",
-            values=["fatal", "error", "warning", "info", "debug", "trace"],
             exclusive=True,
             uid=[],
         ),

--- a/meshroom/nodes/aliceVision/LdrToHdrCalibration.py
+++ b/meshroom/nodes/aliceVision/LdrToHdrCalibration.py
@@ -6,7 +6,7 @@ import os
 from collections import Counter
 
 from meshroom.core import desc
-from meshroom.core.utils import COLORSPACES
+from meshroom.core.utils import COLORSPACES, VERBOSE_LEVEL
 
 def findMetadata(d, keys, defaultValue):
     v = None
@@ -150,8 +150,8 @@ Calibrate LDR to HDR response curve from samples.
             name="verboseLevel",
             label="Verbose Level",
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
+            values=VERBOSE_LEVEL,
             value="info",
-            values=["fatal", "error", "warning", "info", "debug", "trace"],
             exclusive=True,
             uid=[],
         )

--- a/meshroom/nodes/aliceVision/LdrToHdrCalibration.py
+++ b/meshroom/nodes/aliceVision/LdrToHdrCalibration.py
@@ -62,7 +62,7 @@ Calibrate LDR to HDR response curve from samples.
             uid=[],
             group="user",  # not used directly on the command line
             errorMessage="The set number of brackets is not a multiple of the number of input images.\n"
-                         "Errors will occur during the computation."
+                         "Errors will occur during the computation.",
         ),
         desc.IntParam(
             name="nbBrackets",
@@ -73,7 +73,7 @@ Calibrate LDR to HDR response curve from samples.
             value=0,
             range=(0, 15, 1),
             uid=[0],
-            group="bracketsParams"
+            group="bracketsParams",
         ),
         desc.BoolParam(
             name="byPass",
@@ -154,7 +154,7 @@ Calibrate LDR to HDR response curve from samples.
             value="info",
             exclusive=True,
             uid=[],
-        )
+        ),
     ]
 
     outputs = [
@@ -164,7 +164,7 @@ Calibrate LDR to HDR response curve from samples.
             description="Path to the output response file.",
             value=desc.Node.internalFolder + "response_<INTRINSIC_ID>.csv",
             uid=[],
-        )
+        ),
     ]
 
     def processChunk(self, chunk):

--- a/meshroom/nodes/aliceVision/LdrToHdrMerge.py
+++ b/meshroom/nodes/aliceVision/LdrToHdrMerge.py
@@ -61,7 +61,7 @@ Merge LDR images into HDR images.
             uid=[],
             group="user",  # not used directly on the command line
             errorMessage="The set number of brackets is not a multiple of the number of input images.\n"
-                         "Errors will occur during the computation."
+                         "Errors will occur during the computation.",
         ),
         desc.IntParam(
             name="nbBrackets",
@@ -72,7 +72,7 @@ Merge LDR images into HDR images.
             value=0,
             range=(0, 15, 1),
             uid=[0],
-            group="bracketsParams"
+            group="bracketsParams",
         ),
         desc.BoolParam(
             name="offsetRefBracketIndexEnabled",
@@ -242,7 +242,7 @@ Merge LDR images into HDR images.
             value="info",
             exclusive=True,
             uid=[],
-        )
+        ),
     ]
 
     outputs = [
@@ -260,7 +260,7 @@ Merge LDR images into HDR images.
             description="Path to the output SfMData file.",
             value=desc.Node.internalFolder + "sfmData.sfm",
             uid=[],
-        )
+        ),
     ]
 
     @classmethod

--- a/meshroom/nodes/aliceVision/LdrToHdrMerge.py
+++ b/meshroom/nodes/aliceVision/LdrToHdrMerge.py
@@ -6,7 +6,7 @@ import math
 from collections import Counter
 
 from meshroom.core import desc
-from meshroom.core.utils import COLORSPACES
+from meshroom.core.utils import COLORSPACES, EXR_STORAGE_DATA_TYPE, VERBOSE_LEVEL
 
 def findMetadata(d, keys, defaultValue):
     v = None
@@ -229,8 +229,8 @@ Merge LDR images into HDR images.
                         " - half: Use half float (16 bits per channel).\n"
                         " - halfFinite: Use half float, but clamp values to avoid non-finite values.\n"
                         " - auto: Use half float if all values can fit, else use full float.",
+            values=EXR_STORAGE_DATA_TYPE,
             value="float",
-            values=["float", "half", "halfFinite", "auto"],
             exclusive=True,
             uid=[0],
         ),
@@ -238,8 +238,8 @@ Merge LDR images into HDR images.
             name="verboseLevel",
             label="Verbose Level",
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
+            values=VERBOSE_LEVEL,
             value="info",
-            values=["fatal", "error", "warning", "info", "debug", "trace"],
             exclusive=True,
             uid=[],
         )

--- a/meshroom/nodes/aliceVision/LdrToHdrSampling.py
+++ b/meshroom/nodes/aliceVision/LdrToHdrSampling.py
@@ -6,7 +6,7 @@ import os
 from collections import Counter
 
 from meshroom.core import desc
-from meshroom.core.utils import COLORSPACES
+from meshroom.core.utils import COLORSPACES, VERBOSE_LEVEL
 
 
 def findMetadata(d, keys, defaultValue):
@@ -175,8 +175,8 @@ Sample pixels from Low range images for HDR creation.
             name="verboseLevel",
             label="Verbose Level",
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
+            values=VERBOSE_LEVEL,
             value="info",
-            values=["fatal", "error", "warning", "info", "debug", "trace"],
             exclusive=True,
             uid=[],
         )

--- a/meshroom/nodes/aliceVision/LdrToHdrSampling.py
+++ b/meshroom/nodes/aliceVision/LdrToHdrSampling.py
@@ -76,7 +76,7 @@ Sample pixels from Low range images for HDR creation.
             uid=[],
             group="user",  # not used directly on the command line
             errorMessage="The set number of brackets is not a multiple of the number of input images.\n"
-                         "Errors will occur during the computation."
+                         "Errors will occur during the computation.",
         ),
         desc.IntParam(
             name="nbBrackets",
@@ -87,7 +87,7 @@ Sample pixels from Low range images for HDR creation.
             value=0,
             range=(0, 15, 1),
             uid=[0],
-            group="bracketsParams"
+            group="bracketsParams",
         ),
         desc.BoolParam(
             name="byPass",
@@ -179,7 +179,7 @@ Sample pixels from Low range images for HDR creation.
             value="info",
             exclusive=True,
             uid=[],
-        )
+        ),
     ]
 
     outputs = [

--- a/meshroom/nodes/aliceVision/LightingCalibration.py
+++ b/meshroom/nodes/aliceVision/LightingCalibration.py
@@ -1,6 +1,7 @@
 __version__ = "1.0"
 
 from meshroom.core import desc
+from meshroom.core.utils import VERBOSE_LEVEL
 
 
 class LightingCalibration(desc.CommandLineNode):
@@ -47,8 +48,8 @@ Can also be used to calibrate a lighting dome (RTI type).
             name="verboseLevel",
             label="Verbose Level",
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
+            values=VERBOSE_LEVEL,
             value="info",
-            values=["fatal", "error", "warning", "info", "debug", "trace"],
             exclusive=True,
             uid=[],
         )

--- a/meshroom/nodes/aliceVision/LightingCalibration.py
+++ b/meshroom/nodes/aliceVision/LightingCalibration.py
@@ -18,21 +18,21 @@ Can also be used to calibrate a lighting dome (RTI type).
             label="Input SfMData",
             description="Input SfMData file.",
             value="",
-            uid=[0]
+            uid=[0],
         ),
         desc.File(
             name="inputJSON",
             label="Sphere Detection File",
             description="Input JSON file containing sphere centers and radiuses.",
             value="",
-            uid=[0]
+            uid=[0],
         ),
         desc.BoolParam(
             name="saveAsModel",
             label="Save As Model",
             description="Check if this calibration file will be used with other datasets.",
             value=False,
-            uid=[0]
+            uid=[0],
         ),
         desc.ChoiceParam(
             name="method",
@@ -42,7 +42,7 @@ Can also be used to calibrate a lighting dome (RTI type).
             values=["brightestPoint", "whiteSphere"],
             value="brightestPoint",
             exclusive=True,
-            uid=[0]
+            uid=[0],
         ),
         desc.ChoiceParam(
             name="verboseLevel",
@@ -52,7 +52,7 @@ Can also be used to calibrate a lighting dome (RTI type).
             value="info",
             exclusive=True,
             uid=[],
-        )
+        ),
     ]
 
     outputs = [
@@ -61,6 +61,6 @@ Can also be used to calibrate a lighting dome (RTI type).
             label="Light File",
             description="Light information will be written here.",
             value=desc.Node.internalFolder + "/lights.json",
-            uid=[]
-        )
+            uid=[],
+        ),
     ]

--- a/meshroom/nodes/aliceVision/LightingEstimation.py
+++ b/meshroom/nodes/aliceVision/LightingEstimation.py
@@ -81,7 +81,7 @@ class LightingEstimation(desc.AVCommandLineNode):
             value="info",
             exclusive=True,
             uid=[],
-        )
+        ),
     ]
     
     outputs = [

--- a/meshroom/nodes/aliceVision/LightingEstimation.py
+++ b/meshroom/nodes/aliceVision/LightingEstimation.py
@@ -1,6 +1,7 @@
 __version__ = "1.0"
 
 from meshroom.core import desc
+from meshroom.core.utils import VERBOSE_LEVEL
 
 
 class LightingEstimation(desc.AVCommandLineNode):
@@ -76,8 +77,8 @@ class LightingEstimation(desc.AVCommandLineNode):
             name="verboseLevel",
             label="Verbose Level",
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
+            values=VERBOSE_LEVEL,
             value="info",
-            values=["fatal", "error", "warning", "info", "debug", "trace"],
             exclusive=True,
             uid=[],
         )

--- a/meshroom/nodes/aliceVision/MergeMeshes.py
+++ b/meshroom/nodes/aliceVision/MergeMeshes.py
@@ -1,6 +1,7 @@
 __version__ = "1.0"
 
 from meshroom.core import desc
+from meshroom.core.utils import VERBOSE_LEVEL
 
 
 class MergeMeshes(desc.AVCommandLineNode):
@@ -59,8 +60,8 @@ Operation types used to merge two meshes:
             name="verboseLevel",
             label="Verbose Level",
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
+            values=VERBOSE_LEVEL,
             value="info",
-            values=["fatal", "error", "warning", "info", "debug", "trace"],
             exclusive=True,
             uid=[],
         )

--- a/meshroom/nodes/aliceVision/MergeMeshes.py
+++ b/meshroom/nodes/aliceVision/MergeMeshes.py
@@ -64,7 +64,7 @@ Operation types used to merge two meshes:
             value="info",
             exclusive=True,
             uid=[],
-        )
+        ),
     ]
 
     outputs = [

--- a/meshroom/nodes/aliceVision/MeshDecimate.py
+++ b/meshroom/nodes/aliceVision/MeshDecimate.py
@@ -72,7 +72,7 @@ This node allows to reduce the density of the Mesh.
             value="info",
             exclusive=True,
             uid=[],
-        )
+        ),
     ]
 
     outputs = [

--- a/meshroom/nodes/aliceVision/MeshDecimate.py
+++ b/meshroom/nodes/aliceVision/MeshDecimate.py
@@ -1,6 +1,7 @@
 __version__ = "1.0"
 
 from meshroom.core import desc
+from meshroom.core.utils import VERBOSE_LEVEL
 
 
 class MeshDecimate(desc.AVCommandLineNode):
@@ -67,8 +68,8 @@ This node allows to reduce the density of the Mesh.
             name="verboseLevel",
             label="Verbose Level",
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
+            values=VERBOSE_LEVEL,
             value="info",
-            values=["fatal", "error", "warning", "info", "debug", "trace"],
             exclusive=True,
             uid=[],
         )

--- a/meshroom/nodes/aliceVision/MeshDenoising.py
+++ b/meshroom/nodes/aliceVision/MeshDenoising.py
@@ -1,6 +1,7 @@
 __version__ = "1.0"
 
 from meshroom.core import desc
+from meshroom.core.utils import VERBOSE_LEVEL
 
 
 class MeshDenoising(desc.AVCommandLineNode):
@@ -85,8 +86,8 @@ for now, the parameters are difficult to control and vary a lot from one dataset
             name="verboseLevel",
             label="Verbose Level",
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
+            values=VERBOSE_LEVEL,
             value="info",
-            values=["fatal", "error", "warning", "info", "debug", "trace"],
             exclusive=True,
             uid=[],
         )

--- a/meshroom/nodes/aliceVision/MeshDenoising.py
+++ b/meshroom/nodes/aliceVision/MeshDenoising.py
@@ -90,7 +90,7 @@ for now, the parameters are difficult to control and vary a lot from one dataset
             value="info",
             exclusive=True,
             uid=[],
-        )
+        ),
     ]
 
     outputs = [

--- a/meshroom/nodes/aliceVision/MeshFiltering.py
+++ b/meshroom/nodes/aliceVision/MeshFiltering.py
@@ -1,6 +1,7 @@
 __version__ = "3.0"
 
 from meshroom.core import desc
+from meshroom.core.utils import VERBOSE_LEVEL
 
 
 class MeshFiltering(desc.AVCommandLineNode):
@@ -115,8 +116,8 @@ This node applies a Laplacian filtering to remove local defects from the raw Mes
             name="verboseLevel",
             label="Verbose Level",
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
+            values=VERBOSE_LEVEL,
             value="info",
-            values=["fatal", "error", "warning", "info", "debug", "trace"],
             exclusive=True,
             uid=[],
         )

--- a/meshroom/nodes/aliceVision/MeshFiltering.py
+++ b/meshroom/nodes/aliceVision/MeshFiltering.py
@@ -120,7 +120,7 @@ This node applies a Laplacian filtering to remove local defects from the raw Mes
             value="info",
             exclusive=True,
             uid=[],
-        )
+        ),
     ]
 
     outputs = [

--- a/meshroom/nodes/aliceVision/MeshMasking.py
+++ b/meshroom/nodes/aliceVision/MeshMasking.py
@@ -55,7 +55,7 @@ Decimate triangles based on image masks.
             value="png",
             values=["exr", "jpg", "png"],
             exclusive=True,
-            uid=[0]
+            uid=[0],
         ),
         desc.IntParam(
             name="threshold",
@@ -63,14 +63,14 @@ Decimate triangles based on image masks.
             description="The minimum number of visibilities to keep a vertex.",
             value=1,
             range=(1, 100, 1),
-            uid=[0]
+            uid=[0],
         ),
         desc.BoolParam(
             name="smoothBoundary",
             label="Smooth Boundary",
             description="Modify the triangles at the boundary to fit the masks.",
             value=False,
-            uid=[0]
+            uid=[0],
         ),
         desc.BoolParam(
             name="invert",
@@ -78,7 +78,7 @@ Decimate triangles based on image masks.
             description="If ticked, the selected area is ignored.\n"
                         "If not, only the selected area is considered.",
             value=False,
-            uid=[0]
+            uid=[0],
         ),
         desc.BoolParam(
             name="undistortMasks",
@@ -86,7 +86,7 @@ Decimate triangles based on image masks.
             description="Undistort the masks with the same parameters as the matching image.\n"
                         "Select it if the masks are drawn on the original images.",
             value=False,
-            uid=[0]
+            uid=[0],
         ),
         desc.BoolParam(
             name="usePointsVisibilities",
@@ -104,7 +104,7 @@ Decimate triangles based on image masks.
             value="info",
             exclusive=True,
             uid=[],
-        )
+        ),
     ]
 
     outputs = [

--- a/meshroom/nodes/aliceVision/MeshMasking.py
+++ b/meshroom/nodes/aliceVision/MeshMasking.py
@@ -1,6 +1,7 @@
 __version__ = "1.1"
 
 from meshroom.core import desc
+from meshroom.core.utils import VERBOSE_LEVEL
 
 
 class MeshMasking(desc.AVCommandLineNode):
@@ -99,8 +100,8 @@ Decimate triangles based on image masks.
             name="verboseLevel",
             label="Verbose Level",
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
+            values=VERBOSE_LEVEL,
             value="info",
-            values=["fatal", "error", "warning", "info", "debug", "trace"],
             exclusive=True,
             uid=[],
         )

--- a/meshroom/nodes/aliceVision/MeshResampling.py
+++ b/meshroom/nodes/aliceVision/MeshResampling.py
@@ -1,6 +1,7 @@
 __version__ = "1.0"
 
 from meshroom.core import desc
+from meshroom.core.utils import VERBOSE_LEVEL
 
 
 class MeshResampling(desc.AVCommandLineNode):
@@ -73,8 +74,8 @@ This node allows to recompute the mesh surface with a new topology and uniform d
             name="verboseLevel",
             label="Verbose Level",
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
+            values=VERBOSE_LEVEL,
             value="info",
-            values=["fatal", "error", "warning", "info", "debug", "trace"],
             exclusive=True,
             uid=[],
         )

--- a/meshroom/nodes/aliceVision/MeshResampling.py
+++ b/meshroom/nodes/aliceVision/MeshResampling.py
@@ -21,7 +21,7 @@ This node allows to recompute the mesh surface with a new topology and uniform d
             description="Input mesh in the OBJ file format.",
             value="",
             uid=[0],
-            ),
+        ),
         desc.FloatParam(
             name="simplificationFactor",
             label="Simplification Factor",
@@ -78,7 +78,7 @@ This node allows to recompute the mesh surface with a new topology and uniform d
             value="info",
             exclusive=True,
             uid=[],
-        )
+        ),
     ]
 
     outputs = [

--- a/meshroom/nodes/aliceVision/Meshing.py
+++ b/meshroom/nodes/aliceVision/Meshing.py
@@ -1,6 +1,7 @@
 __version__ = "7.0"
 
 from meshroom.core import desc
+from meshroom.core.utils import VERBOSE_LEVEL
 
 
 class Meshing(desc.AVCommandLineNode):
@@ -513,8 +514,8 @@ A Graph Cut Max-Flow is applied to optimally cut the volume. This cut represents
             name="verboseLevel",
             label="Verbose Level",
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
+            values=VERBOSE_LEVEL,
             value="info",
-            values=["fatal", "error", "warning", "info", "debug", "trace"],
             exclusive=True,
             uid=[],
         )

--- a/meshroom/nodes/aliceVision/Meshing.py
+++ b/meshroom/nodes/aliceVision/Meshing.py
@@ -55,7 +55,7 @@ A Graph Cut Max-Flow is applied to optimally cut the volume. This cut represents
                         "Parameters can be adjusted in advanced settings.",
             value=False,
             uid=[0],
-            group=""
+            group="",
         ),
         desc.GroupAttribute(
             name="boundingBox",
@@ -71,22 +71,22 @@ A Graph Cut Max-Flow is applied to optimally cut the volume. This cut represents
                             name="x", label="x", description="X offset.",
                             value=0.0,
                             uid=[0],
-                            range=(-20.0, 20.0, 0.01)
+                            range=(-20.0, 20.0, 0.01),
                         ),
                         desc.FloatParam(
                             name="y", label="y", description="Y offset.",
                             value=0.0,
                             uid=[0],
-                            range=(-20.0, 20.0, 0.01)
+                            range=(-20.0, 20.0, 0.01),
                         ),
                         desc.FloatParam(
                             name="z", label="z", description="Z offset.",
                             value=0.0,
                             uid=[0],
-                            range=(-20.0, 20.0, 0.01)
-                        )
+                            range=(-20.0, 20.0, 0.01),
+                        ),
                     ],
-                    joinChar=","
+                    joinChar=",",
                 ),
                 desc.GroupAttribute(
                     name="bboxRotation",
@@ -110,9 +110,9 @@ A Graph Cut Max-Flow is applied to optimally cut the volume. This cut represents
                             value=0.0,
                             uid=[0],
                             range=(-180.0, 180.0, 1.0)
-                        )
+                        ),
                     ],
-                    joinChar=","
+                    joinChar=",",
                 ),
                 desc.GroupAttribute(
                     name="bboxScale",
@@ -123,23 +123,23 @@ A Graph Cut Max-Flow is applied to optimally cut the volume. This cut represents
                             name="x", label="x", description="X scale.",
                             value=1.0,
                             uid=[0],
-                            range=(0.0, 20.0, 0.01)
+                            range=(0.0, 20.0, 0.01),
                         ),
                         desc.FloatParam(
                             name="y", label="y", description="Y scale.",
                             value=1.0,
                             uid=[0],
-                            range=(0.0, 20.0, 0.01)
+                            range=(0.0, 20.0, 0.01),
                         ),
                         desc.FloatParam(
                             name="z", label="z", description="Z scale.",
                             value=1.0,
                             uid=[0],
-                            range=(0.0, 20.0, 0.01)
-                        )
+                            range=(0.0, 20.0, 0.01),
+                        ),
                     ],
-                    joinChar=","
-                )
+                    joinChar=",",
+                ),
             ],
             joinChar=",",
             enabled=lambda node: node.useBoundingBox.value,
@@ -518,7 +518,7 @@ A Graph Cut Max-Flow is applied to optimally cut the volume. This cut represents
             value="info",
             exclusive=True,
             uid=[],
-        )
+        ),
     ]
 
     outputs = [

--- a/meshroom/nodes/aliceVision/NodalSfM.py
+++ b/meshroom/nodes/aliceVision/NodalSfM.py
@@ -1,6 +1,7 @@
 __version__ = "1.0"
 
 from meshroom.core import desc
+from meshroom.core.utils import DESCRIBER_TYPES, VERBOSE_LEVEL
 
 
 class NodalSfM(desc.AVCommandLineNode):
@@ -51,7 +52,7 @@ A Structure-From-Motion node specifically designed to handle pure rotation camer
             label="Describer Types",
             description="Describer types used to describe an image.",
             value=["dspsift"],
-            values=["sift", "sift_float", "sift_upright", "dspsift", "akaze", "akaze_liop", "akaze_mldb", "cctag3", "cctag4", "sift_ocv", "akaze_ocv", "tag16h5"],
+            values=DESCRIBER_TYPES,
             exclusive=False,
             uid=[0],
             joinChar=",",
@@ -60,8 +61,8 @@ A Structure-From-Motion node specifically designed to handle pure rotation camer
             name="verboseLevel",
             label="Verbose Level",
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
+            values=VERBOSE_LEVEL,
             value="info",
-            values=["fatal", "error", "warning", "info", "debug", "trace"],
             exclusive=True,
             uid=[],
         )

--- a/meshroom/nodes/aliceVision/NodalSfM.py
+++ b/meshroom/nodes/aliceVision/NodalSfM.py
@@ -31,7 +31,7 @@ A Structure-From-Motion node specifically designed to handle pure rotation camer
             ),
             name="featuresFolders",
             label="Features Folders",
-            description="Folder(s) containing the extracted features and descriptors."
+            description="Folder(s) containing the extracted features and descriptors.",
         ),
         desc.File(
             name="tracksFilename",
@@ -65,7 +65,7 @@ A Structure-From-Motion node specifically designed to handle pure rotation camer
             value="info",
             exclusive=True,
             uid=[],
-        )
+        ),
     ]
 
     outputs = [
@@ -75,5 +75,5 @@ A Structure-From-Motion node specifically designed to handle pure rotation camer
             description="Path to the output SfMData file.",
             value=desc.Node.internalFolder + "sfm.abc",
             uid=[],
-        )
+        ),
     ]

--- a/meshroom/nodes/aliceVision/NormalIntegration.py
+++ b/meshroom/nodes/aliceVision/NormalIntegration.py
@@ -1,6 +1,7 @@
 __version__ = "1.0"
 
 from meshroom.core import desc
+from meshroom.core.utils import VERBOSE_LEVEL
 
 class NormalIntegration(desc.CommandLineNode):
     commandLine = 'aliceVision_normalIntegration {allParams}'
@@ -37,8 +38,8 @@ TODO.
             name="verboseLevel",
             label="Verbose Level",
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
+            values=VERBOSE_LEVEL,
             value="info",
-            values=["fatal", "error", "warning", "info", "debug", "trace"],
             exclusive=True,
             uid=[],
         )

--- a/meshroom/nodes/aliceVision/NormalIntegration.py
+++ b/meshroom/nodes/aliceVision/NormalIntegration.py
@@ -16,7 +16,7 @@ TODO.
             label="Normal Maps Folder",
             description="Path to the folder containing the normal maps and the masks.",
             value="",
-            uid=[0]
+            uid=[0],
          ),
         desc.File(
             name="sfmDataFile",
@@ -32,7 +32,7 @@ TODO.
             value=1,
             range=(1, 10, 1),
             advanced=True,
-            uid=[0]
+            uid=[0],
         ),
         desc.ChoiceParam(
             name="verboseLevel",
@@ -42,7 +42,7 @@ TODO.
             value="info",
             exclusive=True,
             uid=[],
-        )
+        ),
     ]
 
     outputs = [
@@ -51,6 +51,6 @@ TODO.
             label="Output Path",
             description="Path to the output folder.",
             value=desc.Node.internalFolder,
-            uid=[]
-        )
+            uid=[],
+        ),
     ]

--- a/meshroom/nodes/aliceVision/PanoramaCompositing.py
+++ b/meshroom/nodes/aliceVision/PanoramaCompositing.py
@@ -4,6 +4,7 @@ import json
 import os
 
 from meshroom.core import desc
+from meshroom.core.utils import EXR_STORAGE_DATA_TYPE, VERBOSE_LEVEL
 
 
 class PanoramaCompositing(desc.AVCommandLineNode):
@@ -89,8 +90,8 @@ Multiple cameras are contributing to the low frequencies and only the best one c
                         " - half: Use half float (16 bits per channel).\n"
                         " - halfFinite: Use half float, but clamp values to avoid non-finite values.\n"
                         " - auto: Use half float if all values can fit, else use full float.",
+            values=EXR_STORAGE_DATA_TYPE,
             value="float",
-            values=["float", "half", "halfFinite", "auto"],
             exclusive=True,
             uid=[0],
         ),
@@ -112,8 +113,8 @@ Multiple cameras are contributing to the low frequencies and only the best one c
             name="verboseLevel",
             label="Verbose Level",
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
+            values=VERBOSE_LEVEL,
             value="info",
-            values=["fatal", "error", "warning", "info", "debug", "trace"],
             exclusive=True,
             uid=[],
         )

--- a/meshroom/nodes/aliceVision/PanoramaCompositing.py
+++ b/meshroom/nodes/aliceVision/PanoramaCompositing.py
@@ -55,7 +55,7 @@ Multiple cameras are contributing to the low frequencies and only the best one c
             value="multiband",
             values=["replace", "alpha", "multiband"],
             exclusive=True,
-            uid=[0]
+            uid=[0],
         ),
         desc.IntParam(
             name="forceMinPyramidLevels",
@@ -107,7 +107,7 @@ Multiple cameras are contributing to the low frequencies and only the best one c
             values=["none", "borders", "seams", "all"],
             exclusive=True,
             advanced=True,
-            uid=[0]
+            uid=[0],
         ),
         desc.ChoiceParam(
             name="verboseLevel",
@@ -117,7 +117,7 @@ Multiple cameras are contributing to the low frequencies and only the best one c
             value="info",
             exclusive=True,
             uid=[],
-        )
+        ),
     ]
 
     outputs = [
@@ -127,5 +127,5 @@ Multiple cameras are contributing to the low frequencies and only the best one c
             description="Output folder containing the composited panorama.",
             value=desc.Node.internalFolder,
             uid=[],
-        )
+        ),
     ]

--- a/meshroom/nodes/aliceVision/PanoramaEstimation.py
+++ b/meshroom/nodes/aliceVision/PanoramaEstimation.py
@@ -34,7 +34,7 @@ Estimate relative camera rotations between input images.
             ),
             name="featuresFolders",
             label="Features Folders",
-            description="Folder(s) containing the extracted features."
+            description="Folder(s) containing the extracted features.",
         ),
         desc.ListAttribute(
             elementDesc=desc.File(
@@ -46,7 +46,7 @@ Estimate relative camera rotations between input images.
             ),
             name="matchesFolders",
             label="Matches Folders",
-            description="Folder(s) in which computed matches are stored."
+            description="Folder(s) in which computed matches are stored.",
         ),
         desc.ChoiceParam(
             name="describerTypes",
@@ -181,7 +181,7 @@ Estimate relative camera rotations between input images.
             value="info",
             exclusive=True,
             uid=[],
-        )
+        ),
     ]
 
     outputs = [

--- a/meshroom/nodes/aliceVision/PanoramaEstimation.py
+++ b/meshroom/nodes/aliceVision/PanoramaEstimation.py
@@ -4,6 +4,7 @@ import json
 import os
 
 from meshroom.core import desc
+from meshroom.core.utils import DESCRIBER_TYPES, VERBOSE_LEVEL
 
 
 class PanoramaEstimation(desc.AVCommandLineNode):
@@ -51,9 +52,8 @@ Estimate relative camera rotations between input images.
             name="describerTypes",
             label="Describer Types",
             description="Describer types used to describe an image.",
+            values=DESCRIBER_TYPES,
             value=["sift"],
-            values=["sift", "sift_float", "sift_upright", "dspsift", "akaze", "akaze_liop", "akaze_mldb", "cctag3", "cctag4",
-                    "sift_ocv", "akaze_ocv"],
             exclusive=False,
             uid=[0],
             joinChar=",",
@@ -177,8 +177,8 @@ Estimate relative camera rotations between input images.
             name="verboseLevel",
             label="Verbose Level",
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
+            values=VERBOSE_LEVEL,
             value="info",
-            values=["fatal", "error", "warning", "info", "debug", "trace"],
             exclusive=True,
             uid=[],
         )

--- a/meshroom/nodes/aliceVision/PanoramaInit.py
+++ b/meshroom/nodes/aliceVision/PanoramaInit.py
@@ -61,7 +61,7 @@ This node allows to setup the Panorama:
                         "The contact sheet consists in a preview of the panorama using the input images.",
             value=True,
             uid=[0],
-            enabled=lambda node: node.config.enabled and node.config.value != ""
+            enabled=lambda node: node.config.enabled and node.config.value != "",
         ),
         desc.ListAttribute(
             elementDesc=desc.IntParam(
@@ -101,17 +101,23 @@ This node allows to setup the Panorama:
             description="Center of the fisheye circle (XY offset to the center in pixels).",
             groupDesc=[
                 desc.FloatParam(
-                    name="fisheyeCenterOffset_x", label="x", description="X offset in pixels.",
+                    name="fisheyeCenterOffset_x",
+                    label="x",
+                    description="X offset in pixels.",
                     value=0.0,
                     uid=[0],
-                    range=(-1000.0, 10000.0, 1.0)),
+                    range=(-1000.0, 10000.0, 1.0),
+                ),
                 desc.FloatParam(
-                    name="fisheyeCenterOffset_y", label="y", description="Y offset in pixels.",
+                    name="fisheyeCenterOffset_y",
+                    label="y",
+                    description="Y offset in pixels.",
                     value=0.0,
                     uid=[0],
-                    range=(-1000.0, 10000.0, 1.0)),
-                ],
-            group=None, # skip group from command line
+                    range=(-1000.0, 10000.0, 1.0),
+                ),
+            ],
+            group=None,  # skip group from command line
             enabled=lambda node: node.useFisheye.value and not node.estimateFisheyeCircle.value,
         ),
         desc.FloatParam(
@@ -130,7 +136,7 @@ This node allows to setup the Panorama:
             value="None",
             values=["None", "rotate90", "rotate180", "rotate270"],
             exclusive=True,
-            uid=[0]
+            uid=[0],
         ),
         desc.BoolParam(
             name="debugFisheyeCircleEstimation",
@@ -149,7 +155,7 @@ This node allows to setup the Panorama:
             value="info",
             exclusive=True,
             uid=[],
-        )
+        ),
     ]
 
     outputs = [
@@ -159,5 +165,5 @@ This node allows to setup the Panorama:
             description="Path to the output SfMData file.",
             value=desc.Node.internalFolder + "sfmData.sfm",
             uid=[],
-        )
+        ),
     ]

--- a/meshroom/nodes/aliceVision/PanoramaInit.py
+++ b/meshroom/nodes/aliceVision/PanoramaInit.py
@@ -1,6 +1,7 @@
 __version__ = "2.0"
 
 from meshroom.core import desc
+from meshroom.core.utils import VERBOSE_LEVEL
 
 
 class PanoramaInit(desc.AVCommandLineNode):
@@ -144,8 +145,8 @@ This node allows to setup the Panorama:
             name="verboseLevel",
             label="Verbose Level",
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
+            values=VERBOSE_LEVEL,
             value="info",
-            values=["fatal", "error", "warning", "info", "debug", "trace"],
             exclusive=True,
             uid=[],
         )

--- a/meshroom/nodes/aliceVision/PanoramaMerging.py
+++ b/meshroom/nodes/aliceVision/PanoramaMerging.py
@@ -71,7 +71,7 @@ Merge all inputs coming from the PanoramaCompositing node.
             value="info",
             exclusive=True,
             uid=[],
-        )
+        ),
     ]
 
     outputs = [

--- a/meshroom/nodes/aliceVision/PanoramaMerging.py
+++ b/meshroom/nodes/aliceVision/PanoramaMerging.py
@@ -4,6 +4,7 @@ import json
 import os
 
 from meshroom.core import desc
+from meshroom.core.utils import EXR_STORAGE_DATA_TYPE, VERBOSE_LEVEL
 
 
 class PanoramaMerging(desc.AVCommandLineNode):
@@ -57,8 +58,8 @@ Merge all inputs coming from the PanoramaCompositing node.
                         " - half: Use half float (16 bits per channel).\n"
                         " - halfFinite: Use half float, but clamp values to avoid non-finite values.\n"
                         " - auto: Use half float if all values can fit, else use full float.\n",
+            values=EXR_STORAGE_DATA_TYPE,
             value="float",
-            values=["float", "half", "halfFinite", "auto"],
             exclusive=True,
             uid=[0],
         ),
@@ -66,8 +67,8 @@ Merge all inputs coming from the PanoramaCompositing node.
             name="verboseLevel",
             label="Verbose Level",
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
+            values=VERBOSE_LEVEL,
             value="info",
-            values=["fatal", "error", "warning", "info", "debug", "trace"],
             exclusive=True,
             uid=[],
         )

--- a/meshroom/nodes/aliceVision/PanoramaPostProcessing.py
+++ b/meshroom/nodes/aliceVision/PanoramaPostProcessing.py
@@ -53,7 +53,7 @@ Post process the panorama.
             description="The width (in pixels) of the output panorama preview.",
             value=1000,
             range=(0, 5000, 100),
-            uid=[0]
+            uid=[0],
         ),
         desc.ChoiceParam(
             name="outputColorSpace",
@@ -82,7 +82,7 @@ Post process the panorama.
             value=0,
             range=(0, 500, 1),
             uid=[0],
-            enabled=lambda node: node.compressionMethod.value in ["dwaa", "dwab", "zip", "zips"]
+            enabled=lambda node: node.compressionMethod.value in ["dwaa", "dwab", "zip", "zips"],
         ),
         desc.StringParam(
             name="panoramaName",
@@ -91,7 +91,7 @@ Post process the panorama.
             value="panorama.exr",
             uid=[],
             group=None,
-            advanced=True
+            advanced=True,
         ),
         desc.StringParam(
             name="previewName",
@@ -110,7 +110,7 @@ Post process the panorama.
             value="info",
             exclusive=True,
             uid=[],
-        )
+        ),
     ]
 
     outputs = [

--- a/meshroom/nodes/aliceVision/PanoramaPostProcessing.py
+++ b/meshroom/nodes/aliceVision/PanoramaPostProcessing.py
@@ -4,7 +4,7 @@ import json
 import os
 
 from meshroom.core import desc
-from meshroom.core.utils import COLORSPACES
+from meshroom.core.utils import COLORSPACES, VERBOSE_LEVEL
 
 
 class PanoramaPostProcessing(desc.CommandLineNode):
@@ -106,8 +106,8 @@ Post process the panorama.
             name="verboseLevel",
             label="Verbose Level",
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
+            values=VERBOSE_LEVEL,
             value="info",
-            values=["fatal", "error", "warning", "info", "debug", "trace"],
             exclusive=True,
             uid=[],
         )

--- a/meshroom/nodes/aliceVision/PanoramaPrepareImages.py
+++ b/meshroom/nodes/aliceVision/PanoramaPrepareImages.py
@@ -1,6 +1,7 @@
 __version__ = "1.1"
 
 from meshroom.core import desc
+from meshroom.core.utils import VERBOSE_LEVEL
 
 import os.path
 
@@ -26,8 +27,8 @@ Prepare images for Panorama pipeline: ensures that images orientations are coher
             name="verboseLevel",
             label="Verbose Level",
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
+            values=VERBOSE_LEVEL,
             value="info",
-            values=["fatal", "error", "warning", "info", "debug", "trace"],
             exclusive=True,
             uid=[],
         ),

--- a/meshroom/nodes/aliceVision/PanoramaSeams.py
+++ b/meshroom/nodes/aliceVision/PanoramaSeams.py
@@ -4,6 +4,7 @@ import json
 import os
 
 from meshroom.core import desc
+from meshroom.core.utils import VERBOSE_LEVEL
 
 
 class PanoramaSeams(desc.AVCommandLineNode):
@@ -51,8 +52,8 @@ Estimate the seams lines between the inputs to provide an optimal compositing in
             name="verboseLevel",
             label="Verbose Level",
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
+            values=VERBOSE_LEVEL,
             value="info",
-            values=["fatal", "error", "warning", "info", "debug", "trace"],
             exclusive=True,
             uid=[],
         )

--- a/meshroom/nodes/aliceVision/PanoramaSeams.py
+++ b/meshroom/nodes/aliceVision/PanoramaSeams.py
@@ -56,7 +56,7 @@ Estimate the seams lines between the inputs to provide an optimal compositing in
             value="info",
             exclusive=True,
             uid=[],
-        )
+        ),
     ]
 
     outputs = [
@@ -74,5 +74,5 @@ Estimate the seams lines between the inputs to provide an optimal compositing in
             description="Path to the output SfMData file.",
             value=desc.Node.internalFolder + "panorama.sfm",
             uid=[],
-        )
+        ),
     ]

--- a/meshroom/nodes/aliceVision/PanoramaWarping.py
+++ b/meshroom/nodes/aliceVision/PanoramaWarping.py
@@ -4,7 +4,7 @@ import json
 import os
 
 from meshroom.core import desc
-from meshroom.core.utils import COLORSPACES
+from meshroom.core.utils import COLORSPACES, EXR_STORAGE_DATA_TYPE, VERBOSE_LEVEL
 
 
 class PanoramaWarping(desc.AVCommandLineNode):
@@ -83,8 +83,8 @@ Compute the image warping for each input image in the panorama coordinate system
                         " - half: Use half float (16 bits per channel).\n"
                         " - halfFinite: Use half float, but clamp values to avoid non-finite values.\n"
                         " - auto: Use half float if all values can fit, else use full float.",
+            values=EXR_STORAGE_DATA_TYPE,
             value="float",
-            values=["float", "half", "halfFinite", "auto"],
             exclusive=True,
             uid=[0],
         ),
@@ -92,8 +92,8 @@ Compute the image warping for each input image in the panorama coordinate system
             name="verboseLevel",
             label="Verbose Level",
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
+            values=VERBOSE_LEVEL,
             value="info",
-            values=["fatal", "error", "warning", "info", "debug", "trace"],
             exclusive=True,
             uid=[],
         ),

--- a/meshroom/nodes/aliceVision/PanoramaWarping.py
+++ b/meshroom/nodes/aliceVision/PanoramaWarping.py
@@ -55,7 +55,7 @@ Compute the image warping for each input image in the panorama coordinate system
             value=50,
             range=(0, 100, 1),
             enabled=lambda node: (node.estimateResolution.value),
-            uid=[0]
+            uid=[0],
         ),
         desc.IntParam(
             name="maxPanoramaWidth",

--- a/meshroom/nodes/aliceVision/PhotometricStereo.py
+++ b/meshroom/nodes/aliceVision/PhotometricStereo.py
@@ -1,6 +1,7 @@
 __version__ = "1.0"
 
 from meshroom.core import desc
+from meshroom.core.utils import VERBOSE_LEVEL
 
 class PhotometricStereo(desc.CommandLineNode):
     commandLine = 'aliceVision_photometricStereo {allParams}'
@@ -75,8 +76,8 @@ The lighting conditions are assumed to be known.
             name="verboseLevel",
             label="Verbose Level",
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
+            values=VERBOSE_LEVEL,
             value="info",
-            values=["fatal", "error", "warning", "info", "debug", "trace"],
             exclusive=True,
             uid=[],
         )

--- a/meshroom/nodes/aliceVision/PhotometricStereo.py
+++ b/meshroom/nodes/aliceVision/PhotometricStereo.py
@@ -17,7 +17,7 @@ The lighting conditions are assumed to be known.
             label="SfMData",
             description="Input SfMData file.",
             value="",
-            uid=[0]
+            uid=[0],
         ),
         desc.File(
             name="pathToJSONLightFile",
@@ -25,14 +25,14 @@ The lighting conditions are assumed to be known.
             description="Path to a JSON file containing the lighting information.\n"
                         "If empty, .txt files are expected in the image folder.",
             value="defaultJSON.txt",
-            uid=[0]
+            uid=[0],
         ),
         desc.File(
             name="maskPath",
             label="Mask Folder Path",
             description="Path to a folder containing masks or to a mask directly.",
             value="",
-            uid=[0]
+            uid=[0],
         ),
         desc.ChoiceParam(
             name="SHOrder",
@@ -45,7 +45,7 @@ The lighting conditions are assumed to be known.
             value="0",
             exclusive=True,
             advanced=True,
-            uid=[0]
+            uid=[0],
         ),
         desc.BoolParam(
             name="removeAmbiant",
@@ -53,7 +53,7 @@ The lighting conditions are assumed to be known.
             description="True if the ambiant light is to be removed on the PS images, false otherwise.",
             value=False,
             advanced=True,
-            uid=[0]
+            uid=[0],
         ),
         desc.BoolParam(
             name="isRobust",
@@ -61,7 +61,7 @@ The lighting conditions are assumed to be known.
             description="True to use the robust algorithm, false otherwise.",
             value=False,
             advanced=True,
-            uid=[0]
+            uid=[0],
         ),
         desc.IntParam(
             name="downscale",
@@ -70,7 +70,7 @@ The lighting conditions are assumed to be known.
             value=1,
             range=(1, 10, 1),
             advanced=True,
-            uid=[0]
+            uid=[0],
         ),
         desc.ChoiceParam(
             name="verboseLevel",
@@ -80,7 +80,7 @@ The lighting conditions are assumed to be known.
             value="info",
             exclusive=True,
             uid=[],
-        )
+        ),
     ]
 
     outputs = [
@@ -105,7 +105,7 @@ The lighting conditions are assumed to be known.
             description="Output SfMData file containing the albedo information.",
             value=desc.Node.internalFolder + "/albedoMaps.sfm",
             uid=[],
-            group="", # remove from command line
+            group="",  # remove from command line
         ),
         desc.File(
             name="outputSfmDataNormal",
@@ -113,7 +113,7 @@ The lighting conditions are assumed to be known.
             description="Output SfMData file containing the normal maps information.",
             value=desc.Node.internalFolder + "/normalMaps.sfm",
             uid=[],
-            group="", # remove from command line
+            group="",  # remove from command line
         ),
         # these attributes are only here to describe more accurately the output of the node
         # by specifying that it generates 2 sequences of images
@@ -125,7 +125,7 @@ The lighting conditions are assumed to be known.
             semantic="image",
             value=desc.Node.internalFolder + "<POSE_ID>_normals.exr",
             uid=[],
-            group="", # do not export on the command line
+            group="",  # do not export on the command line
         ),
         desc.File(
             name="normalsWorld",
@@ -134,7 +134,7 @@ The lighting conditions are assumed to be known.
             semantic="image",
             value=desc.Node.internalFolder + "<POSE_ID>_normals_w.exr",
             uid=[],
-            group="", # do not export on the command line
+            group="",  # do not export on the command line
         ),
         desc.File(
             name="albedo",
@@ -143,6 +143,6 @@ The lighting conditions are assumed to be known.
             semantic="image",
             value=desc.Node.internalFolder + "<POSE_ID>_albedo.exr",
             uid=[],
-            group="", # do not export on the command line
+            group="",  # do not export on the command line
         ),
     ]

--- a/meshroom/nodes/aliceVision/PrepareDenseScene.py
+++ b/meshroom/nodes/aliceVision/PrepareDenseScene.py
@@ -54,7 +54,7 @@ This node export undistorted images so the depth map and texturing can be comput
             value="png",
             values=["exr", "jpg", "png"],
             exclusive=True,
-            uid=[0]
+            uid=[0],
         ),
         desc.ChoiceParam(
             name="outputFileType",
@@ -64,7 +64,7 @@ This node export undistorted images so the depth map and texturing can be comput
             values=["jpg", "png", "tif", "exr"],
             exclusive=True,
             uid=[0],
-            advanced=True
+            advanced=True,
         ),
         desc.BoolParam(
             name="saveMetadata",
@@ -72,7 +72,7 @@ This node export undistorted images so the depth map and texturing can be comput
             description="Save projections and intrinsics information in images metadata (only for .exr images).",
             value=True,
             uid=[0],
-            advanced=True
+            advanced=True,
         ),
         desc.BoolParam(
             name="saveMatricesTxtFiles",
@@ -80,7 +80,7 @@ This node export undistorted images so the depth map and texturing can be comput
             description="Save projections and intrinsics information in text files.",
             value=False,
             uid=[0],
-            advanced=True
+            advanced=True,
         ),
         desc.BoolParam(
             name="evCorrection",
@@ -88,7 +88,7 @@ This node export undistorted images so the depth map and texturing can be comput
             description="Apply a correction on images' exposure value.",
             value=False,
             uid=[0],
-            advanced=True
+            advanced=True,
         ),
         desc.ChoiceParam(
             name="verboseLevel",
@@ -117,6 +117,6 @@ This node export undistorted images so the depth map and texturing can be comput
             value=desc.Node.internalFolder + "<VIEW_ID>.{outputFileTypeValue}",
             uid=[],
             group="",
-            advanced=True
+            advanced=True,
         ),
     ]

--- a/meshroom/nodes/aliceVision/PrepareDenseScene.py
+++ b/meshroom/nodes/aliceVision/PrepareDenseScene.py
@@ -1,6 +1,7 @@
 __version__ = "3.1"
 
 from meshroom.core import desc
+from meshroom.core.utils import VERBOSE_LEVEL
 
 
 class PrepareDenseScene(desc.AVCommandLineNode):
@@ -93,8 +94,8 @@ This node export undistorted images so the depth map and texturing can be comput
             name="verboseLevel",
             label="Verbose Level",
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
+            values=VERBOSE_LEVEL,
             value="info",
-            values=["fatal", "error", "warning", "info", "debug", "trace"],
             exclusive=True,
             uid=[],
         ),

--- a/meshroom/nodes/aliceVision/Publish.py
+++ b/meshroom/nodes/aliceVision/Publish.py
@@ -3,6 +3,8 @@ from __future__ import print_function
 __version__ = "1.3"
 
 from meshroom.core import desc
+from meshroom.core.utils import VERBOSE_LEVEL
+
 import distutils.dir_util as du
 import shutil
 import glob
@@ -42,8 +44,8 @@ This node allows to copy files into a specific folder.
             name="verboseLevel",
             label="Verbose Level",
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
+            values=VERBOSE_LEVEL,
             value="info",
-            values=["fatal", "error", "warning", "info", "debug", "trace"],
             exclusive=True,
             uid=[],
         ),

--- a/meshroom/nodes/aliceVision/RelativePoseEstimating.py
+++ b/meshroom/nodes/aliceVision/RelativePoseEstimating.py
@@ -1,6 +1,7 @@
 __version__ = "1.0"
 
 from meshroom.core import desc
+from meshroom.core.utils import DESCRIBER_TYPES, VERBOSE_LEVEL
 
 class RelativePoseEstimating(desc.AVCommandLineNode):
     commandLine = 'aliceVision_relativePoseEstimating {allParams}'
@@ -45,8 +46,8 @@ Estimate relative pose between each pair of views that share tracks.
             name="describerTypes",
             label="Describer Types",
             description="Describer types used to describe an image.",
+            values=DESCRIBER_TYPES,
             value=["dspsift"],
-            values=["sift", "sift_float", "sift_upright", "dspsift", "akaze", "akaze_liop", "akaze_mldb", "cctag3", "cctag4", "sift_ocv", "akaze_ocv", "tag16h5"],
             exclusive=False,
             uid=[0],
             joinChar=",",
@@ -62,8 +63,8 @@ Estimate relative pose between each pair of views that share tracks.
             name="verboseLevel",
             label="Verbose Level",
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
+            values=VERBOSE_LEVEL,
             value="info",
-            values=["fatal", "error", "warning", "info", "debug", "trace"],
             exclusive=True,
             uid=[],
         )

--- a/meshroom/nodes/aliceVision/RelativePoseEstimating.py
+++ b/meshroom/nodes/aliceVision/RelativePoseEstimating.py
@@ -33,7 +33,7 @@ Estimate relative pose between each pair of views that share tracks.
             ),
             name="featuresFolders",
             label="Features Folders",
-            description="Folder(s) containing the extracted features and descriptors."
+            description="Folder(s) containing the extracted features and descriptors.",
         ),
         desc.File(
             name="tracksFilename",
@@ -67,7 +67,7 @@ Estimate relative pose between each pair of views that share tracks.
             value="info",
             exclusive=True,
             uid=[],
-        )
+        ),
     ]
 
     outputs = [
@@ -77,5 +77,5 @@ Estimate relative pose between each pair of views that share tracks.
             description="Path to the output Pairs info files directory.",
             value=desc.Node.internalFolder,
             uid=[],
-        )
+        ),
     ]

--- a/meshroom/nodes/aliceVision/SfMAlignment.py
+++ b/meshroom/nodes/aliceVision/SfMAlignment.py
@@ -1,6 +1,7 @@
 __version__ = "2.0"
 
 from meshroom.core import desc
+from meshroom.core.utils import VERBOSE_LEVEL
 
 import os.path
 
@@ -104,8 +105,8 @@ The alignment can be based on:
             name="verboseLevel",
             label="Verbose Level",
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
+            values=VERBOSE_LEVEL,
             value="info",
-            values=["fatal", "error", "warning", "info", "debug", "trace"],
             exclusive=True,
             uid=[],
         ),

--- a/meshroom/nodes/aliceVision/SfMAlignment.py
+++ b/meshroom/nodes/aliceVision/SfMAlignment.py
@@ -85,21 +85,21 @@ The alignment can be based on:
             label="Scale",
             description="Apply scale transformation.",
             value=True,
-            uid=[0]
+            uid=[0],
         ),
         desc.BoolParam(
             name="applyRotation",
             label="Rotation",
             description="Apply rotation transformation.",
             value=True,
-            uid=[0]
+            uid=[0],
         ),
         desc.BoolParam(
             name="applyTranslation",
             label="Translation",
             description="Apply translation transformation.",
             value=True,
-            uid=[0]
+            uid=[0],
         ),
         desc.ChoiceParam(
             name="verboseLevel",

--- a/meshroom/nodes/aliceVision/SfMDistances.py
+++ b/meshroom/nodes/aliceVision/SfMDistances.py
@@ -1,6 +1,7 @@
 __version__ = "3.0"
 
 from meshroom.core import desc
+from meshroom.core.utils import DESCRIBER_TYPES, VERBOSE_LEVEL
 
 
 class SfMDistances(desc.AVCommandLineNode):
@@ -31,8 +32,8 @@ class SfMDistances(desc.AVCommandLineNode):
             name="landmarksDescriberTypes",
             label="Describer Types",
             description="Describer types used to describe an image (only used when using 'landmarks').",
+            values=DESCRIBER_TYPES,
             value=["cctag3"],
-            values=["sift", "sift_float", "sift_upright", "akaze", "akaze_liop", "akaze_mldb", "cctag3", "cctag4", "sift_ocv", "akaze_ocv"],
             exclusive=False,
             uid=[0],
             joinChar=",",
@@ -59,8 +60,8 @@ class SfMDistances(desc.AVCommandLineNode):
             name="verboseLevel",
             label="Verbose Level",
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
+            values=VERBOSE_LEVEL,
             value="info",
-            values=["fatal", "error", "warning", "info", "debug", "trace"],
             exclusive=True,
             uid=[],
         ),

--- a/meshroom/nodes/aliceVision/SfMMerge.py
+++ b/meshroom/nodes/aliceVision/SfMMerge.py
@@ -1,6 +1,8 @@
 __version__ = "1.0"
 
 from meshroom.core import desc
+from meshroom.core.utils import VERBOSE_LEVEL
+
 import os.path
 
 
@@ -57,8 +59,8 @@ Merges two SfMData files into a single one. Fails if some UID is shared among th
             name="verboseLevel",
             label="Verbose Level",
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
+            values=VERBOSE_LEVEL,
             value="info",
-            values=["fatal", "error", "warning", "info", "debug", "trace"],
             exclusive=True,
             uid=[],
         )

--- a/meshroom/nodes/aliceVision/SfMMerge.py
+++ b/meshroom/nodes/aliceVision/SfMMerge.py
@@ -63,7 +63,7 @@ Merges two SfMData files into a single one. Fails if some UID is shared among th
             value="info",
             exclusive=True,
             uid=[],
-        )
+        ),
     ]
 
     outputs = [

--- a/meshroom/nodes/aliceVision/SfMSplitReconstructed.py
+++ b/meshroom/nodes/aliceVision/SfMSplitReconstructed.py
@@ -48,5 +48,5 @@ class SfMSplitReconstructed(desc.AVCommandLineNode):
             description="SfMData file containing the non-reconstructed cameras.",
             value=desc.Node.internalFolder + "sfmNonReconstructed.abc",
             uid=[],
-        )
+        ),
     ]

--- a/meshroom/nodes/aliceVision/SfMSplitReconstructed.py
+++ b/meshroom/nodes/aliceVision/SfMSplitReconstructed.py
@@ -1,6 +1,7 @@
 __version__ = "1.0"
 
 from meshroom.core import desc
+from meshroom.core.utils import VERBOSE_LEVEL
 
 
 class SfMSplitReconstructed(desc.AVCommandLineNode):
@@ -26,8 +27,8 @@ class SfMSplitReconstructed(desc.AVCommandLineNode):
             name="verboseLevel",
             label="Verbose Level",
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
+            values=VERBOSE_LEVEL,
             value="info",
-            values=["fatal", "error", "warning", "info", "debug", "trace"],
             exclusive=True,
             uid=[],
         ),

--- a/meshroom/nodes/aliceVision/SfMToRig.py
+++ b/meshroom/nodes/aliceVision/SfMToRig.py
@@ -30,7 +30,7 @@ Assumes the input SfMData describes a set of cameras capturing a scene at a comm
             value="info",
             exclusive=True,
             uid=[],
-        )
+        ),
     ]
 
     outputs = [

--- a/meshroom/nodes/aliceVision/SfMToRig.py
+++ b/meshroom/nodes/aliceVision/SfMToRig.py
@@ -1,6 +1,8 @@
 __version__ = "1.0"
 
 from meshroom.core import desc
+from meshroom.core.utils import VERBOSE_LEVEL
+
 import os.path
 
 class SfMToRig(desc.AVCommandLineNode):
@@ -24,8 +26,8 @@ Assumes the input SfMData describes a set of cameras capturing a scene at a comm
             name="verboseLevel",
             label="Verbose Level",
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
+            values=VERBOSE_LEVEL,
             value="info",
-            values=["fatal", "error", "warning", "info", "debug", "trace"],
             exclusive=True,
             uid=[],
         )

--- a/meshroom/nodes/aliceVision/SfMTransfer.py
+++ b/meshroom/nodes/aliceVision/SfMTransfer.py
@@ -1,6 +1,7 @@
 __version__ = "2.1"
 
 from meshroom.core import desc
+from meshroom.core.utils import VERBOSE_LEVEL
 
 import os.path
 
@@ -96,8 +97,8 @@ This node allows to transfer poses and/or intrinsics form one SfM scene onto ano
             name="verboseLevel",
             label="Verbose Level",
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
+            values=VERBOSE_LEVEL,
             value="info",
-            values=["fatal", "error", "warning", "info", "debug", "trace"],
             exclusive=True,
             uid=[],
         ),

--- a/meshroom/nodes/aliceVision/SfMTransfer.py
+++ b/meshroom/nodes/aliceVision/SfMTransfer.py
@@ -77,21 +77,21 @@ This node allows to transfer poses and/or intrinsics form one SfM scene onto ano
             label="Poses",
             description="Transfer poses.",
             value=True,
-            uid=[0]
+            uid=[0],
         ),
         desc.BoolParam(
             name="transferIntrinsics",
             label="Intrinsics",
             description="Transfer cameras intrinsics.",
             value=True,
-            uid=[0]
+            uid=[0],
         ),
         desc.BoolParam(
             name="transferLandmarks",
             label="Landmarks",
             description="Transfer landmarks.",
             value=True,
-            uid=[0]
+            uid=[0],
         ),
         desc.ChoiceParam(
             name="verboseLevel",

--- a/meshroom/nodes/aliceVision/SfMTransform.py
+++ b/meshroom/nodes/aliceVision/SfMTransform.py
@@ -1,6 +1,7 @@
 __version__ = "3.1"
 
 from meshroom.core import desc
+from meshroom.core.utils import DESCRIBER_TYPES, VERBOSE_LEVEL
 
 import os.path
 
@@ -135,8 +136,8 @@ The transformation can be based on:
             name="landmarksDescriberTypes",
             label="Landmarks Describer Types",
             description="Image describer types used to compute the mean of the point cloud (only for 'landmarks' method).",
+            values=DESCRIBER_TYPES,
             value=["sift", "dspsift", "akaze"],
-            values=["sift", "sift_float", "sift_upright", "dspsift", "akaze", "akaze_liop", "akaze_mldb", "cctag3", "cctag4", "sift_ocv", "akaze_ocv", "tag16h5", "unknown"],
             exclusive=False,
             uid=[0],
             joinChar=",",
@@ -190,8 +191,8 @@ The transformation can be based on:
             name="verboseLevel",
             label="Verbose Level",
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
+            values=VERBOSE_LEVEL,
             value="info",
-            values=["fatal", "error", "warning", "info", "debug", "trace"],
             exclusive=True,
             uid=[],
         ),

--- a/meshroom/nodes/aliceVision/SfMTransform.py
+++ b/meshroom/nodes/aliceVision/SfMTransform.py
@@ -74,25 +74,31 @@ The transformation can be based on:
                     description="Translation in space.",
                     groupDesc=[
                         desc.FloatParam(
-                            name="x", label="x", description="X offset.",
+                            name="x",
+                            label="x",
+                            description="X offset.",
                             value=0.0,
                             uid=[0],
-                            range=(-20.0, 20.0, 0.01)
+                            range=(-20.0, 20.0, 0.01),
                         ),
                         desc.FloatParam(
-                            name="y", label="y", description="Y offset.",
+                            name="y",
+                            label="y",
+                            description="Y offset.",
                             value=0.0,
                             uid=[0],
-                            range=(-20.0, 20.0, 0.01)
+                            range=(-20.0, 20.0, 0.01),
                         ),
                         desc.FloatParam(
-                            name="z", label="z", description="Z offset.",
+                            name="z",
+                            label="z",
+                            description="Z offset.",
                             value=0.0,
                             uid=[0],
-                            range=(-20.0, 20.0, 0.01)
-                        )
+                            range=(-20.0, 20.0, 0.01),
+                        ),
                     ],
-                    joinChar=","
+                    joinChar=",",
                 ),
                 desc.GroupAttribute(
                     name="manualRotation",
@@ -100,25 +106,31 @@ The transformation can be based on:
                     description="Rotation in Euler angles.",
                     groupDesc=[
                         desc.FloatParam(
-                            name="x", label="x", description="Euler X rotation.",
+                            name="x",
+                            label="x",
+                            description="Euler X rotation.",
                             value=0.0,
                             uid=[0],
-                            range=(-90.0, 90.0, 1.0)
+                            range=(-90.0, 90.0, 1.0),
                         ),
                         desc.FloatParam(
-                            name="y", label="y", description="Euler Y rotation.",
+                            name="y",
+                            label="y",
+                            description="Euler Y rotation.",
                             value=0.0,
                             uid=[0],
-                            range=(-180.0, 180.0, 1.0)
+                            range=(-180.0, 180.0, 1.0),
                         ),
                         desc.FloatParam(
-                            name="z", label="z", description="Euler Z rotation.",
+                            name="z",
+                            label="z",
+                            description="Euler Z rotation.",
                             value=0.0,
                             uid=[0],
-                            range=(-180.0, 180.0, 1.0)
-                        )
+                            range=(-180.0, 180.0, 1.0),
+                        ),
                     ],
-                    joinChar=","
+                    joinChar=",",
                 ),
                 desc.FloatParam(
                     name="manualScale",
@@ -126,8 +138,8 @@ The transformation can be based on:
                     description="Uniform scale.",
                     value=1.0,
                     uid=[0],
-                    range=(0.0, 20.0, 0.01)
-                )
+                    range=(0.0, 20.0, 0.01),
+                ),
             ],
             joinChar=",",
             enabled=lambda node: node.method.value == "manual",
@@ -152,14 +164,54 @@ The transformation can be based on:
         ),
         desc.ListAttribute(
             name="markers",
-            elementDesc=desc.GroupAttribute(name="markerAlign", label="Marker Align", description="", joinChar=":", groupDesc=[
-                desc.IntParam(name="markerId", label="Marker", description="Marker ID.", value=0, uid=[0], range=(0, 32, 1)),
-                desc.GroupAttribute(name="markerCoord", label="Coord", description="Marker coordinates.", joinChar=",", groupDesc=[
-                    desc.FloatParam(name="x", label="x", description="X coordinates for the marker.", value=0.0, uid=[0], range=(-2.0, 2.0, 1.0)),
-                    desc.FloatParam(name="y", label="y", description="Y coordinates for the marker.", value=0.0, uid=[0], range=(-2.0, 2.0, 1.0)),
-                    desc.FloatParam(name="z", label="z", description="Z coordinates for the marker.", value=0.0, uid=[0], range=(-2.0, 2.0, 1.0)),
-                ])
-            ]),
+            elementDesc=desc.GroupAttribute(
+                name="markerAlign",
+                label="Marker Align",
+                description="",
+                joinChar=":",
+                groupDesc=[
+                    desc.IntParam(
+                        name="markerId",
+                        label="Marker",
+                        description="Marker ID.",
+                        value=0,
+                        uid=[0],
+                        range=(0, 32, 1),
+                    ),
+                    desc.GroupAttribute(
+                        name="markerCoord",
+                        label="Coord",
+                        description="Marker coordinates.",
+                        joinChar=",",
+                        groupDesc=[
+                            desc.FloatParam(
+                                name="x",
+                                label="x",
+                                description="X coordinates for the marker.",
+                                value=0.0,
+                                uid=[0],
+                                range=(-2.0, 2.0, 1.0),
+                            ),
+                            desc.FloatParam(
+                                name="y",
+                                label="y",
+                                description="Y coordinates for the marker.",
+                                value=0.0,
+                                uid=[0],
+                                range=(-2.0, 2.0, 1.0),
+                            ),
+                            desc.FloatParam(
+                                name="z",
+                                label="z",
+                                description="Z coordinates for the marker.",
+                                value=0.0,
+                                uid=[0],
+                                range=(-2.0, 2.0, 1.0),
+                            ),
+                        ],
+                    ),
+                ],
+            ),
             label="Markers",
             description="Markers alignment points.",
         ),

--- a/meshroom/nodes/aliceVision/SfMTriangulation.py
+++ b/meshroom/nodes/aliceVision/SfMTriangulation.py
@@ -1,6 +1,7 @@
 __version__ = "1.0"
 
 from meshroom.core import desc
+from meshroom.core.utils import DESCRIBER_TYPES, VERBOSE_LEVEL
 
 
 class SfMTriangulation(desc.AVCommandLineNode):
@@ -49,8 +50,8 @@ Contrary to the StructureFromMotion node, this node does not infer the camera po
             name="describerTypes",
             label="Describer Types",
             description="Describer types used to describe an image.",
+            values=DESCRIBER_TYPES,
             value=["dspsift"],
-            values=["sift", "sift_float", "sift_upright", "dspsift", "akaze", "akaze_liop", "akaze_mldb", "cctag3", "cctag4", "sift_ocv", "akaze_ocv", "tag16h5"],
             exclusive=False,
             uid=[0],
             joinChar=",",
@@ -143,8 +144,8 @@ Contrary to the StructureFromMotion node, this node does not infer the camera po
             name="verboseLevel",
             label="Verbose Level",
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
+            values=VERBOSE_LEVEL,
             value="info",
-            values=["fatal", "error", "warning", "info", "debug", "trace"],
             exclusive=True,
             uid=[],
         )

--- a/meshroom/nodes/aliceVision/SfMTriangulation.py
+++ b/meshroom/nodes/aliceVision/SfMTriangulation.py
@@ -32,7 +32,7 @@ Contrary to the StructureFromMotion node, this node does not infer the camera po
             ),
             name="featuresFolders",
             label="Features Folders",
-            description="Folder(s) containing the extracted features and descriptors."
+            description="Folder(s) containing the extracted features and descriptors.",
         ),
         desc.ListAttribute(
             elementDesc=desc.File(
@@ -44,7 +44,7 @@ Contrary to the StructureFromMotion node, this node does not infer the camera po
             ),
             name="matchesFolders",
             label="Matches Folders",
-            description="Folder(s) in which computed matches are stored."
+            description="Folder(s) in which computed matches are stored.",
         ),
         desc.ChoiceParam(
             name="describerTypes",
@@ -148,7 +148,7 @@ Contrary to the StructureFromMotion node, this node does not infer the camera po
             value="info",
             exclusive=True,
             uid=[],
-        )
+        ),
     ]
 
     outputs = [

--- a/meshroom/nodes/aliceVision/SfmBootstraping.py
+++ b/meshroom/nodes/aliceVision/SfmBootstraping.py
@@ -30,7 +30,7 @@ class SfMBootStraping(desc.AVCommandLineNode):
             ),
             name="featuresFolders",
             label="Features Folders",
-            description="Folder(s) containing the extracted features and descriptors."
+            description="Folder(s) containing the extracted features and descriptors.",
         ),
         desc.File(
             name="tracksFilename",
@@ -64,7 +64,7 @@ class SfMBootStraping(desc.AVCommandLineNode):
             value="info",
             exclusive=True,
             uid=[],
-        )
+        ),
     ]
 
     outputs = [
@@ -74,5 +74,5 @@ class SfMBootStraping(desc.AVCommandLineNode):
             description="Path to the output SfMData file.",
             value=desc.Node.internalFolder + "sfm.json",
             uid=[],
-        )
+        ),
     ]

--- a/meshroom/nodes/aliceVision/SfmBootstraping.py
+++ b/meshroom/nodes/aliceVision/SfmBootstraping.py
@@ -1,6 +1,7 @@
 __version__ = "1.0"
 
 from meshroom.core import desc
+from meshroom.core.utils import DESCRIBER_TYPES, VERBOSE_LEVEL
 
 
 class SfMBootStraping(desc.AVCommandLineNode):
@@ -49,8 +50,8 @@ class SfMBootStraping(desc.AVCommandLineNode):
             name="describerTypes",
             label="Describer Types",
             description="Describer types used to describe an image.",
+            values=DESCRIBER_TYPES,
             value=["dspsift"],
-            values=["sift", "sift_float", "sift_upright", "dspsift", "akaze", "akaze_liop", "akaze_mldb", "cctag3", "cctag4", "sift_ocv", "akaze_ocv", "tag16h5"],
             exclusive=False,
             uid=[0],
             joinChar=",",
@@ -59,8 +60,8 @@ class SfMBootStraping(desc.AVCommandLineNode):
             name="verboseLevel",
             label="Verbose Level",
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
+            values=VERBOSE_LEVEL,
             value="info",
-            values=["fatal", "error", "warning", "info", "debug", "trace"],
             exclusive=True,
             uid=[],
         )

--- a/meshroom/nodes/aliceVision/SketchfabUpload.py
+++ b/meshroom/nodes/aliceVision/SketchfabUpload.py
@@ -1,6 +1,8 @@
 __version__ = "1.0"
 
 from meshroom.core import desc
+from meshroom.core.utils import VERBOSE_LEVEL
+
 import glob
 import os
 import json
@@ -177,9 +179,9 @@ Upload a textured mesh on Sketchfab.
         desc.ChoiceParam(
             name="verboseLevel",
             label="Verbose Level",
-            description="Verbosity level (critical, error, warning, info, debug).",
+            description="Verbosity level (fatal, error, warning, info, debug, trace).",
+            values=VERBOSE_LEVEL,
             value="info",
-            values=["critical", "error", "warning", "info", "debug"],
             exclusive=True,
             uid=[],
         ),

--- a/meshroom/nodes/aliceVision/SphereDetection.py
+++ b/meshroom/nodes/aliceVision/SphereDetection.py
@@ -18,21 +18,21 @@ Spheres can be automatically detected or manually defined in the interface.
             label="SfMData",
             description="Input SfMData file.",
             value="",
-            uid=[0]
+            uid=[0],
         ),
         desc.File(
             name="modelPath",
             label="Detection Network",
             description="Deep learning network for automatic calibration sphere detection.",
             value="${ALICEVISION_SPHERE_DETECTION_MODEL}",
-            uid=[0]
+            uid=[0],
         ),
         desc.BoolParam(
             name="autoDetect",
             label="Automatic Sphere Detection",
             description="Automatic detection of calibration spheres.",
             value=False,
-            uid=[0]
+            uid=[0],
         ),
         desc.FloatParam(
             name="minScore",
@@ -41,7 +41,7 @@ Spheres can be automatically detected or manually defined in the interface.
             value=0.0,
             range=(0.0, 50.0, 0.01),
             advanced=True,
-            uid=[0]
+            uid=[0],
         ),
         desc.GroupAttribute(
             name="sphereCenter",
@@ -49,18 +49,24 @@ Spheres can be automatically detected or manually defined in the interface.
             description="Center of the circle (XY offset to the center of the image in pixels).",
             groupDesc=[
                 desc.FloatParam(
-                    name="x", label="x", description="X offset in pixels.",
+                    name="x",
+                    label="x",
+                    description="X offset in pixels.",
                     value=0.0,
                     uid=[0],
-                    range=(-1000.0, 10000.0, 1.0)),
+                    range=(-1000.0, 10000.0, 1.0),
+                ),
                 desc.FloatParam(
-                    name="y", label="y", description="Y offset in pixels.",
+                    name="y",
+                    label="y",
+                    description="Y offset in pixels.",
                     value=0.0,
                     uid=[0],
-                    range=(-1000.0, 10000.0, 1.0)),
-                ],
+                    range=(-1000.0, 10000.0, 1.0),
+                ),
+            ],
             enabled=lambda node: not node.autoDetect.value,
-            group=None # skip group from command line
+            group=None,  # skip group from command line
         ),
         desc.FloatParam(
             name="sphereRadius",
@@ -69,7 +75,7 @@ Spheres can be automatically detected or manually defined in the interface.
             value=500.0,
             range=(0.0, 1000.0, 0.1),
             enabled=lambda node: not node.autoDetect.value,
-            uid=[0]
+            uid=[0],
         ),
         desc.ChoiceParam(
             name="verboseLevel",
@@ -79,7 +85,7 @@ Spheres can be automatically detected or manually defined in the interface.
             value="info",
             exclusive=True,
             uid=[],
-        )
+        ),
     ]
 
     outputs = [
@@ -88,6 +94,6 @@ Spheres can be automatically detected or manually defined in the interface.
             label="Output Folder",
             description="Sphere detection information will be written here.",
             value=desc.Node.internalFolder,
-            uid=[]
-        )
+            uid=[],
+        ),
     ]

--- a/meshroom/nodes/aliceVision/SphereDetection.py
+++ b/meshroom/nodes/aliceVision/SphereDetection.py
@@ -1,6 +1,7 @@
 __version__ = "1.0"
 
 from meshroom.core import desc
+from meshroom.core.utils import VERBOSE_LEVEL
 
 
 class SphereDetection(desc.CommandLineNode):
@@ -74,8 +75,8 @@ Spheres can be automatically detected or manually defined in the interface.
             name="verboseLevel",
             label="Verbose Level",
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
+            values=VERBOSE_LEVEL,
             value="info",
-            values=["fatal", "error", "warning", "info", "debug", "trace"],
             exclusive=True,
             uid=[],
         )

--- a/meshroom/nodes/aliceVision/Split360Images.py
+++ b/meshroom/nodes/aliceVision/Split360Images.py
@@ -1,6 +1,7 @@
 __version__ = "3.0"
 
 from meshroom.core import desc
+from meshroom.core.utils import VERBOSE_LEVEL
 
 
 class Split360InputNodeSize(desc.DynamicNodeSize):
@@ -124,8 +125,8 @@ class Split360Images(desc.AVCommandLineNode):
             name="verboseLevel",
             label="Verbose Level",
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
+            values=VERBOSE_LEVEL,
             value="info",
-            values=["fatal", "error", "warning", "info", "debug", "trace"],
             exclusive=True,
             uid=[],
         ),

--- a/meshroom/nodes/aliceVision/Split360Images.py
+++ b/meshroom/nodes/aliceVision/Split360Images.py
@@ -44,7 +44,11 @@ class Split360Images(desc.AVCommandLineNode):
             exclusive=True,
             uid=[0],
         ),
-        desc.GroupAttribute(name="dualFisheyeGroup", label="Dual Fisheye", description="Dual Fisheye.", group=None,
+        desc.GroupAttribute(
+            name="dualFisheyeGroup",
+            label="Dual Fisheye",
+            description="Dual Fisheye.",
+            group=None,
             enabled=lambda node: node.splitMode.value == "dualfisheye",
             groupDesc=[
                 desc.ChoiceParam(
@@ -74,9 +78,13 @@ class Split360Images(desc.AVCommandLineNode):
                     exclusive=True,
                     uid=[0],
                 ),
-            ]
+            ],
         ),
-        desc.GroupAttribute(name="equirectangularGroup", label="Equirectangular", description="Equirectangular", group=None,
+        desc.GroupAttribute(
+            name="equirectangularGroup",
+            label="Equirectangular",
+            description="Equirectangular",
+            group=None,
             enabled=lambda node: node.splitMode.value == "equirectangular",
             groupDesc=[
                 desc.IntParam(
@@ -110,7 +118,7 @@ class Split360Images(desc.AVCommandLineNode):
                     range=(0.0, 180.0, 1.0),
                     uid=[0],
                 ),
-            ]
+            ],
         ),
         desc.ChoiceParam(
             name="extension",

--- a/meshroom/nodes/aliceVision/StructureFromMotion.py
+++ b/meshroom/nodes/aliceVision/StructureFromMotion.py
@@ -80,7 +80,7 @@ It iterates like that, adding cameras and triangulating new 2D features into 3D 
             ),
             name="featuresFolders",
             label="Features Folders",
-            description="Folder(s) containing the extracted features and descriptors."
+            description="Folder(s) containing the extracted features and descriptors.",
         ),
         desc.ListAttribute(
             elementDesc=desc.File(
@@ -92,7 +92,7 @@ It iterates like that, adding cameras and triangulating new 2D features into 3D 
             ),
             name="matchesFolders",
             label="Matches Folders",
-            description="Folder(s) in which the computed matches are stored."
+            description="Folder(s) in which the computed matches are stored.",
         ),
         desc.ChoiceParam(
             name="describerTypes",
@@ -180,7 +180,7 @@ It iterates like that, adding cameras and triangulating new 2D features into 3D 
             value=30,
             range=(0, 100, 1),
             uid=[0],
-            advanced=True
+            advanced=True,
         ),
         desc.IntParam(
             name="maxImagesPerGroup",
@@ -190,7 +190,7 @@ It iterates like that, adding cameras and triangulating new 2D features into 3D 
             value=30,
             range=(0, 100, 1),
             uid=[0],
-            advanced=True
+            advanced=True,
         ),
         desc.IntParam(
             name="bundleAdjustmentMaxOutliers",
@@ -200,7 +200,7 @@ It iterates like that, adding cameras and triangulating new 2D features into 3D 
             value=50,
             range=(-1, 1000, 1),
             uid=[0],
-            advanced=True
+            advanced=True,
         ),
         desc.IntParam(
             name="maxNumberOfMatches",
@@ -389,7 +389,7 @@ It iterates like that, adding cameras and triangulating new 2D features into 3D 
             description="Dump the current state of the scene as an SfMData file every 3 resections.",
             value=False,
             uid=[],
-            advanced=True
+            advanced=True,
         ),
         desc.ChoiceParam(
             name="verboseLevel",
@@ -399,7 +399,7 @@ It iterates like that, adding cameras and triangulating new 2D features into 3D 
             value="info",
             exclusive=True,
             uid=[],
-        )
+        ),
     ]
 
     outputs = [

--- a/meshroom/nodes/aliceVision/StructureFromMotion.py
+++ b/meshroom/nodes/aliceVision/StructureFromMotion.py
@@ -1,6 +1,7 @@
 __version__ = "3.3"
 
 from meshroom.core import desc
+from meshroom.core.utils import DESCRIBER_TYPES, VERBOSE_LEVEL
 
 
 class StructureFromMotion(desc.AVCommandLineNode):
@@ -97,8 +98,8 @@ It iterates like that, adding cameras and triangulating new 2D features into 3D 
             name="describerTypes",
             label="Describer Types",
             description="Describer types used to describe an image.",
+            values=DESCRIBER_TYPES,
             value=["dspsift"],
-            values=["sift", "sift_float", "sift_upright", "dspsift", "akaze", "akaze_liop", "akaze_mldb", "cctag3", "cctag4", "sift_ocv", "akaze_ocv", "tag16h5"],
             exclusive=False,
             uid=[0],
             joinChar=",",
@@ -394,8 +395,8 @@ It iterates like that, adding cameras and triangulating new 2D features into 3D 
             name="verboseLevel",
             label="Verbose Level",
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
+            values=VERBOSE_LEVEL,
             value="info",
-            values=["fatal", "error", "warning", "info", "debug", "trace"],
             exclusive=True,
             uid=[],
         )

--- a/meshroom/nodes/aliceVision/Texturing.py
+++ b/meshroom/nodes/aliceVision/Texturing.py
@@ -1,7 +1,8 @@
 __version__ = "6.0"
 
 from meshroom.core import desc, Version
-from meshroom.core.utils import COLORSPACES
+from meshroom.core.utils import COLORSPACES, VERBOSE_LEVEL
+
 import logging
 
 
@@ -325,8 +326,8 @@ Many cameras are contributing to the low frequencies and only the best ones cont
             name="verboseLevel",
             label="Verbose Level",
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
+            values=VERBOSE_LEVEL,
             value="info",
-            values=["fatal", "error", "warning", "info", "debug", "trace"],
             exclusive=True,
             uid=[],
         ),

--- a/meshroom/nodes/aliceVision/Texturing.py
+++ b/meshroom/nodes/aliceVision/Texturing.py
@@ -83,7 +83,10 @@ Many cameras are contributing to the low frequencies and only the best ones cont
             exclusive=True,
             uid=[0],
         ),
-        desc.GroupAttribute(name="colorMapping", label="Color Mapping", description="Color map parameters.",
+        desc.GroupAttribute(
+            name="colorMapping",
+            label="Color Mapping",
+            description="Color map parameters.",
             enabled=lambda node: (node.imagesFolder.value != ''),
             group=None,
             groupDesc=[
@@ -107,7 +110,10 @@ Many cameras are contributing to the low frequencies and only the best ones cont
                 ),
             ],
         ),
-        desc.GroupAttribute(name="bumpMapping", label="Bump Mapping", description="Bump mapping parameters.",
+        desc.GroupAttribute(
+            name="bumpMapping",
+            label="Bump Mapping",
+            description="Bump mapping parameters.",
             enabled=lambda node: (node.inputRefMesh.value != ''),
             group=None,
             groupDesc=[
@@ -151,7 +157,10 @@ Many cameras are contributing to the low frequencies and only the best ones cont
                 ),
             ],
         ),
-        desc.GroupAttribute(name="displacementMapping", label="Displacement Mapping", description="Displacement mapping parameters.",
+        desc.GroupAttribute(
+            name="displacementMapping",
+            label="Displacement Mapping",
+            description="Displacement mapping parameters.",
             enabled=lambda node: (node.inputRefMesh.value != ""),
             group=None,
             groupDesc=[
@@ -168,7 +177,7 @@ Many cameras are contributing to the low frequencies and only the best ones cont
                     label="File Type",
                     description="File type for the height map texture.",
                     value="exr",
-                    values=("exr",),
+                    values=("exr"),
                     exclusive=True,
                     uid=[0],
                     enabled=lambda node: node.displacementMapping.enable.value,
@@ -223,10 +232,38 @@ Many cameras are contributing to the low frequencies and only the best ones cont
             name="multiBandNbContrib",
             label="Multi-Band Contributions",
             groupDesc=[
-                desc.IntParam(name="high", label="High Freq", description="High frequency band.", value=1, uid=[0], range=None),
-                desc.IntParam(name="midHigh", label="Mid-High Freq", description="Mid-high frequency band.", value=5, uid=[0], range=None),
-                desc.IntParam(name="midLow", label="Mid-Low Freq", description="Mid-low frequency band.", value=10, uid=[0], range=None),
-                desc.IntParam(name="low", label="Low Freq", description="Low frequency band", value=0, uid=[0], range=None),
+                desc.IntParam(
+                    name="high",
+                    label="High Freq",
+                    description="High frequency band.",
+                    value=1,
+                    uid=[0],
+                    range=None,
+                ),
+                desc.IntParam(
+                    name="midHigh",
+                    label="Mid-High Freq",
+                    description="Mid-high frequency band.",
+                    value=5,
+                    uid=[0],
+                    range=None,
+                ),
+                desc.IntParam(
+                    name="midLow",
+                    label="Mid-Low Freq",
+                    description="Mid-low frequency band.",
+                    value=10,
+                    uid=[0],
+                    range=None,
+                ),
+                desc.IntParam(
+                    name="low",
+                    label="Low Freq",
+                    description="Low frequency band",
+                    value=0,
+                    uid=[0],
+                    range=None,
+                ),
             ],
             description="Number of contributions per frequency band for multi-band blending (each frequency band also contributes to lower bands).",
             advanced=True,
@@ -333,7 +370,6 @@ Many cameras are contributing to the low frequencies and only the best ones cont
         ),
     ]
 
-
     outputs = [
         desc.File(
             name="output",
@@ -365,8 +401,8 @@ Many cameras are contributing to the low frequencies and only the best ones cont
             description="Output texture files.",
             value=lambda attr: desc.Node.internalFolder + "texture_*." + attr.node.colorMapping.colorMappingFileType.value if attr.node.colorMapping.enable.value else "",
             uid=[],
-            group=""
-        )
+            group="",
+        ),
     ]
 
     def upgradeAttributeValues(self, attrValues, fromVersion):

--- a/meshroom/nodes/aliceVision/TracksBuilding.py
+++ b/meshroom/nodes/aliceVision/TracksBuilding.py
@@ -31,7 +31,7 @@ It fuses all feature matches between image pairs into tracks. Each track represe
             ),
             name="featuresFolders",
             label="Features Folders",
-            description="Folder(s) containing the extracted features and descriptors."
+            description="Folder(s) containing the extracted features and descriptors.",
         ),
         desc.ListAttribute(
             elementDesc=desc.File(
@@ -43,7 +43,7 @@ It fuses all feature matches between image pairs into tracks. Each track represe
             ),
             name="matchesFolders",
             label="Matches Folders",
-            description="Folder(s) in which computed matches are stored."
+            description="Folder(s) in which computed matches are stored.",
         ),
         desc.ChoiceParam(
             name="describerTypes",
@@ -88,7 +88,7 @@ It fuses all feature matches between image pairs into tracks. Each track represe
             value="info",
             exclusive=True,
             uid=[],
-        )
+        ),
     ]
 
     outputs = [

--- a/meshroom/nodes/aliceVision/TracksBuilding.py
+++ b/meshroom/nodes/aliceVision/TracksBuilding.py
@@ -1,6 +1,7 @@
 __version__ = "1.0"
 
 from meshroom.core import desc
+from meshroom.core.utils import DESCRIBER_TYPES, VERBOSE_LEVEL
 
 
 class TracksBuilding(desc.AVCommandLineNode):
@@ -48,8 +49,8 @@ It fuses all feature matches between image pairs into tracks. Each track represe
             name="describerTypes",
             label="Describer Types",
             description="Describer types used to describe an image.",
+            values=DESCRIBER_TYPES,
             value=["dspsift"],
-            values=["sift", "sift_float", "sift_upright", "dspsift", "akaze", "akaze_liop", "akaze_mldb", "cctag3", "cctag4", "sift_ocv", "akaze_ocv", "tag16h5"],
             exclusive=False,
             uid=[0],
             joinChar=",",
@@ -83,8 +84,8 @@ It fuses all feature matches between image pairs into tracks. Each track represe
             name="verboseLevel",
             label="Verbose Level",
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
+            values=VERBOSE_LEVEL,
             value="info",
-            values=["fatal", "error", "warning", "info", "debug", "trace"],
             exclusive=True,
             uid=[],
         )

--- a/meshroom/nodes/blender/ScenePreview.py
+++ b/meshroom/nodes/blender/ScenePreview.py
@@ -105,7 +105,7 @@ One frame per viewpoint will be rendered, and the undistorted views can optional
                     exclusive=True,
                     uid=[0],
                 ),
-            ]
+            ],
         ),
         desc.GroupAttribute(
             name="meshParams",
@@ -132,7 +132,7 @@ One frame per viewpoint will be rendered, and the undistorted views can optional
                     exclusive=True,
                     uid=[0],
                 ),
-            ]
+            ],
         ),
     ]
 


### PR DESCRIPTION
## Description

A `utils.py` file was added in #2251 to store utilitary constants for the list of values of `ChoiceParams` that are used across several nodes in order to reduce code duplication.

In addition to the already existing `COLORSPACES` constant, the following ones are added:
- `VERBOSE_LEVEL`, which lists the criticity of the displayed logs (used in every node);
- `EXR_STORAGE_DATA_TYPE`, which lists the type of storage to use for EXR output files;
- `DESCRIBER_TYPES`, which lists the types of image describers;
- `RAW_COLOR_INTERPRETATION`, which lists the way RAW images can be color-processed.

All the nodes using these lists of values for one (or more) of their `ChoiceParam` attribute are updated to use the relevant utilitary constant instead.

An additional commit of formatting has been pushed to harmonize the use of trailing commas in lists across all the nodes.