### PR TITLE
Remove plugin loading from core __init__

### DIFF
--- a/bin/meshroom_batch
+++ b/bin/meshroom_batch
@@ -14,6 +14,7 @@ from meshroom import multiview
 from meshroom.core.desc import InitNode
 import logging
 
+meshroom.core.initPlugins()
 
 parser = argparse.ArgumentParser(description='Launch the full photogrammetry or Panorama HDR pipeline.')
 parser.add_argument('-i', '--input', metavar='NODEINSTANCE:"SFM/FOLDERS/IMAGES;..."', type=str, nargs='*',

--- a/bin/meshroom_compute
+++ b/bin/meshroom_compute
@@ -31,6 +31,8 @@ parser.add_argument('-i', '--iteration', type=int,
 
 args = parser.parse_args()
 
+meshroom.core.initNodes()
+
 graph = meshroom.core.graph.loadGraph(args.graphFile)
 if args.cache:
     graph.cacheDir = args.cache

--- a/bin/meshroom_submit
+++ b/bin/meshroom_submit
@@ -22,4 +22,7 @@ parser.add_argument("--submitLabel",
 
 args = parser.parse_args()
 
+meshroom.core.initNodes()
+meshroom.core.initSubmitters()
+
 meshroom.core.graph.submit(args.meshroomFile, args.submitter, toNode=args.toNode, submitLabel=args.submitLabel)

--- a/meshroom/core/__init__.py
+++ b/meshroom/core/__init__.py
@@ -330,30 +330,32 @@ def loadPipelineTemplates(folder):
         if file.endswith(".mg") and file not in pipelineTemplates:
             pipelineTemplates[os.path.splitext(file)[0]] = os.path.join(folder, file)
 
-meshroomFolder = os.path.dirname(os.path.dirname(__file__))
+def initNodes():
+    meshroomFolder = os.path.dirname(os.path.dirname(__file__))
+    additionalNodesPath = os.environ.get("MESHROOM_NODES_PATH", "").split(os.pathsep)
+    # filter empty strings
+    additionalNodesPath = [i for i in additionalNodesPath if i]
+    nodesFolders = [os.path.join(meshroomFolder, 'nodes')] + additionalNodesPath
+    for f in nodesFolders:
+        loadAllNodes(folder=f)
 
-additionalNodesPath = os.environ.get("MESHROOM_NODES_PATH", "").split(os.pathsep)
-# filter empty strings
-additionalNodesPath = [i for i in additionalNodesPath if i]
+def initSubmitters():
+    meshroomFolder = os.path.dirname(os.path.dirname(__file__))
+    subs = loadSubmitters(os.environ.get("MESHROOM_SUBMITTERS_PATH", meshroomFolder), 'submitters')
+    for sub in subs:
+        registerSubmitter(sub())
 
-# Load plugins:
-# - Nodes
-nodesFolders = [os.path.join(meshroomFolder, 'nodes')] + additionalNodesPath
+def initPipelines():
+    meshroomFolder = os.path.dirname(os.path.dirname(__file__))
+    # Load pipeline templates: check in the default folder and any folder the user might have
+    # added to the environment variable
+    additionalPipelinesPath = os.environ.get("MESHROOM_PIPELINE_TEMPLATES_PATH", "").split(os.pathsep)
+    additionalPipelinesPath = [i for i in additionalPipelinesPath if i]
+    pipelineTemplatesFolders = [os.path.join(meshroomFolder, 'pipelines')] + additionalPipelinesPath
+    for f in pipelineTemplatesFolders:
+        loadPipelineTemplates(f)
 
-for f in nodesFolders:
-    loadAllNodes(folder=f)
-
-# - Submitters
-subs = loadSubmitters(os.environ.get("MESHROOM_SUBMITTERS_PATH", meshroomFolder), 'submitters')
-
-for sub in subs:
-    registerSubmitter(sub())
-
-# Load pipeline templates: check in the default folder and any folder the user might have
-# added to the environment variable
-additionalPipelinesPath = os.environ.get("MESHROOM_PIPELINE_TEMPLATES_PATH", "").split(os.pathsep)
-additionalPipelinesPath = [i for i in additionalPipelinesPath if i]
-pipelineTemplatesFolders = [os.path.join(meshroomFolder, 'pipelines')] + additionalPipelinesPath
-
-for f in pipelineTemplatesFolders:
-    loadPipelineTemplates(f)
+def initPlugins():
+    initNodes()
+    initSubmitters()
+    initPipelines()

--- a/meshroom/ui/app.py
+++ b/meshroom/ui/app.py
@@ -124,6 +124,8 @@ class MeshroomApp(QApplication):
         # - clean cache directory and make sure it exists on disk
         ThumbnailCache.initialize()
 
+        meshroom.core.initPlugins()
+
         # QML engine setup
         qmlDir = os.path.join(pwd, "qml")
         url = os.path.join(qmlDir, "main.qml")

--- a/tests/test_multiviewPipeline.py
+++ b/tests/test_multiviewPipeline.py
@@ -9,6 +9,9 @@ from meshroom.core.node import Node
 
 
 def test_multiviewPipeline():
+    meshroom.core.initNodes()
+    meshroom.core.initPipelines()
+
     graph1InputImages = ['/non/existing/fileA']
     graph1 = loadGraph(meshroom.core.pipelineTemplates["photogrammetry"])
     graph1.name = "graph1"

--- a/tests/test_nodeCommandLineFormatting.py
+++ b/tests/test_nodeCommandLineFormatting.py
@@ -9,6 +9,8 @@ from meshroom.core.node import Node
 
 
 def test_formatting_listOfFiles():
+    meshroom.core.initNodes()
+
     inputImages = ['/non/existing/fileA', '/non/existing/with space/fileB']
 
     graph = Graph('')
@@ -37,6 +39,8 @@ def test_formatting_listOfFiles():
 
 
 def test_formatting_strings():
+    meshroom.core.initNodes()
+
     graph = Graph('')
     n1 = graph.addNewNode('ImageMatching')
     name = 'weights'
@@ -61,6 +65,8 @@ def test_formatting_strings():
 
 
 def test_formatting_groups():
+    meshroom.core.initNodes()
+
     graph = Graph('')
     n3 = graph.addNewNode('ImageProcessing')
     n3._buildCmdVars()  # prepare vars for command line creation

--- a/tests/test_templatesVersion.py
+++ b/tests/test_templatesVersion.py
@@ -15,6 +15,8 @@ def test_templateVersions():
     It fails when an upgrade of a templates is needed. Any template can still be opened even if its
     nodes are not up-to-date, as they will be automatically upgraded.
     """
+    meshroom.core.initNodes()
+    meshroom.core.initPipelines()
 
     assert len(pipelineTemplates) >= 1
 


### PR DESCRIPTION
<!-- Checklist before submission:

 - I have read the [contribution guidelines](../CONTRIBUTING.md).
 - I have updated the documentation, if applicable.
 - I have ensured that the change is tested somewhere.
 - I have followed the prevailing code style (for history readability and limit conflicts for maintainance).

-->
## Description

Avoid plugins load at meshroom.core import by replacing direct loading of nodes, submitters and pipelines in meshroom.core __init__.py with functions and call them appropriately in app and bin.

## Features list

<!--
- [ ] Feature one. Fix #XXX
- [ ] Improve something else
- [ ] Connect to #3 (to declare link to issues without closing it when the PR is merged).
- [X] Add "X" when it is done.
-->


## Implementation remarks

One function created per type, nodes, submitters and pipelines and one global function calling all of them.

<!--
Explain main implementation choices.
It is also the right place to ask for feedback and help when you hesitate on the implementation.
-->
