### PR TITLE
[ui] Conversion of relative paths to absolute ones

### DIFF
--- a/meshroom/multiview.py
+++ b/meshroom/multiview.py
@@ -130,6 +130,7 @@ def findFilesByTypeInFolder(folder, recursive=False):
 
     output = FilesByType()
     for currentFolder in inputFolders:
+        currentFolder = os.path.abspath(currentFolder)
         if os.path.isfile(currentFolder):
             output.addFile(currentFolder)
             continue

--- a/meshroom/ui/app.py
+++ b/meshroom/ui/app.py
@@ -170,6 +170,7 @@ class MeshroomApp(QApplication):
                 "Invalid value: '{}'".format(args.project))
 
         if args.project:
+            args.project = os.path.abspath(args.project)
             r.load(args.project)
             self.addRecentProjectFile(args.project)
         else:


### PR DESCRIPTION
## Description
Project, import and import recursive in meshroom command are now absolute paths.
Prevent from having some files gone while reopening the scene not from the same folder.
