### PR TITLE
[core] BugFix : Upgrade of Dynamic Choice Param fixed

### DIFF
--- a/meshroom/core/attribute.py
+++ b/meshroom/core/attribute.py
@@ -193,7 +193,8 @@ class Attribute(BaseObject):
             convertedValue = self.validateValue(value)
             self._value = convertedValue
 
-        self.node.onAttributeChanged(self)
+        if not self.node.isCompatibilityNode:
+            self.node.onAttributeChanged(self)
         # Request graph update when input parameter value is set
         # and parent node belongs to a graph
         # Output attributes value are set internally during the update process,


### PR DESCRIPTION
## Description
Dynamic Param with onAttributeChanged behavior should not be applied if CompatibilityNode.
If it is a CompatibilityNode, we should only get the value of the attribute to create fully all the attributes instead of throwing an error.

Related to this [PR](https://github.com/alicevision/Meshroom/pull/2350)