### PR TITLE
[ui] app: Correctly reload list of available templates

### DIFF
--- a/meshroom/ui/app.py
+++ b/meshroom/ui/app.py
@@ -223,8 +223,7 @@ class MeshroomApp(QApplication):
 
     @Slot()
     def reloadTemplateList(self):
-        for f in meshroom.core.pipelineTemplatesFolders:
-            meshroom.core.loadPipelineTemplates(f)
+        meshroom.core.initPipelines()
         self.pipelineTemplateFilesChanged.emit()
 
     def _recentProjectFiles(self):


### PR DESCRIPTION
## Description

Following https://github.com/alicevision/Meshroom/pull/2458 which replaced loading the nodes, templates and submitters upon `meshroom.core`'s import with dedicated functions, `pipelineTemplatesFolders` is not available anymore as a global variable in `meshroom.core`. 

The automatic reload of the list of available templates whenever a new template is saved (through the "Save As Template" menu), which used to iterate directly over that global variable, thus needs `initPipelines()` to perform these iterations over it. 