### PR TITLE
[GraphEditor] Internal Custom Color Picker disabled when node is locked

### DIFF
--- a/meshroom/ui/qml/GraphEditor/AttributeItemDelegate.qml
+++ b/meshroom/ui/qml/GraphEditor/AttributeItemDelegate.qml
@@ -289,6 +289,7 @@ RowLayout {
                     id: color_checkbox
                     Layout.alignment: Qt.AlignLeft
                     checked: node && node.color === "" ? false : true
+                    checkable: root.editable
                     text: "Custom Color"
                     onClicked: {
                         if (checked) {
@@ -302,9 +303,9 @@ RowLayout {
                     id: colorText
                     Layout.alignment: Qt.AlignLeft
                     implicitWidth: 100
-                    enabled: color_checkbox.checked
-                    visible: enabled
-                    text: enabled ? attribute.value : ""
+                    enabled: color_checkbox.checked && root.editable
+                    visible: color_checkbox.checked
+                    text: color_checkbox.checked ? attribute.value : ""
                     selectByMouse: true
                     onEditingFinished: setTextFieldAttribute(text)
                     onAccepted: setTextFieldAttribute(text)
@@ -322,6 +323,7 @@ RowLayout {
                     color: color_checkbox.checked ? attribute.value : ""
 
                     MouseArea {
+                        enabled: root.editable
                         anchors.fill: parent
                         onClicked: colorDialog.open()
                     }


### PR DESCRIPTION
Internal Custom Color Picker disabled when node is locked.
