### PR TITLE
[pipelines] PhotogCamTrack: Invert masks for segmentation

### DIFF
--- a/meshroom/pipelines/photogrammetryAndCameraTracking.mg
+++ b/meshroom/pipelines/photogrammetryAndCameraTracking.mg
@@ -405,7 +405,9 @@
             ],
             "inputs": {
                 "input": "{ImageDetectionPrompt_1.input}",
-                "bboxFolder": "{ImageDetectionPrompt_1.output}"
+                "bboxFolder": "{ImageDetectionPrompt_1.output}",
+                "maskInvert": true,
+                "keepFilename": true
             },
             "internalInputs": {
                 "color": "#575963"


### PR DESCRIPTION
## Description

This PR enables the inversion of masks and keeps the same filename for all the masks that are generated with the `ImageSegmentationBox` node in the "Photogrammetry and Camera Tracking" template.