### PR TITLE
[ui] Fix function evaluations in invalid QML context and minor fixes

### DIFF
--- a/meshroom/ui/qml/Application.qml
+++ b/meshroom/ui/qml/Application.qml
@@ -383,6 +383,10 @@ Page {
             fireCallback()
         }
 
+        onRejected: {
+            _window.isClosing = false
+        }
+
         onAccepted: {
             // Save current file
             if (saveAction.enabled && _reconstruction.graph.filepath) {

--- a/meshroom/ui/qml/GraphEditor/AttributePin.qml
+++ b/meshroom/ui/qml/GraphEditor/AttributePin.qml
@@ -130,8 +130,8 @@ RowLayout {
             readonly property string connectorType: "input"
             readonly property alias attribute: root.attribute
             readonly property alias nodeItem: root.nodeItem
-            readonly property bool isOutput: attribute.isOutput
-            readonly property string baseType: attribute.baseType
+            readonly property bool isOutput: Boolean(attribute.isOutput)
+            readonly property string baseType: attribute.baseType !== undefined ? attribute.baseType : ""
             readonly property alias isList: root.isList
             property bool dragAccepted: false
             anchors.verticalCenter: parent.verticalCenter
@@ -192,7 +192,7 @@ RowLayout {
 
             enabled: !root.readOnly
             property bool hovered: (inputConnectMA.containsMouse || inputConnectMA.drag.active || inputDropArea.containsDrag || outputConnectMA.containsMouse || outputConnectMA.drag.active || outputDropArea.containsDrag)
-            text: attribute ? attribute.label : ""
+            text: (attribute && attribute.label) !== undefined ? attribute.label : ""
             elide: hovered ? Text.ElideNone : Text.ElideMiddle
             width: hovered ? contentWidth : parent.width
             font.pointSize: 7
@@ -279,9 +279,9 @@ RowLayout {
             readonly property string connectorType: "output"
             readonly property alias attribute: root.attribute
             readonly property alias nodeItem: root.nodeItem
-            readonly property bool isOutput: attribute.isOutput
+            readonly property bool isOutput: Boolean(attribute.isOutput)
             readonly property alias isList: root.isList
-            readonly property string baseType: attribute.baseType
+            readonly property string baseType: attribute.baseType !== undefined ? attribute.baseType : ""
             property bool dropAccepted: false
             anchors.horizontalCenter: parent.horizontalCenter
             anchors.verticalCenter: parent.verticalCenter

--- a/meshroom/ui/qml/GraphEditor/GraphEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/GraphEditor.qml
@@ -542,11 +542,15 @@ Item {
 
                     Component.onDestruction: {
                         // Handles the case where the edge is destroyed while hidden because it is replaced: the pins should be re-enabled
-                        if (src && src !== undefined)
-                            src.updatePin(true, true)  // isSrc = true, isVisible = true
-                        if (dst && dst !== undefined)
-                            dst.updatePin(false, true)  // isSrc = false, isVisible = true
+                        if (!_window.isClosing) {
+                            // When the window is closing, the QML context becomes invalid, which causes function calls to result in errors
+                            if (src && src !== undefined)
+                                src.updatePin(true, true)  // isSrc = true, isVisible = true
+                            if (dst && dst !== undefined)
+                                dst.updatePin(false, true)  // isSrc = false, isVisible = true
+                        }
                     }
+
                 }
             }
 

--- a/meshroom/ui/qml/GraphEditor/Node.qml
+++ b/meshroom/ui/qml/GraphEditor/Node.qml
@@ -407,8 +407,8 @@ Item {
 
                                 delegate: Loader {
                                     id: outputLoader
-                                    active: object.isOutput && object.desc.visible
-                                    visible: object.enabled || object.hasOutputConnections
+                                    active: Boolean(object.isOutput && object.desc.visible)
+                                    visible: Boolean(object.enabled || object.hasOutputConnections)
                                     anchors.right: parent.right
                                     width: outputs.width
 
@@ -443,7 +443,7 @@ Item {
                                 delegate: Loader {
                                     id: inputLoader
                                     active: !object.isOutput && isFileAttributeBaseType(object)
-                                    visible: object.enabled
+                                    visible: Boolean(object.enabled)
                                     width: inputs.width
 
                                     sourceComponent: AttributePin {
@@ -503,8 +503,8 @@ Item {
                                     delegate: Loader {
                                         id: paramLoader
                                         active: !object.isOutput && !isFileAttributeBaseType(object)
-                                        visible: object.enabled || object.isLink || object.hasOutputConnections
-                                        property bool isFullyActive: (m.displayParams || object.isLink || object.hasOutputConnections)
+                                        visible: Boolean(object.enabled || object.isLink || object.hasOutputConnections)
+                                        property bool isFullyActive: Boolean(m.displayParams || object.isLink || object.hasOutputConnections)
                                         width: parent.width
 
                                         sourceComponent: AttributePin {
@@ -517,7 +517,7 @@ Item {
                                             Behavior on height { PropertyAnimation {easing.type: Easing.Linear} }
                                             visible: (height == childrenRect.height)
                                             attribute: object
-                                            readOnly: root.readOnly || object.isReadOnly
+                                            readOnly: Boolean(root.readOnly || object.isReadOnly)
                                             Component.onCompleted: attributePinCreated(attribute, inParamsPin)
                                             Component.onDestruction: attributePinDeleted(attribute, inParamsPin)
                                             onPressed: root.pressed(mouse)

--- a/meshroom/ui/qml/Viewer3D/MediaLibrary.qml
+++ b/meshroom/ui/qml/Viewer3D/MediaLibrary.qml
@@ -167,7 +167,7 @@ Entity {
 
             // Specific properties to the MESHING node (declared and initialized for every Entity anyway)
             property bool hasBoundingBox: {
-                if (currentNode.hasAttribute("useBoundingBox")) // Can have a BoundingBox
+                if (currentNode && currentNode.hasAttribute("useBoundingBox")) // Can have a BoundingBox
                     return currentNode.attribute("useBoundingBox").value
                 return false
             }

--- a/meshroom/ui/qml/main.qml
+++ b/meshroom/ui/qml/main.qml
@@ -14,6 +14,8 @@ ApplicationWindow {
     minimumHeight: 500
     visible: true
 
+    property bool isClosing: false
+
     title: {
         var t = (_reconstruction && _reconstruction.graph && _reconstruction.graph.filepath) ? _reconstruction.graph.filepath : "Untitled"
         if (_reconstruction && !_reconstruction.undoStack.clean)
@@ -27,6 +29,7 @@ ApplicationWindow {
         close.accepted = false
         if (!ensureNotComputing())
             return
+        isClosing = true
         ensureSaved(function() { Qt.quit() })
     }
 


### PR DESCRIPTION
## Description

This PR fixes the following QML warning:
`QQmlVMEMetaObject: Internal error - attempted to evaluate a function in an invalid context`
which was introduced in #1925 and occurred when edges were being destroyed while the QML context was invalid (meaning the application had entered its closing phase).

The status of the application's window is monitored to detect when it's entering its closing phase (which will lead to the QML context being invalidated). If the window is closing, during the destruction of edges components, no pin operation to re-enable pins will be performed. 


Additionally, this PR also fixes minor QML warnings:
- calls to `hasAttribute` when `currentNode` is `null`
- assignments of `undefined` to edge-related properties when the graph is being updated


## Features list

- [x] Add a property that monitors when the QML context might become invalid;
- [x] Do not call functions while components are being destroyed if the QML context has become invalid;
- [x] Do not call functions on non-existing objects
- [x] Prevent assigning `undefined` to typed properties
