### PR TITLE
[Viewer] fix lens distortion viewer status when switching between projects

### DIFF
--- a/meshroom/ui/qml/Viewer/Viewer2D.qml
+++ b/meshroom/ui/qml/Viewer/Viewer2D.qml
@@ -1096,6 +1096,9 @@ FocusScope {
                         }
                         MaterialToolButton {
                             id: displayLensDistortionViewer
+
+                            property int numberChanges: null
+                            property bool previousChecked: null
                             property var activeNode: root.aliceVisionPluginAvailable && _reconstruction ? _reconstruction.activeNodes.get('sfmData').node : null
                             property bool isComputed: {
                                 if (!activeNode)
@@ -1125,6 +1128,22 @@ FocusScope {
                                     displayPanoramaViewer.checked = false
                                 } else if (!checked) {
                                     displayHDR.checked = true
+                                }
+                            }
+
+                            onActiveNodeChanged: {
+                                numberChanges += 1
+                            }
+
+                            onEnabledChanged: {
+                                if (!enabled) {
+                                    previousChecked = checked
+                                    checked = false
+                                    numberChanges = 0
+                                }
+
+                                if (enabled && (numberChanges == 1) && previousChecked) {
+                                    checked = true
                                 }
                             }
                         }


### PR DESCRIPTION
## Description

When opening an empty pipeline while the lens distortion viewer was enabled, we ended up in a state where the distortion viewer remained enabled and could not be disabled anymore as its button was greyed out.
