### PR TITLE
Prevent updates of the latest SfM node when the graph's topology is dirty

### DIFF
--- a/meshroom/ui/reconstruction.py
+++ b/meshroom/ui/reconstruction.py
@@ -1020,7 +1020,7 @@ class Reconstruction(UIGraph):
                     nodesByCategory[category] = node
         for category, node in nodesByCategory.items():
             self.activeNodes.get(category).node = node
-            if category == 'sfm':
+            if category == 'sfm' and not self._graph.dirtyTopology:
                 self.setActiveNode(self.lastSfmNode())
         for node in nodes:
             if node is None:


### PR DESCRIPTION
## Description

When graph is in dirty topology, we do not want to update the last SfM node in the graph.