### PR TITLE
[core/ui] Load image sequence from node's output in SequencePlayer

### DIFF
--- a/meshroom/__init__.py
+++ b/meshroom/__init__.py
@@ -150,3 +150,4 @@ def setupEnvironment(backend=Backend.STANDALONE):
 
 
 os.environ["QML_XHR_ALLOW_FILE_READ"] = '1'
+os.environ["PYSEQ_STRICT_PAD"] = '1'

--- a/meshroom/core/attribute.py
+++ b/meshroom/core/attribute.py
@@ -37,9 +37,9 @@ def attributeFactory(description, value, isOutput, node, root=None, parent=None)
         cls = Attribute
     attr = cls(node, description, isOutput, root, parent)
     if value is not None:
-        attr.value = value
+        attr._set_value(value, emitSignals=False)
     else:
-        attr.resetToDefaultValue()
+        attr.resetToDefaultValue(emitSignals=False)
     return attr
 
 

--- a/meshroom/core/node.py
+++ b/meshroom/core/node.py
@@ -1289,7 +1289,7 @@ class BaseNode(BaseObject):
         Return True if at least one attribute has the 'sequence' semantic (and can thus be loaded in the 2D Viewer), False otherwise.
         """
         for attr in self._attributes:
-            if attr.enabled and attr.isOutput and attr.desc.semantic == "sequence":
+            if attr.enabled and attr.isOutput and (attr.desc.semantic == "sequence" or attr.desc.semantic == "imageList"):
                 return True
         return False
 

--- a/meshroom/core/node.py
+++ b/meshroom/core/node.py
@@ -1284,6 +1284,15 @@ class BaseNode(BaseObject):
                 return True
         return False
 
+    def hasSequenceOutputAttribute(self):
+        """
+        Return True if at least one attribute has the 'sequence' semantic (and can thus be loaded in the 2D Viewer), False otherwise.
+        """
+        for attr in self._attributes:
+            if attr.enabled and attr.isOutput and attr.desc.semantic == "sequence":
+                return True
+        return False
+
     def has3DOutputAttribute(self):
         """
         Return True if at least one attribute is a File that can be loaded in the 3D Viewer, False otherwise.
@@ -1345,6 +1354,7 @@ class BaseNode(BaseObject):
 
     outputAttrEnabledChanged = Signal()
     hasImageOutput = Property(bool, hasImageOutputAttribute, notify=outputAttrEnabledChanged)
+    hasSequenceOutput = Property(bool, hasSequenceOutputAttribute, notify=outputAttrEnabledChanged)
     has3DOutput = Property(bool, has3DOutputAttribute, notify=outputAttrEnabledChanged)
 
 class Node(BaseNode):

--- a/meshroom/ui/components/filepath.py
+++ b/meshroom/ui/components/filepath.py
@@ -4,6 +4,7 @@ from PySide2.QtCore import QUrl, QFileInfo
 from PySide2.QtCore import QObject, Slot
 
 import os
+import glob
 
 
 class FilepathHelper(QObject):
@@ -103,19 +104,44 @@ class FilepathHelper(QObject):
     def resolve(self, path, vp):
         # Resolve dynamic path that depends on viewpoint
 
