### PR TITLE
[ui] Add and improve multiple UI tools for Photometric stereo

### DIFF
--- a/meshroom/ui/components/scene3D.py
+++ b/meshroom/ui/components/scene3D.py
@@ -354,7 +354,23 @@ class Transformations3DHelper(QObject):
         U = M * quaternion * M
 
         return U.toEulerAngles()
-
+    
+    @Slot(QVector3D, QVector3D, float, float, result=QVector3D)
+    def getRotatedCameraViewVector(self, camereViewVector, cameraUpVector, pitch, yaw):
+        """ Compute the rotated camera view vector with given pitch and yaw (in degrees).
+            Args:
+                camereViewVector (QVector3D): Camera view vector, the displacement from the camera position to its target
+                cameraUpVector (QVector3D): Camera up vector, the direction the top of the camera is facing
+                pitch (float): Rotation pitch (in degrees)
+                yaw (float): Rotation yaw (in degrees)
+            Returns:
+                QVector3D: rotated camera view vector
+        """
+        cameraSideVector = QVector3D.crossProduct(camereViewVector, cameraUpVector)
+        yawRot = QQuaternion.fromAxisAndAngle(cameraUpVector, yaw)
+        pitchRot = QQuaternion.fromAxisAndAngle(cameraSideVector, pitch)
+        return (yawRot * pitchRot).rotatedVector(camereViewVector)
+    
     @Slot(QVector3D, QMatrix4x4, Qt3DRender.QCamera, QSize, result=float)
     def computeScaleUnitFromModelMatrix(self, axis, modelMat, camera, windowSize):
         """ Compute the length of the screen projected vector axis unit transformed by the model matrix.

--- a/meshroom/ui/qml/Controls/DirectionalLightPane.qml
+++ b/meshroom/ui/qml/Controls/DirectionalLightPane.qml
@@ -1,0 +1,261 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import Qt5Compat.GraphicalEffects // for OpacityMask & Glow
+import MaterialIcons 2.2
+import Utils 1.0
+
+/**
+* Directional Light Pane
+*
+* @biref A small pane to control a directional light with a 2d ball controller.
+*
+* @param lightYawValue - directional light yaw (degrees)
+* @param lightPitchValue - directional light pitch (degrees)
+*/
+
+FloatingPane {
+    id: root
+
+    // yaw and pitch properties
+    property double lightYawValue: 0
+    property double lightPitchValue: 0
+
+    // 2d controller display size properties
+    readonly property real controllerSize: 80
+    readonly property real controllerRadius: controllerSize * 0.5
+
+    function reset() {
+        lightYawValue = 0;
+        lightPitchValue = 0;
+    }
+
+    // update 2d controller if yaw value changed
+    onLightYawValueChanged: { lightBallController.update() }
+
+    // update 2d controller if pitch value changed
+    onLightPitchValueChanged: { lightBallController.update() }
+
+    anchors.margins: 0
+    padding: 5
+    radius: 0
+
+    ColumnLayout {
+        anchors.fill: parent
+        spacing: 5
+
+        // header
+        RowLayout {
+            // pane title
+            Label {
+                text: "Directional Light"
+                font.bold: true
+                Layout.fillWidth: true
+            }
+
+            // minimize or maximize button
+            MaterialToolButton {
+                id: bodyButton
+                text: lightPaneBody.visible ? MaterialIcons.arrow_drop_down : MaterialIcons.arrow_drop_up
+                font.pointSize: 10
+                ToolTip.text: lightPaneBody.visible ? "Minimize" : "Maximize"
+                onClicked: { lightPaneBody.visible = !lightPaneBody.visible }
+            }
+
+            // reset button
+            MaterialToolButton {
+                id: resetButton
+                text: MaterialIcons.refresh
+                font.pointSize: 10
+                ToolTip.text: "Reset"
+                onClicked: reset()
+            }
+        }
+
+        // body
+        RowLayout {
+            id: lightPaneBody
+            spacing: 10
+
+            // light parameters
+            GridLayout {
+                columns: 3
+                rowSpacing: 2
+                columnSpacing: 8
+                Layout.alignment: Qt.AlignBottom
+
+                // light yaw
+                Label {
+                    text: "Yaw"
+                }
+                TextField {
+                    id: lightYawTF
+                    text: lightYawValue.toFixed(2)
+                    selectByMouse: true
+                    horizontalAlignment: TextInput.AlignRight
+                    validator: doubleDegreeValidator
+                    onEditingFinished: { lightYawValue = lightYawTF.text }
+                    ToolTip.text: "Light yaw (degrees)."
+                    ToolTip.visible: hovered
+                    Layout.preferredWidth: textMetricsDegreeValue.width
+                }
+                Label {
+                    text: "°"
+                }
+
+                // light pitch
+                Label {
+                    text: "Pitch"
+                }
+                TextField {
+                    id: lightPitchTF
+                    text: lightPitchValue.toFixed(2)
+                    selectByMouse: true
+                    horizontalAlignment: TextInput.AlignRight
+                    validator: doubleDegreeValidator
+                    onEditingFinished: { lightPitchValue = lightPitchTF.text }
+                    ToolTip.text: "Light pitch (degrees)."
+                    ToolTip.visible: hovered
+                    Layout.preferredWidth: textMetricsDegreeValue.width
+                }
+                Label {
+                    text: "°"
+                }
+            }
+
+            // directional light ball controller
+            Rectangle {
+                id: lightBallController
+                anchors.margins: 0
+                width: controllerSize
+                height: controllerSize
+                radius: 180 // circle
+                color: "#FF000000"
+                Layout.rightMargin: 5
+                Layout.leftMargin: 5
+                Layout.bottomMargin: 5
+
+                function update() {
+                    // get point from light yaw and pitch
+                    var y = (lightPitchValue / 90 * controllerRadius)
+                    var xMax = Math.sqrt(controllerRadius * controllerRadius - y * y) // get sphere maximum x coordinate
+                    var x = (lightYawValue / 90 * xMax)
+
+                    // get angle and distance
+                    var angleRad = Math.atan2(y, x)
+                    var distance = Math.sqrt(x * x + y * y)
+
+                    // avoid controller overflow  
+                    if(distance > controllerRadius)
+                    {
+                        x = controllerRadius * Math.cos(angleRad)
+                        y = controllerRadius * Math.sin(angleRad)
+                    }
+
+                    // compute distance function for light gradient emulation
+                    var distanceRatio = Math.min(distance, controllerRadius) / controllerRadius
+                    var distanceFunct = distanceRatio * distanceRatio * 0.3 
+
+                    // update light point
+                    lightPoint.x = lightPoint.startOffset + x
+                    lightPoint.y = lightPoint.startOffset + y
+
+                    // update light gradient
+                    lightGradient.angle = angleRad * (180 / Math.PI) // radians to degrees
+                    lightGradient.horizontalRadius = controllerSize * (1 - distanceFunct)
+                    lightGradient.verticalRadius = controllerSize * (1 + distanceFunct)
+                    lightGradient.horizontalOffset = x * (1 - distanceFunct)
+                    lightGradient.verticalOffset = y * (1 - distanceFunct)
+                }
+
+                RadialGradient {
+                    id: lightGradient
+                    anchors.centerIn: parent
+                    width: controllerSize
+                    height: width
+                    horizontalRadius: controllerSize
+                    verticalRadius: controllerSize
+                    angle: 0
+                    gradient: Gradient {
+                        GradientStop { position: 0.00; color: "#FFFFFFFF" }
+                        GradientStop { position: 0.10; color: "#FFAAAAAA" }
+                        GradientStop { position: 0.50; color: "#FF0C0C0C" }
+                    }
+                    layer.enabled: true
+                    layer.effect: OpacityMask {
+                        id: mask
+                        maskSource: Rectangle {
+                            height: lightGradient.height
+                            width: lightGradient.width
+                            radius: 180 // circle
+                        }
+                    }
+                }
+
+                Rectangle {
+                    id: lightPoint
+
+                    property double startOffset : (parent.width - width) * 0.5 
+
+                    x: startOffset
+                    y: startOffset
+                    width: controllerRadius / 6
+                    height: width
+                    radius: 180 // circle
+                    color: "white"
+                }
+
+                Glow {
+                    anchors.fill: lightPoint
+                    radius: controllerRadius / 5
+                    samples: 17
+                    color: "white"
+                    source: lightPoint
+                }
+
+                MouseArea {
+                    id: lightMouseArea
+                    anchors.centerIn: parent
+                    anchors.fill: parent
+
+                    onPositionChanged: {
+                        // get coordinates from center
+                        var x = mouseX - controllerRadius
+                        var y = mouseY - controllerRadius
+
+                        // get distance to center
+                        var distance = Math.sqrt(x * x + y * y)
+
+                        // avoid controller overflow  
+                        if(distance > controllerRadius)
+                        {
+                            var angleRad = Math.atan2(y, x)
+                            x = controllerRadius * Math.cos(angleRad)
+                            y = controllerRadius * Math.sin(angleRad)
+                        }
+
+                        // get sphere maximum x coordinate
+                        var xMax = Math.sqrt(controllerRadius * controllerRadius - y * y)
+
+                        // update light yaw and pitch
+                        lightYawValue = (xMax > 0) ? ((x / xMax) * 90) : 0 // between -90 and 90 degrees
+                        lightPitchValue = (y / controllerRadius) * 90      // between -90 and 90 degrees
+                    }
+                }
+            }
+        }
+    }
+
+    DoubleValidator {
+        id: doubleDegreeValidator
+        locale: 'C' // use '.' decimal separator disregarding of the system locale
+        bottom: -90.0
+        top: 90.0
+    }
+
+    TextMetrics {
+        id: textMetricsDegreeValue
+        font: lightYawTF.font
+        text: "12.3456" 
+    }
+}

--- a/meshroom/ui/qml/Controls/qmldir
+++ b/meshroom/ui/qml/Controls/qmldir
@@ -15,3 +15,4 @@ FilterComboBox 1.0 FilterComboBox.qml
 IntSelector 1.0 IntSelector.qml
 MScrollBar 1.0 MScrollBar.qml
 MSplitView 1.0 MSplitView.qml
+DirectionalLightPane 1.0 DirectionalLightPane.qml

--- a/meshroom/ui/qml/Viewer/PhongImageViewer.qml
+++ b/meshroom/ui/qml/Viewer/PhongImageViewer.qml
@@ -1,0 +1,48 @@
+import QtQuick
+import Utils 1.0
+
+import AliceVision 1.0 as AliceVision
+
+/**
+ * PhongImageViewer displays an Image (albedo + normal) with a given light direction.
+ * Shading is done using Blinn-Phong reflection model, material and light direction parameters available.
+ * Accept HdrImageToolbar controls (gamma / offset / channel).
+ *
+ * <!> Requires QtAliceVision plugin.
+ */
+
+AliceVision.PhongImageViewer {
+    id: root
+
+    width: sourceSize.width
+    height: sourceSize.height
+    visible: true
+
+    // paintedWidth / paintedHeight / imageStatus for compatibility with standard Image
+    property int paintedWidth: sourceSize.width
+    property int paintedHeight: sourceSize.height
+    property var imageStatus: {
+        if (root.status === AliceVision.PhongImageViewer.EStatus.LOADING) {
+            return Image.Loading
+        } else if (root.status === AliceVision.PhongImageViewer.EStatus.LOADING_ERROR ||
+                   root.status === AliceVision.PhongImageViewer.EStatus.MISSING_FILE) {
+            return Image.Error
+        } else if ((root.sourcePath === "") || (root.sourceSize.height <= 0) || (root.sourceSize.width <= 0)) {
+            return Image.Null
+        }
+
+        return Image.Ready
+    }
+
+    property string channelModeString : "rgba"
+    channelMode: {
+        switch (channelModeString) {
+            case "rgb": return AliceVision.PhongImageViewer.EChannelMode.RGB
+            case "r": return AliceVision.PhongImageViewer.EChannelMode.R
+            case "g": return AliceVision.PhongImageViewer.EChannelMode.G
+            case "b": return AliceVision.PhongImageViewer.EChannelMode.B
+            case "a": return AliceVision.PhongImageViewer.EChannelMode.A
+            default: return AliceVision.PhongImageViewer.EChannelMode.RGBA
+        }
+    }
+}

--- a/meshroom/ui/qml/Viewer/PhongImageViewerToolbar.qml
+++ b/meshroom/ui/qml/Viewer/PhongImageViewerToolbar.qml
@@ -1,0 +1,275 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import QtQuick.Dialogs
+import MaterialIcons 2.2
+import Controls 1.0
+import Utils 1.0
+
+FloatingPane {
+    id: root
+
+    property color baseColorValue: colorText.text
+    property real textureOpacityValue: textureTF.text
+    property real kaValue: ambientTF.text
+    property real kdValue: diffuseTF.text
+    property real ksValue: specularTF.text
+    property real shininessValue: shininessTF.text
+    property bool displayLightController: true
+
+    function reset () {
+        colorText.text = "#333333"
+        textureCtrl.value = 1.0
+        ambientCtrl.value = 0.0
+        diffuseCtrl.value = 1.0
+        specularCtrl.value = 0.5
+        shininessCtrl.value = 20.0
+    }
+
+    anchors.margins: 0
+    padding: 5
+    radius: 0
+
+    ColumnLayout {
+        id: phongLightingParameters
+        anchors.fill: parent
+        spacing: 5
+
+        // header
+        RowLayout {
+            // pane title
+            Label {
+                text: _reconstruction && _reconstruction.activeNodes.get("PhotometricStereo").node ? _reconstruction.activeNodes.get("PhotometricStereo").node.label : ""
+                font.bold: true
+                Layout.fillWidth: true
+            }
+
+            // minimize or maximize button
+            MaterialToolButton {
+                id: bodyButton
+                text: phongLightingToolbarBody.visible ? MaterialIcons.arrow_drop_down : MaterialIcons.arrow_drop_up
+                font.pointSize: 10
+                ToolTip.text: phongLightingToolbarBody.visible ? "Minimize" : "Maximize"
+                onClicked: { phongLightingToolbarBody.visible = !phongLightingToolbarBody.visible }
+            }
+
+            // reset button
+            MaterialToolButton {
+                id: resetButton
+                text: MaterialIcons.refresh
+                font.pointSize: 10
+                ToolTip.text: "Reset"
+                onClicked: reset()
+            }
+
+            // settings menu
+            MaterialToolButton {
+                text: MaterialIcons.settings
+                font.pointSize: 10
+                onClicked: settingsMenu.popup(width, 0)
+                Menu {
+                    id: settingsMenu
+                    padding: 4
+                    implicitWidth: 250
+
+                    RowLayout {
+                        Label {
+                            text: "Display Directional Light Contoller:"
+                        }
+                        CheckBox {
+                            id: displayLightControllerCB
+                            ToolTip.text: "Hides directional light controller."
+                            ToolTip.visible: hovered
+                            Layout.fillHeight: true
+                            Layout.alignment: Qt.AlignRight
+                            checked: root.displayLightController
+                            onClicked: root.displayLightController = displayLightControllerCB.checked
+                        }
+                    }
+                }
+            }
+        }
+        
+        // body
+        GridLayout {
+            id: phongLightingToolbarBody
+            columns: 3
+            rowSpacing: 2
+            columnSpacing: 8
+
+            // base color
+            Label {
+                text: "Base Color"
+            }
+            Rectangle {
+                height: colorText.height * 0.8
+                color: colorText.text
+                Layout.alignment: Qt.AlignVCenter | Qt.AlignRight
+                Layout.preferredWidth: textMetricsNormValue.width
+
+                MouseArea {
+                    anchors.fill: parent
+                    onClicked: colorDialog.open()
+                }
+            }
+            TextField {
+                id: colorText
+                text: "#333333"
+                selectByMouse: true
+                Layout.alignment: Qt.AlignLeft
+                Layout.fillWidth: true 
+            }
+            ColorDialog {
+                id: colorDialog
+                title: "Please choose a color"
+                options: ColorDialog.NoEyeDropperButton 
+                selectedColor: colorText.text
+                onAccepted: {
+                    colorText.text = selectedColor
+                    colorText.editingFinished() // artificially trigger change of attribute value
+                    close()
+                }
+                onRejected: close()
+            }
+
+            // texture opacity
+            Label {
+                text: "Texture"
+            }
+            TextField {
+                id: textureTF
+                text: textureCtrl.value.toFixed(2)
+                selectByMouse: true
+                horizontalAlignment: TextInput.AlignRight
+                validator: doubleNormalizedValidator
+                onEditingFinished: { textureCtrl.value = textureTF.text }
+                ToolTip.text: "Texture Opacity."
+                ToolTip.visible: hovered
+                Layout.preferredWidth: textMetricsNormValue.width
+            }
+            Slider {
+                id: textureCtrl
+                from: 0.0
+                to: 1.0
+                value: 1.0
+                stepSize: 0.01
+                Layout.fillWidth: true                                       
+            }
+
+            // diffuse (kd)
+            Label {
+                text: "Diffuse"
+            }
+            TextField {
+                id: diffuseTF
+                text: diffuseCtrl.value.toFixed(2)
+                selectByMouse: true
+                horizontalAlignment: TextInput.AlignRight
+                validator: doubleNormalizedValidator
+                onEditingFinished: { diffuseCtrl.value = diffuseTF.text }
+                ToolTip.text: "Diffuse reflection (kd)."
+                ToolTip.visible: hovered
+                Layout.preferredWidth: textMetricsNormValue.width
+            }
+            Slider {
+                id: diffuseCtrl
+                from: 0.0
+                to: 1.0
+                value: 1.0
+                stepSize: 0.01
+                Layout.fillWidth: true                                       
+            }
+
+            // ambient (ka)
+            Label {
+                text: "Ambient"
+            }
+            TextField {
+                id: ambientTF
+                text: ambientCtrl.value.toFixed(2)
+                selectByMouse: true
+                horizontalAlignment: TextInput.AlignRight
+                validator: doubleNormalizedValidator
+                onEditingFinished: { ambientCtrl.value = ambientTF.text }
+                ToolTip.text: "Ambient reflection (ka)."
+                ToolTip.visible: hovered
+                Layout.preferredWidth: textMetricsNormValue.width
+            }
+            Slider {
+                id: ambientCtrl
+                from: 0.0
+                to: 1.0
+                value: 0.0
+                stepSize: 0.01 
+                Layout.fillWidth: true                                 
+            }
+
+            // specular (ks)
+            Label {
+                text: "Specular"
+            }
+            TextField {
+                id: specularTF
+                text: specularCtrl.value.toFixed(2)
+                selectByMouse: true
+                horizontalAlignment: TextInput.AlignRight
+                validator: doubleNormalizedValidator
+                onEditingFinished: { specularCtrl.value = specularTF.text }
+                ToolTip.text: "Specular reflection (ks)."
+                ToolTip.visible: hovered
+                Layout.preferredWidth: textMetricsNormValue.width
+            }
+            Slider {
+                id: specularCtrl
+                from: 0.0
+                to: 1.0
+                value: 0.5
+                stepSize: 0.01
+                Layout.fillWidth: true                                         
+            }
+
+            // shininess
+            Label {
+                text: "Shininess"
+            }
+            TextField {
+                id: shininessTF
+                text: shininessCtrl.value
+                selectByMouse: true
+                horizontalAlignment: TextInput.AlignRight
+                validator: intShininessValidator
+                onEditingFinished: { shininessCtrl.value = shininessTF.text }
+                ToolTip.text: "Shininess constant."
+                ToolTip.visible: hovered
+                Layout.preferredWidth: textMetricsNormValue.width
+            }
+            Slider {
+                id: shininessCtrl
+                from: 1
+                to: 128
+                value: 20
+                stepSize: 1
+                Layout.fillWidth: true                                         
+            }
+        }
+    }
+
+    DoubleValidator {
+        id: doubleNormalizedValidator
+        locale: 'C' // use '.' decimal separator disregarding of the system locale
+        bottom: 0.0
+        top: 1.0
+    }
+
+    IntValidator {
+        id: intShininessValidator
+        bottom: 1
+        top: 128
+    }
+
+    TextMetrics {
+        id: textMetricsNormValue
+        font: ambientTF.font
+        text: "1.2345" 
+    }
+}

--- a/meshroom/ui/qml/Viewer3D/Inspector3D.qml
+++ b/meshroom/ui/qml/Viewer3D/Inspector3D.qml
@@ -70,6 +70,12 @@ FloatingPane {
                         checked: Viewer3DSettings.displayOrigin
                         onClicked: Viewer3DSettings.displayOrigin = !Viewer3DSettings.displayOrigin
                     }
+                    MaterialToolButton {
+                        text: MaterialIcons.light_mode
+                        ToolTip.text: "Display Light Controller"
+                        checked: Viewer3DSettings.displayLightController
+                        onClicked: Viewer3DSettings.displayLightController = !Viewer3DSettings.displayLightController
+                    }
                 }
                 MaterialLabel {
                     text: MaterialIcons.grain

--- a/meshroom/ui/qml/Viewer3D/Viewer3D.qml
+++ b/meshroom/ui/qml/Viewer3D/Viewer3D.qml
@@ -20,7 +20,7 @@ FocusScope {
     readonly property alias mainCamera: mainCamera
 
     readonly property vector3d defaultCamPosition: Qt.vector3d(12.0, 10.0, -12.0)
-    readonly property vector3d defaultCamUpVector: Qt.vector3d(0.0, 1.0, 0.0)
+    readonly property vector3d defaultCamUpVector: Qt.vector3d(-0.358979, 0.861550, 0.358979) // should be accurate, consistent with camera view center
     readonly property vector3d defaultCamViewCenter: Qt.vector3d(0.0, 0.0, 0.0)
 
     readonly property var viewpoint: _reconstruction ? _reconstruction.selectedViewpoint : null

--- a/meshroom/ui/qml/Viewer3D/Viewer3D.qml
+++ b/meshroom/ui/qml/Viewer3D/Viewer3D.qml
@@ -107,15 +107,6 @@ FocusScope {
                 upVector: defaultCamUpVector
                 viewCenter: defaultCamViewCenter
                 aspectRatio: width/height
-
-                // Scene light, attached to the camera
-                Entity {
-                    components: [
-                        PointLight {
-                            color: "white"
-                        }
-                    ]
-                }
             }
 
             ViewpointCamera {
@@ -123,6 +114,15 @@ FocusScope {
                 enabled: cameraSelector.camera === camera
                 viewpoint: root.viewpoint
                 camera.aspectRatio: width/height
+            }
+
+            Entity {
+                components: [
+                    DirectionalLight{
+                        color: "white"
+                        worldDirection: Transformations3DHelper.getRotatedCameraViewVector(cameraSelector.camera.viewVector, cameraSelector.camera.upVector, directionalLightPane.lightPitchValue, directionalLightPane.lightYawValue).normalized()
+                    }
+                ]
             }
 
             TrackballGizmo {
@@ -316,6 +316,17 @@ FocusScope {
                 }
             }
         }
+    }
+
+    // Directional light controller
+    DirectionalLightPane {
+        id: directionalLightPane
+        anchors {
+            bottom: parent.bottom
+            right: parent.right
+            margins: 2
+        }
+        visible: Viewer3DSettings.displayLightController
     }
 
     // Menu

--- a/meshroom/ui/qml/Viewer3D/Viewer3DSettings.qml
+++ b/meshroom/ui/qml/Viewer3D/Viewer3DSettings.qml
@@ -51,6 +51,7 @@ Item {
     property bool displayGrid: true
     property bool displayGizmo: true
     property bool displayOrigin: false
+    property bool displayLightController: false
     // Camera
     property bool syncViewpointCamera: false
     property bool syncWithPickedViewId: false  // Sync active camera with picked view ID from sequence player if the setting is enabled

--- a/meshroom/ui/qml/Viewer3D/ViewpointCamera.qml
+++ b/meshroom/ui/qml/Viewer3D/ViewpointCamera.qml
@@ -16,15 +16,6 @@ Entity {
         nearPlane : 0.1
         farPlane : 10000.0
         viewCenter: Qt.vector3d(0.0, 0.0, -1.0)
-
-        // Scene light, attached to the camera
-        Entity {
-            components: [
-                PointLight {
-                    color: "white"
-                }
-            ]
-        }
     }
 
     components: [


### PR DESCRIPTION
## Description

**Add the new QtAliceVision 2D viewer with toolbar and a new light direction controller.**

<p align="center"><img src="https://github.com/alicevision/Meshroom/assets/16002026/b017f244-0452-4440-826d-f4b249f4dcc1" width=40%> <img src="https://github.com/alicevision/Meshroom/assets/16002026/5b52e62c-2887-4cd9-8709-0009414c3791" width=40%></p>

<p align="center"><i>A normal map with two light directions.</i></p>

**Add the ability to change the camera-relative light direction in the 3D viewer**

<p align="center"><img src="https://github.com/alicevision/Meshroom/assets/16002026/7d9527f7-d2c6-4669-807d-a178cbae7ddc" width=40%> <img src="https://github.com/alicevision/Meshroom/assets/16002026/8ff7194f-313a-4819-92e3-48930d74784b" width=40%></p>

<p align="center"><i>Same object with two different light directions using the new light direction controller.</i></p>

**Improve `SphereDetection` widget in order to handle automatic detection of calibration spheres.**

<p align="center"><img src="https://github.com/alicevision/Meshroom/assets/16002026/7c82ae76-44d2-43ee-9a65-dc9089a3f7ac" width=40%></p>

<p align="center"><i>Automatically detected calibration sphere shown with the green circle.</i></p>

## Features list

- [x] Improve `SphereDetection` widget in order to handle automatic detection of calibration spheres.
- [x] Add the new QtAliceVision 2D viewer with Blinn-Phong model with shader control toolbar and light direction toolbar.
- [x] Add the ability to change the camera-relative light direction in the 3D viewer.

## Implementation remarks

This PR is based on the Qt6 migration branch: https://github.com/alicevision/Meshroom/tree/dev/qt6.6
Linked to QtAliceVision PR: https://github.com/alicevision/QtAliceVision/pull/72
