### PR TITLE
[core] Simplify node descriptions

### DIFF
--- a/meshroom/core/desc.py
+++ b/meshroom/core/desc.py
@@ -336,7 +336,7 @@ class BoolParam(Param):
 class IntParam(Param):
     """
     """
-    def __init__(self, name, label, description, value, range, group="allParams", advanced=False, enabled=True,
+    def __init__(self, name, label, description, value, range=None, group="allParams", advanced=False, enabled=True,
                  invalidate=True, semantic="", validValue=True, errorMessage="", visible=True, exposed=False):
         self._range = range
         super(IntParam, self).__init__(name=name, label=label, description=description, value=value,
@@ -366,7 +366,7 @@ class IntParam(Param):
 class FloatParam(Param):
     """
     """
-    def __init__(self, name, label, description, value, range, group="allParams", advanced=False, enabled=True,
+    def __init__(self, name, label, description, value, range=None, group="allParams", advanced=False, enabled=True,
                  invalidate=True, semantic="", validValue=True, errorMessage="", visible=True, exposed=False):
         self._range = range
         super(FloatParam, self).__init__(name=name, label=label, description=description, value=value,

--- a/meshroom/core/desc.py
+++ b/meshroom/core/desc.py
@@ -417,7 +417,7 @@ class PushButtonParam(Param):
 class ChoiceParam(Param):
     """
     """
-    def __init__(self, name, label, description, value, values, exclusive, group="allParams", joinChar=" ",
+    def __init__(self, name, label, description, value, values, exclusive=True, group="allParams", joinChar=" ",
                  advanced=False, enabled=True, invalidate=True, semantic="", validValue=True, errorMessage="",
                  visible=True, exposed=False):
         assert values

--- a/meshroom/nodes/aliceVision/ApplyCalibration.py
+++ b/meshroom/nodes/aliceVision/ApplyCalibration.py
@@ -36,7 +36,6 @@ class ApplyCalibration(desc.AVCommandLineNode):
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
             values=VERBOSE_LEVEL,
             value="info",
-            exclusive=True,
         ),
     ]
 

--- a/meshroom/nodes/aliceVision/CameraCalibration.py
+++ b/meshroom/nodes/aliceVision/CameraCalibration.py
@@ -27,7 +27,6 @@ class CameraCalibration(desc.AVCommandLineNode):
             description="Type of pattern (CHESSBOARD, CIRCLES, ASYMMETRIC_CIRCLES, ASYMMETRIC_CCTAG).",
             value="CHESSBOARD",
             values=["CHESSBOARD", "CIRCLES", "ASYMMETRIC_CIRCLES", "ASYMMETRIC_CCTAG"],
-            exclusive=True,
         ),
         desc.GroupAttribute(
             name="size",
@@ -117,7 +116,6 @@ class CameraCalibration(desc.AVCommandLineNode):
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
             values=VERBOSE_LEVEL,
             value="info",
-            exclusive=True,
         ),
     ]
 

--- a/meshroom/nodes/aliceVision/CameraInit.py
+++ b/meshroom/nodes/aliceVision/CameraInit.py
@@ -134,7 +134,6 @@ Intrinsic = [
                     " - equidistant: Non-projective camera model suited for full-fisheye optics.\n",
         value="pinhole",
         values=["pinhole", "equidistant"],
-        exclusive=True,
     ),
     desc.ChoiceParam(
         name="distortionType",
@@ -149,7 +148,6 @@ Intrinsic = [
                     " - fisheye4: distortion with 4 parameters suited for fisheye optics (like 120deg FoV).\n",
         value="radialk3",
         values=["none", "radialk1", "radialk3", "radialk3pt", "brown", "fisheye4", "fisheye1"],
-        exclusive=True,
     ),
     desc.IntParam(
         name="width",
@@ -216,7 +214,6 @@ Intrinsic = [
                     " - none: not set.",
         values=["calibrated", "estimated", "unknown", "none"],
         value="none",
-        exclusive=True,
     ),
     desc.ChoiceParam(
         name="distortionInitializationMode",
@@ -228,7 +225,6 @@ Intrinsic = [
                     " - none: not set.",
         values=["calibrated", "estimated", "unknown", "none"],
         value="none",
-        exclusive=True,
     ),
     desc.ListAttribute(
         name="distortionParams",
@@ -418,7 +414,6 @@ The needed metadata are:
                         " - image: never group images from comparable devices.",
             values=["global", "folder", "image"],
             value="folder",
-            exclusive=True,
             invalidate=False,
         ),
         desc.ChoiceParam(
@@ -432,7 +427,6 @@ The needed metadata are:
                         " - DCPMetadata: Same as None with DCP info added in metadata.",
             values=RAW_COLOR_INTERPRETATION,
             value="DCPLinearProcessing" if os.environ.get("ALICEVISION_COLOR_PROFILE_DB", "") else "LibRawWhiteBalancing",
-            exclusive=True,
         ),
         desc.File(
             name="colorProfileDatabase",
@@ -459,7 +453,6 @@ The needed metadata are:
                         " - filename : Generate viewId from filename using regex.",
             value="metadata",
             values=["metadata", "filename"],
-            exclusive=True,
             invalidate=False,
             advanced=True,
         ),
@@ -485,7 +478,6 @@ The needed metadata are:
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
             values=VERBOSE_LEVEL,
             value="info",
-            exclusive=True,
         ),
     ]
 

--- a/meshroom/nodes/aliceVision/CameraLocalization.py
+++ b/meshroom/nodes/aliceVision/CameraLocalization.py
@@ -51,7 +51,6 @@ class CameraLocalization(desc.AVCommandLineNode):
             description="Preset for the feature extractor when localizing a new image (low, medium, normal, high, ultra).",
             value="normal",
             values=["low", "medium", "normal", "high", "ultra"],
-            exclusive=True,
         ),
         desc.ChoiceParam(
             name="resectionEstimator",
@@ -59,7 +58,6 @@ class CameraLocalization(desc.AVCommandLineNode):
             description="The type of *sac framework to use for resection (acransac, loransac).",
             value="acransac",
             values=["acransac", "loransac"],
-            exclusive=True,
         ),
         desc.ChoiceParam(
             name="matchingEstimator",
@@ -67,7 +65,6 @@ class CameraLocalization(desc.AVCommandLineNode):
             description="The type of *sac framework to use for matching (acransac, loransac).",
             value="acransac",
             values=["acransac", "loransac"],
-            exclusive=True,
         ),
         desc.File(
             name="calibration",
@@ -127,7 +124,6 @@ class CameraLocalization(desc.AVCommandLineNode):
             description="[voctree] Algorithm type: FirstBest, AllResults.",
             value="AllResults",
             values=["FirstBest", "AllResults"],
-            exclusive=True,
         ),
         desc.FloatParam(
             name="matchingError",
@@ -187,7 +183,6 @@ class CameraLocalization(desc.AVCommandLineNode):
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
             values=VERBOSE_LEVEL,
             value="info",
-            exclusive=True,
         ),
     ]
 

--- a/meshroom/nodes/aliceVision/CameraRigCalibration.py
+++ b/meshroom/nodes/aliceVision/CameraRigCalibration.py
@@ -58,7 +58,6 @@ class CameraRigCalibration(desc.AVCommandLineNode):
             description="Preset for the feature extractor when localizing a new image (low, medium, normal, high, ultra).",
             value="normal",
             values=["low", "medium", "normal", "high", "ultra"],
-            exclusive=True,
         ),
         desc.ChoiceParam(
             name="resectionEstimator",
@@ -66,7 +65,6 @@ class CameraRigCalibration(desc.AVCommandLineNode):
             description="The type of *sac framework to use for resection (acransac, loransac).",
             value="acransac",
             values=["acransac", "loransac"],
-            exclusive=True,
         ),
         desc.ChoiceParam(
             name="matchingEstimator",
@@ -74,7 +72,6 @@ class CameraRigCalibration(desc.AVCommandLineNode):
             description="The type of *sac framework to use for matching (acransac, loransac).",
             value="acransac",
             values=["acransac", "loransac"],
-            exclusive=True,
         ),
         desc.StringParam(
             name="refineIntrinsics",
@@ -115,7 +112,6 @@ class CameraRigCalibration(desc.AVCommandLineNode):
             description="[voctree] Algorithm type: {FirstBest, AllResults}.",
             value="AllResults",
             values=["FirstBest", "AllResults"],
-            exclusive=True,
         ),
         desc.IntParam(
             name="nbImageMatch",
@@ -152,7 +148,6 @@ class CameraRigCalibration(desc.AVCommandLineNode):
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
             values=VERBOSE_LEVEL,
             value="info",
-            exclusive=True,
         ),
     ]
 

--- a/meshroom/nodes/aliceVision/CameraRigLocalization.py
+++ b/meshroom/nodes/aliceVision/CameraRigLocalization.py
@@ -57,7 +57,6 @@ class CameraRigLocalization(desc.AVCommandLineNode):
             description="Preset for the feature extractor when localizing a new image (low, medium, normal, high, ultra).",
             value="normal",
             values=["low", "medium", "normal", "high", "ultra"],
