### PR TITLE
[core] New dynamic output attributes

### DIFF
--- a/meshroom/core/__init__.py
+++ b/meshroom/core/__init__.py
@@ -128,6 +128,8 @@ def validateNodeDesc(nodeDesc):
             errors.append(err)
 
     for param in nodeDesc.outputs:
+        if param.value is None:
+            continue
         err = param.checkValueTypes()
         if err:
             errors.append(err)

--- a/meshroom/core/attribute.py
+++ b/meshroom/core/attribute.py
@@ -276,8 +276,10 @@ class Attribute(BaseObject):
             # only dependent on the hash of its value without the cache folder
             return hashValue(self._invalidationValue)
         if self.isLink:
-            return self.getLinkParam().uid(uidIndex)
+            linkParam = self.getLinkParam(recursive=True)
+            return linkParam.uid(uidIndex)
         if isinstance(self._value, (list, tuple, set,)):
+            # non-exclusive choice param
             # hash of sorted values hashed
             return hashValue([hashValue(v) for v in sorted(self._value)])
         return hashValue(self._value)

--- a/meshroom/core/attribute.py
+++ b/meshroom/core/attribute.py
@@ -274,8 +274,9 @@ class Attribute(BaseObject):
         # it will not be the case (so we cannot have an assert).
         if self.isOutput:
             if self.desc.isDynamicValue:
-                # if it is dynamic, the uid is the one from the node itself
-                return self.node._uids.get(uidIndex)
+                # If the attribute is a dynamic output, the UID is derived from the node UID.
+                # To guarantee that each output attribute receives a unique ID, we add the attribute name to it.
+                return hashValue((self.name, self.node._uids.get(uidIndex)))
             else:
                 # only dependent on the hash of its value without the cache folder
                 return hashValue(self._invalidationValue)

--- a/meshroom/core/attribute.py
+++ b/meshroom/core/attribute.py
@@ -273,8 +273,12 @@ class Attribute(BaseObject):
         # 'uidIndex' should be in 'self.desc.uid' but in the case of linked attribute
         # it will not be the case (so we cannot have an assert).
         if self.isOutput:
-            # only dependent on the hash of its value without the cache folder
-            return hashValue(self._invalidationValue)
+            if self.desc.isDynamicValue:
+                # if it is dynamic, the uid is the one from the node itself
+                return self.node._uids.get(uidIndex)
+            else:
+                # only dependent on the hash of its value without the cache folder
+                return hashValue(self._invalidationValue)
         if self.isLink:
             linkParam = self.getLinkParam(recursive=True)
             return linkParam.uid(uidIndex)

--- a/meshroom/core/graph.py
+++ b/meshroom/core/graph.py
@@ -341,8 +341,13 @@ class Graph(BaseObject):
         for nodeName, nodeData in sorted(data.items(), key=lambda x: self.getNodeIndexFromName(x[0])):
             node = self.node(nodeName)
 
-            savedUid = nodeData.get("uids", "").get("0", "")  # Node's UID from the graph file
-            graphUid = node._uids.get(0)  # Node's UID from the graph itself
+            savedUid = nodeData.get("uids", {})  # Node's UID from the graph file
+            # JSON enfore keys to be strings, see
+            # https://docs.python.org/3.8/library/json.html#json.dump
+            # We know our keys are integers, so we convert them back to int.
+            savedUid = {int(k): v for k, v in savedUid.items()}
+
+            graphUid = node._uids  # Node's UID from the graph itself
             if savedUid != graphUid and graphUid is not None:
                 # Different UIDs, remove the existing node from the graph and replace it with a CompatibilityNode
                 logging.debug("UID conflict detected for {}".format(nodeName))

--- a/meshroom/core/graph.py
+++ b/meshroom/core/graph.py
@@ -14,7 +14,7 @@ import meshroom
 import meshroom.core
 from meshroom.common import BaseObject, DictModel, Slot, Signal, Property
 from meshroom.core import Version
-from meshroom.core.attribute import Attribute, ListAttribute
+from meshroom.core.attribute import Attribute, ListAttribute, GroupAttribute
 from meshroom.core.exception import StopGraphVisit, StopBranchVisit
 from meshroom.core.node import nodeFactory, Status, Node, CompatibilityNode
 
@@ -320,7 +320,10 @@ class Graph(BaseObject):
             # that were computed.
             if not isTemplate:  # UIDs are not stored in templates
                 self._evaluateUidConflicts(graphData)
-                self._applyExpr()
+                try:
+                    self._applyExpr()
+                except Exception as e:
+                    logging.warning(e)
 
         return True
 
