### PR TITLE
Provide access to the current frame from the graph

### DIFF
--- a/meshroom/core/graph.py
+++ b/meshroom/core/graph.py
@@ -226,6 +226,8 @@ class Graph(BaseObject):
         self._fileDateVersion = 0
         self.header = {}
 
+        self._selectedViewpoint = None
+
     def clear(self):
         self.header.clear()
         self._compatibilityNodes.clear()
@@ -1563,6 +1565,12 @@ class Graph(BaseObject):
         self.updateInternals(force=True)
         self.updateStatusFromCache(force=True)
         self.cacheDirChanged.emit()
+
+    @property
+    def selectedViewpoint(self):
+        """ Return the attribute describing the viewpoint that is
+        currently set as the 'selected viewpoint'. """
+        return self._selectedViewpoint
 
     @property
     def fileDateVersion(self):

--- a/meshroom/ui/reconstruction.py
+++ b/meshroom/ui/reconstruction.py
@@ -1158,6 +1158,7 @@ class Reconstruction(UIGraph):
             # Reconstruction has ownership of Viewpoint object - destroy it when not needed anymore
             self._selectedViewpoint.deleteLater()
         self._selectedViewpoint = ViewpointWrapper(viewpointAttribute, self) if viewpointAttribute else None
+        self._graph._selectedViewpoint = self._selectedViewpoint.attribute if viewpointAttribute else None
         self.selectedViewpointChanged.emit()
 
     def setPickedViewId(self, viewId):


### PR DESCRIPTION
## Description

This PR adds a `viewpoint` property to the `Graph` object, containing the viewpoint attribute corresponding to the image that is currently selected in the Image Gallery.

This property is updated every time the selected viewpoint changes, and can thus be accessed from any object that has access to the `Graph` object itself (e.g. from inside a node, with `node.graph.viewpoint`).