### PR TITLE
Fix attribute value change propagation and callback handling

### DIFF
--- a/meshroom/core/attribute.py
+++ b/meshroom/core/attribute.py
@@ -182,21 +182,6 @@ class Attribute(BaseObject):
             return self.getLinkParam().value
         return self._value
 
-    def onChanged(self):
-        """ Called when the attribute value has changed """
-        if self.node.isCompatibilityNode:
-            # We have no access to the node's implementation,
-            # so we cannot call the custom method.
-            return
-        if self.isOutput and not self.node.isInputNode:
-            # Ignore changes on output attributes for non-input nodes
-            # as they are updated during the node's computation.
-            # And we do not want notifications during the graph processing.
-            return
-        # notify the node that the attribute has changed
-        # this will call the node descriptor "onAttrNameChanged" method
-        self.node.onAttributeChanged(self)
-
     def _set_value(self, value, emitSignals=True):
         if self._value == value:
             return

--- a/meshroom/core/attribute.py
+++ b/meshroom/core/attribute.py
@@ -25,11 +25,14 @@ def attributeFactory(description, value, isOutput, node, root=None, parent=None)
         root: (optional) parent Attribute (must be ListAttribute or GroupAttribute)
         parent (BaseObject): (optional) the parent BaseObject if any
     """
-    attr = description.instanceType(node, description, isOutput, root, parent)
+    attr: Attribute = description.instanceType(node, description, isOutput, root, parent)
     if value is not None:
         attr._set_value(value, emitSignals=False)
     else:
         attr.resetToDefaultValue(emitSignals=False)
+
+    attr.valueChanged.connect(lambda attr=attr: node._onAttributeChanged(attr))
+
     return attr
 
 
@@ -67,7 +70,6 @@ class Attribute(BaseObject):
         self._value = None
         self.initValue()
 
-        self.valueChanged.connect(self.onChanged)
 
     @property
     def node(self):

--- a/meshroom/core/node.py
+++ b/meshroom/core/node.py
@@ -933,6 +933,10 @@ class BaseNode(BaseObject):
     def _getAttributeChangedCallback(self, attr: Attribute) -> Optional[Callable]:
         """Get the node descriptor-defined value changed callback associated to `attr` if any."""
 
+        # Callbacks cannot be defined on nested attributes.
+        if attr.root is not None:
+            return None
+
         attrCapitalizedName = attr.name[:1].upper() + attr.name[1:]
         callbackName = f"on{attrCapitalizedName}Changed"
 

--- a/meshroom/core/node.py
+++ b/meshroom/core/node.py
@@ -961,6 +961,10 @@ class BaseNode(BaseObject):
             # And we do not want notifications during the graph processing.
             return
 
+        if attr.value is None:
+            # Discard dynamic values depending on the graph processing.
+            return
+
         callback = self._getAttributeChangedCallback(attr)
 
         if callback:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+import tempfile
+
+import pytest
+
+from meshroom.core.graph import Graph
+
+
+@pytest.fixture
+def graphWithIsolatedCache():
+    """
+    Yield a Graph instance using a unique temporary cache directory.
+
+    Can be used for testing graph computation in isolation, without having to save the graph to disk.
+    """
+    with tempfile.TemporaryDirectory() as cacheDir:
+        graph = Graph("")
+        graph.cacheDir = cacheDir
+        yield graph
+
+    
+@pytest.fixture
+def graphSavedOnDisk():
+    """
+    Yield a Graph instance saved in a unique temporary folder.
+
+    Can be used for testing graph IO and computation in isolation.
+    """
+    with tempfile.TemporaryDirectory() as cacheDir:
+        graph = Graph("")
+        graph.save(Path(cacheDir) / "test_graph.mg")
+        yield graph

--- a/tests/test_nodeAttributeChangedCallback.py
+++ b/tests/test_nodeAttributeChangedCallback.py
@@ -387,3 +387,23 @@ class TestAttributeCallbackBehaviorWithUpstreamDynamicOutputs:
 
         assert nodeB.input.value == 20
         assert nodeB.affectedInput.value == 0
+
+        
+    def test_clearingDynamicOutputValueDoesNotTriggerDownstreamAttributeChangedCallback(
+        self, graphWithIsolatedCache
+    ):
+        graph: Graph = graphWithIsolatedCache
+        nodeA = graph.addNewNode(NodeWithDynamicOutputValue.__name__)
+        nodeB = graph.addNewNode(NodeWithAttributeChangedCallback.__name__)
+
+        nodeA.input.value = 10
+        executeGraph(graph)
+
+        graph.addEdge(nodeA.output, nodeB.input)
+
+        expectedPreClearValue = nodeA.input.value * 2 * 2
+        assert nodeB.affectedInput.value == expectedPreClearValue
+
+        nodeA.clearData()
+        assert nodeA.output.value == nodeB.input.value is None
+        assert nodeB.affectedInput.value == expectedPreClearValue

--- a/tests/test_nodeAttributeChangedCallback.py
+++ b/tests/test_nodeAttributeChangedCallback.py
@@ -1,0 +1,162 @@
+# coding:utf-8
+
+from meshroom.core.graph import Graph, loadGraph
+from meshroom.core import desc, registerNodeType, unregisterNodeType
+from meshroom.core.node import Node
+
+
+class NodeWithAttributeChangedCallback(desc.Node):
+    """
+    A Node containing an input Attribute with an 'on{Attribute}Changed' method,
+    called whenever the value of this attribute is changed explicitly.
+    """
+
+    inputs = [
+        desc.IntParam(
+            name="input",
+            label="Input",
+            description="Attribute with a value changed callback (onInputChanged)",
+            value=0,
+            range=None,
+        ),
+        desc.IntParam(
+            name="affectedInput",
+            label="Affected Input",
+            description="Updated to input.value * 2 whenever 'input' is explicitly modified",
+            value=0,
+            range=None,
+        ),
+    ]
+
+    def onInputChanged(self, instance: Node):
+        instance.affectedInput.value = instance.input.value * 2
+
+    def processChunk(self, chunk):
+        pass  # No-op.
+
+
+
+class TestNodeWithAttributeChangedCallback:
+    @classmethod
+    def setup_class(cls):
+        registerNodeType(NodeWithAttributeChangedCallback)
+
+    @classmethod
+    def teardown_class(cls):
+        unregisterNodeType(NodeWithAttributeChangedCallback)
+
+    def test_assignValueTriggersCallback(self):
+        node = Node(NodeWithAttributeChangedCallback.__name__)
+        assert node.affectedInput.value == 0
+
+        node.input.value = 10
+        assert node.affectedInput.value == 20
+
+    def test_specifyDefaultValueDoesNotTriggerCallback(self):
+        node = Node(NodeWithAttributeChangedCallback.__name__, input=10)
+        assert node.affectedInput.value == 0
+
+    def test_assignDefaultValueDoesNotTriggerCallback(self):
+        node = Node(NodeWithAttributeChangedCallback.__name__, input=10)
+        node.input.value = 10
+        assert node.affectedInput.value == 0
+
+    def test_assignNonDefaultValueTriggersCallback(self):
+        node = Node(NodeWithAttributeChangedCallback.__name__, input=10)
+        node.input.value = 2
+        assert node.affectedInput.value == 4
+
+
+class TestAttributeCallbackTriggerInGraph:
+    @classmethod
+    def setup_class(cls):
+        registerNodeType(NodeWithAttributeChangedCallback)
+
+    @classmethod
+    def teardown_class(cls):
+        unregisterNodeType(NodeWithAttributeChangedCallback)
+
+    def test_connectionTriggersCallback(self):
+        graph = Graph("")
+        nodeA = graph.addNewNode(NodeWithAttributeChangedCallback.__name__)
+        nodeB = graph.addNewNode(NodeWithAttributeChangedCallback.__name__)
+
+        assert nodeA.affectedInput.value == nodeB.affectedInput.value == 0
+
+        nodeA.input.value = 1
+        graph.addEdge(nodeA.input, nodeB.input)
+
+        assert nodeA.affectedInput.value == nodeB.affectedInput.value == 2
+
+    def test_connectedValueChangeTriggersCallback(self):
+        graph = Graph("")
+        nodeA = graph.addNewNode(NodeWithAttributeChangedCallback.__name__)
+        nodeB = graph.addNewNode(NodeWithAttributeChangedCallback.__name__)
+
+        assert nodeA.affectedInput.value == nodeB.affectedInput.value == 0
+
+        graph.addEdge(nodeA.input, nodeB.input)
+        nodeA.input.value = 1
+
+        assert nodeA.affectedInput.value == 2
+        assert nodeB.affectedInput.value == 2
+
+    def test_defaultValueOnlyTriggersCallbackDownstream(self):
+        graph = Graph("")
+        nodeA = graph.addNewNode(NodeWithAttributeChangedCallback.__name__, input=1)
+        nodeB = graph.addNewNode(NodeWithAttributeChangedCallback.__name__)
+
+        assert nodeA.affectedInput.value == 0
+        assert nodeB.affectedInput.value == 0
+
+        graph.addEdge(nodeA.input, nodeB.input)
+
+        assert nodeA.affectedInput.value == 0
+        assert nodeB.affectedInput.value == 2
+
+    def test_valueChangeIsPropagatedAlongNodeChain(self):
+        graph = Graph("")
+        nodeA = graph.addNewNode(NodeWithAttributeChangedCallback.__name__)
+        nodeB = graph.addNewNode(NodeWithAttributeChangedCallback.__name__)
+        nodeC = graph.addNewNode(NodeWithAttributeChangedCallback.__name__)
+        nodeD = graph.addNewNode(NodeWithAttributeChangedCallback.__name__)
+
+        graph.addEdges(
+            (nodeA.affectedInput, nodeB.input),
+            (nodeB.affectedInput, nodeC.input),
+            (nodeC.affectedInput, nodeD.input),
+        )
+
+        nodeA.input.value = 5
+
+        assert nodeA.affectedInput.value == nodeB.input.value == 10
+        assert nodeB.affectedInput.value == nodeC.input.value == 20
+        assert nodeC.affectedInput.value == nodeD.input.value == 40
+        assert nodeD.affectedInput.value == 80
+
+    def test_disconnectionTriggersCallback(self):
+        graph = Graph("")
+        nodeA = graph.addNewNode(NodeWithAttributeChangedCallback.__name__)
+        nodeB = graph.addNewNode(NodeWithAttributeChangedCallback.__name__)
+
+        graph.addEdge(nodeA.input, nodeB.input)
+        nodeA.input.value = 5
+        assert nodeB.affectedInput.value == 10
+
+        graph.removeEdge(nodeB.input)
+
+        assert nodeB.input.value == 0
+        assert nodeB.affectedInput.value == 0
+
+    def test_loadingGraphDoesNotTriggerCallback(self, graphSavedOnDisk):
+        graph: Graph = graphSavedOnDisk
+        node = graph.addNewNode(NodeWithAttributeChangedCallback.__name__)
+
+        node.input.value = 5
+        node.affectedInput.value = 2
+        graph.save()
+
+        loadedGraph = loadGraph(graph.filepath)
+        loadedNode = loadedGraph.node(node.name)
+        assert loadedNode
+        assert loadedNode.affectedInput.value == 2

--- a/tests/test_nodeAttributeChangedCallback.py
+++ b/tests/test_nodeAttributeChangedCallback.py
@@ -160,3 +160,22 @@ class TestAttributeCallbackTriggerInGraph:
         loadedNode = loadedGraph.node(node.name)
         assert loadedNode
         assert loadedNode.affectedInput.value == 2
+
+    def test_loadingGraphDoesNotTriggerCallbackForConnectedAttributes(
+        self, graphSavedOnDisk
+    ):
+        graph: Graph = graphSavedOnDisk
+        nodeA = graph.addNewNode(NodeWithAttributeChangedCallback.__name__)
+        nodeB = graph.addNewNode(NodeWithAttributeChangedCallback.__name__)
+
+        graph.addEdge(nodeA.input, nodeB.input)
+        nodeA.input.value = 5
+        nodeB.affectedInput.value = 2
+
+        graph.save()
+
+        loadedGraph = loadGraph(graph.filepath)
+        loadedNodeB = loadedGraph.node(nodeB.name)
+        assert loadedNodeB
+        assert loadedNodeB.affectedInput.value == 2
+


### PR DESCRIPTION
## Description
This PR aims to improve attribute value change propagation, introduced with the concept of "onAttributeChanged" callback system on node descriptors.
The goal is to fix data model access issues happening randomly in Meshroom, leading to broken UI components as shown below in the ImageGallery:
![imageGallery](https://github.com/user-attachments/assets/db51ac38-1c5b-4643-a671-d2dc93c437e7)


## Features list

- [X] Test suites for validating both the current expected behavior and the refactoring.
- [X] Move attribute value change propagation and callback handling as part of the Node logic.


## Implementation remarks

Part of the current implementation lives in the Attribute class, binding the `valueChanged` signal to a slot directly within the class constructor. This seems to be the root issue that breaks Qt's evaluation system.

This PR move that connection logic to the `attributeFactory` function, and bind it to a slot defined on the `Node` class, where all the attribute callback and value change propagation is now dealt with.

Unit tests were added to validate the expected behavior of this system.
And while not being able to write a specific test to validate this PR fixes the main visible problem stated in the description, many manual tests that were failing fast on the current implementation are now working fine.