### PR TITLE
[ui] Add project to recent projects when dropping a file

### DIFF
--- a/meshroom/ui/qml/WorkspaceView.qml
+++ b/meshroom/ui/qml/WorkspaceView.qml
@@ -83,7 +83,9 @@ Item {
                 onFilesDropped: {
                     if (drop["meshroomScenes"].length == 1) {
                         ensureSaved(function() {
-                            reconstruction.handleFilesUrl(drop, augmentSfm ? null : cameraInit)
+                            if (reconstruction.handleFilesUrl(drop, augmentSfm ? null : cameraInit)) {
+                                MeshroomApp.addRecentProjectFile(drop["meshroomScenes"][0])
+                            }
                         })
                     } else {
                         reconstruction.handleFilesUrl(drop, augmentSfm ? null : cameraInit)

--- a/meshroom/ui/qml/main.qml
+++ b/meshroom/ui/qml/main.qml
@@ -1255,7 +1255,9 @@ ApplicationWindow {
                         var filesByType = _reconstruction.getFilesByTypeFromDrop(drop.urls)
                         if (filesByType["meshroomScenes"].length == 1) {
                             ensureSaved(function() {
-                                _reconstruction.handleFilesUrl(filesByType, null, mousePosition)
+                                if (_reconstruction.handleFilesUrl(filesByType, null, mousePosition)) {
+                                    MeshroomApp.addRecentProjectFile(filesByType["meshroomScenes"][0])
+                                }
                             })
                         } else {
                             _reconstruction.handleFilesUrl(filesByType, null, mousePosition)

--- a/meshroom/ui/reconstruction.py
+++ b/meshroom/ui/reconstruction.py
@@ -752,9 +752,9 @@ class Reconstruction(UIGraph):
         """ Get all view Ids involved in the reconstruction. """
         return [vp.viewId.value for node in self._cameraInits for vp in node.viewpoints.value]
 
-    @Slot("QVariantMap")
-    @Slot("QVariantMap", Node)
-    @Slot("QVariantMap", Node, "QPoint")
+    @Slot("QVariantMap", result=bool)
+    @Slot("QVariantMap", Node, result=bool)
+    @Slot("QVariantMap", Node, "QPoint", result=bool)
     def handleFilesUrl(self, filesByType, cameraInit=None, position=None):
         """ Handle drop events aiming to add images to the Reconstruction.
         This method allows to reduce process time by doing it on Python side.
@@ -830,7 +830,8 @@ class Reconstruction(UIGraph):
                     )
                 )
             else:
-                self.loadUrl(filesByType["meshroomScenes"][0])
+                return self.loadUrl(filesByType["meshroomScenes"][0])
+
 
 
         if not filesByType["images"] and not filesByType["videos"] and not filesByType["panoramaInfo"] and not filesByType["meshroomScenes"]:
@@ -843,6 +844,10 @@ class Reconstruction(UIGraph):
                         "Unknown file extensions: " + ', '.join(extensions)
                     )
                 )
+        
+        # As the boolean is introduced to check if the project is loaded or not, the return value is added to the function.
+        # The default value is False, which means the project is not loaded.
+        return False
 
     @Slot("QList<QUrl>", result="QVariantMap")
     def getFilesByTypeFromDrop(self, urls):


### PR DESCRIPTION
## Description
As it was not the case, we add the behavior to extend the Recent Projects variable with the projects dropped within Meshroom.
To do wo, we had to implement a boolean as a return from handleFilesByUrl to know if the loading was a success or not.