### PR TITLE
[core] Prevent from having undefined attribute and connect onChanged after first init

### DIFF
--- a/meshroom/core/attribute.py
+++ b/meshroom/core/attribute.py
@@ -73,10 +73,7 @@ class Attribute(BaseObject):
         # invalidation value for output attributes
         self._invalidationValue = ""
 
-        self._value = None
         self.initValue()
-
-        self.valueChanged.connect(self.onChanged)
 
     @property
     def node(self):
@@ -259,6 +256,7 @@ class Attribute(BaseObject):
     def initValue(self):
         if self.desc._valueType is not None:
             self._value = self.desc._valueType()
+        self.valueChanged.connect(self.onChanged)
 
     def resetToDefaultValue(self, emitSignals=True):
         self._set_value(copy.copy(self.defaultValue()), emitSignals=emitSignals)


### PR DESCRIPTION
## Description
To remove all errors raised in Image Gallery, we need to first set the value of the attribute before connecting it to onChanged. Plus, we remove the self._value = None to be sure that the UI never fails to display something.