-            exclusive=True,
         ),
         desc.ChoiceParam(
             name="resectionEstimator",
@@ -65,7 +64,6 @@ class CameraRigLocalization(desc.AVCommandLineNode):
             description="The type of *sac framework to use for resection (acransac, loransac).",
             value="acransac",
             values=["acransac", "loransac"],
-            exclusive=True,
         ),
         desc.ChoiceParam(
             name="matchingEstimator",
@@ -73,7 +71,6 @@ class CameraRigLocalization(desc.AVCommandLineNode):
             description="The type of *sac framework to use for matching (acransac, loransac).",
             value="acransac",
             values=["acransac", "loransac"],
-            exclusive=True,
         ),
         desc.StringParam(
             name="refineIntrinsics",
@@ -120,7 +117,6 @@ class CameraRigLocalization(desc.AVCommandLineNode):
             description="[voctree] Algorithm type: {FirstBest, AllResults}.",
             value="AllResults",
             values=["FirstBest", "AllResults"],
-            exclusive=True,
         ),
         desc.IntParam(
             name="nbImageMatch",
@@ -158,7 +154,6 @@ class CameraRigLocalization(desc.AVCommandLineNode):
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
             values=VERBOSE_LEVEL,
             value="info",
-            exclusive=True,
         ),
     ]
 

--- a/meshroom/nodes/aliceVision/CheckerboardCalibration.py
+++ b/meshroom/nodes/aliceVision/CheckerboardCalibration.py
@@ -39,7 +39,6 @@ Estimate the camera intrinsics and extrinsincs on a set of checkerboard images.
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
             values=VERBOSE_LEVEL,
             value="info",
-            exclusive=True,
         ),
     ]
 

--- a/meshroom/nodes/aliceVision/CheckerboardDetection.py
+++ b/meshroom/nodes/aliceVision/CheckerboardDetection.py
@@ -53,7 +53,6 @@ The detection method also supports nested calibration grids.
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
             values=VERBOSE_LEVEL,
             value="info",
-            exclusive=True,
         ),
     ]
 

--- a/meshroom/nodes/aliceVision/ColorCheckerCorrection.py
+++ b/meshroom/nodes/aliceVision/ColorCheckerCorrection.py
@@ -43,7 +43,6 @@ If multiple color charts are submitted, only the first one will be taken in acco
             description="Output image file extension.",
             value="exr",
             values=["exr", ""],
-            exclusive=True,
         ),
         desc.ChoiceParam(
             name="storageDataType",
@@ -55,7 +54,6 @@ If multiple color charts are submitted, only the first one will be taken in acco
                         " - auto: Use half float if all values can fit, else use full float.",
             values=EXR_STORAGE_DATA_TYPE,
             value="float",
-            exclusive=True,
         ),
         desc.ChoiceParam(
             name="verboseLevel",
@@ -63,7 +61,6 @@ If multiple color charts are submitted, only the first one will be taken in acco
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
             values=VERBOSE_LEVEL,
             value="info",
-            exclusive=True,
         ),
     ]
 

--- a/meshroom/nodes/aliceVision/ColorCheckerDetection.py
+++ b/meshroom/nodes/aliceVision/ColorCheckerDetection.py
@@ -54,7 +54,6 @@ Dev notes:
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
             values=VERBOSE_LEVEL,
             value="info",
-            exclusive=True,
         ),
     ]
 

--- a/meshroom/nodes/aliceVision/ConvertDistortion.py
+++ b/meshroom/nodes/aliceVision/ConvertDistortion.py
@@ -26,7 +26,6 @@ class ConvertDistortion(desc.AVCommandLineNode):
             description="Distortion model to convert from.",
             value="distortion",
             values=["distortion", "undistortion"],
-            exclusive=True,
         ),
         desc.ChoiceParam(
             name="to",
@@ -34,7 +33,6 @@ class ConvertDistortion(desc.AVCommandLineNode):
             description="Distortion model to convert to.",
             value="undistortion",
             values=["distortion", "undistortion"],
-            exclusive=True,
         ),
         desc.ChoiceParam(
             name="verboseLevel",
@@ -42,7 +40,6 @@ class ConvertDistortion(desc.AVCommandLineNode):
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
             values=VERBOSE_LEVEL,
             value="info",
-            exclusive=True,
         ),
     ]
 

--- a/meshroom/nodes/aliceVision/ConvertMesh.py
+++ b/meshroom/nodes/aliceVision/ConvertMesh.py
@@ -23,7 +23,6 @@ class ConvertMesh(desc.AVCommandLineNode):
             description="Output mesh format (*.obj, *.gltf, *.fbx, *.stl).",
             value="obj",
             values=["gltf", "obj", "fbx", "stl"],
-            exclusive=True,
             group="",
         ),
         desc.ChoiceParam(
@@ -32,7 +31,6 @@ class ConvertMesh(desc.AVCommandLineNode):
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
             values=VERBOSE_LEVEL,
             value="info",
-            exclusive=True,
         ),
     ]
 

--- a/meshroom/nodes/aliceVision/ConvertSfMFormat.py
+++ b/meshroom/nodes/aliceVision/ConvertSfMFormat.py
@@ -27,7 +27,6 @@ It can also be used to remove specific parts of from an SfM scene (like filter a
             description="Output SfM file format.",
             value="abc",
             values=["abc", "sfm", "json", "ply", "baf"],
-            exclusive=True,
             group="",  # exclude from command line
         ),
         desc.ChoiceParam(
@@ -87,7 +86,6 @@ It can also be used to remove specific parts of from an SfM scene (like filter a
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
             values=VERBOSE_LEVEL,
             value="info",
-            exclusive=True,
         ),
     ]
 

--- a/meshroom/nodes/aliceVision/DepthMap.py
+++ b/meshroom/nodes/aliceVision/DepthMap.py
@@ -48,7 +48,6 @@ Use a downscale factor of one (full-resolution) only if the quality of the input
                         "specularities), a larger downscale may improve.",
             value=2,
             values=[1, 2, 4, 8, 16],
-            exclusive=True,
         ),
         desc.FloatParam(
             name="minViewAngle",
@@ -440,7 +439,6 @@ Use a downscale factor of one (full-resolution) only if the quality of the input
                                 description="Patch pattern subpart type.",
                                 value="full",
                                 values=["full", "circle"],
-                                exclusive=True,
                             ),
                             desc.FloatParam(
                                 name="customPatchPatternSubpartRadius",
@@ -559,7 +557,6 @@ Use a downscale factor of one (full-resolution) only if the quality of the input
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
             values=VERBOSE_LEVEL,
             value="info",
-            exclusive=True,
         ),
     ]
 

--- a/meshroom/nodes/aliceVision/DepthMapFilter.py
+++ b/meshroom/nodes/aliceVision/DepthMapFilter.py
@@ -105,7 +105,6 @@ This allows to filter unstable points before starting the fusion of all depth ma
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
             values=VERBOSE_LEVEL,
             value="info",
-            exclusive=True,
         ),
     ]
 

--- a/meshroom/nodes/aliceVision/DistortionCalibration.py
+++ b/meshroom/nodes/aliceVision/DistortionCalibration.py
@@ -32,7 +32,6 @@ Calibration of a camera/lens couple distortion using a full screen checkerboard.
             description="model used to estimate undistortion.",
             value="3deanamorphic4",
             values=["3deanamorphic4", "3declassicld", "3deradial4"],
-            exclusive=True,
         ),
         desc.BoolParam(
             name="handleSqueeze",
@@ -52,7 +51,6 @@ Calibration of a camera/lens couple distortion using a full screen checkerboard.
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
             values=VERBOSE_LEVEL,
             value="info",
-            exclusive=True,
         ),
     ]
 

--- a/meshroom/nodes/aliceVision/ExportAnimatedCamera.py
+++ b/meshroom/nodes/aliceVision/ExportAnimatedCamera.py
@@ -54,7 +54,6 @@ Based on the input image filenames, it will recognize the input video sequence t
             description="Image file format to use for undistorted images ('jpg', 'png', 'tif', 'exr (half)').",
             value="exr",
             values=["jpg", "png", "tif", "exr"],
-            exclusive=True,
             enabled=lambda node: node.exportUndistortedImages.value,
         ),
         desc.BoolParam(
@@ -76,7 +75,6 @@ Based on the input image filenames, it will recognize the input video sequence t
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
             values=VERBOSE_LEVEL,
             value="info",
-            exclusive=True,
         ),
     ]
 

--- a/meshroom/nodes/aliceVision/ExportColoredPointCloud.py
+++ b/meshroom/nodes/aliceVision/ExportColoredPointCloud.py
@@ -24,7 +24,6 @@ class ExportColoredPointCloud(desc.AVCommandLineNode):
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
             values=VERBOSE_LEVEL,
             value="info",
-            exclusive=True,
         ),
     ]
 

--- a/meshroom/nodes/aliceVision/ExportDistortion.py
+++ b/meshroom/nodes/aliceVision/ExportDistortion.py
@@ -45,7 +45,6 @@ It also allows to export an undistorted image of the lens grids for validation.
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
             values=VERBOSE_LEVEL,
             value="info",
-            exclusive=True,
         ),
     ]
 

--- a/meshroom/nodes/aliceVision/ExportMatches.py
+++ b/meshroom/nodes/aliceVision/ExportMatches.py
@@ -56,7 +56,6 @@ class ExportMatches(desc.AVCommandLineNode):
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
             values=VERBOSE_LEVEL,
             value="info",
-            exclusive=True,
         ),
     ]
 

