### PR TITLE
[nodes] ImageProcessing : use keepImageFilename attribute

### DIFF
--- a/meshroom/nodes/aliceVision/ImageProcessing.py
+++ b/meshroom/nodes/aliceVision/ImageProcessing.py
@@ -12,8 +12,9 @@ def outputImagesValueFunct(attr):
     outputExt =  ('.' + attr.node.extension.value) if attr.node.extension.value else None
 
     if inputExt in ['.abc', '.sfm']:
+        fileStem = '<FILENAME>' if attr.node.keepImageFilename.value else '<VIEW_ID>'
         # If we have an SfM in input
-        return desc.Node.internalFolder + '<VIEW_ID>' + (outputExt or '.*')
+        return desc.Node.internalFolder + fileStem + (outputExt or '.*')
 
     if inputExt:
         # if we have one or multiple files in input


### PR DESCRIPTION
## Description
In ImageProcessing node the attribute Keep Image Filename was not used. Now for the outputs that are based on VIEW_ID if the attribute is true then VIEW_ID is change to FILENAME.