### PR TITLE
[GraphEditor] AttributeItemDelegate: Return valid component for `PushButton`

### DIFF
--- a/meshroom/ui/qml/GraphEditor/AttributeItemDelegate.qml
+++ b/meshroom/ui/qml/GraphEditor/AttributeItemDelegate.qml
@@ -193,8 +193,8 @@ RowLayout {
         Layout.fillWidth: true
 
         sourceComponent: {
-            if (attribute.value === undefined)
-            {
+            // PushButtonParam always has value == undefined, so it needs to be excluded from this check
+            if (attribute.type != "PushButtonParam" && attribute.value === undefined) {
                 return notComputed_component
             }
             switch (attribute.type) {


### PR DESCRIPTION
## Description

This PR fixes an issue related to the component display for push button attributes.

The value of a `PushButtonParam` being always `None`, it is necessary to check that the type of the component is not `PushButtonParam` before comparing its value to `undefined`. 

Otherwise, any `PushButtonParam` will always be represented by a "notComputed" component, making the `PushButtonParam` unusable.