--- a/meshroom/nodes/aliceVision/ExportMaya.py
+++ b/meshroom/nodes/aliceVision/ExportMaya.py
@@ -28,7 +28,6 @@ MeshroomMaya contains a user interface to browse all cameras.
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
             values=VERBOSE_LEVEL,
             value="info",
-            exclusive=True,
         ),
     ]
 

--- a/meshroom/nodes/aliceVision/FeatureExtraction.py
+++ b/meshroom/nodes/aliceVision/FeatureExtraction.py
@@ -50,7 +50,6 @@ It is robust to motion-blur, depth-of-field, occlusion. Be careful to have enoug
             description="File extension for masks.",
             value="png",
             values=["png", "exr", "jpg"],
-            exclusive=True,
         ),
         desc.BoolParam(
             name="maskInvert",
@@ -75,7 +74,6 @@ It is robust to motion-blur, depth-of-field, occlusion. Be careful to have enoug
                         "Warning: Use ULTRA only on small datasets.",
             value="normal",
             values=["low", "medium", "normal", "high", "ultra", "custom"],
-            exclusive=True,
             group=lambda node: 'allParams' if node.describerPreset.value != 'custom' else None,
         ),
         desc.IntParam(
@@ -93,7 +91,6 @@ It is robust to motion-blur, depth-of-field, occlusion. Be careful to have enoug
             description="Control the ImageDescriber quality (low, medium, normal, high, ultra).",
             value="normal",
             values=["low", "medium", "normal", "high", "ultra"],
-            exclusive=True,
         ),
         desc.ChoiceParam(
             name="contrastFiltering",
@@ -108,7 +105,6 @@ It is robust to motion-blur, depth-of-field, occlusion. Be careful to have enoug
                         " - NonExtremaFiltering: Filter non-extrema peakValues.\n",
             value="GridSort",
             values=["Static", "AdaptiveToMedianVariance", "NoFiltering", "GridSortOctaves", "GridSort", "GridSortScaleSteps", "GridSortOctaveSteps", "NonExtremaFiltering"],
-            exclusive=True,
             advanced=True,
         ),
         desc.FloatParam(
@@ -133,7 +129,6 @@ It is robust to motion-blur, depth-of-field, occlusion. Be careful to have enoug
             description="Allows you to choose the color space in which the data are processed.",
             values=COLORSPACES,
             value="sRGB",
-            exclusive=True,
         ),
         desc.BoolParam(
             name="forceCpuExtraction",
@@ -157,7 +152,6 @@ It is robust to motion-blur, depth-of-field, occlusion. Be careful to have enoug
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
             values=VERBOSE_LEVEL,
             value="info",
-            exclusive=True,
         ),
     ]
 

--- a/meshroom/nodes/aliceVision/FeatureMatching.py
+++ b/meshroom/nodes/aliceVision/FeatureMatching.py
@@ -80,7 +80,6 @@ then it checks the number of features that validates this model and iterate thro
                         " - BRUTE_FORCE_HAMMING: BruteForce Hamming matching",
             value="ANN_L2",
             values=["BRUTE_FORCE_L2", "ANN_L2", "CASCADE_HASHING_L2", "FAST_CASCADE_HASHING_L2", "BRUTE_FORCE_HAMMING"],
-            exclusive=True,
             advanced=True,
         ),
         desc.ChoiceParam(
@@ -91,7 +90,6 @@ then it checks the number of features that validates this model and iterate thro
                         " - loransac: LO-Ransac (only available for 'fundamental_matrix' model).",
             value="acransac",
             values=["acransac", "loransac"],
-            exclusive=True,
             advanced=True,
         ),
         desc.ChoiceParam(
@@ -106,7 +104,6 @@ then it checks the number of features that validates this model and iterate thro
                         " - no_filtering",
             value="fundamental_matrix",
             values=["fundamental_matrix", "fundamental_with_distortion", "essential_matrix", "homography_matrix", "homography_growing", "no_filtering"],
-            exclusive=True,
             advanced=True,
         ),
         desc.FloatParam(
@@ -201,7 +198,6 @@ then it checks the number of features that validates this model and iterate thro
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
             values=VERBOSE_LEVEL,
             value="info",
-            exclusive=True,
         ),
     ]
     outputs = [

--- a/meshroom/nodes/aliceVision/FeatureRepeatability.py
+++ b/meshroom/nodes/aliceVision/FeatureRepeatability.py
@@ -38,7 +38,6 @@ Compare feature/descriptor matching repeatability on some dataset with known hom
                         "Warning: Use ULTRA only on small datasets.",
             value="normal",
             values=["low", "medium", "normal", "high", "ultra"],
-            exclusive=True,
         ),
         desc.ChoiceParam(
             name="describerQuality",
@@ -46,7 +45,6 @@ Compare feature/descriptor matching repeatability on some dataset with known hom
             description="Control the ImageDescriber quality (low, medium, normal, high, ultra).",
             value="normal",
             values=["low", "medium", "normal", "high", "ultra"],
-            exclusive=True,
         ),
         desc.ChoiceParam(
             name="contrastFiltering",
@@ -61,7 +59,6 @@ Compare feature/descriptor matching repeatability on some dataset with known hom
                         " - NonExtremaFiltering: Filter non-extrema peakValues.",
             value="Static",
             values=["Static", "AdaptiveToMedianVariance", "NoFiltering", "GridSortOctaves", "GridSort", "GridSortScaleSteps", "GridSortOctaveSteps", "NonExtremaFiltering"],
-            exclusive=True,
             advanced=True,
         ),
         desc.FloatParam(
@@ -110,7 +107,6 @@ Compare feature/descriptor matching repeatability on some dataset with known hom
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
             values=VERBOSE_LEVEL,
             value="info",
-            exclusive=True,
         ),
     ]
 

--- a/meshroom/nodes/aliceVision/GlobalSfM.py
+++ b/meshroom/nodes/aliceVision/GlobalSfM.py
@@ -61,7 +61,6 @@ It is known to be faster but less robust to challenging datasets than the Increm
                         " - L2 minimization",
             values=["L1_minimization", "L2_minimization"],
             value="L2_minimization",
-            exclusive=True,
         ),
         desc.ChoiceParam(
             name="translationAveraging",
@@ -72,7 +71,6 @@ It is known to be faster but less robust to challenging datasets than the Increm
                         " - L1 soft minimization",
             values=["L1_minimization", "L2_minimization", "L1_soft_minimization"],
             value="L1_soft_minimization",
-            exclusive=True,
         ),
         desc.BoolParam(
             name="lockAllIntrinsics",
@@ -88,7 +86,6 @@ It is known to be faster but less robust to challenging datasets than the Increm
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
             values=VERBOSE_LEVEL,
             value="info",
-            exclusive=True,
         ),
     ]
 

--- a/meshroom/nodes/aliceVision/ImageMasking.py
+++ b/meshroom/nodes/aliceVision/ImageMasking.py
@@ -26,7 +26,6 @@ class ImageMasking(desc.AVCommandLineNode):
             description="",
             value="HSV",
             values=["HSV", "AutoGrayscaleThreshold"],
-            exclusive=True,
         ),
         desc.GroupAttribute(
             name="hsv",
@@ -124,7 +123,6 @@ class ImageMasking(desc.AVCommandLineNode):
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
             values=VERBOSE_LEVEL,
             value="info",
-            exclusive=True,
         ),
     ]
 

--- a/meshroom/nodes/aliceVision/ImageMatching.py
+++ b/meshroom/nodes/aliceVision/ImageMatching.py
@@ -66,7 +66,6 @@ If images have known poses, use frustum intersection else use VocabularuTree.
                         " - FrustumOrVocabularyTree: If images have known poses, use frustum intersection else use VocabularyTree.\n",
             value="SequentialAndVocabularyTree",
             values=["VocabularyTree", "Sequential", "SequentialAndVocabularyTree", "Exhaustive", "Frustum", "FrustumOrVocabularyTree"],
-            exclusive=True,
         ),
         desc.File(
             name="tree",
@@ -128,7 +127,6 @@ If images have known poses, use frustum intersection else use VocabularuTree.
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
             values=VERBOSE_LEVEL,
             value="info",
-            exclusive=True,
         ),
     ]
 

--- a/meshroom/nodes/aliceVision/ImageMatchingMultiSfM.py
+++ b/meshroom/nodes/aliceVision/ImageMatchingMultiSfM.py
@@ -62,7 +62,6 @@ Thanks to this node, the FeatureMatching node will only compute the matches betw
                         "use VocabularyTree.\n",
             value="SequentialAndVocabularyTree",
             values=["VocabularyTree", "SequentialAndVocabularyTree", "Exhaustive", "Frustum"],
-            exclusive=True,
         ),
         desc.File(
             name="tree",
@@ -90,7 +89,6 @@ Thanks to this node, the FeatureMatching node will only compute the matches betw
                         "- 'a/b' for A with B.",
             value="a/a+a/b",
             values=["a/a+a/b","a/ab", "a/b"],
-            exclusive=True,
         ),
         desc.IntParam(
             name="minNbImages",
@@ -135,7 +133,6 @@ Thanks to this node, the FeatureMatching node will only compute the matches betw
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
             values=VERBOSE_LEVEL,
             value="info",
-            exclusive=True,
         ),
     ]
 

--- a/meshroom/nodes/aliceVision/ImageProcessing.py
+++ b/meshroom/nodes/aliceVision/ImageProcessing.py
@@ -83,7 +83,6 @@ Convert or apply filtering to the input images.
                         "If unset, the output file extension will match the input's if possible.",
             value="",
             values=["", "exr", "jpg", "tiff", "png"],
