### PR TITLE
[core] Check provided template folder exists before attempting to load it

### DIFF
--- a/meshroom/core/__init__.py
+++ b/meshroom/core/__init__.py
@@ -353,4 +353,7 @@ def initPipelines():
     additionalPipelinesPath = [i for i in additionalPipelinesPath if i]
     pipelineTemplatesFolders = [os.path.join(meshroomFolder, 'pipelines')] + additionalPipelinesPath
     for f in pipelineTemplatesFolders:
-        loadPipelineTemplates(f)
+        if os.path.isdir(f):
+            loadPipelineTemplates(f)
+        else:
+            logging.error("Pipeline templates folder '{}' does not exist.".format(f))


### PR DESCRIPTION
## Description

This PR checks that the paths provided as template folders (through the `MESHROOM_PIPELINE_TEMPLATES_PATH` environment variable) exist before attempting to load templates in them. 

Performing this check allows to simply print an error and carry on with the initialisation, while Meshroom was crashing during startup prior to this PR.