### PR TITLE
Fix 3D Viewer zooming problem

### DIFF
--- a/meshroom/ui/qml/Viewer3D/DefaultCameraController.qml
+++ b/meshroom/ui/qml/Viewer3D/DefaultCameraController.qml
@@ -81,17 +81,42 @@ Entity {
                 return
             }
             if (zooming) { // zoom with alt + RMD
-                d = (root.camera.viewCenter.minus(root.camera.position)).length() * 0.1
-                var tz = axisMX.value * root.translateSpeed * d
                 mouseHandler.hasMoved = true
-                root.camera.translate(Qt.vector3d(0, 0, tz).times(dt), Camera.DontTranslateViewCenter)
+                d = root.camera.viewCenter.minus(root.camera.position).length() // Distance between camera position and center position
+                var zoomPower = 0.2
+                var tz = axisMX.value * root.translateSpeed * zoomPower // Translation to apply depending on user action (mouse move), bigger absolute value means we'll zoom/dezoom more
+                var tzThreshold = 0.001
+
+                // We forbid too big zoom, as it means the distance between camera and center would be too low and we'll have no translation after (due to float representation)
+                if (tz >= 0.9 * d)
+                    return
+
+                // We forbid too small zoom as it means we are getting very close to center position and next zoom may lead to similar problem as previous cases (no translation), problem occurs only if tz > 0 (when we zoom)
+                if (tz > 0 && tz <= tzThreshold)
+                    return
+
+                root.camera.translate(Qt.vector3d(0, 0, tz), Camera.DontTranslateViewCenter)
                 return
             }
         }
+
         onDoubleClicked: mouseDoubleClicked(mouse)
         onWheel: {
-            var d = (root.camera.viewCenter.minus(root.camera.position)).length() * 0.2
-            var tz = (wheel.angleDelta.y / 120) * d
+            var d = root.camera.viewCenter.minus(root.camera.position).length() // Distance between camera position and center position
+            var zoomPower = 0.2
+            var angleStep = 120 // wheel.angleDelta.y = +- 120 * number of wheel rotations
+            var tz = (wheel.angleDelta.y / angleStep) * d * zoomPower // Translation to apply depending on user action (mouse wheel), bigger absolute value means we'll zoom/dezoom more
+            var tzThreshold = 0.001
+
+            // We forbid too big zoom, as it means the distance between camera and center would be too low and we'll have no translation after (due to float representation)
+            if (tz >= 0.9 * d) {
+                return
+            }
+
+            // We forbid too small zoom as it means we are getting very close to center position and next zoom may lead to similar problem as previous cases (no translation), problem occurs only if tz > 0 (when we zoom)
+            if (tz > 0 && tz <= tzThreshold) {
+                return
+            }
             root.camera.translate(Qt.vector3d(0, 0, tz), Camera.DontTranslateViewCenter)
         }
     }


### PR DESCRIPTION
## Description
When zooming in the 3D Viewer, we get stuck when we come the camera position and the viewpoint are too close.
This fix solves this problem by not allowing us those two points to get too close.
Solved with @almarouk and @Just-Kiel


## Implementation remarks
The zoom and dezoom depends on the distance between camera and center position, if this distance is too low, the translation we apply to zoom/dezoom won't have any impact in the worst case as we are limited by float representation (and that's why we are stuck), or would be very low in the other case (and we'll need more user actions to have a visible dezoom).

There are two possibilities for the camera position to be too close to the center.
1/ We forbid too big zoom, as it means the distance between camera and center would be too low and we'll have no translation after (due to float representation)
2/ We forbid too small zoom as it means we are getting very close to center position and next zoom may lead to similar problem as previous case (no translation)

We could have done it in another way: if we compute the next camera position (without applying it), and test future dezooms with the new distance, we can notice if it will lead the 3D viewer to be stuck and forbid this camera position.
We didn't do it, as it is leading to a more complex code and a higher computational cost, and our code already solves this issue in a convenient way for the user.


<!--
Explain main implementation choices.
It is also the right place to ask for feedback and help when you hesitate on the implementation.
-->