-            exclusive=True,
         ),
         desc.BoolParam(
             name="reconstructedViewsOnly",
@@ -334,7 +333,6 @@ Convert or apply filtering to the input images.
                                 " - salt: changes to value A a portion of pixels given by B.\n",
                     value="uniform",
                     values=["uniform", "gaussian", "salt"],
-                    exclusive=True,
                     enabled=lambda node: node.noiseFilter.noiseEnabled.value,
                 ),
                 desc.FloatParam(
@@ -449,7 +447,6 @@ Convert or apply filtering to the input images.
             description="Allows you to choose the format of the output image.",
             value="rgba",
             values=["rgba", "rgb", "grayscale"],
-            exclusive=True,
         ),
         desc.ChoiceParam(
             name="inputColorSpace",
@@ -457,7 +454,6 @@ Convert or apply filtering to the input images.
             description="Allows you to force the color space of the input image.",
             values=COLORSPACES,
             value="AUTO",
-            exclusive=True,
         ),
         desc.ChoiceParam(
             name="outputColorSpace",
@@ -465,7 +461,6 @@ Convert or apply filtering to the input images.
             description="Allows you to choose the color space of the output image.",
             values=COLORSPACES,
             value="AUTO",
-            exclusive=True,
         ),
         desc.ChoiceParam(
             name="workingColorSpace",
@@ -473,7 +468,6 @@ Convert or apply filtering to the input images.
             description="Allows you to choose the color space in which the data are processed.",
             values=COLORSPACES,
             value="Linear",
-            exclusive=True,
             enabled=lambda node: not node.applyDcpMetadata.value,
         ),
         desc.ChoiceParam(
@@ -482,7 +476,6 @@ Convert or apply filtering to the input images.
             description="Allows you to choose how RAW data are color processed.",
             values=RAW_COLOR_INTERPRETATION,
             value="DCPLinearProcessing" if os.environ.get("ALICEVISION_COLOR_PROFILE_DB", "") else "LibRawWhiteBalancing",
-            exclusive=True,
         ),
         desc.BoolParam(
             name="applyDcpMetadata",
@@ -525,7 +518,6 @@ Convert or apply filtering to the input images.
             description="LibRaw demosaicing algorithm to use.",
             value="AHD",
             values=["linear", "VNG", "PPG", "AHD", "DCB", "AHD-Mod", "AFD", "VCD", "Mixed", "LMMSE", "AMaZE", "DHT", "AAHD", "none"],
-            exclusive=True,
         ),
         desc.ChoiceParam(
             name="highlightMode",
@@ -537,7 +529,6 @@ Convert or apply filtering to the input images.
                         " - 3-9: Rebuild",
             value=0,
             values=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
-            exclusive=True,
         ),
         desc.FloatParam(
             name="correlatedColorTemperature",
@@ -571,7 +562,6 @@ Convert or apply filtering to the input images.
                         " - auto: Use half float if all values can fit, else use full float.",
             values=EXR_STORAGE_DATA_TYPE,
             value="float",
-            exclusive=True,
         ),
         desc.ChoiceParam(
             name="exrCompressionMethod",
@@ -579,7 +569,6 @@ Convert or apply filtering to the input images.
             description="Compression method for EXR output images.",
             value="auto",
             values=["none", "auto", "rle", "zip", "zips", "piz", "pxr24", "b44", "b44a", "dwaa", "dwab"],
-            exclusive=True,
         ),
         desc.IntParam(
             name="exrCompressionLevel",
@@ -611,7 +600,6 @@ Convert or apply filtering to the input images.
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
             values=VERBOSE_LEVEL,
             value="info",
-            exclusive=True,
         ),
     ]
 

--- a/meshroom/nodes/aliceVision/ImageSegmentation.py
+++ b/meshroom/nodes/aliceVision/ImageSegmentation.py
@@ -73,7 +73,6 @@ Generate a mask with segmented labels for each pixel.
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
             values=VERBOSE_LEVEL,
             value="info",
-            exclusive=True,
         ),
     ]
 

--- a/meshroom/nodes/aliceVision/ImportE57.py
+++ b/meshroom/nodes/aliceVision/ImportE57.py
@@ -52,7 +52,6 @@ Import an E57 file and generate an SfMData.
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
             values=VERBOSE_LEVEL,
             value="info",
-            exclusive=True,
         ),
     ]
 

--- a/meshroom/nodes/aliceVision/ImportKnownPoses.py
+++ b/meshroom/nodes/aliceVision/ImportKnownPoses.py
@@ -31,7 +31,6 @@ class ImportKnownPoses(desc.AVCommandLineNode):
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
             values=VERBOSE_LEVEL,
             value="info",
-            exclusive=True,
         ),
     ]
 

--- a/meshroom/nodes/aliceVision/KeyframeSelection.py
+++ b/meshroom/nodes/aliceVision/KeyframeSelection.py
@@ -283,7 +283,6 @@ You can extract frames at regular interval by configuring only the min/maxFrameS
                         "For input videos, 'none' should not be used since the written keyframes are used to generate the output SfMData file.",
             value="none",
             values=["none", "exr", "jpg", "png"],
-            exclusive=True,
             validValue=lambda node: not (any(ext in input.value.lower() for ext in videoExts for input in node.inputPaths.value) and node.outputExtension.value == "none"),
             errorMessage="A video input has been provided. The output extension should be different from 'none'.",
         ),
@@ -297,7 +296,6 @@ You can extract frames at regular interval by configuring only the min/maxFrameS
                         " - auto: Use half float if all values can fit, else use full float.",
             values=EXR_STORAGE_DATA_TYPE,
             value="float",
-            exclusive=True,
             enabled=lambda node: node.outputExtension.value == "exr",
             advanced=True,
         ),
@@ -384,7 +382,6 @@ You can extract frames at regular interval by configuring only the min/maxFrameS
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
             values=VERBOSE_LEVEL,
             value="info",
-            exclusive=True,
         ),
     ]
 

--- a/meshroom/nodes/aliceVision/LdrToHdrCalibration.py
+++ b/meshroom/nodes/aliceVision/LdrToHdrCalibration.py
@@ -92,7 +92,6 @@ Calibrate LDR to HDR response curve from samples.
                         " - Laguerre: Simple but robust method estimating the minimal number of parameters.",
             values=["auto", "linear", "debevec", "grossberg", "laguerre"],
             value="auto",
-            exclusive=True,
             enabled=lambda node: node.byPass.enabled and not node.byPass.value,
             exposed=True,
         ),
@@ -106,7 +105,6 @@ Calibrate LDR to HDR response curve from samples.
                         " - plateau",
             value="default",
             values=["default", "gaussian", "triangle", "plateau"],
-            exclusive=True,
             enabled=lambda node: node.byPass.enabled and not node.byPass.value,
         ),
         desc.IntParam(
@@ -126,7 +124,6 @@ Calibrate LDR to HDR response curve from samples.
                         "If 'auto' is selected, the working color space will be 'Linear' if RAW images are detected; otherwise, it will be set to 'sRGB'.",
             values=COLORSPACES,
             value="AUTO",
-            exclusive=True,
             invalidate=False,
             group="user",  # not used directly on the command line
             enabled=lambda node: node.byPass.enabled and not node.byPass.value,
@@ -149,7 +146,6 @@ Calibrate LDR to HDR response curve from samples.
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
             values=VERBOSE_LEVEL,
             value="info",
-            exclusive=True,
         ),
     ]
 

--- a/meshroom/nodes/aliceVision/LdrToHdrMerge.py
+++ b/meshroom/nodes/aliceVision/LdrToHdrMerge.py
@@ -142,7 +142,6 @@ Merge LDR images into HDR images.
                         " - plateau",
             value="gaussian",
             values=["gaussian", "triangle", "plateau"],
-            exclusive=True,
             enabled=lambda node: node.byPass.enabled and not node.byPass.value,
         ),
         desc.IntParam(
@@ -162,7 +161,6 @@ Merge LDR images into HDR images.
                         "If 'auto' is selected, the working color space will be 'Linear' if RAW images are detected; otherwise, it will be set to 'sRGB'.",
             values=COLORSPACES,
             value="AUTO",
-            exclusive=True,
             enabled=lambda node: node.byPass.enabled and not node.byPass.value,
             exposed=True,
         ),
@@ -218,7 +216,6 @@ Merge LDR images into HDR images.
                         " - auto: Use half float if all values can fit, else use full float.",
             values=EXR_STORAGE_DATA_TYPE,
             value="float",
-            exclusive=True,
         ),
         desc.ChoiceParam(
             name="verboseLevel",
@@ -226,7 +223,6 @@ Merge LDR images into HDR images.
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
             values=VERBOSE_LEVEL,
             value="info",
-            exclusive=True,
         ),
     ]
 

--- a/meshroom/nodes/aliceVision/LdrToHdrSampling.py
+++ b/meshroom/nodes/aliceVision/LdrToHdrSampling.py
@@ -107,7 +107,6 @@ Sample pixels from Low range images for HDR creation.
                         " - Laguerre: Simple but robust method estimating the minimal number of parameters.",
             values=["auto", "linear", "debevec", "grossberg", "laguerre"],
             value="auto",
-            exclusive=True,
             enabled=lambda node: node.byPass.enabled and not node.byPass.value,
             exposed=True,
         ),
