### PR TITLE
[core] Plugins: Introduction of NodePluginManager

### DIFF
--- a/meshroom/core/__init__.py
+++ b/meshroom/core/__init__.py
@@ -20,6 +20,7 @@ except Exception:
 
 from meshroom.core.submitter import BaseSubmitter
 from . import desc
+from . import _plugins
 
 # Setup logging
 logging.basicConfig(format='[%(asctime)s][%(levelname)s] %(message)s', level=logging.INFO)
@@ -29,9 +30,11 @@ sessionUid = str(uuid.uuid1())
 
 cacheFolderName = 'MeshroomCache'
 defaultCacheFolder = os.environ.get('MESHROOM_CACHE', os.path.join(tempfile.gettempdir(), cacheFolderName))
-nodesDesc = {}
 submitters = {}
 pipelineTemplates = {}
+
+# Manages plugins for Meshroom Nodes
+pluginManager = _plugins.NodePluginManager()
 
 
 def hashValue(value):
@@ -283,17 +286,14 @@ def registerNodeType(nodeType):
 
     After registration, nodes of this type can be instantiated in a Graph.
     """
-    global nodesDesc
-    if nodeType.__name__ in nodesDesc:
-        logging.error("Node Desc {} is already registered.".format(nodeType.__name__))
-    nodesDesc[nodeType.__name__] = nodeType
+    # Register the node in plugin manager
+    pluginManager.registerNode(nodeType)
 
 
 def unregisterNodeType(nodeType):
     """ Remove 'nodeType' from the list of register node types. """
-    global nodesDesc
-    assert nodeType.__name__ in nodesDesc
-    del nodesDesc[nodeType.__name__]
+    # Unregister the node from plugin manager
+    pluginManager.unregisterNode(nodeType)
 
 
 def loadNodes(folder, packageName):
@@ -301,7 +301,6 @@ def loadNodes(folder, packageName):
 
 
 def loadAllNodes(folder):
-    global nodesDesc
     for importer, package, ispkg in pkgutil.walk_packages([folder]):
         if ispkg:
             nodeTypes = loadNodes(folder, package)

--- a/meshroom/core/_plugins/__init__.py
+++ b/meshroom/core/_plugins/__init__.py
@@ -1,0 +1,6 @@
+""" Plugins.
+"""
+from .node import NodePluginManager
+
+
+__all__ = ["NodePluginManager"]

--- a/meshroom/core/_plugins/node.py
+++ b/meshroom/core/_plugins/node.py
@@ -1,0 +1,138 @@
+""" Node plugins.
+"""
+# Types
+from typing import Dict
+from types import ModuleType
+
+# Internal
+from meshroom.core import desc
+
+
+class NodeDescriptor(object):
+    """ Class to describe a Node Plugin.
+    """
+
+    def __init__(self, name: str, descriptor: desc.Node, module: ModuleType=None):
+        """ Constructor.
+
+        Args:
+            name (str): Name of the Node.
+            descriptor (desc.Node): The Node descriptor.
+
+        Keyword Args:
+            module (ModuleType): Plugin module.
+        """
+        super().__init__()
+
+        # Node descriptions
+        self._name: str = name
+        self._descriptor: desc.Node = descriptor
+
+        # Module descriptions
+        self._module: ModuleType = module
+
+    # Properties
+    descriptor = property(lambda self: self._descriptor)
+    category = property(lambda self: self._descriptor.category)
+
+
+class NodePluginManager(object):
+    """ A Singleton class Managing the Node plugins for Meshroom.
+    """
+    # Static class instance to ensure we have only one created at all times
+    _instance = None
+
+    def __new__(cls):
+        # Verify that the instance we have is of the current type
+        if not isinstance(cls._instance, cls):
+            # Create an instance to work with
+            cls._instance = object.__new__(cls)
+
+            # Init the class parameters
+            # The class parameters need to be initialised outside __init__ as when Cls() gets invoked __init__ gets
+            # called as well, so even when we get the same instance back, the params are updated for this and every
+            # other instance and that what will affect attrs in all places where the current instance is being used
+            cls._instance.init()
+
+        # Return the instantiated instance
+        return cls._instance
+
+    def init(self):
+        """ Constructor for members.
+        """
+        self._descriptors: Dict[str: NodeDescriptor] = {}     # pylint: disable=attribute-defined-outside-init
+
+    # Properties
+    descriptors = property(lambda self: self._descriptors)
+
+    # Public
+    def registered(self, name: str) -> bool:
+        """ Returns whether the plugin has been registered already or not.
+
+        Args:
+            name (str): Name of the plugin.
+        """
+        return name in self._descriptors
+
+    def registerNode(self, descriptor: desc.Node) -> bool:
+        """ Registers a Node into Meshroom.
+
+        Args:
+            descriptor (desc.Node): The Node descriptor.
+
+        Returns:
+            bool. Returns True if the node is registered. False if it is already registered.
+        """
+        # Plugin name
+        name = descriptor.__name__
+
+        # Already registered ?
+        if self.registered(name):
+            return False
+
+        # # Register it
+        # self._descriptors[name] = NodeDescriptor(name, descriptor)
+        self.register(name, descriptor)
+
+        return True
+
+    def unregisterNode(self, descriptor: desc.Node) -> None:
+        """ Unregisters the Node from the Registered Set of Nodes.
+
+        Args:
+            descriptor (desc.Node): The Node descriptor.
+        """
+        # Plugin name
+        name = descriptor.__name__
+
+        # Ensure that we have this node already present
+        assert name in self._descriptors
+        # Delete the instance
+        del self._descriptors[name]
+
+    def register(self, name: str, descriptor: desc.Node) -> None:
+        """ Registers a Node within meshroom.
+
+        Args:
+            descriptor (desc.Node): The Node descriptor.
+        """
+        self._descriptors[name] = NodeDescriptor(name, descriptor)
+
+    def descriptor(self, name: str) -> desc.Node:
+        """ Returns the Node Desc for the provided name.
+
+        Args:
+            name (str): Name of the plugin.
+
+        Returns:
+            desc.Node. The Node Desc instance.
+        """
+        # Returns the plugin for the provided name
+        plugin = self._descriptors.get(name)
+
+        # Plugin not found with the name
+        if not plugin:
+            return None
+
+        # Return the Node Descriptor for the plugin
+        return plugin.descriptor

--- a/meshroom/core/graph.py
+++ b/meshroom/core/graph.py
@@ -431,7 +431,7 @@ class Graph(BaseObject):
         # Second pass to update all the links in the input/output attributes for every node with the new names
         for nodeName, nodeData in updatedData.items():
             nodeType = nodeData.get("nodeType", None)
-            nodeDesc = meshroom.core.nodesDesc[nodeType]
+            nodeDesc = meshroom.core.pluginManager.descriptor(nodeType)
 
             inputs = nodeData.get("inputs", {})
             outputs = nodeData.get("outputs", {})

--- a/meshroom/core/node.py
+++ b/meshroom/core/node.py
@@ -491,9 +491,9 @@ class BaseNode(BaseObject):
         self._nodeType = nodeType
         self.nodeDesc = None
 
-        # instantiate node description if nodeType is valid
-        if nodeType in meshroom.core.nodesDesc:
-            self.nodeDesc = meshroom.core.nodesDesc[nodeType]()
+        # instantiate node description if nodeType has been registered
+        if meshroom.core.pluginManager.registered(nodeType):
+            self.nodeDesc = meshroom.core.pluginManager.descriptor(nodeType)()
 
         self.packageName = self.packageVersion = ""
         self._internalFolder = ""
@@ -1852,11 +1852,11 @@ def nodeFactory(nodeDict, name=None, template=False, uidConflict=False):
 
     compatibilityIssue = None
 
-    nodeDesc = None
-    try:
-        nodeDesc = meshroom.core.nodesDesc[nodeType]
-    except KeyError:
-        # Unknown node type
+    # Returns the desc.Node inherited class or None if the plugin was not registered
+    nodeDesc = meshroom.core.pluginManager.descriptor(nodeType)
+
+    # Node plugin was not registered
+    if not nodeDesc:
         compatibilityIssue = CompatibilityIssue.UnknownNodeType
 
     # Unknown node type should take precedence over UID conflict, as it cannot be resolved

--- a/meshroom/ui/app.py
+++ b/meshroom/ui/app.py
@@ -10,7 +10,7 @@ from PySide2.QtGui import QIcon
 from PySide2.QtWidgets import QApplication
 
 import meshroom
-from meshroom.core import nodesDesc
+from meshroom.core import pluginManager
 from meshroom.core.taskManager import TaskManager
 from meshroom.common import Property, Variant, Signal, Slot
 
@@ -241,6 +241,7 @@ class MeshroomApp(QApplication):
         components.registerTypes()
 
         # expose available node types that can be instantiated
+        nodesDesc = pluginManager.descriptors
         self.engine.rootContext().setContextProperty("_nodeTypes", {n: {"category": nodesDesc[n].category} for n in sorted(nodesDesc.keys())})
 
         # instantiate Reconstruction object

--- a/meshroom/ui/reconstruction.py
+++ b/meshroom/ui/reconstruction.py
@@ -496,7 +496,8 @@ class Reconstruction(UIGraph):
         # Create all possible entries
         for category, _ in self.activeNodeCategories.items():
             self._activeNodes.add(ActiveNode(category, parent=self))
-        for nodeType, _ in meshroom.core.nodesDesc.items():
+
+        for nodeType in meshroom.core.pluginManager.descriptors:
             self._activeNodes.add(ActiveNode(nodeType, parent=self))
 
     def clearActiveNodes(self):
@@ -648,7 +649,9 @@ class Reconstruction(UIGraph):
         if not sfmFile or not os.path.isfile(sfmFile):
             self.tempCameraInit = None
             return
-        nodeDesc = meshroom.core.nodesDesc["CameraInit"]()
+
+        # The camera init node should always exist
+        nodeDesc = meshroom.core.pluginManager.descriptor("CameraInit")()
         views, intrinsics = nodeDesc.readSfMData(sfmFile)
         tmpCameraInit = Node("CameraInit", viewpoints=views, intrinsics=intrinsics)
         tmpCameraInit.locked = True

--- a/tests/test_compatibility.py
+++ b/tests/test_compatibility.py
@@ -197,7 +197,7 @@ def test_description_conflict():
     Test compatibility behavior for conflicting node descriptions.
     """
     # copy registered node types to be able to restore them
