### PR TITLE
[ui] Fix BoundingBox visibility icon because of mapping name

### DIFF
--- a/meshroom/ui/qml/Viewer3D/Inspector3D.qml
+++ b/meshroom/ui/qml/Viewer3D/Inspector3D.qml
@@ -471,7 +471,7 @@ FloatingPane {
                                     enabled: model.visible
                                     Layout.alignment: Qt.AlignTop
                                     Layout.fillHeight: true
-                                    text: MaterialIcons.transform
+                                    text: MaterialIcons.transform_
                                     font.pointSize: 10
                                     ToolTip.text: model.displayBoundingBox ? "Hide BBox" : "Show BBox"
                                     flat: true


### PR DESCRIPTION
Fix BoundingBox visibility icon because of mapping name. Before it was not shown.