### PR TITLE
Initialize `core` plugins at different moments

### DIFF
--- a/bin/meshroom_batch
+++ b/bin/meshroom_batch
@@ -14,7 +14,7 @@ from meshroom import multiview
 from meshroom.core.desc import InitNode
 import logging
 
-meshroom.core.initPlugins()
+meshroom.core.initPipelines()
 
 parser = argparse.ArgumentParser(description='Launch the full photogrammetry or Panorama HDR pipeline.')
 parser.add_argument('-i', '--input', metavar='NODEINSTANCE:"SFM/FOLDERS/IMAGES;..."', type=str, nargs='*',
@@ -91,6 +91,8 @@ if args.verbose:
 if not args.input and not args.inputRecursive:
     print('Nothing to compute. You need to set --input or --inputRecursive.')
     sys.exit(1)
+
+meshroom.core.initNodes()
 
 graph = multiview.Graph(name=args.pipeline)
 
@@ -218,6 +220,7 @@ if not args.output:
 toNodes = graph.findNodes(args.toNode) if args.toNode else None
 
 if args.submit:
+    meshroom.core.initSubmitters()
     if not args.save:
         raise ValueError('Need to save the project to file to submit on renderfarm.')
     # submit on renderfarm

--- a/meshroom/core/__init__.py
+++ b/meshroom/core/__init__.py
@@ -354,8 +354,3 @@ def initPipelines():
     pipelineTemplatesFolders = [os.path.join(meshroomFolder, 'pipelines')] + additionalPipelinesPath
     for f in pipelineTemplatesFolders:
         loadPipelineTemplates(f)
-
-def initPlugins():
-    initNodes()
-    initSubmitters()
-    initPipelines()

--- a/meshroom/ui/app.py
+++ b/meshroom/ui/app.py
@@ -73,6 +73,8 @@ class MessageHandler(object):
 class MeshroomApp(QApplication):
     """ Meshroom UI Application. """
     def __init__(self, args):
+        meshroom.core.initPipelines()
+
         QtArgs = [args[0], '-style', 'fusion'] + args[1:]  # force Fusion style by default
 
         parser = argparse.ArgumentParser(prog=args[0], description='Launch Meshroom UI.', add_help=True)
@@ -124,7 +126,8 @@ class MeshroomApp(QApplication):
         # - clean cache directory and make sure it exists on disk
         ThumbnailCache.initialize()
 
-        meshroom.core.initPlugins()
+        meshroom.core.initNodes()
+        meshroom.core.initSubmitters()
 
         # QML engine setup
         qmlDir = os.path.join(pwd, "qml")


### PR DESCRIPTION
## Description

This PR changes the order of initialization of the `core` plugins both in the main app and `meshroom_batch`.

- For the main app, the pipelines are now initialized prior to the parsing of the command line to ensure that the names of all the available templates can be provided to the "help" message. The nodes and submitters remain initialized at the same point.
- For `meshroom_batch`, the pipelines are also initialized prior to the parsing of the command line (for the same reasons), the nodes are initialized at the same point, and the submitters are initialized if and only if the `--submit` argument has been provided.