@@ -548,12 +551,16 @@ class Graph(BaseObject):
             skippedEdges = {}
             if not withEdges:
                 for n, attr in node.attributes.items():
+                    if attr.isOutput:
+                        # edges are declared in input with an expression linking
+                        # to another param (which could be an output)
+                        continue
                     # find top-level links
                     if Attribute.isLinkExpression(attr.value):
                         skippedEdges[attr] = attr.value
                         attr.resetToDefaultValue()
                     # find links in ListAttribute children
-                    elif isinstance(attr, ListAttribute):
+                    elif isinstance(attr, (ListAttribute, GroupAttribute)):
                         for child in attr.value:
                             if Attribute.isLinkExpression(child.value):
                                 skippedEdges[child] = child.value
@@ -584,6 +591,7 @@ class Graph(BaseObject):
 
             # re-create edges taking into account what has been duplicated
             for attr, linkExpression in duplicateEdges.items():
+                logging.warning("attr={} linkExpression={}".format(attr.fullName, linkExpression))
                 link = linkExpression[1:-1]  # remove starting '{' and trailing '}'
                 # get source node and attribute name
                 edgeSrcNodeName, edgeSrcAttrName = link.split(".", 1)
@@ -1625,6 +1633,7 @@ def executeGraph(graph, toNodes=None, forceCompute=False, forceStatus=False):
 
     for n, node in enumerate(nodes):
         try:
+            node.preprocess()
             multiChunks = len(node.chunks) > 1
             for c, chunk in enumerate(node.chunks):
                 if multiChunks:
@@ -1635,6 +1644,7 @@ def executeGraph(graph, toNodes=None, forceCompute=False, forceStatus=False):
                     print('\n[{node}/{nbNodes}] {nodeName}'.format(
                         node=n + 1, nbNodes=len(nodes), nodeName=node.nodeType))
                 chunk.process(forceCompute)
+            node.postprocess()
         except Exception as e:
             logging.error("Error on node computation: {}".format(e))
             graph.clearSubmittedNodes()

--- a/meshroom/core/node.py
+++ b/meshroom/core/node.py
@@ -1023,7 +1023,10 @@ class BaseNode(BaseObject):
         # logging.warning("resetOutputAttr: {}".format(self.name))
         for output in self.nodeDesc.outputs:
             if output.isDynamicValue:
-                self.attribute(output.name).value = None
+                if self.hasAttribute(output.name):
+                    self.attribute(output.name).value = None
+                else:
+                    logging.warning(f"resetOutputAttr: Missing dynamic output attribute: {self.name}.{output.name}")
 
     def loadOutputAttr(self):
         """ Load output attributes with dynamic values from a values.json file.
@@ -1042,7 +1045,10 @@ class BaseNode(BaseObject):
         # logging.warning(data)
         for output in self.nodeDesc.outputs:
             if output.isDynamicValue:
-                self.attribute(output.name).value = data[output.name]
+                if self.hasAttribute(output.name):
+                    self.attribute(output.name).value = data[output.name]
+                else:
+                    logging.warning(f"loadOutputAttr: Missing dynamic output attribute: {self.name}.{output.name}")
 
     def saveOutputAttr(self):
         """ Save output attributes with dynamic values into a values.json file.
@@ -1052,7 +1058,10 @@ class BaseNode(BaseObject):
         data = {}
         for output in self.nodeDesc.outputs:
             if output.isDynamicValue:
-                data[output.name] = self.attribute(output.name).value
+                if self.hasAttribute(output.name):
+                    data[output.name] = self.attribute(output.name).value
+                else:
+                    logging.warning(f"saveOutputAttr: Missing dynamic output attribute: {self.name}.{output.name}")
 
         valuesFile = self.valuesFile
         # logging.warning("save output attr: {}, value: {}".format(self.name, valuesFile))

--- a/meshroom/core/node.py
+++ b/meshroom/core/node.py
@@ -1518,6 +1518,10 @@ class CompatibilityNode(BaseNode):
         self.outputs = self.nodeDict.get("outputs", {})
         self._internalFolder = self.nodeDict.get("internalFolder", "")
         self._uids = self.nodeDict.get("uids", {})
+        # JSON enfore keys to be strings, see
+        # https://docs.python.org/3.8/library/json.html#json.dump
+        # We know our keys are integers, so we convert them back to int.
+        self._uids = {int(k): v for k, v in self._uids.items()}
 
         # restore parallelization settings
         self.parallelization = self.nodeDict.get("parallelization", {})

