### PR TITLE
[ui] Bounding Box are usable in other nodes, not only Meshing

### DIFF
--- a/meshroom/ui/qml/Viewer3D/MediaLibrary.qml
+++ b/meshroom/ui/qml/Viewer3D/MediaLibrary.qml
@@ -167,7 +167,7 @@ Entity {
 
             // Specific properties to the MESHING node (declared and initialized for every Entity anyway)
             property bool hasBoundingBox: {
-                if (nodeType === "Meshing" && currentNode.attribute("useBoundingBox")) // Can have a BoundingBox
+                if (currentNode.hasAttribute("useBoundingBox")) // Can have a BoundingBox
                     return currentNode.attribute("useBoundingBox").value
                 return false
             }

--- a/meshroom/ui/qml/main.qml
+++ b/meshroom/ui/qml/main.qml
@@ -1001,7 +1001,7 @@ ApplicationWindow {
                 }
 
                 function viewIn3D(attribute, mouse) {
-                    if (!panel3dViewer || !attribute.node.has3DOutput)
+                    if (!panel3dViewer || (!attribute.node.has3DOutput && !attribute.node.hasAttribute("useBoundingBox")))
                         return false
                     var loaded = panel3dViewer.viewer3D.view(attribute)
 


### PR DESCRIPTION
## Description
Bounding boxes can be used in nodes, not only Meshing. It only needs to have an attribute with useBoundingBox name.