### PR TITLE
[nodes/ui] Fix ExportAnimatedCamera outputs for ScenePreview use

### DIFF
--- a/meshroom/nodes/aliceVision/ExportAnimatedCamera.py
+++ b/meshroom/nodes/aliceVision/ExportAnimatedCamera.py
@@ -107,10 +107,18 @@ Based on the input image filenames, it will recognize the input video sequence t
         ),
         desc.File(
             name="outputUndistorted",
+            label="Undistorted Folder",
+            description="Output undistorted folder.",
+            value=desc.Node.internalFolder + "undistort/",
+            group="",  # exclude from command line
+            uid=[],
+        ),
+        desc.File(
+            name="outputImages",
             label="Undistorted Images",
             description="Output undistorted images.",
-            semantic="image",
             value=desc.Node.internalFolder + "undistort/" + "<INTRINSIC_ID>_<FILESTEM>.{undistortedImageTypeValue}",
+            semantic="image",
             group="",  # exclude from command line
             uid=[],
         ),

--- a/meshroom/ui/reconstruction.py
+++ b/meshroom/ui/reconstruction.py
@@ -247,7 +247,7 @@ class ViewpointWrapper(QObject):
         """ Update internal members depending on PrepareDenseScene or ExportAnimatedCamera. """
         # undistorted image path
         if self._activeNode_ExportAnimatedCamera.node:
-            self._undistortedImagePath = FilepathHelper.resolve(FilepathHelper, self._activeNode_ExportAnimatedCamera.node.outputUndistorted.value, self._viewpoint)
+            self._undistortedImagePath = FilepathHelper.resolve(FilepathHelper, self._activeNode_ExportAnimatedCamera.node.outputImages.value, self._viewpoint)
             self._principalPointCorrected = self._activeNode_ExportAnimatedCamera.node.correctPrincipalPoint.value
         elif self._activeNode_PrepareDenseScene.node:
             self._undistortedImagePath = FilepathHelper.resolve(FilepathHelper, self._activeNode_PrepareDenseScene.node.undistorted.value, self._viewpoint)


### PR DESCRIPTION
## Description
ExportAnimatedCamera output changed before from folder to image expression needs to be folder for Scene Preview use. So now we have a new output to see the images.