### PR TITLE
[ui] Correctly lose focus on `StringParam` when clicking outside of its text field

### DIFF
--- a/meshroom/ui/qml/GraphEditor/AttributeEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/AttributeEditor.qml
@@ -59,7 +59,7 @@ ListView {
     // when clicking on the background
     MouseArea {
         anchors.fill: parent
-        onClicked: root.forceActiveFocus()
+        onClicked: forceActiveFocus()
         z: -1
     }
 }


### PR DESCRIPTION
## Description

When editing an attribute which is a text, if we click outside we want to lose focus of it.

Prior to this PR, the focus was only lost if a click was made on the attribute's label field, or if another attribute was gaining focus. 