### PR TITLE
Discard attribute changed callbacks during graph loading

### DIFF
--- a/meshroom/core/exception.py
+++ b/meshroom/core/exception.py
@@ -12,6 +12,21 @@ class GraphException(MeshroomException):
     pass
 
 
+class GraphCompatibilityError(GraphException):
+    """
+    Raised when node compatibility issues occur when loading a graph.
+    
+    Args:
+        filepath: The path to the file that caused the error.
+        issues: A dictionnary of node names and their respective compatibility issues.
+    """
+    def __init__(self, filepath, issues: dict[str, str]) -> None:
+        self.filepath = filepath
+        self.issues = issues
+        msg = f"Compatibility issues found when loading {self.filepath}: {self.issues}"
+        super().__init__(msg)
+
+
 class UnknownNodeTypeError(GraphException):
     """
     Raised when asked to create a unknown node type.

--- a/meshroom/core/graph.py
+++ b/meshroom/core/graph.py
@@ -214,6 +214,7 @@ class Graph(BaseObject):
     def __init__(self, name, parent=None):
         super(Graph, self).__init__(parent)
         self.name = name
+        self._loading = False
         self._updateEnabled = True
         self._updateRequested = False
         self.dirtyTopology = False
@@ -246,6 +247,11 @@ class Graph(BaseObject):
         """ Get loaded file supported features based on its version. """
         return Graph.IO.getFeaturesForVersion(self.header.get(Graph.IO.Keys.FileVersion, "0.0"))
 
+    @property
+    def isLoading(self):
+        """ Return True if the graph is currently being loaded. """
+        return self._loading
+
     @Slot(str)
     def load(self, filepath, setupProjectFile=True, importProject=False, publishOutputs=False):
         """
@@ -259,6 +265,13 @@ class Graph(BaseObject):
                            of opened.
             publishOutputs: True if "Publish" nodes from templates should not be ignored.
         """
+        self._loading = True
+        try:
+            self._load(filepath, setupProjectFile, importProject, publishOutputs)
+        finally:
+            self._loading = False
+
+    def _load(self, filepath, setupProjectFile, importProject, publishOutputs):
         if not importProject:
             self.clear()
         with open(filepath) as jsonFile:

--- a/meshroom/core/graph.py
+++ b/meshroom/core/graph.py
@@ -15,7 +15,7 @@ import meshroom.core
 from meshroom.common import BaseObject, DictModel, Slot, Signal, Property
 from meshroom.core import Version
 from meshroom.core.attribute import Attribute, ListAttribute, GroupAttribute
-from meshroom.core.exception import StopGraphVisit, StopBranchVisit
+from meshroom.core.exception import GraphCompatibilityError, StopGraphVisit, StopBranchVisit
 from meshroom.core.node import nodeFactory, Status, Node, CompatibilityNode
 
 # Replace default encoder to support Enums
@@ -1633,11 +1633,27 @@ class Graph(BaseObject):
     canComputeLeaves = Property(bool, lambda self: self._canComputeLeaves, notify=canComputeLeavesChanged)
 
 
-def loadGraph(filepath):
+def loadGraph(filepath, strictCompatibility: bool = False) -> Graph:
     """
+    Load a Graph from a Meshroom Graph (.mg) file.
+
+    Args:
+        filepath: The path to the Meshroom Graph file.
+        strictCompatibility: If True, raise a GraphCompatibilityError if the loaded Graph has node compatibility issues.
+
+    Returns:
+        Graph: The loaded Graph instance.
+
+    Raises:
+        GraphCompatibilityError: If the Graph has node compatibility issues and `strictCompatibility` is False.
     """
     graph = Graph("")
     graph.load(filepath)
+
+    compatibilityIssues = len(graph.compatibilityNodes) > 0
+    if compatibilityIssues and strictCompatibility:
+        raise GraphCompatibilityError(filepath, {n.name: str(n.issue) for n in graph.compatibilityNodes})
+
     graph.update()
     return graph
 

--- a/meshroom/core/graph.py
+++ b/meshroom/core/graph.py
@@ -1658,7 +1658,7 @@ def loadGraph(filepath, strictCompatibility: bool = False) -> Graph:
         Graph: The loaded Graph instance.
 
     Raises:
-        GraphCompatibilityError: If the Graph has node compatibility issues and `strictCompatibility` is False.
+        GraphCompatibilityError: If the Graph has node compatibility issues and `strictCompatibility` is True.
     """
     graph = Graph("")
     graph.load(filepath)

--- a/meshroom/core/node.py
+++ b/meshroom/core/node.py
@@ -964,6 +964,10 @@ class BaseNode(BaseObject):
         if attr.value is None:
             # Discard dynamic values depending on the graph processing.
             return
+        
+        if self.graph and self.graph.isLoading:
+            # Do not trigger attribute callbacks during the graph loading.
+            return
 
         callback = self._getAttributeChangedCallback(attr)
 


### PR DESCRIPTION
## Description
Ensure attribute changed callbacks are not triggered on graph loading.

When loading a graph, we expect nodes to be deserialized in the exact state they were saved.
Attribute callbacks may modify attribute values and impact the UID of the nodes.
This was leading to UID compatibility conflicts on file opening, for Graph containing Nodes using such mechanisms.

## Features list

- [X] Add "strictCompatibility" mode for graph loading
- [x] Discard attribute callbacks when graph is being loaded


## Implementation remarks
While this behavior was covered by a test, it turned out to be a false positive.
The error was hidden behind the fact that the tested Node was actually UID conflicting due to the callback, and swapped to a Compatibility Node. Therefore, attribute values were restored to the serialized ones, with expected values.
The introduction of the "strictCompatibility" mode allows to test this behavior more efficiently.
