### PR TITLE
[AttributeItemDelegate] Position the attribute description tooltip

### DIFF
--- a/meshroom/ui/qml/GraphEditor/AttributeItemDelegate.qml
+++ b/meshroom/ui/qml/GraphEditor/AttributeItemDelegate.qml
@@ -74,6 +74,9 @@ RowLayout {
                 ToolTip {
                     id: parameterTooltip
 
+                    // Position in y at mouse position
+                    y: parameterMA.mouseY + 10
+
                     text: {
                         var tooltip = ""
                         if (!object.validValue && object.desc.errorMessage !== "")

--- a/meshroom/ui/qml/GraphEditor/AttributePin.qml
+++ b/meshroom/ui/qml/GraphEditor/AttributePin.qml
@@ -35,10 +35,13 @@ RowLayout {
     layoutDirection: Qt.LeftToRight
     spacing: 3
 
-    ToolTip.text: attribute.name + ": " + attribute.type
-    ToolTip.visible: nameLabel.hovered
-    ToolTip.toolTip.y: nameLabel.y + nameLabel.height
-    ToolTip.toolTip.x: nameLabel.x
+    ToolTip {
+        text: attribute.name + ": " + attribute.type
+        visible: nameLabel.hovered
+
+        y: nameLabel.y + nameLabel.height
+        x: nameLabel.x
+    }
 
     function updatePin(isSrc, isVisible)
     {


### PR DESCRIPTION
## Description
Under the mouse position to be sure it doesn't slide on the screen, there were some problems for the elements in list attributes such as intrinsics.

Also, it fixes dangerous behavior that displays the tooltip on the mouse position.