### PR TITLE
[ImageGallery] Display CameraInit label and defaultLabel to avoid confusion

### DIFF
--- a/meshroom/ui/qml/ImageGallery/ImageGallery.qml
+++ b/meshroom/ui/qml/ImageGallery/ImageGallery.qml
@@ -674,7 +674,7 @@ Panel {
 
             Label {
                 id: groupName
-                text: root.cameraInit ? root.cameraInit.label : ""
+                text: root.cameraInit ? "<b>" + root.cameraInit.label + "</b>" + (root.cameraInit.label !== root.cameraInit.defaultLabel ? " (" + root.cameraInit.defaultLabel + ")" : "") : ""
                 font.pointSize: 8
             }
         }


### PR DESCRIPTION
## Description
Done in the same way as the Node Editor. It detects if it's the default label or not and displays it in addition to the label. Avoids confusion between CameraInit that might have the same name.
Put in bold the label, as in NodeEditor to see it well.