### PR TITLE
[ui] Use ExportAnimatedCamera output for image overlay in Viewer3D

### DIFF
--- a/meshroom/nodes/aliceVision/ExportAnimatedCamera.py
+++ b/meshroom/nodes/aliceVision/ExportAnimatedCamera.py
@@ -109,7 +109,8 @@ Based on the input image filenames, it will recognize the input video sequence t
             name="outputUndistorted",
             label="Undistorted Images",
             description="Output undistorted images.",
-            value=desc.Node.internalFolder + "undistort",
+            semantic="image",
+            value=desc.Node.internalFolder + "undistort/" + "<INTRINSIC_ID>_<FILESTEM>.{undistortedImageTypeValue}",
             group="",  # exclude from command line
             uid=[],
         ),

--- a/meshroom/nodes/aliceVision/ImageSegmentation.py
+++ b/meshroom/nodes/aliceVision/ImageSegmentation.py
@@ -96,7 +96,7 @@ Generate a mask with segmented labels for each pixel.
             label="Masks",
             description="Generated segmentation masks.",
             semantic="image",
-            value=lambda attr: desc.Node.internalFolder + "<VIEW_ID>.exr" if not attr.node.keepFilename.value else desc.Node.internalFolder + "<FILENAME>.exr",
+            value=lambda attr: desc.Node.internalFolder + "<VIEW_ID>.exr" if not attr.node.keepFilename.value else desc.Node.internalFolder + "<FILESTEM>.exr",
             group="",
             uid=[],
         ),

--- a/meshroom/nodes/blender/ScenePreview.py
+++ b/meshroom/nodes/blender/ScenePreview.py
@@ -149,7 +149,7 @@ One frame per viewpoint will be rendered, and the undistorted views can optional
             label="Frames",
             description="Frames rendered in Blender.",
             semantic="image",
-            value=desc.Node.internalFolder + "<FILENAME>_preview.jpg",
+            value=desc.Node.internalFolder + "<FILESTEM>_preview.jpg",
             uid=[],
             group="",
         ),

--- a/meshroom/ui/components/filepath.py
+++ b/meshroom/ui/components/filepath.py
@@ -98,3 +98,22 @@ class FilepathHelper(QObject):
     def fileSizeMB(self, path):
         """ Returns the file size in MB. """
         return QFileInfo(self.asStr(path)).size() / (1024*1024)
+
+    @Slot(str, QObject, result=str)
+    def resolve(self, path, vp):
+        # Resolve dynamic path that depends on viewpoint
+
+        replacements = {
+            "<VIEW_ID>": str(vp.childAttribute("viewId").value),
+            "<INTRINSIC_ID>": str(vp.childAttribute("intrinsicId").value),
+            "<POSE_ID>": str(vp.childAttribute("poseId").value),
+            "<PATH>": vp.childAttribute("path").value,
+            "<FILENAME>": FilepathHelper.basename(FilepathHelper, vp.childAttribute("path").value),
+            "<FILESTEM>": FilepathHelper.removeExtension(FilepathHelper, FilepathHelper.basename(FilepathHelper, vp.childAttribute("path").value)),
+        }
+
+        resolved = path
+        for key in replacements:
+            resolved = resolved.replace(key, replacements[key])
+
+        return resolved

--- a/meshroom/ui/qml/Viewer/Viewer2D.qml
+++ b/meshroom/ui/qml/Viewer/Viewer2D.qml
@@ -222,24 +222,6 @@ FocusScope {
         return undefined
     }
 
-    function resolve(path, vp) {
-        // Resolve dynamic path that depends on viewpoint
-
-        let replacements = {
-            "<VIEW_ID>": vp.childAttribute("viewId").value,
-            "<INTRINSIC_ID>": vp.childAttribute("intrinsicId").value,
-            "<POSE_ID>": vp.childAttribute("poseId").value,
-            "<PATH>": vp.childAttribute("path").value,
-            "<FILENAME>": Filepath.removeExtension(Filepath.basename(vp.childAttribute("path").value)),
-        }
-
-        let resolved = path;
-        for (let key in replacements) {
-            resolved = resolved.replace(key, replacements[key])
-        }
-
-        return resolved;
-    }
 
     function getImageFile() {
         // Entry point for getting the image file URL
@@ -258,7 +240,7 @@ FocusScope {
             let vp = getViewpoint(_reconstruction.pickedViewId)
             let attr = getAttributeByName(displayedNode, outputAttribute.name)
             let path = attr ? attr.value : ""
-            let resolved = vp ? resolve(path, vp) : path
+            let resolved = vp ? Filepath.resolve(path, vp) : path
             return Filepath.stringToUrl(resolved)
         }
 
@@ -277,7 +259,7 @@ FocusScope {
 
         let seq = [];
         for (let i = 0; i < objs.length; i++) {
-            seq.push(resolve(path_template, objs[i]))
+            seq.push(Filepath.resolve(path_template, objs[i]))
         }
 
         return seq
@@ -1032,7 +1014,7 @@ FocusScope {
                         property var vp: _reconstruction ? getViewpoint(_reconstruction.selectedViewId) : null
 
                         sourceComponent: CameraResponseGraph {
-                            responsePath: resolve(path, vp)
+                            responsePath: Filepath.resolve(path, vp)
                         }
                     }
                 }


### PR DESCRIPTION
## Description
Update undistorted image paths according on ExportAnimatedCamera node if exists. It is useful for the overlay for the camera active in Viewer 3D.