### PR TITLE
[ui] Fix local computation of subgraphs for unsaved projects

### DIFF
--- a/meshroom/ui/qml/main.qml
+++ b/meshroom/ui/qml/main.qml
@@ -219,7 +219,7 @@ ApplicationWindow {
         function compute(nodes, force) {
             if (!force && warnIfUnsaved && !_reconstruction.graph.filepath)
             {
-                unsavedComputeDialog.currentNode = nodes[0];
+                unsavedComputeDialog.selectedNodes = nodes;
                 unsavedComputeDialog.open();
             }
             else {
@@ -323,7 +323,7 @@ ApplicationWindow {
         MessageDialog {
             id: unsavedComputeDialog
 
-            property var currentNode: null
+            property var selectedNodes: null
 
             canCopy: false
             icon.text: MaterialIcons.warning
@@ -349,7 +349,7 @@ ApplicationWindow {
 
             onDiscarded: {
                 close()
-                computeManager.compute(currentNode, true)
+                computeManager.compute(selectedNodes, true)
             }
 
             onAccepted: saveAsAction.trigger()


### PR DESCRIPTION
## Description
If a project is not saved but you still want to process part of the graph, it is great to know all the selected nodes, to then be able to compute only them.