### PR TITLE
[ui] Graph: Connect all chunks when setting a graph for the first time

### DIFF
--- a/meshroom/ui/graph.py
+++ b/meshroom/ui/graph.py
@@ -377,6 +377,10 @@ class UIGraph(QObject):
 
         self._graph.updated.connect(self.onGraphUpdated)
         self._taskManager.update(self._graph)
+
+        # update and connect chunks when the graph is set for the first time
+        self.updateChunks()
+
         # perform auto-layout if graph does not provide nodes positions
         if Graph.IO.Features.NodesPositions not in self._graph.fileFeatures:
             self._layout.reset()


### PR DESCRIPTION
## Description

This PR fixes an issue introduced in df70f992563070a07ae60238b43470fb0d0dcc5d, which reduced the calls to `graph.update()` when setting the graph. 

Connecting the chunks was initially done after a call to `graph.update()`, but as the calls to the entire update have been removed when opening up a project, the chunks are never connected then, meaning the progress bar remains invisible until an explicit call to `graph.update()` is done.

Instead of updating the whole graph when it is set up for the first time, we rather explicitly connect the chunks.