### PR TITLE
[ui] setSfm only depends on nodes with category "sfm" and CameraInit should be set only if it is different from the current one

### DIFF
--- a/meshroom/ui/reconstruction.py
+++ b/meshroom/ui/reconstruction.py
@@ -627,6 +627,8 @@ class Reconstruction(UIGraph):
             self.setSelectedViewId(self.viewpoints[0].viewId.value)
 
     def setCameraInitNode(self, node):
+        if self._cameraInit == node:
+            return
         self.setCameraInitIndex(self._cameraInits.indexOf(node))
 
     @Slot()
@@ -1020,7 +1022,7 @@ class Reconstruction(UIGraph):
                 if node.nodeType in nodeTypes:
                     self.activeNodes.getr(category).node = node
 
-                    if category == "sfmData":
+                    if category == "sfm":
                         self.setSfm(node)
 
         if node.nodeType == "CameraInit":


### PR DESCRIPTION
## Description
setSFM was changed to rely on sfmData nodes but it is not working.
And setCameraInitNode should be triggered only if the node is different from the current one.