### PR TITLE
[ui] Improve Search Bar component

### DIFF
--- a/meshroom/ui/qml/Controls/SearchBar.qml
+++ b/meshroom/ui/qml/Controls/SearchBar.qml
@@ -9,8 +9,23 @@ import MaterialIcons 2.2
  */
 
 FocusScope {
+    id: root
     property alias textField: field
     property alias text: field.text
+
+    // Enables hiding and showing of the text field on Search button click
+    property bool toggle: false
+    property bool isVisible: false
+
+    // Size properties
+    property int maxWidth: 150
+    property int minWidth: 30
+
+    // The default width is computed based on whether toggling is enabled and if the visibility is true
+    width: toggle && isVisible ? maxWidth : minWidth
+
+    // Keyboard interaction related signals
+    signal accepted()
 
     implicitHeight: childrenRect.height
     Keys.forwardTo: [field]
@@ -24,10 +39,17 @@ FocusScope {
     }
 
     RowLayout {
+        spacing: 0
         width: parent.width
 
-        MaterialLabel {
+        MaterialToolButton {
             text: MaterialIcons.search
+
+            onClicked: {
+                isVisible = !root.isVisible
+                // Set Focus on the Text Field
+                field.focus = field.visible
+            }
         }
 
         TextField {
@@ -36,9 +58,45 @@ FocusScope {
             Layout.fillWidth: true
             selectByMouse: true
 
+            rightPadding: clear.width
+
+            // The text field is visible either when toggle is not activated or the visible property is set
+            visible: root.toggle ? root.isVisible : true
+
             // Ensure the field has focus when the text is modified
             onTextChanged: {
                 forceActiveFocus()
+            }
+
+            // Handle enter Key press and forward it to the parent
+            Keys.onPressed: (event)=> {
+                if ((event.key == Qt.Key_Return || event.key == Qt.Key_Enter)) {
+                    event.accepted = true
+                    root.accepted()
+                }
+            }
+
+            MaterialToolButton {
+                id: clear
+
+                // Anchors
+                anchors.right: parent.right
+                anchors.rightMargin: 2  // Leave a tiny bit of space so that its highlight does not overlap with the boundary of the parent
+                anchors.verticalCenter: parent.verticalCenter
+
+                // Style
+                font.pointSize: 8
+                text: MaterialIcons.close
+                ToolTip.text: "Clears text."
+
+                // States
+                visible: field.text
+
+                // Signals -> Slots
+                onClicked: {
+                    field.text = ""
+                    parent.focus = true
+                }
             }
         }
     }

--- a/meshroom/ui/qml/GraphEditor/GraphEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/GraphEditor.qml
@@ -1096,32 +1096,23 @@ Item {
                 textField.onTextChanged: navigation.currentIndex = -1
 
                 onAccepted: {
-                    nextArrow.clicked()
+                    navigation.navigateForward()
                 }
             }
 
             MaterialToolButton {
                 text: MaterialIcons.arrow_left
                 padding: 0
-                enabled: graphSearchBar.text !== ""
-                onClicked: {
-                    navigation.currentIndex--
-                    if (navigation.currentIndex === -1)
-                        navigation.currentIndex = filteredNodes.count - 1
-                    navigation.nextItem()
-                }
+                visible: graphSearchBar.text !== ""
+                onClicked: navigation.navigateBackward()
             }
 
             MaterialToolButton {
+                id: nextArrow
                 text: MaterialIcons.arrow_right
                 padding: 0
-                enabled: graphSearchBar.text !== ""
-                onClicked: {
-                    navigation.currentIndex++
-                    if (navigation.currentIndex === filteredNodes.count)
-                        navigation.currentIndex = 0
-                    navigation.nextItem()
-                }
+                visible: graphSearchBar.text !== ""
+                onClicked: navigation.navigateForward()
             }
 
             Label {
@@ -1145,6 +1136,32 @@ Item {
                         return item.model.object[roleName_]
                     }
                 }
+            }
+
+            function navigateForward() {
+                /**
+                 * Moves the navigation index forwards and focuses on the next node as per index.
+                 */
+                if (!filteredNodes.count)
+                    return
+
+                navigation.currentIndex++
+                if (navigation.currentIndex === filteredNodes.count)
+                    navigation.currentIndex = 0
+                navigation.nextItem()
+            }
+
+            function navigateBackward() {
+                /**
+                 * Moves the navigation index backwards and focuses on the previous node as per index.
+                 */
+                if (!filteredNodes.count)
+                    return
+
+                navigation.currentIndex--
+                if (navigation.currentIndex === -1)
+                    navigation.currentIndex = filteredNodes.count - 1
+                navigation.nextItem()
             }
 
             function nextItem() {

--- a/meshroom/ui/qml/GraphEditor/NodeEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/NodeEditor.qml
@@ -104,7 +104,9 @@ Panel {
 
         SearchBar {
             id: searchBar
-            width: 150
+            toggle: true  // Enable toggling the actual text field by the search button
+            Layout.minimumWidth: searchBar.width
+            maxWidth: 150
             enabled: tabBar.currentIndex === 0 || tabBar.currentIndex === 5
         }
 

--- a/meshroom/ui/qml/ImageGallery/ImageGallery.qml
+++ b/meshroom/ui/qml/ImageGallery/ImageGallery.qml
@@ -121,7 +121,9 @@ Panel {
     headerBar: RowLayout {
         SearchBar {
             id: searchBar
-            width: 150
+            toggle: true  // Enable toggling the actual text field by the search button
+            Layout.minimumWidth: searchBar.width
+            maxWidth: 150
         }
 
         MaterialToolButton {


### PR DESCRIPTION
## Description 
### Search bar Updates
* Search bar can now be toggled with the Search Button.
* The GraphEditor had an obstructive search before and now it is clubbed with the bottom panel options.
* The Search Bar now supports "Return Key Press" to move on the next filtered item in the Graph Editor.
* Search Bar also gets a clear text action when text is entered in the field.
* Updated SearchBar in ImageGallery, Node Editor, 3D Inspector to now be toggled.
