### PR TITLE
Add a Python ScriptEditor in the GraphEditor tab

### DIFF
--- a/meshroom/__init__.py
+++ b/meshroom/__init__.py
@@ -150,4 +150,5 @@ def setupEnvironment(backend=Backend.STANDALONE):
 
 
 os.environ["QML_XHR_ALLOW_FILE_READ"] = '1'
+os.environ["QML_XHR_ALLOW_FILE_WRITE"] = '1'
 os.environ["PYSEQ_STRICT_PAD"] = '1'

--- a/meshroom/ui/app.py
+++ b/meshroom/ui/app.py
@@ -17,6 +17,7 @@ from meshroom.ui import components
 from meshroom.ui.components.clipboard import ClipboardHelper
 from meshroom.ui.components.filepath import FilepathHelper
 from meshroom.ui.components.scene3D import Scene3DHelper, Transformations3DHelper
+from meshroom.ui.components.scriptEditor import ScriptEditorManager
 from meshroom.ui.components.thumbnail import ThumbnailCache
 from meshroom.ui.palette import PaletteManager
 from meshroom.ui.reconstruction import Reconstruction
@@ -160,6 +161,7 @@ class MeshroomApp(QApplication):
 
         # additional context properties
         self.engine.rootContext().setContextProperty("_PaletteManager", PaletteManager(self.engine, parent=self))
+        self.engine.rootContext().setContextProperty("ScriptEditorManager", ScriptEditorManager(parent=self))
         self.engine.rootContext().setContextProperty("MeshroomApp", self)
 
         # request any potential computation to stop on exit

--- a/meshroom/ui/components/scriptEditor.py
+++ b/meshroom/ui/components/scriptEditor.py
@@ -27,9 +27,9 @@ class ScriptEditorManager(QObject):
 
         result = stdout.getvalue().strip()
 
-        # Add the script to the history and move up the index
+        # Add the script to the history and move up the index to the top of history stack
         self._history.append(script)
-        self._index = self._index + 1
+        self._index = len(self._history)
 
         return result
 

--- a/meshroom/ui/components/scriptEditor.py
+++ b/meshroom/ui/components/scriptEditor.py
@@ -1,0 +1,60 @@
+from PySide2.QtCore import QObject, Slot
+
+from io import StringIO
+from contextlib import redirect_stdout
+
+class ScriptEditorManager(QObject):
+
+    def __init__(self, parent=None):
+        super(ScriptEditorManager, self).__init__(parent=parent)
+        self._history = []
+        self._index = -1
+
+        self._globals = {}
+        self._locals = {}
+
+
+    @Slot(str, result=str)
+    def process(self, script):
+        """ Execute the provided input script, capture the output from the standard output, and return it. """
+        stdout = StringIO()
+        with redirect_stdout(stdout):
+            try:
+                exec(script, self._globals, self._locals)
+            except Exception as exception:
+                # Format and print the exception to stdout, which will be captured
+                print("{}: {}".format(type(exception).__name__, exception))
+
+        result = stdout.getvalue().strip()
+
+        # Add the script to the history and move up the index
+        self._history.append(script)
+        self._index = self._index + 1
+
+        return result
+
+    @Slot()
+    def clearHistory(self):
+        """ Clear the list of executed scripts and reset the index. """
+        self._history = []
+        self._index = -1
+
+    @Slot(result=str)
+    def getNextScript(self):
+        """ Get the next entry in the history of executed scripts and update the index adequately.
+            If there is no next entry, return an empty string. """
+        if self._index + 1 < len(self._history) and len(self._history) > 0:
+            self._index = self._index + 1
+            return self._history[self._index]
+        return ""
+
+    @Slot(result=str)
+    def getPreviousScript(self):
+        """ Get the previous entry in the history of executed scripts and update the index adequately.
+            If there is no previous entry, return an empty string. """
+        if self._index - 1 >= 0 and self._index - 1 < len(self._history):
+            self._index = self._index - 1
+            return self._history[self._index]
+        elif self._index == 0 and len(self._history):
+            return self._history[self._index]
+        return ""