-    originalNodeTypes = copy.copy(meshroom.core.nodesDesc)
+    originalNodeTypes = copy.copy(meshroom.core.pluginManager.descriptors)
 
     nodeTypes = [SampleNodeV1, SampleNodeV2, SampleNodeV3, SampleNodeV4, SampleNodeV5]
     nodes = []
@@ -224,7 +224,7 @@ def test_description_conflict():
     # offset node types register to create description conflicts
     # each node type name now reference the next one's implementation
     for i, nt in enumerate(nodeTypes[:-1]):
-        meshroom.core.nodesDesc[nt.__name__] = nodeTypes[i+1]
+        meshroom.core.pluginManager.register(nt.__name__, nodeTypes[i+1])
 
     # reload file
     g = loadGraph(graphFile)
@@ -306,7 +306,7 @@ def test_description_conflict():
             raise ValueError("Unexpected node type: " + srcNode.nodeType)
 
     # restore original node types
-    meshroom.core.nodesDesc = originalNodeTypes
+    meshroom.core.pluginManager._descriptors = originalNodeTypes        # pylint: disable=protected-access
 
 
 def test_upgradeAllNodes():
@@ -331,8 +331,8 @@ def test_upgradeAllNodes():
     unregisterNodeType(SampleNodeV2)
     unregisterNodeType(SampleInputNodeV2)
     # replace SampleNodeV1 by SampleNodeV2 and SampleInputNodeV1 by SampleInputNodeV2
