### PR TITLE
[GraphEditor] Base `ChoiceParam` model on attribute instead of description

### DIFF
--- a/meshroom/ui/qml/GraphEditor/AttributeItemDelegate.qml
+++ b/meshroom/ui/qml/GraphEditor/AttributeItemDelegate.qml
@@ -506,7 +506,7 @@ RowLayout {
             Flow {
                 Repeater {
                     id: checkbox_repeater
-                    model: attribute.desc.values
+                    model: attribute.values
                     delegate: CheckBox {
                         enabled: root.editable
                         text: modelData


### PR DESCRIPTION
## Description

The model for the values of a `ChoiceParam` attribute is now based on the attribute's list of available values instead of its description's list of available values.

This allows to edit dynamically the values for a non-exclusive `ChoiceParam` and have the UI immediately reflect these edits.