@@ -128,7 +127,6 @@ Sample pixels from Low range images for HDR creation.
                         "If 'auto' is selected, the working color space will be 'Linear' if RAW images are detected; otherwise, it will be set to 'sRGB'.",
             values=COLORSPACES,
             value="AUTO",
-            exclusive=True,
             enabled=lambda node: node.byPass.enabled and not node.byPass.value,
             exposed=True,
         ),
@@ -173,7 +171,6 @@ Sample pixels from Low range images for HDR creation.
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
             values=VERBOSE_LEVEL,
             value="info",
-            exclusive=True,
         ),
     ]
 

--- a/meshroom/nodes/aliceVision/LidarDecimating.py
+++ b/meshroom/nodes/aliceVision/LidarDecimating.py
@@ -38,7 +38,6 @@ class LidarDecimating(desc.AVCommandLineNode):
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
             values=VERBOSE_LEVEL,
             value="info",
-            exclusive=True,
         ),
     ]
 

--- a/meshroom/nodes/aliceVision/LidarMerging.py
+++ b/meshroom/nodes/aliceVision/LidarMerging.py
@@ -27,7 +27,6 @@ class LidarMerging(desc.AVCommandLineNode):
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
             values=VERBOSE_LEVEL,
             value="info",
-            exclusive=True,
         ),
     ]
 

--- a/meshroom/nodes/aliceVision/LidarMeshing.py
+++ b/meshroom/nodes/aliceVision/LidarMeshing.py
@@ -118,7 +118,6 @@ class LidarMeshing(desc.AVCommandLineNode):
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
             values=VERBOSE_LEVEL,
             value="info",
-            exclusive=True,
         ),
     ]
 

--- a/meshroom/nodes/aliceVision/LightingCalibration.py
+++ b/meshroom/nodes/aliceVision/LightingCalibration.py
@@ -45,7 +45,6 @@ Can also be used to calibrate a lighting dome (RTI type).
                         "Spherical Harmonic lighting can be estimated using 'SH' method.",
             values=["brightestPoint", "whiteSphere", "SH"],
             value="brightestPoint",
-            exclusive=True,
         ),
         desc.ChoiceParam(
             name="verboseLevel",
@@ -53,7 +52,6 @@ Can also be used to calibrate a lighting dome (RTI type).
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
             values=VERBOSE_LEVEL,
             value="info",
-            exclusive=True,
         ),
     ]
 

--- a/meshroom/nodes/aliceVision/LightingEstimation.py
+++ b/meshroom/nodes/aliceVision/LightingEstimation.py
@@ -37,7 +37,6 @@ class LightingEstimation(desc.AVCommandLineNode):
             description="Lighting estimation mode.",
             value="global",
             values=["global", "per_image"],
-            exclusive=True,
             advanced=True,
         ),
         desc.ChoiceParam(
@@ -46,7 +45,6 @@ class LightingEstimation(desc.AVCommandLineNode):
             description="Lighting color mode.",
             value="RGB",
             values=["RGB", "Luminance"],
-            exclusive=True,
             advanced=True,
         ),
         desc.ChoiceParam(
@@ -55,7 +53,6 @@ class LightingEstimation(desc.AVCommandLineNode):
             description="Albedo estimation method used for light estimation.",
             value="constant",
             values=["constant", "picture", "median_filter", "blur_filter"],
-            exclusive=True,
             advanced=True,
         ),
         desc.IntParam(
@@ -72,7 +69,6 @@ class LightingEstimation(desc.AVCommandLineNode):
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
             values=VERBOSE_LEVEL,
             value="info",
-            exclusive=True,
         ),
     ]
     

--- a/meshroom/nodes/aliceVision/MergeMeshes.py
+++ b/meshroom/nodes/aliceVision/MergeMeshes.py
@@ -37,7 +37,6 @@ Operation types used to merge two meshes:
             description="Operation types used to merge two meshes.",
             value="boolean_union",
             values=["boolean_union", "boolean_intersection", "boolean_difference"],
-            exclusive=True,
         ),
         desc.BoolParam(
             name="preProcess",
@@ -57,7 +56,6 @@ Operation types used to merge two meshes:
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
             values=VERBOSE_LEVEL,
             value="info",
-            exclusive=True,
         ),
     ]
 

--- a/meshroom/nodes/aliceVision/MeshDecimate.py
+++ b/meshroom/nodes/aliceVision/MeshDecimate.py
@@ -64,7 +64,6 @@ This node allows to reduce the density of the Mesh.
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
             values=VERBOSE_LEVEL,
             value="info",
-            exclusive=True,
         ),
     ]
 

--- a/meshroom/nodes/aliceVision/MeshDenoising.py
+++ b/meshroom/nodes/aliceVision/MeshDenoising.py
@@ -72,7 +72,6 @@ for now, the parameters are difficult to control and vary a lot from one dataset
                         " - POISSON_UPDATE: Poisson-based update from [Wang et al. 2015] 'Rolling guidance normal filter for geometric processing'.",
             value=0,
             values=[0, 1],
-            exclusive=True,
         ),
         desc.ChoiceParam(
             name="verboseLevel",
@@ -80,7 +79,6 @@ for now, the parameters are difficult to control and vary a lot from one dataset
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
             values=VERBOSE_LEVEL,
             value="info",
-            exclusive=True,
         ),
     ]
 

--- a/meshroom/nodes/aliceVision/MeshFiltering.py
+++ b/meshroom/nodes/aliceVision/MeshFiltering.py
@@ -25,7 +25,6 @@ This node applies a Laplacian filtering to remove local defects from the raw Mes
             description="File type for the output mesh.",
             value="obj",
             values=["gltf", "obj", "fbx", "stl"],
-            exclusive=True,
             group="",
         ),
         desc.BoolParam(
@@ -40,7 +39,6 @@ This node applies a Laplacian filtering to remove local defects from the raw Mes
             description="Subset for smoothing (all, surface_boundaries, surface_inner_part).",
             value="all",
             values=["all", "surface_boundaries", "surface_inner_part"],
-            exclusive=True,
             advanced=True,
         ),
         desc.IntParam(
@@ -72,7 +70,6 @@ This node applies a Laplacian filtering to remove local defects from the raw Mes
             description="Subset for filtering (all, surface_boundaries, surface_inner_part).",
             value="all",
             values=["all", "surface_boundaries", "surface_inner_part"],
-            exclusive=True,
             advanced=True,
         ),
         desc.IntParam(
@@ -107,7 +104,6 @@ This node applies a Laplacian filtering to remove local defects from the raw Mes
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
             values=VERBOSE_LEVEL,
             value="info",
-            exclusive=True,
         ),
     ]
 

--- a/meshroom/nodes/aliceVision/MeshMasking.py
+++ b/meshroom/nodes/aliceVision/MeshMasking.py
@@ -30,7 +30,6 @@ Decimate triangles based on image masks.
             description="File type of the output mesh.",
             value="obj",
             values=["obj", "gltf", "fbx", "stl"],
-            exclusive=True,
             group="",
         ),
         desc.ListAttribute(
@@ -50,7 +49,6 @@ Decimate triangles based on image masks.
             description="File extension for the masks to use.",
             value="png",
             values=["exr", "jpg", "png"],
-            exclusive=True,
         ),
         desc.IntParam(
             name="threshold",
@@ -92,7 +90,6 @@ Decimate triangles based on image masks.
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
             values=VERBOSE_LEVEL,
             value="info",
-            exclusive=True,
         ),
     ]
 

--- a/meshroom/nodes/aliceVision/MeshRemoveUnseenFaces.py
+++ b/meshroom/nodes/aliceVision/MeshRemoveUnseenFaces.py
@@ -34,7 +34,6 @@ Remove triangles from the mesh when the vertices are not visible by any camera.
             description="File type for the output mesh.",
             value="obj",
             values=["gltf", "obj", "fbx", "stl"],
-            exclusive=True,
             group="",
         ),
         desc.IntParam(
@@ -57,7 +56,6 @@ Remove triangles from the mesh when the vertices are not visible by any camera.
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
             values=VERBOSE_LEVEL,
             value="info",
-            exclusive=True,
         ),
     ]
 

--- a/meshroom/nodes/aliceVision/MeshResampling.py
+++ b/meshroom/nodes/aliceVision/MeshResampling.py
@@ -69,7 +69,6 @@ This node allows to recompute the mesh surface with a new topology and uniform d
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
             values=VERBOSE_LEVEL,
             value="info",
-            exclusive=True,
         ),
     ]
 

--- a/meshroom/nodes/aliceVision/Meshing.py
+++ b/meshroom/nodes/aliceVision/Meshing.py
@@ -41,7 +41,6 @@ A Graph Cut Max-Flow is applied to optimally cut the volume. This cut represents
             description="File type for the output mesh.",
             value="obj",
             values=["gltf", "obj", "fbx", "stl"],
-            exclusive=True,
             group="",
         ),
         desc.BoolParam(
@@ -193,7 +192,6 @@ A Graph Cut Max-Flow is applied to optimally cut the volume. This cut represents
             description="Single block or auto partitioning.",
             value="singleBlock",
             values=["singleBlock", "auto"],
-            exclusive=True,
             advanced=True,
         ),
         desc.ChoiceParam(
@@ -202,7 +200,6 @@ A Graph Cut Max-Flow is applied to optimally cut the volume. This cut represents
             description="Multi-resolution or regular grid-based repartition.",
             value="multiResolution",
             values=["multiResolution", "regularGrid"],
-            exclusive=True,
             advanced=True,
         ),
         desc.FloatParam(
@@ -467,7 +464,6 @@ A Graph Cut Max-Flow is applied to optimally cut the volume. This cut represents
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
             values=VERBOSE_LEVEL,
             value="info",
-            exclusive=True,
         ),
     ]
 

