### PR TITLE
SequencePlayer: Forbid "selecting" an invalid frame number

### DIFF
--- a/meshroom/ui/qml/Viewer/SequencePlayer.qml
+++ b/meshroom/ui/qml/Viewer/SequencePlayer.qml
@@ -130,7 +130,9 @@ FloatingPane {
             ToolTip.text: "Previous Frame"
 
             onClicked: {
-                m.frame -= 1;
+                if (m.frame > 0) {
+                    m.frame -= 1;
+                }
             }
         }
 
@@ -161,7 +163,9 @@ FloatingPane {
             ToolTip.text: "Next Frame"
 
             onClicked: {
-                m.frame += 1;
+                if (m.frame < sortedViewIds.length - 1) {
+                    m.frame += 1;
+                }
             }
         }
 
@@ -197,7 +201,9 @@ FloatingPane {
                     ToolTip.text: "Previous Frame"
 
                     onClicked: {
-                        m.frame -= 1;
+                        if (m.frame > 0) {
+                            m.frame -= 1;
+                        }
                     }
                 }
 
@@ -213,7 +219,9 @@ FloatingPane {
                     Layout.preferredWidth: frameMetrics.width
 
                     onEditingFinished: {
-                        m.frame = parseInt(text);
+                        // We first assign the frame to the entered text even if it is an invalid frame number. We do it for extreme cases, for example without doing it, if we are at 0, and put a negative number, m.frame would be still 0 and nothing happens but we will still see the wrong number
+                        m.frame = parseInt(text) 
+                        m.frame = Math.min((sortedViewIds.length - 1), Math.max(0, parseInt(text)));
                         focus = false;
                     }
                 }
@@ -230,7 +238,9 @@ FloatingPane {
                     ToolTip.text: "Next Frame"
 
                     onClicked: {
-                        m.frame += 1;
+                        if (m.frame < sortedViewIds.length - 1) {
+                            m.frame += 1;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Description
With the current UI, it is possible to use the "previous frame" or "next frame" buttons of the Sequence Player to select negative frame numbers or frame numbers that are larger than the actual number of frames in the sequence. 

Selecting an invalid frame number has no functional impact on the Sequence Player (it is not allowed on QtAliceVision's side) but it is still a glitch from a user standpoint. 

When typing in a negative frame number, said number is immediately replaced by "0" (as it should). However, when typing in a frame number that is larger than the number of frames, no such check is performed.

We would like to disable the "previous frame" buttons when the selected frame ID is 0, since it makes no sense to go lower than that; conversely, we would like to disable the "next frame" buttons when the selected frame ID corresponds to the last frame.

The buttons should correctly be re-enabled when going in the opposite direction.


## Implementation remarks
For the buttons, we take no action if we push the previous button when we are on the first frame (same for when we are on the last frame) and for typing, we apply min and max functions to force the entered number to be a valid frame number (if we are below 0, we consider that the user wants to retrieve the first frame, and similarly if we are after the last frame)