--- a/meshroom/ui/qml/GraphEditor/ScriptEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/ScriptEditor.qml
@@ -1,0 +1,334 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.11
+import Controls 1.0
+import Utils 1.0
+import MaterialIcons 2.2
+
+import Qt.labs.platform 1.0 as Platform
+import QtQuick.Dialogs 1.3
+
+Item {
+    id: root
+
+    function formatInput(text) {
+        var lines = text.split("\n")
+        for (let i = 0; i < lines.length; ++i) {
+            lines[i] = ">>> " + lines[i]
+        }
+        return lines.join("\n")
+    }
+
+    function processScript() {
+        output.clear()
+        var ret = ScriptEditorManager.process(input.text)
+        output.text = formatInput(input.text) + "\n\n" + ret
+        input.clear()
+    }
+
+    function loadScript(fileUrl) {
+        var request = new XMLHttpRequest()
+        request.open("GET", fileUrl, false)
+        request.send(null)
+        return request.responseText
+    }
+
+    function saveScript(fileUrl, content) {
+        var request = new XMLHttpRequest()
+        request.open("PUT", fileUrl, false)
+        request.send(content)
+        return request.status
+    }
+
+    implicitWidth: 500
+    implicitHeight: 500
+
+    Platform.FileDialog {
+        id: loadScriptDialog
+        options: Platform.FileDialog.DontUseNativeDialog
+        title: "Load Script"
+        nameFilters: ["Python Script (*.py)"]
+        onAccepted: {
+            input.clear()
+            input.text = loadScript(currentFile)
+        }
+    }
+
+    Platform.FileDialog {
+        id: saveScriptDialog
+        options: Platform.FileDialog.DontUseNativeDialog
+        title: "Save script"
+        nameFilters: ["Python Script (*.py)"]
+        fileMode: Platform.FileDialog.SaveFile
+
+        signal closed(var result)
+
+        onAccepted: {
+            if (Filepath.extension(currentFile) != ".py")
+                currentFile = currentFile + ".py"
+            var ret = saveScript(currentFile, input.text)
+            if (ret)
+                closed(Platform.Dialog.Accepted)
+            else
+                closed(Platform.Dialog.Rejected)
+        }
+
+        onRejected: closed(Platform.Dialog.Rejected)
+    }
+
+    ColumnLayout {
+        anchors.fill: parent
+
+        RowLayout {
+            Layout.alignment: Qt.AlignVCenter | Qt.AlignHCenter
+
+            Item {
+                Layout.fillWidth: true
+            }
+
+            MaterialToolButton {
+                font.pointSize: 13
+                text: MaterialIcons.download
+                ToolTip.text: "Load Script"
+
+                onClicked: {
+                    loadScriptDialog.open()
+                }
+            }
+
+            MaterialToolButton {
+                font.pointSize: 13
+                text: MaterialIcons.upload
+                ToolTip.text: "Save Script"
+
+                onClicked: {
+                    saveScriptDialog.open()
+                }
+            }
+
+            Item {
+                width: executeButton.width
+            }
+
+            MaterialToolButton {
+                id: executeButton
+                font.pointSize: 13
+                text: MaterialIcons.slideshow
+                ToolTip.text: "Execute Script"
+
+                onClicked: {
+                    processScript()
+                }
+            }
+
+            MaterialToolButton {
+                font.pointSize: 13
+                text: MaterialIcons.cancel_presentation
+                ToolTip.text: "Clear Output Window"
+
+                onClicked: {
+                    output.clear()
+                }
+            }
+
+            Item {
+                width: executeButton.width
+            }
+
+            MaterialToolButton {
+                font.pointSize: 13
+                text: MaterialIcons.history
+                ToolTip.text: "Get Previous Script"
+
+                onClicked: {
+                    var ret = ScriptEditorManager.getPreviousScript()
+
+                    if (ret != "") {
+                        input.clear()
+                        input.text = ret
+                    }
+                }
+            }
+
+            MaterialToolButton {
+                font.pointSize: 13
+                text: MaterialIcons.update
+                ToolTip.text: "Get Next Script"
+
+                onClicked: {
+                    var ret = ScriptEditorManager.getNextScript()
+
+                    if (ret != "") {
+                        input.clear()
+                        input.text = ret
+                    }
+                }
+            }
+
+            MaterialToolButton {
+                font.pointSize: 13
+                text: MaterialIcons.backspace
+                ToolTip.text: "Clear History"
+
+                onClicked: {
+                    ScriptEditorManager.clearHistory()
+                    input.clear()
+                    output.clear()
+                }
+            }
+
+            Item {
+                Layout.fillWidth: true
+            }
+        }
+
+        RowLayout {
+            Label {
+                text: "Input"
+                font.bold: true
+                horizontalAlignment: Text.AlignHCenter
+                Layout.fillWidth: true
+            }
+
+            Label {
+                text: "Output"
+                font.bold: true
+                horizontalAlignment: Text.AlignHCenter
+                Layout.fillWidth: true
+            }
+        }
+
+        RowLayout {
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+            width: root.width
+
+            Rectangle {
+                id: inputArea
+                Layout.fillHeight: true
+                Layout.fillWidth: true
+
+                color: palette.base
+
+                ListView {
+                    id: lineNumbers
+                    property TextMetrics textMetrics: TextMetrics { text: "9999" }
+                    model: input.text.split(/\n/g)
+                    anchors.left: parent.left
+                    anchors.top: parent.top
+                    anchors.bottom: parent.bottom
+                    width: lineNumbers.textMetrics.boundingRect.width
+                    clip: false
+
+                    delegate: Rectangle {
+                        width: lineNumbers.width
+                        height: lineText.height
+                        color: palette.mid
+                        Text {
+                            id: lineNumber
+                            anchors.horizontalCenter: parent.horizontalCenter
+                            text: index + 1
+                            font.bold: true
+                            color: palette.text
+                        }
+
+                        Text {
+                            id: lineText
+                            width: flickableInput.width
+                            text: modelData
+                            visible: false
+                            wrapMode: Text.WordWrap
+                        }
+                    }
+
+                    onContentYChanged: {
+                        if (!moving)
+                            return
+                        flickableInput.contentY = contentY
+                    }
+                }
+
+                Flickable {
+                    id: flickableInput
+                    width: parent.width
+                    height: parent.height
+                    contentWidth: width
+                    contentHeight: height
+
+                    anchors.left: lineNumbers.right
+                    anchors.top: parent.top
+                    anchors.right: parent.right
+                    anchors.bottom: parent.bottom
+
+                    ScrollBar.vertical: ScrollBar {
+                        policy: ScrollBar.AsNeeded
+                    }
+
+                    TextArea.flickable: TextArea {
+                        id: input
+
+                        text: {
+                            var str = "from meshroom.ui import uiInstance\n\n"
+                            str += "graph = uiInstance.activeProject.graph\n"
+                            str += "for node in graph.nodes:\n"
+                            str += "    print(node.name)"
+                            return str
+                        }
+                        font: lineNumbers.textMetrics.font
+                        Layout.fillHeight: true
+                        Layout.fillWidth: true
+
+                        wrapMode: Text.WordWrap
+                        selectByMouse: true
+                        padding: 0
+
+                        onPressed: {
+                            root.forceActiveFocus()
+                        }
+
+                        Keys.onPressed: {
+                            if ((event.key === Qt.Key_Enter || event.key === Qt.Key_Return) && event.modifiers === Qt.ControlModifier) {
+                                processScript()
+                            }
+                        }
+                    }
+
+                    onContentYChanged: {
+                        if (lineNumbers.moving)
+                            return
+                        lineNumbers.contentY = contentY
+                    }
+                }
+            }
+            
+            Rectangle {
+                id: outputArea
+                Layout.fillHeight: true
+                Layout.fillWidth: true
+
+                color: palette.base
+
+                Flickable {
+                    width: parent.width
+                    height: parent.height
+                    contentWidth: width
+                    contentHeight: height
+
+                    ScrollBar.vertical: ScrollBar {
+                        policy: ScrollBar.AsNeeded
+                    }
+
+                    TextArea.flickable: TextArea {
+                        id: output
+
+                        readOnly: true
+                        selectByMouse: true
+                        padding: 0
+                        Layout.fillHeight: true
+                        Layout.fillWidth: true
+                    }
+                }
+            }
+        }
+    }
+}

