### PR TITLE
[nodes] KeyframeSelection: Update default minimum number of keyframes

### DIFF
--- a/meshroom/nodes/aliceVision/KeyframeSelection.py
+++ b/meshroom/nodes/aliceVision/KeyframeSelection.py
@@ -212,7 +212,7 @@ You can extract frames at regular interval by configuring only the min/maxFrameS
                             name="minNbOutFrames",
                             label="Min Nb Output Frames",
                             description="Minimum number of frames selected to be keyframes.",
-                            value=10,
+                            value=40,
                             range=(1, 100, 1),
                             uid=[0],
                             enabled=lambda node: node.smartSelection.enabled,


### PR DESCRIPTION
## Description

This PR updates the default value for the `minNbOutFrames` parameter of the KeyframeSelection node from 10 to 40.

## Implementation remarks

All the templates that include a KeyframeSelection node use its default value for the minimum number of output keyframes. They will thus be automatically updated with the latest default value.