### PR TITLE
Some fixes for dynamic output attributes

### DIFF
--- a/bin/meshroom_compute
+++ b/bin/meshroom_compute
@@ -55,11 +55,14 @@ if args.node:
             if chunk.status.status in submittedStatuses:
                 print('Warning: Node is already submitted with status "{}". See file: "{}"'.format(chunk.status.status.name, chunk.statusFile))
                 # sys.exit(-1)
+
+    node.preprocess()
     if args.iteration != -1:
         chunk = node.chunks[args.iteration]
         chunk.process(args.forceCompute)
     else:
         node.process(args.forceCompute)
+    node.postprocess()
 else:
     if args.iteration != -1:
         print('Error: "--iteration" only make sense when used with "--node".')

--- a/meshroom/core/node.py
+++ b/meshroom/core/node.py
@@ -1064,10 +1064,13 @@ class BaseNode(BaseObject):
         # logging.warning(data)
         for output in self.nodeDesc.outputs:
             if output.isDynamicValue:
-                if self.hasAttribute(output.name):
+                if self.hasAttribute(output.name) and output.name in data:
                     self.attribute(output.name).value = data[output.name]
                 else:
-                    logging.warning(f"loadOutputAttr: Missing dynamic output attribute: {self.name}.{output.name}")
+                    if not self.hasAttribute(output.name):
+                        logging.warning(f"loadOutputAttr: Missing dynamic output attribute. Node={self.name}, Attribute={output.name}")
+                    if output.name not in data:
+                        logging.warning(f"loadOutputAttr: Missing dynamic output value in file. Node={self.name}, Attribute={output.name}, File={valuesFile}, Data keys={data.keys()}")
 
     def saveOutputAttr(self):
         """ Save output attributes with dynamic values into a values.json file.

--- a/meshroom/ui/graph.py
+++ b/meshroom/ui/graph.py
@@ -190,6 +190,7 @@ class ChunksMonitor(QObject):
             # update chunk status if last modification time has changed since previous record
             if fileModTime != chunk.statusFileLastModTime:
                 chunk.updateStatusFromCache()
+                chunk.node.updateOutputAttr()
 
     def onFilePollerRefreshUpdated(self):
         """

--- a/meshroom/ui/qml/GraphEditor/AttributeItemDelegate.qml
+++ b/meshroom/ui/qml/GraphEditor/AttributeItemDelegate.qml
@@ -193,6 +193,10 @@ RowLayout {
         Layout.fillWidth: true
 
         sourceComponent: {
+            if (attribute.value === undefined)
+            {
+                return notComputed_component
+            }
             switch (attribute.type) {
                 case "PushButtonParam":
                     return pushButton_component
@@ -217,6 +221,22 @@ RowLayout {
                     return color_component
                 default:
                     return textField_component
+            }
+        }
+
+        Component {
+            id: notComputed_component
+            Label {
+                anchors.fill: parent
+                text: MaterialIcons.do_not_disturb_alt
+                horizontalAlignment: Text.AlignHCenter
+                verticalAlignment: Text.AlignVCenter
+                background: Rectangle {
+                    anchors.fill: parent
+                    border.width: 0
+                    radius: 20
+                    color: Qt.darker(palette.window, 1.1)
+                }
             }
         }
 


### PR DESCRIPTION
- [x] add missing preprocess/postprocess calls to meshroom_compute
- [x] update dynamic output attributes when the chunk status changes from outside
- [x] UI: do not display the value of attributes when it is not computed (for dynamic output attributes only)