### PR TITLE
[pipelines] NodalTracking: Apply masks in `ScenePreview`

### DIFF
--- a/meshroom/pipelines/nodalCameraTracking.mg
+++ b/meshroom/pipelines/nodalCameraTracking.mg
@@ -170,7 +170,6 @@
                 "cameras": "{ConvertSfMFormat_1.output}",
                 "model": "{NodalSfM_1.output}",
                 "undistortedImages": "{ExportAnimatedCamera_1.outputUndistorted}",
-                "useMasks": false,
                 "masks": "{ImageSegmentation_1.output}",
                 "pointCloudParams": {
                     "particleSize": 0.001,

--- a/meshroom/pipelines/nodalCameraTrackingWithoutCalibration.mg
+++ b/meshroom/pipelines/nodalCameraTrackingWithoutCalibration.mg
@@ -166,7 +166,6 @@
                 "cameras": "{ConvertSfMFormat_1.output}",
                 "model": "{NodalSfM_1.output}",
                 "undistortedImages": "{ExportAnimatedCamera_1.outputUndistorted}",
-                "useMasks": false,
                 "masks": "{ImageSegmentation_1.output}",
                 "pointCloudParams": {
                     "particleSize": 0.001,


### PR DESCRIPTION
## Description

Enable the "Apply Masks" option in the `ScenePreview` node for the Nodal Camera Tracking templates. 