### PR TITLE
[ui] Selected node header set to base color

### DIFF
--- a/meshroom/ui/qml/GraphEditor/Node.qml
+++ b/meshroom/ui/qml/GraphEditor/Node.qml
@@ -150,8 +150,20 @@ Item {
             anchors.fill: nodeContent
             anchors.margins: -border.width
             visible: root.mainSelected || root.hovered || root.selected
-            border.width: 2.5
-            border.color: root.mainSelected ? activePalette.highlight : Qt.darker(activePalette.highlight, 1.5)
+            border.width: {
+                if(root.mainSelected)
+                    return 3
+                if(root.selected)
+                    return 2.5
+                return 2
+            }
+            border.color: {
+                if(root.mainSelected)
+                    return activePalette.highlight
+                if(root.selected)
+                    return Qt.darker(activePalette.highlight, 1.2)
+                return Qt.lighter(activePalette.base, 3)
+            }
             opacity: 0.9
             radius: background.radius + border.width
             color: "transparent"

--- a/meshroom/ui/qml/GraphEditor/Node.qml
+++ b/meshroom/ui/qml/GraphEditor/Node.qml
@@ -149,7 +149,7 @@ Item {
         Rectangle {
             anchors.fill: nodeContent
             anchors.margins: -border.width
-            visible: root.mainSelected || root.hovered
+            visible: root.mainSelected || root.hovered || root.selected
             border.width: 2.5
             border.color: root.mainSelected ? activePalette.highlight : Qt.darker(activePalette.highlight, 1.5)
             opacity: 0.9
@@ -183,7 +183,7 @@ Item {
                     id: header
                     width: parent.width
                     height: headerLayout.height
-                    color: root.mainSelected ? activePalette.highlight : root.selected ? Qt.darker(activePalette.highlight, 1.1): root.baseColor
+                    color: root.baseColor
                     radius: background.radius
 
                     // Fill header's bottom radius


### PR DESCRIPTION
## Description
As we would like maybe to have color for categories of nodes, it is better if we don't hide those colors while selecting nodes. We still have the border but the header keeps its baseColor.