### PR TITLE
Change picking behavior for qt6 upgrade

### DIFF
--- a/meshroom/ui/qml/Viewer3D/MediaLibrary.qml
+++ b/meshroom/ui/qml/Viewer3D/MediaLibrary.qml
@@ -35,7 +35,7 @@ Entity {
         return false
     }
 
-    signal pressed(var pick)
+    signal clicked(var pick)
     signal loadRequest(var idx)
 
     QtObject {
@@ -192,6 +192,8 @@ Entity {
             MediaLoader {
                 id: mediaLoader
 
+                cameraPickingEnabled: !sceneCameraController.pickingActive
+
                 // Whether MediaLoader has been fully instantiated by the NodeInstantiator
                 property bool fullyInstantiated: false
 
@@ -335,7 +337,7 @@ Entity {
                     ObjectPicker {
                         enabled: mediaLoader.enabled && pickingEnabled
                         hoverEnabled: false
-                        onPressed: function(pick) { root.pressed(pick) }
+                        onClicked: function(pick) { root.clicked(pick) }
                     }
                 ]
             }

--- a/meshroom/ui/qml/Viewer3D/MediaLoader.qml
+++ b/meshroom/ui/qml/Viewer3D/MediaLoader.qml
@@ -25,6 +25,7 @@ import Utils 1.0
     property Camera camera: null
 
     property bool cached: false
+    property bool cameraPickingEnabled: false
 
     onSourceChanged: {
         if (cached) {
@@ -109,7 +110,7 @@ import Utils 1.0
                                                "source": source,
                                                "pointSize": Qt.binding(function() { return 0.01 * Viewer3DSettings.pointSize }),
                                                "locatorScale": Qt.binding(function() { return Viewer3DSettings.cameraScale }),
-                                               "cameraPickingEnabled": Qt.binding(function() { return root.enabled }),
+                                               "cameraPickingEnabled": Qt.binding(function() { return root.enabled && root.cameraPickingEnabled }),
                                                "resectionId": Qt.binding(function() { return Viewer3DSettings.resectionId }),
                                                "displayResections": Qt.binding(function() { return Viewer3DSettings.displayResectionIds }),
                                                "syncPickedViewId": Qt.binding(function() { return Viewer3DSettings.syncWithPickedViewId })

--- a/meshroom/ui/qml/Viewer3D/SfmDataLoader.qml
+++ b/meshroom/ui/qml/Viewer3D/SfmDataLoader.qml
@@ -9,13 +9,14 @@ import SfmDataEntity 1.0
  * Support for SfMData files in Qt3D.
  * Create this component dynamically to test for SfmDataEntity plugin availability.
  */
+
 SfmDataEntity {
     id: root
 
     property bool cameraPickingEnabled: true
     property bool syncPickedViewId: false
 
-    // filter out non-reconstructed cameras
+    // Filter out non-reconstructed cameras
     skipHidden: true
 
     signal cameraSelected(var viewId)
@@ -32,7 +33,7 @@ SfmDataEntity {
 
     function spawnCameraSelectors() {
         var validCameras = 0;
-        // spawn camera selector for each camera
+        // Spawn camera selector for each camera
         for (var i = 0; i < root.cameras.length; ++i)
         {
             var cam = root.cameras[i];
@@ -41,6 +42,7 @@ SfmDataEntity {
             if (viewId === undefined)
                 continue;
             camSelectionComponent.createObject(cam, {"viewId": viewId});
+            dummyCamSelectionComponent.createObject(cam, {"viewId": viewId});
             validCameras++;
         }
         return validCameras;
@@ -80,11 +82,11 @@ SfmDataEntity {
         id: activePalette
     }
 
-    // Camera selection picking and display
+    // Camera selection display only
     Component {
-        id: camSelectionComponent
+        id: dummyCamSelectionComponent
         Entity {
-            id: camSelector
+            id: dummyCamSelector
             property string viewId
             property color customColor: Qt.hsva((parseInt(viewId) / 255.0) % 1.0, 0.3, 1.0, 1.0)
             property real extent: cameraPickingEnabled ? 0.2 : 0
@@ -102,8 +104,33 @@ SfmDataEntity {
                 },
                 PhongMaterial{
                     id: mat
-                    ambient: _reconstruction && (viewId === _reconstruction.selectedViewId || (viewId === _reconstruction.pickedViewId && syncPickedViewId)) ? activePalette.highlight : customColor // "#CCC"
-                    diffuse: cameraPicker.containsMouse ? Qt.lighter(activePalette.highlight, 1.2) : ambient
+                    ambient: _reconstruction && (viewId === _reconstruction.selectedViewId ||
+                                                 (viewId === _reconstruction.pickedViewId && syncPickedViewId)) ?
+                                 activePalette.highlight : customColor  // "#CCC"
+                }
+            ]
+        }
+    }
+
+    // Camera selection picking only
+    Component {
+        id: camSelectionComponent
+        Entity {
+            id: camSelector
+            property string viewId
+            property color customColor: Qt.hsva((parseInt(viewId) / 255.0) % 1.0, 0.3, 1.0, 1.0)
+            property real extent: cameraPickingEnabled ? 0.5 : 0
+
+            components: [
+                // Use cuboid to represent the camera
+                Transform {
+                    translation: Qt.vector3d(0, 0, 0.5 * cameraBack.zExtent)
+                },
+                CuboidMesh {
+                    id: cameraBack
+                    xExtent: parent.extent
+                    yExtent: xExtent
+                    zExtent: xExtent
                 },
                 ObjectPicker {
                     id: cameraPicker
@@ -113,11 +140,10 @@ SfmDataEntity {
                         pick.accepted = (pick.buttons & Qt.LeftButton) && cameraPickingEnabled
                     }
                     onReleased: function(pick) {
-                        const delta = Qt.point(Math.abs(pos.x - pick.position.x), Math.abs(pos.y - pick.position.y));
-                        // only trigger picking when mouse has not moved between press and release
-                        if (delta.x + delta.y < 4)
-                        {
-                            _reconstruction.selectedViewId = camSelector.viewId;
+                        const delta = Qt.point(Math.abs(pos.x - pick.position.x), Math.abs(pos.y - pick.position.y))
+                        // Only trigger picking when mouse has not moved between press and release
+                        if (delta.x + delta.y < 4) {
+                            _reconstruction.selectedViewId = camSelector.viewId
                         }
                     }
                 }

--- a/meshroom/ui/qml/Viewer3D/Viewer3D.qml
+++ b/meshroom/ui/qml/Viewer3D/Viewer3D.qml
@@ -154,11 +154,6 @@ FocusScope {
                 focus: scene3D.activeFocus
                 onMousePressed: function(mouse) {
                     scene3D.forceActiveFocus()
-                    if (mouse.button === Qt.LeftButton) {
-                        if (!doubleClickTimer.running)
-                            doubleClickTimer.restart()
-                    } else
-                        doubleClickTimer.stop()
                 }
                 onMouseReleased: function(mouse, moved) {
                     if (moving)
@@ -166,14 +161,6 @@ FocusScope {
                     if (!moved && mouse.button === Qt.RightButton) {
                         contextMenu.popup()
                     }
-                }
-
-                // Manually handle double click to activate object picking
-                // for camera re-centering only during a short amount of time
-                Timer {
-                    id: doubleClickTimer
-                    running: false
-                    interval: 300
                 }
             }
 
@@ -223,8 +210,8 @@ FocusScope {
                 id: mediaLibrary
                 renderMode: Viewer3DSettings.renderMode
                 // Picking to set focus point (camera view center)
-                // Only activate it when a double click may happen or when the 'Control' key is pressed
-                pickingEnabled: cameraController.pickingActive || doubleClickTimer.running
+                // Only activate it when the 'Control' key is pressed
+                pickingEnabled: cameraController.pickingActive
                 camera: cameraSelector.camera
 
                 // Used for TransformGizmo in BoundingBox
@@ -238,11 +225,10 @@ FocusScope {
                     }
                 ]
 
-                onPressed: function(pick) {
+                onClicked: function(pick) {
                     if (pick.button === Qt.LeftButton) {
                         mainCamera.viewCenter = pick.worldIntersection
                     }
-                    doubleClickTimer.stop()
                 }
 
             }


### PR DESCRIPTION
Previously, picking was working by luck.

- I removed the center point selection using double click which was not working and created side effects
- The center point selection is now only active when using CTRL modifier
- Camera picking is disabled if CTRL modifier is active
- I doubled the picking area of the camera for easier picking (using an invisible box).