### PR TITLE
[Viewer] Current frame for Sequence should not be set during changes of Image Gallery

### DIFF
--- a/meshroom/ui/qml/Viewer/Viewer2D.qml
+++ b/meshroom/ui/qml/Viewer/Viewer2D.qml
@@ -294,7 +294,6 @@ FocusScope {
 
             frameRange.min = 0
             frameRange.max = seq.length - 1
-            currentFrame = 0
 
             return seq
         }
@@ -349,6 +348,7 @@ FocusScope {
         } else {
             root.source = ""
             root.sequence = getSequence()
+            currentFrame = frameRange.min
         }
     }
 


### PR DESCRIPTION
## Description
To prevent reset of index in Image Gallery, we need to move the reset of current frame for the Sequence Player.