-    meshroom.core.nodesDesc[SampleNodeV1.__name__] = SampleNodeV2
-    meshroom.core.nodesDesc[SampleInputNodeV1.__name__] = SampleInputNodeV2
+    meshroom.core.pluginManager.register(SampleNodeV1.__name__, SampleNodeV2)
+    meshroom.core.pluginManager.register(SampleInputNodeV1.__name__, SampleInputNodeV2)
 
     # reload file
     g = loadGraph(graphFile)
@@ -369,7 +369,7 @@ def test_conformUpgrade():
     g.save(graphFile)
 
     # replace SampleNodeV5 by SampleNodeV6
-    meshroom.core.nodesDesc[SampleNodeV5.__name__] = SampleNodeV6
+    meshroom.core.pluginManager.register(SampleNodeV5.__name__, SampleNodeV6)
 
     # reload file
     g = loadGraph(graphFile)

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1,0 +1,67 @@
+""" Test for Meshroom Plugins.
+"""
+#!/usr/bin/env python
+# coding:utf-8
+
+from meshroom.core import _plugins
+from meshroom.core import desc, registerNodeType, unregisterNodeType
+
+
+class SampleNode(desc.Node):
+    """ Sample Node for unit testing """
+
+    category = "Sample"
+
+    inputs = [
+        desc.File(name='input', label='Input', description='', value='',),
+        desc.StringParam(name='paramA', label='ParamA', description='', value='', invalidate=False)  # No impact on UID
+    ]
+    outputs = [
+        desc.File(name='output', label='Output', description='', value=desc.Node.internalFolder)
+    ]
+
+
+def test_plugin_management():
+    """ Tests the plugin manager for registering and unregistering node.
+    """
+    # Sample Node name
+    name = SampleNode.__name__
+
+    # Register the node
+    registerNodeType(SampleNode)
+
+    # Since the Node Plugin Manager is a singleton instance
+    # We should still be able to instantiate and have a look at out registered plugins directly
+    pluginManager = _plugins.NodePluginManager()
+
+    # Assert that the plugin we have registered above is indeed registered
+    assert pluginManager.registered(name)
+
+    # Assert that the plugin can only be registered once
+    assert not pluginManager.registerNode(SampleNode)
+
+    # And once un-registered, it should no longer be present in the pluginManager
+    unregisterNodeType(SampleNode)
+
+    # Assert that the plugin we have registered above is indeed registered
+    assert not pluginManager.registered(name)
+    assert name not in pluginManager.descriptors
+
+def test_descriptor():
+    """ Tests the Descriptor and NodeDescriptor instances.
+    """
+    # Register the node
+    registerNodeType(SampleNode)
+
+    # Since the Node Plugin Manager is a singleton instance
+    # We should still be able to instantiate and have a look at out registered plugins directly
+    pluginManager = _plugins.NodePluginManager()
+
+    # Assert the descriptor is same as the Plugin NodeType
+    assert pluginManager.descriptor(SampleNode.__name__).__name__ == SampleNode.__name__
+
+    # Assert that the category of the NodeDescriptor is correct for the registered plugin
+    assert pluginManager.descriptors.get(SampleNode.__name__).category == "Sample"
+
+    # Finally unregister the plugin
+    unregisterNodeType(SampleNode)

