### PR TITLE
[ui] Various minor UI fixes

### DIFF
--- a/meshroom/nodes/aliceVision/Publish.py
+++ b/meshroom/nodes/aliceVision/Publish.py
@@ -28,6 +28,7 @@ This node allows to copy files into a specific folder.
             name="inputFiles",
             label="Input Files",
             description="Input files or folders' content to publish.",
+            exposed=True,
             group="",
         ),
         desc.File(

--- a/meshroom/ui/qml/GraphEditor/AttributePin.qml
+++ b/meshroom/ui/qml/GraphEditor/AttributePin.qml
@@ -236,7 +236,8 @@ RowLayout {
             anchors.fill: parent
             anchors.margins: 2
             color: {
-                if ((!object.hasOutputConnections && object.enabled) && outputConnectMA.containsMouse || outputConnectMA.drag.active || (outputDropArea.containsDrag && outputDropArea.acceptableDrop))
+                if (object.enabled && (outputConnectMA.containsMouse || outputConnectMA.drag.active ||
+                                       (outputDropArea.containsDrag && outputDropArea.acceptableDrop)))
                     return Colors.sysPalette.highlight
                 return Colors.sysPalette.text
             }

--- a/meshroom/ui/qml/GraphEditor/GraphEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/GraphEditor.qml
@@ -521,22 +521,6 @@ Item {
                             }
                         }
                     }
-                    onVisibleChanged: {
-                        if (visible) {
-                            // Enable the pins on both sides
-                            src.updatePin(true, true)  // isSrc = true, isVisible = true
-                            dst.updatePin(false, true)  // isSrc = false, isVisible = true
-                        } else {
-                            // One of the attributes is visible, we do not need to handle the case where both attributes are hidden
-                            if (isValidEdge && (src.visible || dst.visible)) {
-                                if (src.visible) {
-                                    src.updatePin(true, false)  // isSrc = true, isVisible = false
-                                } else {
-                                    dst.updatePin(false, false)  // isSrc = false, isVisible = false
-                                }
-                            }
-                        }
-                    }
 
                     Component.onDestruction: {
                         // Handles the case where the edge is destroyed while hidden because it is replaced: the pins should be re-enabled

--- a/meshroom/ui/qml/Homepage.qml
+++ b/meshroom/ui/qml/Homepage.qml
@@ -22,7 +22,7 @@ Page {
 
         Item {
             
-            SplitView.minimumWidth: 100
+            SplitView.minimumWidth: 250
             SplitView.preferredWidth: 330
             SplitView.maximumWidth: 500
 

--- a/meshroom/ui/qml/Viewer/SequencePlayer.qml
+++ b/meshroom/ui/qml/Viewer/SequencePlayer.qml
@@ -385,7 +385,7 @@ FloatingPane {
                                 verticalAlignment: Text.AlignVCenter
                                 text: {
                                     // number of cached frames is the difference between the first and last frame of all intervals in the cache
-                                    let cachedFrames = viewer.cachedFrames
+                                    let cachedFrames = viewer ? viewer.cachedFrames : []
                                     let cachedFramesCount = 0
                                     for (let i = 0; i < cachedFrames.length; i++) {
                                         cachedFramesCount += cachedFrames[i].y - cachedFrames[i].x + 1
@@ -420,7 +420,7 @@ FloatingPane {
                             ProgressBar {
                                 id: occupiedCacheProgressBar
 
-                                property string occupiedCache: viewer.ramInfo ? Format.GB2SizeStr(viewer.ramInfo.y) : 0
+                                property string occupiedCache: viewer && viewer.ramInfo ? Format.GB2SizeStr(viewer.ramInfo.y) : 0
 
                                 width: parent.width
 


### PR DESCRIPTION
## Description

This PR contains various minor UI fixes:
1. The `inputFiles` parameter in the `Publish` node is exposed, in order to get a display that's identical to what we had prior to #2528.
2. ~~Following the introduction of the homepage, the "application" part of Meshroom could not correctly be resized: if the size of the window was changed while the stack view was displaying the application, the content of the view was fitted vertically, but never horizontally. The window is now filled both vertically and horizontally for the application, just as it was for the homepage.~~ Fixed with #2568. 
3. The split view of the homepage that contains all the logos had a minimal size that could lead to all these logos being hidden. The minimal size now is adjusted to ensure that everything is properly fitted.
4. The condition to highlight output pins was erroneous and always failed in conditions in which it should have succeeded.
5. Some accesses to the sequence player were made without checking that the sequence player existed in the first place, leading to null accesses (when QtAliceVision is not loaded, for example).
6. Pins were edited manually when attributes became visible or invisible, thus leading the edges to appear or disappear. Disappearing edges are now handled differently, and the pins do not need to be reset manually, considering that it also causes errors in regular cases. 