--- a/meshroom/nodes/aliceVision/NodalSfM.py
+++ b/meshroom/nodes/aliceVision/NodalSfM.py
@@ -38,7 +38,6 @@ A Structure-From-Motion node specifically designed to handle pure rotation camer
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
             values=VERBOSE_LEVEL,
             value="info",
-            exclusive=True,
         ),
     ]
 

--- a/meshroom/nodes/aliceVision/NormalIntegration.py
+++ b/meshroom/nodes/aliceVision/NormalIntegration.py
@@ -37,7 +37,6 @@ Evaluate a depth map from a normals map (currently in development)
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
             values=VERBOSE_LEVEL,
             value="info",
-            exclusive=True,
         ),
     ]
 

--- a/meshroom/nodes/aliceVision/PanoramaCompositing.py
+++ b/meshroom/nodes/aliceVision/PanoramaCompositing.py
@@ -51,7 +51,6 @@ Multiple cameras are contributing to the low frequencies and only the best one c
                         " - alpha: debug option with linear transitions.",
             value="multiband",
             values=["replace", "alpha", "multiband"],
-            exclusive=True,
         ),
         desc.IntParam(
             name="forceMinPyramidLevels",
@@ -87,7 +86,6 @@ Multiple cameras are contributing to the low frequencies and only the best one c
                         " - auto: Use half float if all values can fit, else use full float.",
             values=EXR_STORAGE_DATA_TYPE,
             value="float",
-            exclusive=True,
         ),
         desc.ChoiceParam(
             name="overlayType",
@@ -99,7 +97,6 @@ Multiple cameras are contributing to the low frequencies and only the best one c
                         " - all: display borders and seams.",
             value="none",
             values=["none", "borders", "seams", "all"],
-            exclusive=True,
             advanced=True,
         ),
         desc.ChoiceParam(
@@ -108,7 +105,6 @@ Multiple cameras are contributing to the low frequencies and only the best one c
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
             values=VERBOSE_LEVEL,
             value="info",
-            exclusive=True,
         ),
     ]
 

--- a/meshroom/nodes/aliceVision/PanoramaEstimation.py
+++ b/meshroom/nodes/aliceVision/PanoramaEstimation.py
@@ -78,7 +78,6 @@ Estimate relative camera rotations between input images.
                         " - L2 minimization",
             values=["L1_minimization", "L2_minimization"],
             value="L2_minimization",
-            exclusive=True,
             advanced=True,
         ),
         desc.ChoiceParam(
@@ -90,7 +89,6 @@ Estimate relative camera rotations between input images.
                         " - from rotation matrix",
             values=["essential_matrix", "homography_matrix", "rotation_matrix"],
             value="rotation_matrix",
-            exclusive=True,
             advanced=True,
         ),
         desc.BoolParam(
@@ -164,7 +162,6 @@ Estimate relative camera rotations between input images.
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
             values=VERBOSE_LEVEL,
             value="info",
-            exclusive=True,
         ),
     ]
 

--- a/meshroom/nodes/aliceVision/PanoramaInit.py
+++ b/meshroom/nodes/aliceVision/PanoramaInit.py
@@ -34,7 +34,6 @@ This node allows to setup the Panorama:
             description="Initialize cameras.",
             value="No",
             values=["No", "File", "Horizontal", "Horizontal+Zenith", "Zenith+Horizontal", "Spherical"],
-            exclusive=True,
         ),
         desc.File(
             name="config",
@@ -124,7 +123,6 @@ This node allows to setup the Panorama:
             description="Add a rotation to the input XML given poses (CCW).",
             value="None",
             values=["None", "rotate90", "rotate180", "rotate270"],
-            exclusive=True,
         ),
         desc.BoolParam(
             name="debugFisheyeCircleEstimation",
@@ -140,7 +138,6 @@ This node allows to setup the Panorama:
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
             values=VERBOSE_LEVEL,
             value="info",
-            exclusive=True,
         ),
     ]
 

--- a/meshroom/nodes/aliceVision/PanoramaMerging.py
+++ b/meshroom/nodes/aliceVision/PanoramaMerging.py
@@ -37,7 +37,6 @@ Merge all inputs coming from the PanoramaCompositing node.
             description="Output file type for the merged panorama.",
             value="exr",
             values=["jpg", "png", "tif", "exr"],
-            exclusive=True,
             group="",  # not part of allParams, as this is not a parameter for the command line
         ),
         desc.BoolParam(
@@ -57,7 +56,6 @@ Merge all inputs coming from the PanoramaCompositing node.
                         " - auto: Use half float if all values can fit, else use full float.\n",
             values=EXR_STORAGE_DATA_TYPE,
             value="float",
-            exclusive=True,
         ),
         desc.ChoiceParam(
             name="verboseLevel",
@@ -65,7 +63,6 @@ Merge all inputs coming from the PanoramaCompositing node.
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
             values=VERBOSE_LEVEL,
             value="info",
-            exclusive=True,
         ),
     ]
 

--- a/meshroom/nodes/aliceVision/PanoramaPostProcessing.py
+++ b/meshroom/nodes/aliceVision/PanoramaPostProcessing.py
@@ -56,7 +56,6 @@ Post process the panorama.
             description="The color space of the output image.",
             values=COLORSPACES,
             value="Linear",
-            exclusive=True,
         ),
         desc.ChoiceParam(
             name="compressionMethod",
@@ -64,7 +63,6 @@ Post process the panorama.
             description="Compression method for output EXR image.",
             value="auto",
             values=["none", "auto", "rle", "zip", "zips", "piz", "pxr24", "b44", "b44a", "dwaa", "dwab"],
-            exclusive=True,
         ),
         desc.IntParam(
             name="compressionLevel",
@@ -100,7 +98,6 @@ Post process the panorama.
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
             values=VERBOSE_LEVEL,
             value="info",
-            exclusive=True,
         ),
     ]
 

--- a/meshroom/nodes/aliceVision/PanoramaPrepareImages.py
+++ b/meshroom/nodes/aliceVision/PanoramaPrepareImages.py
@@ -28,7 +28,6 @@ Prepare images for Panorama pipeline: ensures that images orientations are coher
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
             values=VERBOSE_LEVEL,
             value="info",
-            exclusive=True,
         ),
     ]
 

--- a/meshroom/nodes/aliceVision/PanoramaSeams.py
+++ b/meshroom/nodes/aliceVision/PanoramaSeams.py
@@ -50,7 +50,6 @@ Estimate the seams lines between the inputs to provide an optimal compositing in
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
             values=VERBOSE_LEVEL,
             value="info",
-            exclusive=True,
         ),
     ]
 

--- a/meshroom/nodes/aliceVision/PanoramaWarping.py
+++ b/meshroom/nodes/aliceVision/PanoramaWarping.py
@@ -67,7 +67,6 @@ Compute the image warping for each input image in the panorama coordinate system
             description="Colorspace in which the panorama warping will be performed.",
             values=COLORSPACES,
             value="Linear",
-            exclusive=True,
         ),
        desc.ChoiceParam(
             name="storageDataType",
@@ -79,7 +78,6 @@ Compute the image warping for each input image in the panorama coordinate system
                         " - auto: Use half float if all values can fit, else use full float.",
             values=EXR_STORAGE_DATA_TYPE,
             value="float",
-            exclusive=True,
         ),
         desc.ChoiceParam(
             name="verboseLevel",
@@ -87,7 +85,6 @@ Compute the image warping for each input image in the panorama coordinate system
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
             values=VERBOSE_LEVEL,
             value="info",
-            exclusive=True,
         ),
     ]
 

--- a/meshroom/nodes/aliceVision/PhotometricStereo.py
+++ b/meshroom/nodes/aliceVision/PhotometricStereo.py
@@ -40,7 +40,6 @@ The lighting conditions are assumed to be known.
                         " - 2: second order spherical harmonics.",
             values=["0", "1", "2"],
             value="0",
-            exclusive=True,
             advanced=True,
         ),
         desc.BoolParam(
@@ -71,7 +70,6 @@ The lighting conditions are assumed to be known.
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
             values=VERBOSE_LEVEL,
             value="info",
-            exclusive=True,
         ),
     ]
 

--- a/meshroom/nodes/aliceVision/PrepareDenseScene.py
+++ b/meshroom/nodes/aliceVision/PrepareDenseScene.py
@@ -50,7 +50,6 @@ This node export undistorted images so the depth map and texturing can be comput
             description="File extension for the masks to use.",
             value="png",
             values=["exr", "jpg", "png"],
-            exclusive=True,
         ),
         desc.ChoiceParam(
             name="outputFileType",
@@ -58,7 +57,6 @@ This node export undistorted images so the depth map and texturing can be comput
             description="Output file type for the undistorted images.",
             value="exr",
             values=["jpg", "png", "tif", "exr"],
-            exclusive=True,
             advanced=True,
         ),
         desc.BoolParam(
@@ -88,7 +86,6 @@ This node export undistorted images so the depth map and texturing can be comput
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
             values=VERBOSE_LEVEL,
             value="info",
-            exclusive=True,
         ),
     ]
 

