### PR TITLE
[Viewer3D] Apply the pixel aspect ratio for the Frame Overlay

### DIFF
--- a/meshroom/ui/qml/Viewer3D/Viewer3D.qml
+++ b/meshroom/ui/qml/Viewer3D/Viewer3D.qml
@@ -248,7 +248,7 @@ FocusScope {
         sourceComponent: ImageOverlay {
             id: imageOverlay
             source: root.viewpoint.undistortedImageSource
-            imageRatio: root.viewpoint.orientedImageSize.width / root.viewpoint.orientedImageSize.height
+            imageRatio: root.viewpoint.orientedImageSize.width * root.viewpoint.pixelAspectRatio / root.viewpoint.orientedImageSize.height
             uvCenterOffset: root.viewpoint.uvCenterOffset
             showFrame: Viewer3DSettings.showViewpointImageFrame
             imageOpacity: Viewer3DSettings.viewpointImageOverlayOpacity

--- a/meshroom/ui/reconstruction.py
+++ b/meshroom/ui/reconstruction.py
@@ -367,6 +367,14 @@ class ViewpointWrapper(QObject):
         else:
             sensorHeight = self.solvedIntrinsics["sensorHeight"]
             return 2.0 * math.atan(float(sensorHeight) / (2.0 * float(focalLength))) * 180.0 / math.pi
+        
+    @Property(type=float, notify=sfmParamsChanged)
+    def pixelAspectRatio(self):
+        """ Get camera pixel aspect ratio. """
+        if not self.solvedIntrinsics:
+            return 1.0
+        
+        return float(self.solvedIntrinsics["pixelRatio"])
 
     @Property(type=QUrl, notify=undistortedImageParamsChanged)
     def undistortedImageSource(self):


### PR DESCRIPTION
Make sure pixel aspect ratio is used inside 3d viewer (when viewing through camera)

Associated to https://github.com/alicevision/AliceVision/pull/1745