### PR TITLE
[nodes] `LightingCalibration`: Exclude visualization output from command line

### DIFF
--- a/meshroom/nodes/aliceVision/LightingCalibration.py
+++ b/meshroom/nodes/aliceVision/LightingCalibration.py
@@ -68,5 +68,6 @@ Can also be used to calibrate a lighting dome (RTI type).
             description="Estimated Lighting Visualization.",
             semantic="image",
             value=desc.Node.internalFolder + "/<FILESTEM>_{methodValue}.png",
+            group=None,
         ),
     ]


### PR DESCRIPTION
## Description

This PR excludes the `lightingEstimationVisualization` output attribute from the command line. Without it, the node cannot be run as the AliceVision binary does not expect such an attribute in its command line.
