### PR TITLE
[pipelines] Add distortion export for templates without calibration

### DIFF
--- a/meshroom/pipelines/cameraTrackingWithoutCalibration.mg
+++ b/meshroom/pipelines/cameraTrackingWithoutCalibration.mg
@@ -10,6 +10,7 @@
             "DepthMap": "5.0",
             "DepthMapFilter": "4.0",
             "ExportAnimatedCamera": "2.0",
+            "ExportDistortion": "1.0",
             "FeatureExtraction": "1.3",
             "FeatureMatching": "2.0",
             "ImageMatching": "2.0",
@@ -108,6 +109,19 @@
             "inputs": {
                 "input": "{StructureFromMotion_1.output}",
                 "exportUndistortedImages": true
+            },
+            "internalInputs": {
+                "color": "#80766f"
+            }
+        },
+        "ExportDistortion_1": {
+            "nodeType": "ExportDistortion",
+            "position": [
+                1800,
+                200
+            ],
+            "inputs": {
+                "input": "{ExportAnimatedCamera_1.input}"
             },
             "internalInputs": {
                 "color": "#80766f"
@@ -341,7 +355,7 @@
                     "{ExportAnimatedCamera_1.output}",
                     "{Texturing_1.output}",
                     "{ScenePreview_1.output}",
-                    ""
+                    "{ExportDistortion_1.output}"
                 ]
             }
         },

--- a/meshroom/pipelines/nodalCameraTrackingWithoutCalibration.mg
+++ b/meshroom/pipelines/nodalCameraTrackingWithoutCalibration.mg
@@ -7,6 +7,7 @@
             "CameraInit": "11.0",
             "ConvertSfMFormat": "2.0",
             "ExportAnimatedCamera": "2.0",
+            "ExportDistortion": "1.0",
             "FeatureExtraction": "1.3",
             "FeatureMatching": "2.0",
             "ImageMatching": "2.0",
@@ -55,6 +56,19 @@
             "inputs": {
                 "input": "{NodalSfM_1.output}",
                 "exportUndistortedImages": true
+            },
+            "internalInputs": {
+                "color": "#80766f"
+            }
+        },
+        "ExportDistortion_1": {
+            "nodeType": "ExportDistortion",
+            "position": [
+                1600,
+                0
+            ],
+            "inputs": {
+                "input": "{ExportAnimatedCamera_1.input}"
             },
             "internalInputs": {
                 "color": "#80766f"
@@ -145,7 +159,8 @@
             "inputs": {
                 "inputFiles": [
                     "{ExportAnimatedCamera_1.output}",
-                    "{ScenePreview_1.output}"
+                    "{ScenePreview_1.output}",
+                    "{ExportDistortion_1.output}"
                 ]
             }
         },


### PR DESCRIPTION
## Description

This PR updates the "Camera Tracking Without Calibration" and "Nodal Camera Tracking Without Calibration" templates by adding an `ExportDistortion` node to them and connecting its output (which includes a LensDistortion Nuke node) to the `Publish` node.