--- a/meshroom/core/node.py
+++ b/meshroom/core/node.py
@@ -959,7 +959,6 @@ class BaseNode(BaseObject):
         }
         self._computeUids()
         self._buildCmdVars()
-        self.updateOutputAttr()
         if self.nodeDesc:
             self.nodeDesc.postUpdate(self)
         # Notify internal folder change if needed

--- a/meshroom/core/node.py
+++ b/meshroom/core/node.py
@@ -686,6 +686,10 @@ class BaseNode(BaseObject):
     def minDepth(self):
         return self.graph.getDepth(self, minimal=True)
 
+    @property
+    def valuesFile(self):
+        return os.path.join(self.graph.cacheDir, self.internalFolder, 'values')
+
     def getInputNodes(self, recursive, dependenciesOnly):
         return self.graph.getInputNodes(self, recursive=recursive, dependenciesOnly=dependenciesOnly)
 
@@ -955,6 +959,7 @@ class BaseNode(BaseObject):
         }
         self._computeUids()
         self._buildCmdVars()
+        self.updateOutputAttr()
         if self.nodeDesc:
             self.nodeDesc.postUpdate(self)
         # Notify internal folder change if needed
@@ -972,8 +977,11 @@ class BaseNode(BaseObject):
         """
         Update node status based on status file content/existence.
         """
+        s = self.globalStatus
         for chunk in self._chunks:
             chunk.updateStatusFromCache()
+        # logging.warning("updateStatusFromCache: {}, status: {} => {}".format(self.name, s, self.globalStatus))
+        self.updateOutputAttr()
 
     def submit(self, forceCompute=False):
         for chunk in self._chunks:
@@ -988,9 +996,70 @@ class BaseNode(BaseObject):
     def processIteration(self, iteration):
         self._chunks[iteration].process()
 
+    def preprocess(self):
+        pass
+
     def process(self, forceCompute=False):
         for chunk in self._chunks:
             chunk.process(forceCompute)
+
+    def postprocess(self):
+        self.saveOutputAttr()
+
+    def updateOutputAttr(self):
+        if not self.nodeDesc:
+            return
+        if not self.nodeDesc.hasDynamicOutputAttribute:
+            return
+        # logging.warning("updateOutputAttr: {}, status: {}".format(self.name, self.globalStatus))
+        if self.getGlobalStatus() == Status.SUCCESS:
+            self.loadOutputAttr()
+        else:
+            self.resetOutputAttr()
+
+    def resetOutputAttr(self):
+        if not self.nodeDesc.hasDynamicOutputAttribute:
+            return
+        # logging.warning("resetOutputAttr: {}".format(self.name))
+        for output in self.nodeDesc.outputs:
+            if output.isDynamicValue:
+                self.attribute(output.name).value = None
+
+    def loadOutputAttr(self):
+        """ Load output attributes with dynamic values from a values.json file.
+        """
+        if not self.nodeDesc.hasDynamicOutputAttribute:
+            return
+        valuesFile = self.valuesFile
+        if not os.path.exists(valuesFile):
+            logging.warning("No output attr file: {}".format(valuesFile))
+            return
+
+        # logging.warning("load output attr: {}, value: {}".format(self.name, valuesFile))
+        with open(valuesFile, 'r') as jsonFile:
+            data = json.load(jsonFile)
+
+        # logging.warning(data)
+        for output in self.nodeDesc.outputs:
+            if output.isDynamicValue:
+                self.attribute(output.name).value = data[output.name]
+
+    def saveOutputAttr(self):
+        """ Save output attributes with dynamic values into a values.json file.
+        """
+        if not self.nodeDesc.hasDynamicOutputAttribute:
+            return
+        data = {}
+        for output in self.nodeDesc.outputs:
+            if output.isDynamicValue:
+                data[output.name] = self.attribute(output.name).value
+
+        valuesFile = self.valuesFile
+        # logging.warning("save output attr: {}, value: {}".format(self.name, valuesFile))
+        valuesFilepathWriting = getWritingFilepath(valuesFile)
+        with open(valuesFilepathWriting, 'w') as jsonFile:
+            json.dump(data, jsonFile, indent=4)
+        renameWritingToFinalPath(valuesFilepathWriting, valuesFile)
 
     def endSequence(self):
         pass
@@ -1227,6 +1296,7 @@ class BaseNode(BaseObject):
     comment = Property(str, getComment, notify=internalAttributesChanged)
     internalFolderChanged = Signal()
     internalFolder = Property(str, internalFolder.fget, notify=internalFolderChanged)
