### PR TITLE
[nodes] SphereDetection: Increase max value for `sphereRadius`

### DIFF
--- a/meshroom/nodes/aliceVision/SphereDetection.py
+++ b/meshroom/nodes/aliceVision/SphereDetection.py
@@ -73,7 +73,7 @@ Spheres can be automatically detected or manually defined in the interface.
             label="Radius",
             description="Sphere radius in pixels.",
             value=500.0,
-            range=(0.0, 1000.0, 0.1),
+            range=(0.0, 10000.0, 0.1),
             enabled=lambda node: not node.autoDetect.value,
             uid=[0],
         ),


### PR DESCRIPTION
## Description

This PR updates the maximum value for the `sphereRadius` parameter of the `SphereDetection` node from 1000 to 10000.