### PR TITLE
[nodes] LdrToHdr: Move import of `pyalicevision` within functions

### DIFF
--- a/meshroom/nodes/aliceVision/LdrToHdrCalibration.py
+++ b/meshroom/nodes/aliceVision/LdrToHdrCalibration.py
@@ -1,9 +1,6 @@
 __version__ = "3.1"
 
 import json
-import math
-import os
-from collections import Counter
 
 from meshroom.core import desc
 from meshroom.core.utils import COLORSPACES, VERBOSE_LEVEL

--- a/meshroom/nodes/aliceVision/LdrToHdrCalibration.py
+++ b/meshroom/nodes/aliceVision/LdrToHdrCalibration.py
@@ -5,9 +5,6 @@ import math
 import os
 from collections import Counter
 
-from pyalicevision import sfmData as avsfmdata
-from pyalicevision import hdr as avhdr
-
 from meshroom.core import desc
 from meshroom.core.utils import COLORSPACES, VERBOSE_LEVEL
 
@@ -174,6 +171,8 @@ Calibrate LDR to HDR response curve from samples.
 
     @classmethod
     def update(cls, node):
+        from pyalicevision import hdr as avhdr
+
         if not isinstance(node.nodeDesc, cls):
             raise ValueError("Node {} is not an instance of type {}".format(node, cls))
         # TODO: use Node version for this test
@@ -251,6 +250,8 @@ Calibrate LDR to HDR response curve from samples.
 
     @staticmethod
     def getExposure(exp, refIso = 100.0, refFnumber = 1.0):
+        from pyalicevision import sfmData as avsfmdata
+
         fnumber, shutterSpeed, iso = exp
         obj = avsfmdata.ExposureSetting(shutterSpeed, fnumber, iso)
         return obj.getExposure()

--- a/meshroom/nodes/aliceVision/LdrToHdrMerge.py
+++ b/meshroom/nodes/aliceVision/LdrToHdrMerge.py
@@ -1,9 +1,6 @@
 __version__ = "4.1"
 
 import json
-import os
-import math
-from collections import Counter
 
 from meshroom.core import desc
 from meshroom.core.utils import COLORSPACES, EXR_STORAGE_DATA_TYPE, VERBOSE_LEVEL

--- a/meshroom/nodes/aliceVision/LdrToHdrMerge.py
+++ b/meshroom/nodes/aliceVision/LdrToHdrMerge.py
@@ -5,9 +5,6 @@ import os
 import math
 from collections import Counter
 
-from pyalicevision import sfmData as avsfmdata
-from pyalicevision import hdr as avhdr
-
 from meshroom.core import desc
 from meshroom.core.utils import COLORSPACES, EXR_STORAGE_DATA_TYPE, VERBOSE_LEVEL
 
@@ -247,6 +244,8 @@ Merge LDR images into HDR images.
 
     @classmethod
     def update(cls, node):
+        from pyalicevision import hdr as avhdr
+
         if not isinstance(node.nodeDesc, cls):
             raise ValueError("Node {} is not an instance of type {}".format(node, cls))
         # TODO: use Node version for this test
@@ -324,6 +323,8 @@ Merge LDR images into HDR images.
 
     @staticmethod
     def getExposure(exp, refIso = 100.0, refFnumber = 1.0):
+        from pyalicevision import sfmData as avsfmdata
+
         fnumber, shutterSpeed, iso = exp
         obj = avsfmdata.ExposureSetting(shutterSpeed, fnumber, iso)
         return obj.getExposure()

--- a/meshroom/nodes/aliceVision/LdrToHdrSampling.py
+++ b/meshroom/nodes/aliceVision/LdrToHdrSampling.py
@@ -1,9 +1,6 @@
 __version__ = "4.0"
 
 import json
-import math
-import os
-from collections import Counter
 
 from meshroom.core import desc
 from meshroom.core.utils import COLORSPACES, VERBOSE_LEVEL

--- a/meshroom/nodes/aliceVision/LdrToHdrSampling.py
+++ b/meshroom/nodes/aliceVision/LdrToHdrSampling.py
@@ -5,9 +5,6 @@ import math
 import os
 from collections import Counter
 
-from pyalicevision import sfmData as avsfmdata
-from pyalicevision import hdr as avhdr
-
 from meshroom.core import desc
 from meshroom.core.utils import COLORSPACES, VERBOSE_LEVEL
 
@@ -199,6 +196,8 @@ Sample pixels from Low range images for HDR creation.
 
     @classmethod
     def update(cls, node):
+        from pyalicevision import hdr as avhdr
+
         if not isinstance(node.nodeDesc, cls):
             raise ValueError("Node {} is not an instance of type {}".format(node, cls))
         # TODO: use Node version for this test
@@ -281,6 +280,8 @@ Sample pixels from Low range images for HDR creation.
 
     @staticmethod
     def getExposure(exp, refIso = 100.0, refFnumber = 1.0):
+        from pyalicevision import sfmData as avsfmdata
+
         fnumber, shutterSpeed, iso = exp
         obj = avsfmdata.ExposureSetting(shutterSpeed, fnumber, iso)
         return obj.getExposure()


### PR DESCRIPTION
## Description

Since `pyalicevision`, which is provided outside of Meshroom's repository, is now needed for all the LdrToHdr nodes, importing `pyalicevision` at the function level rather than at the file level allows the CI to pass even if `pyalicevision` is not available.

This PR does not fix the import and use of these nodes in Meshroom if `pyalicevision` is unavailable.