### PR TITLE
[core] Exclude edges from `InputNode` nodes in `dfsToProcess`

### DIFF
--- a/meshroom/core/graph.py
+++ b/meshroom/core/graph.py
@@ -1088,7 +1088,7 @@ class Graph(BaseObject):
                 nodes.append(vertex)  # We could collect specific chunks
 
         def finishEdge(edge, graph):
-            if edge[0].hasStatus(Status.SUCCESS) or edge[1].hasStatus(Status.SUCCESS):
+            if edge[0].isComputed or edge[1].isComputed:
                 return
             edges.append(edge)
 

--- a/meshroom/core/node.py
+++ b/meshroom/core/node.py
@@ -811,6 +811,8 @@ class BaseNode(BaseObject):
         return True
 
     def _isComputed(self):
+        if not self.isComputable:
+            return True
         return self.hasStatus(Status.SUCCESS)
 
     def _isComputable(self):


### PR DESCRIPTION
## Description

If the edges of a node to submit include an `InputNode` (which cannot be computed), then that `InputNode` should be excluded from the list of edges to process as if it had already been computed.

This allows to submit any type of graph involving `InputNode` to the farm.