--- a/meshroom/ui/qml/GraphEditor/qmldir
+++ b/meshroom/ui/qml/GraphEditor/qmldir
@@ -12,3 +12,4 @@ CompatibilityBadge 1.0 CompatibilityBadge.qml
 CompatibilityManager 1.0 CompatibilityManager.qml
 singleton GraphEditorSettings 1.0 GraphEditorSettings.qml
 TaskManager 1.0 TaskManager.qml
+ScriptEditor 1.0 ScriptEditor.qml

--- a/meshroom/ui/qml/main.qml
+++ b/meshroom/ui/qml/main.qml
@@ -1088,7 +1088,7 @@ ApplicationWindow {
                 id: graphEditorPanel
                 Layout.fillWidth: true
                 padding: 4
-                tabs: ["Graph Editor", "Task Manager"]
+                tabs: ["Graph Editor", "Task Manager", "Script Editor"]
 
                 headerBar: RowLayout {
                     MaterialToolButton {
@@ -1274,6 +1274,12 @@ ApplicationWindow {
                     anchors.fill: parent
                 }
 
+                ScriptEditor {
+                    id: scriptEditor
+
+                    visible: graphEditorPanel.currentTab === 2
+                    anchors.fill: parent
+                }
             }
 
             NodeEditor {


### PR DESCRIPTION
## Description

This PR adds a new QML component to the GraphEditor tab which allows to easily write and execute Python code within Meshroom. Python scripts can be exported from or imported in the script editor, and the history of executed scripts is saved.

The ScriptEditor's input zone is set by default with a minimal script that lists the nodes that are part of the current graph, thus showing an example on how to access Meshroom elements in Python.

<img src="https://github.com/alicevision/Meshroom/assets/11963329/4fe6561a-8847-44a0-8d0b-44d4c8a79f50" />

## Features list

- [x] Save and load Python scripts
- [x] Execute Python scripts
- [x] Navigate through the history of executed Python scripts during the Meshroom session
