### PR TITLE
[nodes] ExportanimatedCamera: change default value for the principal point correction

### DIFF
--- a/meshroom/nodes/aliceVision/ExportAnimatedCamera.py
+++ b/meshroom/nodes/aliceVision/ExportAnimatedCamera.py
@@ -75,7 +75,7 @@ Based on the input image filenames, it will recognize the input video sequence t
             name="correctPrincipalPoint",
             label="Correct Principal Point",
             description="Correct principal point.",
-            value=True,
+            value=False,
             uid=[0],
         ),
         desc.ChoiceParam(


### PR DESCRIPTION
The export in Alembic (for Maya, blender, etc) now includes the principal point values, so there is no reason to correct the principal point by default.

Linked to https://github.com/alicevision/AliceVision/pull/1686
