### PR TITLE
[core] Node: Do not automatically upgrade unknown nodes in templates

### DIFF
--- a/meshroom/core/node.py
+++ b/meshroom/core/node.py
@@ -1922,7 +1922,9 @@ def nodeFactory(nodeDict, name=None, template=False, uidConflict=False):
         if not internalFolder and nodeDesc:
             logging.warning("No serialized output data: performing automatic upgrade on '{}'".format(name))
             node = node.upgrade()
-        elif template:  # If the node comes from a template file and there is a conflict, it should be upgraded anyway
+        # If the node comes from a template file and there is a conflict, it should be upgraded anyway unless it is
+        # an "unknown node type" conflict (in which case the upgrade would fail)
+        elif template and compatibilityIssue is not CompatibilityIssue.UnknownNodeType:
             node = node.upgrade()
 
     return node


### PR DESCRIPTION
## Description

This PR fixes an error that occurred when a template contained a node whose type is unknown. 

Since all the templates that present compatibility issues are automatically upgraded, the nodes that triggered the "unknown node type" compatibility issue were upgraded, and the upgrade failed as there was no existing description for that kind of node.

For templates, the upgrade is now only performed if any compatibility issue but the "unknown node type" one exists.