### PR TITLE
[core] Attribute: Directly access description's type in `getType()`

### DIFF
--- a/meshroom/core/attribute.py
+++ b/meshroom/core/attribute.py
@@ -112,7 +112,7 @@ class Attribute(BaseObject):
         return "{" + self.getFullNameToNode() + "}"
 
     def getType(self):
-        return self.attributeDesc.__class__.__name__
+        return self.attributeDesc.type
 
     def _isReadOnly(self):
         return not self._isOutput and self.node.isCompatibilityNode


### PR DESCRIPTION
## Description

The attributes' descriptions already have a `type` property which is set with `self.__class__.__name__`. Instead of performing the same call directly within the attributes, the `type` property of the description is used.

In case a description would not have a standard type (i.e. anything that may differ from the class name), this information will be propagated at the attribute level instead of being lost.