-        vpPath = vp.childAttribute("path").value
-        replacements = {
-            "<VIEW_ID>": str(vp.childAttribute("viewId").value),
-            "<INTRINSIC_ID>": str(vp.childAttribute("intrinsicId").value),
-            "<POSE_ID>": str(vp.childAttribute("poseId").value),
-            "<PATH>": vpPath,
-            "<FILENAME>": FilepathHelper.basename(FilepathHelper, vpPath),
-            "<FILESTEM>": FilepathHelper.removeExtension(FilepathHelper, FilepathHelper.basename(FilepathHelper, vpPath)),
-            "<EXTENSION>": FilepathHelper.extension(FilepathHelper, vpPath),
-        }
+        replacements = {}
+        if vp == None:
+            replacements = FilepathHelper.getFilenamesFromFolder(FilepathHelper, FilepathHelper.dirname(FilepathHelper, path), FilepathHelper.extension(FilepathHelper, path))
+            resolved = [path for i in range(len(replacements))]
+            for key in replacements:
+                for i in range(len(resolved)):
+                    resolved[i] = resolved[i].replace("<FRAMEID>", replacements[i])
+            return resolved
+        else:
+
+            vpPath = vp.childAttribute("path").value
+            filename = FilepathHelper.basename(FilepathHelper, vpPath)
+            replacements = {
+                "<VIEW_ID>": str(vp.childAttribute("viewId").value),
+                "<INTRINSIC_ID>": str(vp.childAttribute("intrinsicId").value),
+                "<POSE_ID>": str(vp.childAttribute("poseId").value),
+                "<PATH>": vpPath,
+                "<FILENAME>": filename,
+                "<FILESTEM>": FilepathHelper.removeExtension(FilepathHelper, filename),
+                "<EXTENSION>": FilepathHelper.extension(FilepathHelper, filename),
+            }
 
         resolved = path
         for key in replacements:
             resolved = resolved.replace(key, replacements[key])
 
         return resolved
+    
+    @Slot(str, result="QVariantList")
+    @Slot(str, str, result="QVariantList")
+    def getFilenamesFromFolder(self, folderPath: str, extension: str = None):
+        """
+        Get all filenames from a folder with a specific extension.
+
+        :param folderPath: Path to the folder.
+        :param extension: Extension of the files to get.
+        :return: List of filenames.
+        """
+        if extension is None:
+            extension = ".*"
+        return [self.removeExtension(FilepathHelper, self.basename(FilepathHelper, f)) for f in glob.glob(os.path.join(folderPath, f"*{extension}")) if os.path.isfile(f)]

--- a/meshroom/ui/components/filepath.py
+++ b/meshroom/ui/components/filepath.py
@@ -5,6 +5,7 @@ from PySide2.QtCore import QObject, Slot
 
 import os
 import glob
+import re
 
 
 class FilepathHelper(QObject):
@@ -144,4 +145,26 @@ class FilepathHelper(QObject):
         """
         if extension is None:
             extension = ".*"
-        return [self.basename(FilepathHelper, f) for f in glob.glob(os.path.join(folderPath, f"*{extension}")) if os.path.isfile(f)]
+        return [self.basename(f) for f in glob.glob(os.path.join(folderPath, f"*{extension}")) if os.path.isfile(f)]
+    
+    @Slot(str, result="QVariantList")
+    def resolveSequence(self, path):
+        """
+        Get id of each file in the sequence.
+        """
+        replacements = self.getFilenamesFromFolder(self.dirname(path), self.extension(path))
+
+        ids = []
+        for i in replacements:
+            # convert basename to regex
+            splitBefore = self.basename(path).split("(")
+            splitAfter = splitBefore[1].split(")")
+            id = re.search("["+splitBefore[0]+"]("+splitAfter[0]+")["+splitAfter[1]+"]", i)
+            if id:
+                # put id in replacements as key of replacements[i]
+                ids.append(id[1])
+
+        ids.sort()
+
+        resolved = [path.replace(self.basename(path), replacement) for replacement in replacements]
+        return ids, resolved

--- a/meshroom/ui/components/filepath.py
+++ b/meshroom/ui/components/filepath.py
@@ -144,4 +144,4 @@ class FilepathHelper(QObject):
         """
         if extension is None:
             extension = ".*"
-        return [self.removeExtension(FilepathHelper, self.basename(FilepathHelper, f)) for f in glob.glob(os.path.join(folderPath, f"*{extension}")) if os.path.isfile(f)]
+        return [self.basename(FilepathHelper, f) for f in glob.glob(os.path.join(folderPath, f"*{extension}")) if os.path.isfile(f)]

