### PR TITLE
[GraphEditor] Node: Check if unexposed `ListAttributes` contain links

### DIFF
--- a/meshroom/ui/qml/GraphEditor/Node.qml
+++ b/meshroom/ui/qml/GraphEditor/Node.qml
@@ -495,8 +495,8 @@ Item {
                                     delegate: Loader {
                                         id: paramLoader
                                         active: !object.isOutput && !object.desc.exposed && object.desc.visible
-                                        visible: Boolean(object.enabled || object.isLink || object.hasOutputConnections)
-                                        property bool isFullyActive: Boolean(m.displayParams || object.isLink || object.hasOutputConnections)
+                                        visible: Boolean(object.enabled || object.isLinkNested || object.hasOutputConnections)
+                                        property bool isFullyActive: Boolean(m.displayParams || object.isLinkNested || object.hasOutputConnections)
                                         width: parent.width
 
                                         sourceComponent: AttributePin {


### PR DESCRIPTION
## Description

If unexposed attributes (ie. attributes that are located in the lower side of a node, and hidden by default) are connected, they are meant to remain visible even if the lower part of that node is hidden.

This was working fine for any attribute that was not a `ListAttribute`, as the check was made on whether the attribute's value was a link to another attribute. For `ListAttributes`, whose value is actually a list of values, this was not working as nested links were not checked.

Instead of relying on the `isLink` property, we now use `isLinkNested`: for regular attributes, this is equivalent to using `isLink`, but for `ListAttributes`, the full list of values will be checked.