--- a/tests/test_templatesVersion.py
+++ b/tests/test_templatesVersion.py
@@ -34,9 +34,10 @@ def test_templateVersions():
 
         for _, nodeData in graphData.items():
             nodeType = nodeData["nodeType"]
-            assert nodeType in meshroom.core.nodesDesc
+            # Assert that the plugin (nodeType) is indeed registered to be used
+            assert meshroom.core.pluginManager.registered(nodeType)
 
-            nodeDesc = meshroom.core.nodesDesc[nodeType]
+            nodeDesc = meshroom.core.pluginManager.descriptor(nodeType)
             currentNodeVersion = meshroom.core.nodeVersion(nodeDesc)
 
             inputs = nodeData.get("inputs", {})


### PR DESCRIPTION
## TCSR-1193 | Part 1 - Introduction of a Plugin Management System

### Node Plugin Manager
The NodePluginManager provides a way for registering and managing node plugins within Meshroom. 
This also provides a way for other components to interact with the plugins to understand whether a plugin is available or not.

The **Node Plugin Manager** serves as an initial setup by removing a standard python dictionary "nodesDesc" and using a Singleton class dealing with Plugins.
The Registered Node Plugin is of the type **NodeDescriptor**.
The NodeDescriptor would later evolve into a Class holding the Module and its Modification times.
The Errors should also be stored in the NodeDescriptor along with its Version.

The changes here also replace the usage of standard conditions of dictionary to validate whether a plugin exists with the lingo of now checking "registered".

### What's Next
The Next steps would be to update the plugin registering mechanism to also include the plugins which have an error on them.
Currently the plugins with issues/errors are discarded and not registered.
With the changes proposed here, the Error Nodes should also be allowed to be created in the NodeGraph, but will be of the form of **CompatibilityNode**, allowing the developer/user to visualise the **_Errors_** on the Node.

### Tests
* All existing tests have been updated
* Introduced a test to validate the Plugin Manager behaviour with registering and unregistering Plugins.