--- a/meshroom/nodes/aliceVision/Publish.py
+++ b/meshroom/nodes/aliceVision/Publish.py
@@ -42,7 +42,6 @@ This node allows to copy files into a specific folder.
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
             values=VERBOSE_LEVEL,
             value="info",
-            exclusive=True,
         ),
     ]
 

--- a/meshroom/nodes/aliceVision/RelativePoseEstimating.py
+++ b/meshroom/nodes/aliceVision/RelativePoseEstimating.py
@@ -40,7 +40,6 @@ Estimate relative pose between each pair of views that share tracks.
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
             values=VERBOSE_LEVEL,
             value="info",
-            exclusive=True,
         ),
     ]
 

--- a/meshroom/nodes/aliceVision/SelectConnectedViews.py
+++ b/meshroom/nodes/aliceVision/SelectConnectedViews.py
@@ -51,7 +51,6 @@ Select Connected Views based on SfM landmarks.
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
             values=VERBOSE_LEVEL,
             value="info",
-            exclusive=True,
         ),
     ]
 

--- a/meshroom/nodes/aliceVision/SfMAlignment.py
+++ b/meshroom/nodes/aliceVision/SfMAlignment.py
@@ -48,7 +48,6 @@ The alignment can be based on:
                         " - from_landmarks: Align from matched features.\n",
             value="from_cameras_viewid",
             values=["from_cameras_viewid", "from_cameras_poseid", "from_cameras_filepath", "from_cameras_metadata", "from_markers", 'from_landmarks'],
-            exclusive=True,
         ),
         desc.StringParam(
             name="fileMatchingPattern",
@@ -100,7 +99,6 @@ The alignment can be based on:
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
             values=VERBOSE_LEVEL,
             value="info",
-            exclusive=True,
         ),
     ]
 

--- a/meshroom/nodes/aliceVision/SfMDistances.py
+++ b/meshroom/nodes/aliceVision/SfMDistances.py
@@ -24,7 +24,6 @@ class SfMDistances(desc.AVCommandLineNode):
             description="",
             value="landmarks",
             values=["landmarks", "cameras"],
-            exclusive=True,
         ),
         desc.ChoiceParam(
             name="landmarksDescriberTypes",
@@ -57,7 +56,6 @@ class SfMDistances(desc.AVCommandLineNode):
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
             values=VERBOSE_LEVEL,
             value="info",
-            exclusive=True,
         ),
     ]
 

--- a/meshroom/nodes/aliceVision/SfMMerge.py
+++ b/meshroom/nodes/aliceVision/SfMMerge.py
@@ -61,7 +61,6 @@ Merges two SfMData files into a single one. Fails if some UID is shared among th
                         " - from_landmarks: Align from matched features, try to fuse.\n",
             value="simple_copy",
             values=["simple_copy", 'from_landmarks'],
-            exclusive=True,
         ),
         desc.ListAttribute(
             elementDesc=desc.File(
@@ -89,7 +88,6 @@ Merges two SfMData files into a single one. Fails if some UID is shared among th
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
             values=VERBOSE_LEVEL,
             value="info",
-            exclusive=True,
         ),
     ]
 

--- a/meshroom/nodes/aliceVision/SfMSplitReconstructed.py
+++ b/meshroom/nodes/aliceVision/SfMSplitReconstructed.py
@@ -28,7 +28,6 @@ class SfMSplitReconstructed(desc.AVCommandLineNode):
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
             values=VERBOSE_LEVEL,
             value="info",
-            exclusive=True,
         ),
     ]
 

--- a/meshroom/nodes/aliceVision/SfMToRig.py
+++ b/meshroom/nodes/aliceVision/SfMToRig.py
@@ -27,7 +27,6 @@ Assumes the input SfMData describes a set of cameras capturing a scene at a comm
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
             values=VERBOSE_LEVEL,
             value="info",
-            exclusive=True,
         ),
     ]
 

--- a/meshroom/nodes/aliceVision/SfMTransfer.py
+++ b/meshroom/nodes/aliceVision/SfMTransfer.py
@@ -38,7 +38,6 @@ This node allows to transfer poses and/or intrinsics form one SfM scene onto ano
                 " - from_intrinsicid: Copy intrinsics parameters.\n",
             value="from_viewid",
             values=["from_viewid", "from_filepath", "from_metadata", "from_intrinsicid"],
-            exclusive=True,
         ),
         desc.StringParam(
             name="fileMatchingPattern",
@@ -91,7 +90,6 @@ This node allows to transfer poses and/or intrinsics form one SfM scene onto ano
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
             values=VERBOSE_LEVEL,
             value="info",
-            exclusive=True,
         ),
     ]
 

--- a/meshroom/nodes/aliceVision/SfMTransform.py
+++ b/meshroom/nodes/aliceVision/SfMTransform.py
@@ -50,7 +50,6 @@ The transformation can be based on:
                         " - align_ground: Defines ground level from the point cloud density. It assumes that the scene is oriented.",
             value="auto",
             values=["transformation", "manual", "auto", "auto_from_cameras", "auto_from_cameras_x_axis", "auto_from_landmarks", "from_single_camera", "from_center_camera", "from_markers", "from_gps", "from_lineup", "align_ground"],
-            exclusive=True,
         ),
         desc.File(
             name="lineUp",
@@ -248,7 +247,6 @@ The transformation can be based on:
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
             values=VERBOSE_LEVEL,
             value="info",
-            exclusive=True,
         ),
     ]
 

--- a/meshroom/nodes/aliceVision/SfMTriangulation.py
+++ b/meshroom/nodes/aliceVision/SfMTriangulation.py
@@ -126,7 +126,6 @@ Contrary to the StructureFromMotion node, this node does not infer the camera po
             description="Extension of the intermediate file export.",
             value=".abc",
             values=[".abc", ".ply"],
-            exclusive=True,
             invalidate=False,
             advanced=True,
         ),
@@ -136,7 +135,6 @@ Contrary to the StructureFromMotion node, this node does not infer the camera po
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
             values=VERBOSE_LEVEL,
             value="info",
-            exclusive=True,
         ),
     ]
 

--- a/meshroom/nodes/aliceVision/SfmBootstraping.py
+++ b/meshroom/nodes/aliceVision/SfmBootstraping.py
@@ -37,7 +37,6 @@ class SfMBootStraping(desc.AVCommandLineNode):
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
             values=VERBOSE_LEVEL,
             value="info",
-            exclusive=True,
         ),
     ]
 

--- a/meshroom/nodes/aliceVision/SfmExpanding.py
+++ b/meshroom/nodes/aliceVision/SfmExpanding.py
@@ -153,7 +153,6 @@ class SfMExpanding(desc.AVCommandLineNode):
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
             values=VERBOSE_LEVEL,
             value="info",
-            exclusive=True,
         ),
     ]
 

--- a/meshroom/nodes/aliceVision/SketchfabUpload.py
+++ b/meshroom/nodes/aliceVision/SketchfabUpload.py
@@ -101,7 +101,6 @@ Upload a textured mesh on Sketchfab.
                     "CC Attribution-NonCommercial",
                     "CC Attribution-NonCommercial-ShareAlike",
                     "CC Attribution-NonCommercial-NoDerivs"],
-            exclusive=True,
         ),
         desc.ListAttribute(
             elementDesc=desc.StringParam(
@@ -139,7 +138,6 @@ Upload a textured mesh on Sketchfab.
                     "science-technology",
                     "sports-fitness",
                     "weapons-military"],
-            exclusive=True,
         ),
         desc.BoolParam(
             name="isPublished",
@@ -171,7 +169,6 @@ Upload a textured mesh on Sketchfab.
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
             values=VERBOSE_LEVEL,
             value="info",
-            exclusive=True,
         ),
     ]
     

--- a/meshroom/nodes/aliceVision/SphereDetection.py
+++ b/meshroom/nodes/aliceVision/SphereDetection.py
@@ -76,7 +76,6 @@ Spheres can be automatically detected or manually defined in the interface.
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
             values=VERBOSE_LEVEL,
             value="info",
-            exclusive=True,
         ),
     ]
 

--- a/meshroom/nodes/aliceVision/Split360Images.py
+++ b/meshroom/nodes/aliceVision/Split360Images.py
@@ -40,7 +40,6 @@ class Split360Images(desc.AVCommandLineNode):
             description="Split mode (equirectangular, dualfisheye).",
             value="equirectangular",
             values=["equirectangular", "dualfisheye"],
-            exclusive=True,
         ),
         desc.GroupAttribute(
             name="dualFisheyeGroup",
@@ -55,7 +54,6 @@ class Split360Images(desc.AVCommandLineNode):
                     description="Dual-Fisheye X offset preset.",
                     value="center",
                     values=["center", "left", "right"],
-                    exclusive=True,
                 ),
                 desc.ChoiceParam(
                     name="dualFisheyeOffsetPresetY",
@@ -63,7 +61,6 @@ class Split360Images(desc.AVCommandLineNode):
                     description="Dual-Fisheye Y offset preset.",
                     value="center",
                     values=["center", "top", "bottom"],
-                    exclusive=True,
                 ),
                 desc.ChoiceParam(
                     name="dualFisheyeCameraModel",
@@ -71,7 +68,6 @@ class Split360Images(desc.AVCommandLineNode):
                     description="Dual-Fisheye camera model.",
                     value="fisheye4",
                     values=["fisheye4", "equidistant_r3"],
-                    exclusive=True,
                 ),
             ],
         ),
