### PR TITLE
[ui] Fix Camera Init Group Index should stay the same at adding or removing CameraInit events

### DIFF
--- a/meshroom/ui/reconstruction.py
+++ b/meshroom/ui/reconstruction.py
@@ -607,6 +607,9 @@ class Reconstruction(UIGraph):
         if self.cameraInit is None or self.cameraInit not in cameraInits:
             self.cameraInit = cameraInits[0] if cameraInits else None
 
+        # Manually emit the signal to ensure the active CameraInit index is always up-to-date in the UI
+        self.cameraInitChanged.emit()
+
     def getCameraInitIndex(self):
         if not self._cameraInit:
             # No CameraInit node


### PR DESCRIPTION
## Description
Prevent from putting the index of Camera Init group in the Image Gallery to 1 if we only add or remove an external Camera Init.