### PR TITLE
[nodes] `ExportDistortion`: Add animated distortion option

### DIFF
--- a/meshroom/nodes/aliceVision/ExportDistortion.py
+++ b/meshroom/nodes/aliceVision/ExportDistortion.py
@@ -28,6 +28,12 @@ It also allows to export an undistorted image of the lens grids for validation.
             value=True,
         ),
         desc.BoolParam(
+            name="exportAnimatedNukeNode",
+            label="Export Animated Nuke Node",
+            description="Export animated distortion for this sequence as nuke file.",
+            value=False,
+        ),
+        desc.BoolParam(
             name="exportLensGridsUndistorted",
             label="Export Lens Grids Undistorted",
             description="Export the lens grids undistorted for validation.",

--- a/meshroom/nodes/aliceVision/ExportDistortion.py
+++ b/meshroom/nodes/aliceVision/ExportDistortion.py
@@ -1,4 +1,4 @@
-__version__ = "1.0"
+__version__ = "2.0"
 
 from meshroom.core import desc
 from meshroom.core.utils import VERBOSE_LEVEL

--- a/meshroom/pipelines/cameraTracking.mg
+++ b/meshroom/pipelines/cameraTracking.mg
@@ -12,7 +12,7 @@
             "DepthMapFilter": "4.0",
             "DistortionCalibration": "5.0",
             "ExportAnimatedCamera": "2.0",
-            "ExportDistortion": "1.0",
+            "ExportDistortion": "2.0",
             "FeatureExtraction": "1.3",
             "FeatureMatching": "2.0",
             "ImageMatching": "2.0",

--- a/meshroom/pipelines/cameraTrackingWithoutCalibration.mg
+++ b/meshroom/pipelines/cameraTrackingWithoutCalibration.mg
@@ -11,7 +11,7 @@
             "DepthMap": "5.0",
             "DepthMapFilter": "4.0",
             "ExportAnimatedCamera": "2.0",
-            "ExportDistortion": "1.0",
+            "ExportDistortion": "2.0",
             "FeatureExtraction": "1.3",
             "FeatureMatching": "2.0",
             "ImageMatching": "2.0",

--- a/meshroom/pipelines/distortionCalibration.mg
+++ b/meshroom/pipelines/distortionCalibration.mg
@@ -7,7 +7,7 @@
             "CameraInit": "11.0",
             "CheckerboardDetection": "1.0",
             "DistortionCalibration": "5.0",
-            "ExportDistortion": "1.0",
+            "ExportDistortion": "2.0",
             "Publish": "1.3"
         }
     },

--- a/meshroom/pipelines/nodalCameraTracking.mg
+++ b/meshroom/pipelines/nodalCameraTracking.mg
@@ -10,7 +10,7 @@
             "ConvertSfMFormat": "2.0",
             "DistortionCalibration": "5.0",
             "ExportAnimatedCamera": "2.0",
-            "ExportDistortion": "1.0",
+            "ExportDistortion": "2.0",
             "FeatureExtraction": "1.3",
             "FeatureMatching": "2.0",
             "ImageMatching": "2.0",

--- a/meshroom/pipelines/nodalCameraTrackingWithoutCalibration.mg
+++ b/meshroom/pipelines/nodalCameraTrackingWithoutCalibration.mg
@@ -8,7 +8,7 @@
             "ConvertDistortion": "1.0",
             "ConvertSfMFormat": "2.0",
             "ExportAnimatedCamera": "2.0",
-            "ExportDistortion": "1.0",
+            "ExportDistortion": "2.0",
             "FeatureExtraction": "1.3",
             "FeatureMatching": "2.0",
             "ImageMatching": "2.0",

--- a/meshroom/pipelines/photogrammetryAndCameraTracking.mg
+++ b/meshroom/pipelines/photogrammetryAndCameraTracking.mg
@@ -12,7 +12,7 @@
             "DepthMapFilter": "4.0",
             "DistortionCalibration": "5.0",
             "ExportAnimatedCamera": "2.0",
-            "ExportDistortion": "1.0",
+            "ExportDistortion": "2.0",
             "FeatureExtraction": "1.3",
             "FeatureMatching": "2.0",
             "ImageMatching": "2.0",


### PR DESCRIPTION
In ExportDistortion, add an option to export a nuke file with per frame information about distortion