@@ -117,7 +113,6 @@ class Split360Images(desc.AVCommandLineNode):
             description="Output image file extension.",
             value="",
             values=["", "exr", "jpg", "tiff", "png"],
-            exclusive=True,
         ),
         desc.ChoiceParam(
             name="verboseLevel",
@@ -125,7 +120,6 @@ class Split360Images(desc.AVCommandLineNode):
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
             values=VERBOSE_LEVEL,
             value="info",
-            exclusive=True,
         ),
     ]
 

--- a/meshroom/nodes/aliceVision/StructureFromMotion.py
+++ b/meshroom/nodes/aliceVision/StructureFromMotion.py
@@ -112,7 +112,6 @@ It iterates like that, adding cameras and triangulating new 2D features into 3D 
             description="Estimator type used to localize cameras (acransac, ransac, lsmeds, loransac, maxconsensus).",
             value="acransac",
             values=["acransac", "ransac", "lsmeds", "loransac", "maxconsensus"],
-            exclusive=True,
             advanced=True,
         ),
         desc.ChoiceParam(
@@ -123,7 +122,6 @@ It iterates like that, adding cameras and triangulating new 2D features into 3D 
                         " - Scale: Use reprojection error in pixel coordinates but relative to the feature scale.",
             value="Scale",
             values=["Basic", "Scale"],
-            exclusive=True,
             advanced=True,
         ),
         desc.IntParam(
@@ -353,7 +351,6 @@ It iterates like that, adding cameras and triangulating new 2D features into 3D 
             description="Extension of the intermediate file export.",
             value=".abc",
             values=[".abc", ".ply"],
-            exclusive=True,
             invalidate=False,
             advanced=True,
         ),
@@ -371,7 +368,6 @@ It iterates like that, adding cameras and triangulating new 2D features into 3D 
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
             values=VERBOSE_LEVEL,
             value="info",
-            exclusive=True,
         ),
     ]
 

--- a/meshroom/nodes/aliceVision/Texturing.py
+++ b/meshroom/nodes/aliceVision/Texturing.py
@@ -64,7 +64,6 @@ Many cameras are contributing to the low frequencies and only the best ones cont
             description="Output texture size.",
             value=8192,
             values=[1024, 2048, 4096, 8192, 16384],
-            exclusive=True,
         ),
         desc.ChoiceParam(
             name="downscale",
@@ -72,7 +71,6 @@ Many cameras are contributing to the low frequencies and only the best ones cont
             description="Texture downscale factor.",
             value=2,
             values=[1, 2, 4, 8],
-            exclusive=True,
         ),
         desc.ChoiceParam(
             name="outputMeshFileType",
@@ -80,7 +78,6 @@ Many cameras are contributing to the low frequencies and only the best ones cont
             description="File type for the mesh output.",
             value="obj",
             values=["obj", "gltf", "fbx", "stl"],
-            exclusive=True,
         ),
         desc.GroupAttribute(
             name="colorMapping",
@@ -103,7 +100,6 @@ Many cameras are contributing to the low frequencies and only the best ones cont
                     description="Texture file type.",
                     value="exr",
                     values=["exr", "png", "tiff", "jpg"],
-                    exclusive=True,
                     enabled=lambda node: node.colorMapping.enable.value,
                 ),
             ],
@@ -129,7 +125,6 @@ Many cameras are contributing to the low frequencies and only the best ones cont
                     description="Export normal map or height map.",
                     value="Normal",
                     values=["Height", "Normal"],
-                    exclusive=True,
                     enabled=lambda node: node.bumpMapping.enable.value,
                 ),
                 desc.ChoiceParam(
@@ -138,7 +133,6 @@ Many cameras are contributing to the low frequencies and only the best ones cont
                     description="File type for the normal map texture.",
                     value="exr",
                     values=["exr", "png", "tiff", "jpg"],
-                    exclusive=True,
                     enabled=lambda node: node.bumpMapping.enable.value and node.bumpMapping.bumpType.value == "Normal",
                 ),
                 desc.ChoiceParam(
@@ -147,7 +141,6 @@ Many cameras are contributing to the low frequencies and only the best ones cont
                     description="File type for the height map texture.",
                     value="exr",
                     values=["exr",],
-                    exclusive=True,
                     enabled=lambda node: node.bumpMapping.enable.value and node.bumpMapping.bumpType.value == "Height",
                 ),
             ],
@@ -173,7 +166,6 @@ Many cameras are contributing to the low frequencies and only the best ones cont
                     description="File type for the height map texture.",
                     value="exr",
                     values=["exr"],
-                    exclusive=True,
                     enabled=lambda node: node.displacementMapping.enable.value,
                 ),
             ],
@@ -187,7 +179,6 @@ Many cameras are contributing to the low frequencies and only the best ones cont
                         " - ABF (<= 300k faces): optimize space and stretch. Generates one atlas.",
             value="Basic",
             values=["Basic", "LSCM", "ABF"],
-            exclusive=True,
         ),
         desc.BoolParam(
             name="useUDIM",
@@ -282,7 +273,6 @@ Many cameras are contributing to the low frequencies and only the best ones cont
             description="Color space for the texturing internal computation (does not impact the output file color space).",
             values=COLORSPACES,
             value="sRGB",
-            exclusive=True,
             advanced=True,
         ),
         desc.ChoiceParam(
@@ -291,7 +281,6 @@ Many cameras are contributing to the low frequencies and only the best ones cont
             description="Color space for the output texture files.",
             values=COLORSPACES,
             value="AUTO",
-            exclusive=True,
         ),
         desc.BoolParam(
             name="correctEV",
@@ -320,7 +309,6 @@ Many cameras are contributing to the low frequencies and only the best ones cont
             description="Method to remap visibilities from the reconstruction to the input mesh (Pull, Push, PullPush, MeshItself).",
             value="PullPush",
             values=["Pull", "Push", "PullPush", "MeshItself"],
-            exclusive=True,
             advanced=True,
         ),
         desc.FloatParam(
@@ -340,7 +328,6 @@ Many cameras are contributing to the low frequencies and only the best ones cont
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
             values=VERBOSE_LEVEL,
             value="info",
-            exclusive=True,
         ),
     ]
 

--- a/meshroom/nodes/aliceVision/TracksBuilding.py
+++ b/meshroom/nodes/aliceVision/TracksBuilding.py
@@ -81,7 +81,6 @@ It fuses all feature matches between image pairs into tracks. Each track represe
             description="Verbosity level (fatal, error, warning, info, debug, trace).",
             values=VERBOSE_LEVEL,
             value="info",
-            exclusive=True,
         ),
     ]
 

--- a/meshroom/nodes/blender/ScenePreview.py
+++ b/meshroom/nodes/blender/ScenePreview.py
@@ -95,7 +95,6 @@ One frame per viewpoint will be rendered, and the undistorted views can optional
                     description="Color of particles used for the point cloud.",
                     value="Red",
                     values=["Grey", "White", "Red", "Green", "Magenta"],
-                    exclusive=True,
                 ),
             ],
         ),
@@ -112,7 +111,6 @@ One frame per viewpoint will be rendered, and the undistorted views can optional
                     description="Shading method for visualizing the mesh.",
                     value="wireframe",
                     values=["wireframe", "line_art"],
-                    exclusive=True,
                 ),
                 desc.ChoiceParam(
                     name="edgeColor",
@@ -120,7 +118,6 @@ One frame per viewpoint will be rendered, and the undistorted views can optional
                     description="Color of the mesh edges.",
                     value="Red",
                     values=["Grey", "White", "Red", "Green", "Magenta"],
-                    exclusive=True,
                 ),
             ],
         ),


### PR DESCRIPTION
## Description

Following #2523 which simplify the arguments to include an attribute in a node's UID computation, this PR simplifies the description of nodes with the following changes:

- [x] For `ChoiceParam` attributes, which may be exclusive (only one value among a list of several ones can be selected) or not (several values can be selected at once), the `exclusive` argument is set to `True` by default.
  - If it is not specified, the `ChoiceParam` attribute will be exclusive, and its display in the Node Editor will follow accordingly.
  - If the attribute is not exclusive, it needs to be explicitly stated with `exclusive=False` (which already was the case prior to this PR). 
  - As most `ChoiceParam` attributes are exclusive, this simplifies writing a node's description. All the existing nodes with exclusive `ChoiceParam` attributes have been updated to stop including the `exclusive=True` line in their description.

- [x] For `IntParam` and `FloatParam`, the range that previously needed to be specified for the attribute's description to be valid is now set to `None` by default.
  - If it is explicitly specified with `range=(start, end, step)`, the range is checked to ensure it is valid (for example, no floating number can be specified in the range if the attribute is an `IntParam`) and in case it is not, the description of the node will be rejected (as it currently is).
  - If it is not specified (and thus set implicitly as `range=None`), no check is performed on that argument and the attribute's description will be deemed valid. Instead of displaying a slider in the Node Editor that is parameterized with the provided range, a text field with no slider will be displayed. Invalid values (such as strings, or floating numbers for `IntParam` attributes) are however still not allowed, and the user will not be able to input them, as is expected.
  - No current node is modified by this PR to remove the `range` argument of one of its `IntParam` or `FloatParam` attributes.
