### PR TITLE
[Viewer2D] Only reset index of currentFrame if the currentFrame is after max of frameRange

### DIFF
--- a/meshroom/ui/qml/Viewer/Viewer2D.qml
+++ b/meshroom/ui/qml/Viewer/Viewer2D.qml
@@ -348,7 +348,8 @@ FocusScope {
         } else {
             root.source = ""
             root.sequence = getSequence()
-            currentFrame = frameRange.min
+            if (currentFrame > frameRange.max)
+                currentFrame = frameRange.min
         }
     }
 


### PR DESCRIPTION
## Description
Fix of bug when closing a node the index of ImageGallery is reset. Comes from the building of sequence.