--- a/meshroom/ui/qml/GraphEditor/Node.qml
+++ b/meshroom/ui/qml/GraphEditor/Node.qml
@@ -327,7 +327,7 @@ Item {
 
                             MaterialLabel {
                                 id: nodeImageOutput
-                                visible: (node.hasImageOutput || node.has3DOutput)
+                                visible: (node.hasImageOutput || node.has3DOutput || node.hasSequenceOutput)
                                 text: MaterialIcons.visibility
                                 padding: 2
                                 font.pointSize: 7
@@ -339,9 +339,9 @@ Item {
                                     parent: header
                                     visible: nodeImageOutputMA.containsMouse && nodeImageOutput.visible
                                     text: {
-                                        if (node.hasImageOutput && !node.has3DOutput)
+                                        if ((node.hasImageOutput || node.hasSequenceOutput) && !node.has3DOutput)
                                             return nodeImageOutput.displayable ? "Double-click on this node to load its outputs in the Image Viewer." : "This node has image outputs."
-                                        else if (node.has3DOutput && !node.hasImageOutput)
+                                        else if (node.has3DOutput && !node.hasImageOutput && !node.hasSequenceOutput)
                                             return nodeImageOutput.displayable ? "Double-click on this node to load its outputs in the 3D Viewer." : "This node has 3D outputs."
                                         else  // Handle case where a node might have both 2D and 3D outputs
                                             return nodeImageOutput.displayable ? "Double-click on this node to load its outputs in the Image or 3D Viewer." : "This node has image and 3D outputs."

--- a/meshroom/ui/qml/GraphEditor/NodeEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/NodeEditor.qml
@@ -45,7 +45,7 @@ Panel {
     headerBar: RowLayout {
         Label {
             id: computationInfo
-            color: node ? Colors.statusColors[node.globalStatus] : palette.text
+            color: node && node.isComputable ? Colors.statusColors[node.globalStatus] : palette.text
             Timer {
                 id: timer
                 interval: 2500
@@ -64,7 +64,7 @@ Panel {
             font.italic: true
             visible: {
                 if (node !== null) {
-                    if (node.isFinishedOrRunning() || node.isSubmittedOrRunning() || node.globalStatus=="ERROR") {
+                    if (node.isComputable && (node.isFinishedOrRunning() || node.isSubmittedOrRunning() || node.globalStatus=="ERROR")) {
                         return true
                     }
                 }

--- a/meshroom/ui/qml/Viewer/SequencePlayer.qml
+++ b/meshroom/ui/qml/Viewer/SequencePlayer.qml
@@ -27,6 +27,7 @@ FloatingPane {
     readonly property alias syncFeaturesSelected: m.syncFeaturesSelected
     property bool loading: fetchButton.checked || m.playing
     property alias settings_SequencePlayer: settings_SequencePlayer
+    property alias frameId: m.frame
 
     Settings {
         id: settings_SequencePlayer
@@ -94,7 +95,7 @@ FloatingPane {
         id: timer
 
         repeat: true
-        running: m.playing
+        running: m.playing && root.visible
         interval: 1000 / m.fps
 
         onTriggered: {

--- a/meshroom/ui/qml/Viewer/SequencePlayer.qml
+++ b/meshroom/ui/qml/Viewer/SequencePlayer.qml
@@ -23,6 +23,7 @@ FloatingPane {
     // Exposed properties
     property var sortedViewIds: []
     property var viewer: null
+    property bool isOutputSequence: false
     readonly property alias sync3DSelected: m.sync3DSelected
     readonly property alias syncFeaturesSelected: m.syncFeaturesSelected
     property bool loading: fetchButton.checked || m.playing
@@ -35,6 +36,8 @@ FloatingPane {
     }
 
     function updateReconstructionView() {
+        if (isOutputSequence)
+            return
         if (_reconstruction && m.frame >= 0 && m.frame < sortedViewIds.length) {
             if (!m.playing && !frameSlider.pressed){
                 _reconstruction.selectedViewId = sortedViewIds[m.frame];
@@ -44,6 +47,12 @@ FloatingPane {
                     _reconstruction.updateSelectedViewpoint(_reconstruction.pickedViewId);
                 }
             }
+        }
+    }
+
+    onIsOutputSequenceChanged: {
+        if (!isOutputSequence) {
+            frameId = 0
         }
     }
 

--- a/meshroom/ui/qml/Viewer/SequencePlayer.qml
+++ b/meshroom/ui/qml/Viewer/SequencePlayer.qml
@@ -29,7 +29,7 @@ FloatingPane {
     property bool loading: fetchButton.checked || m.playing
     property alias settings_SequencePlayer: settings_SequencePlayer
     property alias frameId: m.frame
-    property var frameRange: {"min" : 0, "max" : sortedViewIds.length - 1}
+    property var frameRange: {"min" : 0, "max" : 0}
 
     Settings {
         id: settings_SequencePlayer

--- a/meshroom/ui/qml/Viewer/SequencePlayer.qml
+++ b/meshroom/ui/qml/Viewer/SequencePlayer.qml
@@ -39,7 +39,7 @@ FloatingPane {
     function updateReconstructionView() {
         if (isOutputSequence)
             return
-        if (_reconstruction && m.frame >= 0 && m.frame < sortedViewIds.length) {
+        if (_reconstruction && m.frame >= frameRange.min && m.frame < frameRange.max+1) {
             if (!m.playing && !frameSlider.pressed) {
                 _reconstruction.selectedViewId = sortedViewIds[m.frame];
             } else {

--- a/meshroom/ui/qml/Viewer/Viewer2D.qml
+++ b/meshroom/ui/qml/Viewer/Viewer2D.qml
@@ -11,7 +11,7 @@ FocusScope {
     clip: true
 
     property var displayedNode: null
-    property var displayedAttr: (displayedNode && outputAttribute.name != "gallery") ? getAttributeByName(displayedNode, outputAttribute.name) : null
+    property var displayedAttr: (displayedNode && outputAttribute.name != "gallery") ? displayedNode.attributes.get(outputAttribute.name) : null
     property var displayedAttrValue: displayedAttr ? displayedAttr.value : ""
 
     property bool useExternal: false
@@ -214,20 +214,6 @@ FocusScope {
         return undefined
     }
 
-    function getAttributeByName(node, attrName) {
-        // Get attribute from given node by name
-        // This requires to loop over all atributes
-
-        for (var i = 0; i < node.attributes.count; i++) {
-            var attr = node.attributes.at(i)
-            if (attr.name == attrName) {
-                return attr
-            }
-        }
-
-        return undefined
-    }
-
     function getImageFile() {
         if (useExternal) {
             // Entry point for getting the image file from an external URL
@@ -263,7 +249,6 @@ FocusScope {
         // ordered by path
 
         let objs = []
-        let displayedAttr = displayedNode ? getAttributeByName(displayedNode, outputAttribute.name) : undefined
 
         if (displayedNode && displayedNode.hasSequenceOutput && displayedAttr && (displayedAttr.desc.semantic === "imageList" || displayedAttr.desc.semantic === "sequence")) {
             let sequence = Filepath.resolveSequence(path_template)
@@ -513,7 +498,7 @@ FocusScope {
                                 'sequence': Qt.binding(function() { return ((root.enableSequencePlayer && (_reconstruction || (root.displayedNode && root.displayedNode.hasSequenceOutput))) ? getSequence() : []) }),
                                 'targetSize': Qt.binding(function() { return floatImageViewerLoader.targetSize }),
                                 'useSequence': Qt.binding(function() { 
-                                    let attr = root.displayedNode ? getAttributeByName(root.displayedNode, outputAttribute.name) : undefined
+                                    let attr = root.displayedNode ? root.displayedNode.attributes.get(outputAttribute.name) : undefined
                                     return (root.enableSequencePlayer && !useExternal && (_reconstruction || (root.displayedNode && root.displayedNode.hasSequenceOutput)) && (attr.desc.semantic === "imageList" || attr.desc.semantic === "sequence")) 
                                 }),
                                 'fetchingSequence': Qt.binding(function() { return sequencePlayer.loading }),

--- a/meshroom/ui/qml/Viewer/Viewer2D.qml
+++ b/meshroom/ui/qml/Viewer/Viewer2D.qml
@@ -268,20 +268,26 @@ FocusScope {
             let ids = sequence[0]
             let resolved = sequence[1]
 
-            //order by path
-            resolved.sort()
             // reset current frame to 0 if it is imageList but not sequence
             if (attr.desc.semantic === "imageList") {
+                // concat in one array all sequences in resolved
+                resolved = [].concat.apply([], resolved)
                 frameRange.min = 0
                 frameRange.max = resolved.length-1
                 currentFrame = 0
             }
 
             if (attr.desc.semantic === "sequence") {
+                // if there is several sequences, take the first one
+                resolved = resolved[0]
+                ids = ids[0]
                 frameRange.min = ids[0]
                 frameRange.max = ids[ids.length-1]
                 currentFrame = frameRange.min
             }
+            //order by path
+            resolved.sort()
+
             return resolved
         } else {
             for (let i = 0; i < _reconstruction.viewpoints.count; i++) {

--- a/meshroom/ui/qml/Viewer/Viewer2D.qml
+++ b/meshroom/ui/qml/Viewer/Viewer2D.qml
@@ -31,7 +31,7 @@ FocusScope {
 
     readonly property alias sync3DSelected: sequencePlayer.sync3DSelected
     property var sequence: []
-    property int currentFrame: sequencePlayer.frameId
+    property alias currentFrame: sequencePlayer.frameId
 
     QtObject {
         id: m
@@ -261,6 +261,7 @@ FocusScope {
         let objs = []
 
         if (displayedNode && displayedNode.hasSequenceOutput) {
+            currentFrame = 0
             objs = Filepath.resolve(path_template, null)
             //order by path
             objs.sort()
@@ -310,11 +311,7 @@ FocusScope {
             // store attr name for output attributes that represent images
             for (var i = 0; i < displayedNode.attributes.count; i++) {
                 var attr = displayedNode.attributes.at(i)
-                if (attr.isOutput && attr.desc.semantic === "image" && attr.enabled) {
-                    names.push(attr.name)
-                }
-
-                if (attr.isOutput && attr.desc.semantic === "sequence" && attr.enabled) {
+                if (attr.isOutput && (attr.desc.semantic === "image" || attr.desc.semantic === "sequence") && attr.enabled) {
                     names.push(attr.name)
                 }
             }
@@ -324,7 +321,6 @@ FocusScope {
 
         outputAttribute.names = names
         if (displayedNode && !displayedNode.hasSequenceOutput) {
-
             root.source = getImageFile()
         } else {
             root.sequence = getSequence()
@@ -1359,6 +1355,7 @@ FocusScope {
 
                             onNameChanged: {
                                 root.source = getImageFile()
+                                root.sequence = getSequence()
                             }
                         }
 
@@ -1462,6 +1459,7 @@ FocusScope {
                     viewer: floatImageViewerLoader.status === Loader.Ready ? floatImageViewerLoader.item : null
                     visible: root.enableSequencePlayer
                     enabled: root.enableSequencePlayer
+                    isOutputSequence: root.displayedNode && root.displayedNode.hasSequenceOutput
                 }
             }
         }

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ psutil>=5.6.7
 PySide2==5.15.2.1
 markdown==2.6.11
 requests==2.32.0
+pyseq==0.6.1


### PR DESCRIPTION
- Image sequence is detected because the semantic of the output is defined as "sequence" in the description of the node
- SequencePlayer is enabled when double-clicked on the node

- Need to set the path for the image sequence is : `/path/to/define/<FRAMEID>.extension`

- Unsync of Viewers and SequencePlayer when displayed output is sequence output