+    valuesFile = Property(str, valuesFile.fget, notify=internalFolderChanged)
     depthChanged = Signal()
     depth = Property(int, depth.fget, notify=depthChanged)
     minDepth = Property(int, minDepth.fget, notify=depthChanged)
@@ -1281,12 +1351,19 @@ class Node(BaseNode):
         for attrDesc in self.nodeDesc.internalInputs:
             self._internalAttributes.add(attributeFactory(attrDesc, kwargs.get(attrDesc.name, None), isOutput=False, node=self))
 
-        # List attributes per uid
+        # Declare events for specific output attributes
         for attr in self._attributes:
             if attr.isOutput and attr.desc.semantic == "image":
                 attr.enabledChanged.connect(self.outputAttrEnabledChanged)
-            for uidIndex in attr.attributeDesc.uid:
-                self.attributesPerUid[uidIndex].add(attr)
+
+        # List attributes per uid
+        for attr in self._attributes:
+            if attr.isInput:
+                for uidIndex in attr.attributeDesc.uid:
+                    self.attributesPerUid[uidIndex].add(attr)
+            else:
+                if attr.attributeDesc.uid:
+                    logging.error(f"Output Attribute should not contain a UID: '{nodeType}.{attr.name}'")
 
         # Add internal attributes with a UID to the list
         for attr in self._internalAttributes:
@@ -1347,7 +1424,7 @@ class Node(BaseNode):
     def toDict(self):
         inputs = {k: v.getExportValue() for k, v in self._attributes.objects.items() if v.isInput}
         internalInputs = {k: v.getExportValue() for k, v in self._internalAttributes.objects.items()}
-        outputs = ({k: v.getExportValue() for k, v in self._attributes.objects.items() if v.isOutput})
+        outputs = ({k: v.getExportValue() for k, v in self._attributes.objects.items() if v.isOutput and not v.desc.isDynamicValue})
 
         return {
             'nodeType': self.nodeType,
@@ -1714,7 +1791,7 @@ def nodeFactory(nodeDict, name=None, template=False, uidConflict=False):
             # raising compatibility issues if their number differs: in that case, it is only useful
             # if some internal attributes do not exist or are invalid
             if not template and (sorted([attr.name for attr in nodeDesc.inputs if not isinstance(attr, desc.PushButtonParam)]) != sorted(inputs.keys()) or \
-                    sorted([attr.name for attr in nodeDesc.outputs]) != sorted(outputs.keys())):
+                    sorted([attr.name for attr in nodeDesc.outputs if not attr.isDynamicValue]) != sorted(outputs.keys())):
                 compatibilityIssue = CompatibilityIssue.DescriptionConflict
 
             # check whether there are any internal attributes that are invalidating in the node description: if there

--- a/meshroom/core/taskManager.py
+++ b/meshroom/core/taskManager.py
@@ -50,6 +50,7 @@ class TaskThread(Thread):
             except TypeError:
                 continue
 
+            node.preprocess()
             for cId, chunk in enumerate(node.chunks):
                 if chunk.isFinishedOrRunning() or not self.isRunning():
                     continue
@@ -78,6 +79,7 @@ class TaskThread(Thread):
                                 # Node already removed (for instance a global clear of _nodesToProcess)
                                 pass
                             n.clearSubmittedChunks()
+            node.postprocess()
 
             if stopAndRestart:
                 break

--- a/meshroom/ui/graph.py
+++ b/meshroom/ui/graph.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # coding:utf-8
+from collections.abc import Iterable
 import logging
 import os
 import json
@@ -625,6 +626,8 @@ class UIGraph(QObject):
 
     def filterNodes(self, nodes):
         """Filter out the nodes that do not exist on the graph."""
+        if not isinstance(nodes, Iterable):
+            nodes = [nodes]
         return [ n for n in nodes if n in self._graph.nodes.values() ]
 
     @Slot(Node, QPoint, QObject)
@@ -698,7 +701,7 @@ class UIGraph(QObject):
             with self.groupedGraphModification("Node duplication", disableUpdates=True):
                 duplicates = self.push(commands.DuplicateNodesCommand(self._graph, nodes))
             # move nodes below the bounding box formed by the duplicated node(s)
-            bbox = self._layout.boundingBox(duplicates)
+            bbox = self._layout.boundingBox(nodes)
 
             for n in duplicates:
                 idx = duplicates.index(n)


### PR DESCRIPTION
When an output attribute's default value is set to None, it is treated as dynamic. This means that its value will be determined at runtime by the node. As a result, this output value is not saved within the project to prevent invalidating the scene during graph computation. Instead, the output values of these dynamic attributes are stored in the node's cache folder.
