### PR TITLE
Refactor Node selection for better UX and performance

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,3 +1,5 @@
+# [GraphEditor] Indentation fix
+87c0cef605e4ef2b359d7e678155e79b65b2e762
 # [qt6][qml] Clean-up code and harmonize comments
 5a0b1c0c9547b0d00f3f10fae6994d6d8ea0b45e
 # [nodes] Linting: Clean-up files

--- a/meshroom/common/qt.py
+++ b/meshroom/common/qt.py
@@ -283,6 +283,15 @@ class QObjectListModel(QtCore.QAbstractListModel):
 
         self._objectByKey[key] = item
 
+    @QtCore.Slot(int, result=QtCore.QModelIndex)
+    def index(self, row: int, column: int = 0, parent=QtCore.QModelIndex()):
+        """ Returns the model index for the given row, column and parent index. """
+        if parent.isValid() or column != 0:
+            return QtCore.QModelIndex()
+        if row < 0 or row >= self.size():
+            return QtCore.QModelIndex()
+        return self.createIndex(row, column, self._objects[row])
+
     def _dereferenceItem(self, item):
         # Ask for object deletion if parented to the model
         if shiboken6.isValid(item) and item.parent() == self:

--- a/meshroom/ui/components/__init__.py
+++ b/meshroom/ui/components/__init__.py
@@ -1,11 +1,12 @@
 
 def registerTypes():
-    from PySide6.QtQml import qmlRegisterType
+    from PySide6.QtQml import qmlRegisterType, qmlRegisterSingletonType
     from meshroom.ui.components.clipboard import ClipboardHelper
     from meshroom.ui.components.edge import EdgeMouseArea
     from meshroom.ui.components.filepath import FilepathHelper
     from meshroom.ui.components.scene3D import Scene3DHelper, TrackballController, Transformations3DHelper
     from meshroom.ui.components.csvData import CsvData
+    from meshroom.ui.components.geom2D import Geom2D
 
     qmlRegisterType(EdgeMouseArea, "GraphEditor", 1, 0, "EdgeMouseArea")
     qmlRegisterType(ClipboardHelper, "Meshroom.Helpers", 1, 0, "ClipboardHelper")  # TODO: uncreatable
@@ -14,3 +15,5 @@ def registerTypes():
     qmlRegisterType(Transformations3DHelper, "Meshroom.Helpers", 1, 0, "Transformations3DHelper")  # TODO: uncreatable
     qmlRegisterType(TrackballController, "Meshroom.Helpers", 1, 0, "TrackballController")
     qmlRegisterType(CsvData, "DataObjects", 1, 0, "CsvData")
+
+    qmlRegisterSingletonType(Geom2D, "Meshroom.Helpers", 1, 0, "Geom2D")

--- a/meshroom/ui/components/geom2D.py
+++ b/meshroom/ui/components/geom2D.py
@@ -1,0 +1,8 @@
+from PySide6.QtCore import QObject, Slot, QRectF
+
+
+class Geom2D(QObject):
+    @Slot(QRectF, QRectF, result=bool)
+    def rectRectIntersect(self, rect1: QRectF, rect2: QRectF) -> bool:
+        """Check if two rectangles intersect."""
+        return rect1.intersects(rect2)

--- a/meshroom/ui/graph.py
+++ b/meshroom/ui/graph.py
@@ -676,18 +676,23 @@ class UIGraph(QObject):
                 position = Position(node.x + offset.x(), node.y + offset.y())
                 self.moveNode(node, position)
 
-    @Slot(QObject)
-    def removeNodes(self, nodes):
+    @Slot()
+    def removeSelectedNodes(self):
+        """Remove selected nodes from the graph."""
+        self.removeNodes(list(self.iterSelectedNodes()))
+
+    @Slot(list)
+    def removeNodes(self, nodes: list[Node]):
         """
         Remove 'nodes' from the graph.
 
         Args:
-            nodes (list[Node]): the nodes to remove
+            nodes: The nodes to remove.
         """
-        nodes = self.filterNodes(nodes)
-        if any([ n.locked for n in nodes ]):
+        if any(n.locked for n in nodes):
             return
-        with self.groupedGraphModification("Remove Selected Nodes"):
+
+        with self.groupedGraphModification("Remove Nodes"):
             for node in nodes:
                 self.push(commands.RemoveNodeCommand(self._graph, node))
 

--- a/meshroom/ui/graph.py
+++ b/meshroom/ui/graph.py
@@ -813,21 +813,24 @@ class UIGraph(QObject):
                     # update the edges from allSrc
                     allSrc = [e.src for e in self._graph.edges.values()]
 
+    @Slot()
+    def clearSelectedNodesData(self):
+        """Clear data from all selected nodes."""
+        self.clearData(self.iterSelectedNodes())
 
-    @Slot(QObject)
-    def clearData(self, nodes):
+    @Slot(list)
+    def clearData(self, nodes: list[Node]):
         """ Clear data from 'nodes'. """
-        nodes = self.filterNodes(nodes)
         for n in nodes:
             n.clearData()
 
-    @Slot(QObject)
-    def clearDataFrom(self, nodes):
+    @Slot(list)
+    def clearDataFrom(self, nodes: list[Node]):
         """
         Clear data from all nodes starting from 'nodes' to graph leaves.
 
         Args:
-            nodes (list[Node]): the nodes to start from.
+            nodes: The nodes to start from.
         """
         self.clearData(self._graph.dfsOnDiscover(startNodes=nodes, reverse=True, dependenciesOnly=True)[0])
 

--- a/meshroom/ui/graph.py
+++ b/meshroom/ui/graph.py
@@ -651,12 +651,6 @@ class UIGraph(QObject):
             position = Position(position.x(), position.y())
         return self.push(commands.AddNodeCommand(self._graph, nodeType, position=position, **kwargs))
 
-    def filterNodes(self, nodes):
-        """Filter out the nodes that do not exist on the graph."""
-        if not isinstance(nodes, Iterable):
-            nodes = [nodes]
-        return [ n for n in nodes if n in self._graph.nodes.values() ]
-
     def moveNode(self, node: Node, position: Position):
         """
         Move `node` to the given `position`.

--- a/meshroom/ui/graph.py
+++ b/meshroom/ui/graph.py
@@ -952,9 +952,12 @@ class UIGraph(QObject):
         self.selectNodesByIndices(indices, command)
 
     @Slot(Node)
-    def selectFollowing(self, node: Node):
+    @Slot(Node, int)
+    def selectFollowing(self, node: Node, command=QItemSelectionModel.SelectionFlag.ClearAndSelect):
         """Select all the nodes that depend on `node`."""
-        self.selectNodes(self._graph.dfsOnDiscover(startNodes=[node], reverse=True, dependenciesOnly=True)[0])
+        self.selectNodes(
+            self._graph.dfsOnDiscover(startNodes=[node], reverse=True, dependenciesOnly=True)[0], command
+        )
         self.selectedNode = node
 
     @Slot(int)

--- a/meshroom/ui/qml/Application.qml
+++ b/meshroom/ui/qml/Application.qml
@@ -541,7 +541,7 @@ Page {
         enabled: _reconstruction ? _reconstruction.selectedNodes.count > 0 : false
         onTriggered: {
             graphEditor.copyNodes()
-            graphEditor.uigraph.removeNodes(graphEditor.uigraph.selectedNodes)
+            graphEditor.uigraph.removeSelectedNodes()
         }
     }
 

--- a/meshroom/ui/qml/Application.qml
+++ b/meshroom/ui/qml/Application.qml
@@ -30,21 +30,6 @@ Page {
         property alias showImageGallery: imageGalleryVisibilityCB.checked
     }
 
-    // Utility functions for elements in the menubar
-    function getSelectedNodesName() {
-        if (!_reconstruction)
-            return ""
-        var nodesName = ""
-        for (var i = 0; i < _reconstruction.selectedNodes.count; i++) {
-            if (nodesName !== "")
-                nodesName += ", "
-            var node = _reconstruction.selectedNodes.at(i)
-            if(node) {
-                nodesName += node.name
-            }
-        }
-        return nodesName
-    }
 
     property url imagesFolder: {
         var recentImportedImagesFolders = MeshroomApp.recentImportedImagesFolders
@@ -531,14 +516,9 @@ Page {
     Action {
         id: cutAction
 
-        property string tooltip: {
-            var s = "Copy selected node"
-            s += (_reconstruction && _reconstruction.selectedNodes.count > 1 ? "s (" : " (") + getSelectedNodesName()
-            s += ") to the clipboard and remove them from the graph"
-            return s
-        }
-        text: "Cut Node" + (_reconstruction && _reconstruction.selectedNodes.count > 1 ? "s " : " ")
-        enabled: _reconstruction ? _reconstruction.selectedNodes.count > 0 : false
+        property string tooltip: "Cut Selected Node(s)"
+        text: "Cut Node(s)"
+        enabled: _reconstruction ? _reconstruction.nodeSelection.hasSelection : false
         onTriggered: {
             graphEditor.copyNodes()
             graphEditor.uigraph.removeSelectedNodes()
@@ -548,14 +528,9 @@ Page {
     Action {
         id: copyAction
 
-        property string tooltip: {
-            var s = "Copy selected node"
-            s += (_reconstruction && _reconstruction.selectedNodes.count > 1 ? "s (" : " (") + getSelectedNodesName()
-            s += ") to the clipboard"
-            return s
-        }
-        text: "Copy Node" + (_reconstruction && _reconstruction.selectedNodes.count > 1 ? "s " : " ")
-        enabled: _reconstruction ? _reconstruction.selectedNodes.count > 0 : false
+        property string tooltip: "Copy Selected Node(s)" 
+        text: "Copy Node(s)"
+        enabled: _reconstruction ? _reconstruction.nodeSelection.hasSelection : false
         onTriggered: graphEditor.copyNodes()
     }
 

--- a/meshroom/ui/qml/Controls/DelegateSelectionBox.qml
+++ b/meshroom/ui/qml/Controls/DelegateSelectionBox.qml
@@ -1,0 +1,32 @@
+import QtQuick
+import Meshroom.Helpers
+
+/*
+A SelectionBox that can be used to select delegates in a model instantiator (Repeater, ListView...).
+Interesection test is done in the coordinate system of the container Item, using delegate's bounding boxes.
+The list of selected indices is emitted when the selection ends.
+*/
+
+SelectionBox {
+    id: root
+
+    // The Item instantiating the delegates.
+    property Item modelInstantiator
+    // The Item containing the delegates (used for coordinate mapping).
+    property Item container
+    // Emitted when the selection has ended, with the list of selected indices and modifiers.
+    signal delegateSelectionEnded(list<int> indices, int modifiers)
+
+    onSelectionEnded: function(selectionRect, modifiers) {
+        let selectedIndices = [];
+        const mappedSelectionRect = mapToItem(container, selectionRect);
+        for (var i = 0; i < modelInstantiator.count; ++i) {
+            const delegate = modelInstantiator.itemAt(i);
+            const delegateRect = Qt.rect(delegate.x, delegate.y, delegate.width, delegate.height);
+            if (Geom2D.rectRectIntersect(mappedSelectionRect, delegateRect)) {
+                selectedIndices.push(i);
+            }
+        }
+        delegateSelectionEnded(selectedIndices, modifiers);
+    }
+}

--- a/meshroom/ui/qml/Controls/SelectionBox.qml
+++ b/meshroom/ui/qml/Controls/SelectionBox.qml
@@ -1,0 +1,60 @@
+import QtQuick
+
+/*
+Simple selection box that can be used by a MouseArea.
+
+Usage:
+1. Create a MouseArea and a SelectionBox.
+2. Bind the SelectionBox to the MouseArea by setting the `mouseArea` property.
+3. Call startSelection() with coordinates when the selection starts.
+4. Call endSelection() when the selection ends.
+5. Listen to the selectionEnded signal to get the selection rectangle.
+*/
+
+Item {
+    id: root
+
+    property MouseArea mouseArea
+    property alias color: selectionBox.color
+    property alias border: selectionBox.border
+
+    readonly property bool active: mouseArea.drag.target == dragTarget
+
+    signal selectionEnded(rect selectionRect, int modifiers)
+
+    function startSelection(mouse) {
+        dragTarget.startPos.x = dragTarget.x = mouse.x;
+        dragTarget.startPos.y = dragTarget.y = mouse.y;
+        dragTarget.modifiers = mouse.modifiers;
+        mouseArea.drag.target = dragTarget;
+    }
+
+    function endSelection() {
+        if (!active) {
+            return;
+        }
+        mouseArea.drag.target = null;
+        const rect = Qt.rect(selectionBox.x, selectionBox.y, selectionBox.width, selectionBox.height)
+        selectionEnded(rect, dragTarget.modifiers);
+    }
+
+    visible: active
+
+    Rectangle {
+        id: selectionBox
+        color: "#109b9b9b"
+        border.width: 1
+        border.color: "#b4b4b4"
+
+        x: Math.min(dragTarget.startPos.x, dragTarget.x)
+        y: Math.min(dragTarget.startPos.y, dragTarget.y)
+        width: Math.abs(dragTarget.x - dragTarget.startPos.x)
+        height: Math.abs(dragTarget.y - dragTarget.startPos.y)
+    }
+
+    Item {
+        id: dragTarget
+        property point startPos
+        property var modifiers
+    }
+}

--- a/meshroom/ui/qml/Controls/qmldir
+++ b/meshroom/ui/qml/Controls/qmldir
@@ -17,3 +17,5 @@ IntSelector 1.0 IntSelector.qml
 MScrollBar 1.0 MScrollBar.qml
 MSplitView 1.0 MSplitView.qml
 DirectionalLightPane 1.0 DirectionalLightPane.qml
+SelectionBox 1.0 SelectionBox.qml
+DelegateSelectionBox 1.0 DelegateSelectionBox.qml

--- a/meshroom/ui/qml/GraphEditor/GraphEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/GraphEditor.qml
@@ -59,15 +59,6 @@ Item {
         return undefined
     }
 
-    /// Select node delegate
-    function selectNode(node) {
-        uigraph.selectedNode = node
-        if (node !== null) {
-            uigraph.appendSelection(node)
-            uigraph.selectedNodesChanged()
-        }
-    }
-
     /// Duplicate a node and optionally all the following ones
     function duplicateNode(duplicateFollowingNodes) {
         var nodes
@@ -219,14 +210,13 @@ Item {
             height: searchBar.height + nodeMenuRepeater.height + instantiator.height
 
             function createNode(nodeType) {
-                uigraph.clearNodeSelection() // Ensures that only the created node / imported pipeline will be selected
-
                 // "nodeType" might be a pipeline (artificially added in the "Pipelines" category) instead of a node
                 // If it is not a pipeline to import, then it must be a node
                 if (!importPipeline(nodeType)) {
                     // Add node via the proper command in uigraph
-                    var node = uigraph.addNewNode(nodeType, spawnPosition)
-                    selectNode(node)
+                    var node = uigraph.addNewNode(nodeType, spawnPosition);
+                    uigraph.selectedNode = node;
+                    uigraph.selectNodes([node])
                 }
                 close()
             }

--- a/meshroom/ui/qml/GraphEditor/GraphEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/GraphEditor.qml
@@ -555,241 +555,241 @@ Item {
 
             Component {
                 id: nodeMenuComponent
-            Menu {
-                id: nodeMenu
-                
-                property var currentNode: nodeMenuLoader.currentNode
+                Menu {
+                    id: nodeMenu
+                    
+                    property var currentNode: nodeMenuLoader.currentNode
 
-                // Cache computatibility/submitability status of each selected node.
-                readonly property var nodeSubmitOrComputeStatus: {
-                    var collectedStatus = ({});
-                    uigraph.nodeSelection.selectedIndexes.forEach(function(idx) {
-                        const node = uigraph.graph.nodes.at(idx.row);
-                        collectedStatus[node] = uigraph.graph.canSubmitOrCompute(node);
-                    });
-                    return collectedStatus;
-                }
+                    // Cache computatibility/submitability status of each selected node.
+                    readonly property var nodeSubmitOrComputeStatus: {
+                        var collectedStatus = ({});
+                        uigraph.nodeSelection.selectedIndexes.forEach(function(idx) {
+                            const node = uigraph.graph.nodes.at(idx.row);
+                            collectedStatus[node] = uigraph.graph.canSubmitOrCompute(node);
+                        });
+                        return collectedStatus;
+                    }
 
-                readonly property bool isSelectionFullyComputed: {
-                    return uigraph.nodeSelection.selectedIndexes.every(function(idx) {
-                        return uigraph.graph.nodes.at(idx.row).isComputed;
-                    });
-                }
+                    readonly property bool isSelectionFullyComputed: {
+                        return uigraph.nodeSelection.selectedIndexes.every(function(idx) {
+                            return uigraph.graph.nodes.at(idx.row).isComputed;
+                        });
+                    }
 
-                readonly property bool isSelectionOnlyComputableNodes: {
-                    return uigraph.nodeSelection.selectedIndexes.every(function(idx) {
-                        const node = uigraph.graph.nodes.at(idx.row);
-                        return (
-                            node.isComputable
-                            && uigraph.graph.canComputeTopologically(node)
-                        );
-                    });
-                }
-
-                readonly property bool canSelectionBeComputed: {
-                    if(!isSelectionOnlyComputableNodes)
-                        return false;
-                    if(isSelectionFullyComputed)
-                        return true;
-                    return uigraph.nodeSelection.selectedIndexes.every(function(idx) {
-                        const node = uigraph.graph.nodes.at(idx.row);
-                        return (
-                            node.isComputed
-                            // canCompute if canSubmitOrCompute == 1(can compute) or 3(can compute & submit)
-                            || nodeSubmitOrComputeStatus[node] % 2 == 1
-                        );
-                    });
-                }
-
-                readonly property bool isSelectionSubmittable: uigraph.canSubmit && isSelectionOnlyComputableNodes
-
-                readonly property bool canSelectionBeSubmitted: {
-                    if(!isSelectionOnlyComputableNodes)
-                        return false;
-                    if(isSelectionFullyComputed)
-                        return true;
-                    return uigraph.nodeSelection.selectedIndexes.every(function(idx) {
-                        const node = uigraph.graph.nodes.at(idx.row);
-                        return (
-                            node.isComputed
-                            // canSubmit if canSubmitOrCompute == 2(can submit) or 3(can compute & submit)
-                            || nodeSubmitOrComputeStatus[node] > 1
-                        )
-                    });
-                }
-
-                width: 220
-
-                Component.onCompleted: popup()
-                onClosed: nodeMenuLoader.unload()
-
-                MenuItem {
-                    id: computeMenuItem
-                    text: nodeMenu.isSelectionFullyComputed ? "Recompute" : "Compute"
-                    visible: nodeMenu.isSelectionOnlyComputableNodes
-                    height: visible ? implicitHeight : 0
-                    enabled: nodeMenu.canSelectionBeComputed
-
-                    onTriggered: {
-                        if (nodeMenu.isSelectionFullyComputed) {
-                            nodeMenuLoader.showDataDeletionDialog(
-                                false, 
-                                function(request, uigraph) {
-                                    request(uigraph.getSelectedNodes());
-                                }.bind(null, computeRequest, uigraph)
+                    readonly property bool isSelectionOnlyComputableNodes: {
+                        return uigraph.nodeSelection.selectedIndexes.every(function(idx) {
+                            const node = uigraph.graph.nodes.at(idx.row);
+                            return (
+                                node.isComputable
+                                && uigraph.graph.canComputeTopologically(node)
                             );
-                        } else {
-                            computeRequest(uigraph.getSelectedNodes());
-                        }
+                        });
                     }
-                }
-                MenuItem {
-                    id: submitMenuItem
 
-                    text: nodeMenu.isSelectionFullyComputed ? "Re-Submit" : "Submit"
-                    visible: nodeMenu.isSelectionSubmittable
-                    height: visible ? implicitHeight : 0
-                    enabled: nodeMenu.canSelectionBeSubmitted
-
-                    onTriggered: {
-                        if (nodeMenu.isSelectionFullyComputed) {
-                            nodeMenuLoader.showDataDeletionDialog(
-                                false, 
-                                function(request, uigraph) {
-                                    request(uigraph.getSelectedNodes());
-                                }.bind(null, submitRequest, uigraph)
+                    readonly property bool canSelectionBeComputed: {
+                        if(!isSelectionOnlyComputableNodes)
+                            return false;
+                        if(isSelectionFullyComputed)
+                            return true;
+                        return uigraph.nodeSelection.selectedIndexes.every(function(idx) {
+                            const node = uigraph.graph.nodes.at(idx.row);
+                            return (
+                                node.isComputed
+                                // canCompute if canSubmitOrCompute == 1(can compute) or 3(can compute & submit)
+                                || nodeSubmitOrComputeStatus[node] % 2 == 1
                             );
-                        } else {
-                            submitRequest(uigraph.getSelectedNodes());
+                        });
+                    }
+
+                    readonly property bool isSelectionSubmittable: uigraph.canSubmit && isSelectionOnlyComputableNodes
+
+                    readonly property bool canSelectionBeSubmitted: {
+                        if(!isSelectionOnlyComputableNodes)
+                            return false;
+                        if(isSelectionFullyComputed)
+                            return true;
+                        return uigraph.nodeSelection.selectedIndexes.every(function(idx) {
+                            const node = uigraph.graph.nodes.at(idx.row);
+                            return (
+                                node.isComputed
+                                // canSubmit if canSubmitOrCompute == 2(can submit) or 3(can compute & submit)
+                                || nodeSubmitOrComputeStatus[node] > 1
+                            )
+                        });
+                    }
+
+                    width: 220
+
+                    Component.onCompleted: popup()
+                    onClosed: nodeMenuLoader.unload()
+
+                    MenuItem {
+                        id: computeMenuItem
+                        text: nodeMenu.isSelectionFullyComputed ? "Recompute" : "Compute"
+                        visible: nodeMenu.isSelectionOnlyComputableNodes
+                        height: visible ? implicitHeight : 0
+                        enabled: nodeMenu.canSelectionBeComputed
+
+                        onTriggered: {
+                            if (nodeMenu.isSelectionFullyComputed) {
+                                nodeMenuLoader.showDataDeletionDialog(
+                                    false, 
+                                    function(request, uigraph) {
+                                        request(uigraph.getSelectedNodes());
+                                    }.bind(null, computeRequest, uigraph)
+                                );
+                            } else {
+                                computeRequest(uigraph.getSelectedNodes());
+                            }
                         }
                     }
-                }
-                MenuItem {
-                    text: "Stop Computation"
-                    enabled: nodeMenu.currentNode.canBeStopped()
-                    visible: enabled
-                    height: visible ? implicitHeight : 0
-                    onTriggered: uigraph.stopNodeComputation(nodeMenu.currentNode)
-                }
-                MenuItem {
-                    text: "Cancel Computation"
-                    enabled: nodeMenu.currentNode.canBeCanceled()
-                    visible: enabled
-                    height: visible ? implicitHeight : 0
-                    onTriggered: uigraph.cancelNodeComputation(nodeMenu.currentNode)
-                }
-                MenuItem {
-                    text: "Open Folder"
-                    visible: nodeMenu.currentNode.isComputable 
-                    height: visible ? implicitHeight : 0
-                    onTriggered: Qt.openUrlExternally(Filepath.stringToUrl(nodeMenu.currentNode.internalFolder))
-                }
-                MenuSeparator {
-                    visible: nodeMenu.currentNode.isComputable
-                }
-                MenuItem {
-                    text: "Cut Node(s)"
-                    enabled: true
-                    ToolTip.text: "Copy selection to the clipboard and remove it"
-                    ToolTip.visible: hovered
-                    onTriggered: {
-                        copyNodes()
-                        uigraph.removeSelectedNodes()
-                    }
-                }
-                MenuItem {
-                    text: "Copy Node(s)"
-                    enabled: true
-                    ToolTip.text: "Copy selection to the clipboard"
-                    ToolTip.visible: hovered
-                    onTriggered: copyNodes()
-                }
-                MenuItem {
-                    text: "Paste Node(s)"
-                    enabled: true
-                    ToolTip.text: "Copy selection to the clipboard and immediately paste it"
-                    ToolTip.visible: hovered
-                    onTriggered: {
-                        copyNodes()
-                        pasteNodes()
-                    }
-                }
-                MenuItem {
-                    text: "Duplicate Node(s)" + (duplicateFollowingButton.hovered ? " From Here" : "")
-                    enabled: true
-                    onTriggered: duplicateNode(false)
-                    MaterialToolButton {
-                        id: duplicateFollowingButton
-                        height: parent.height
-                        anchors {
-                            right: parent.right
-                            rightMargin: parent.padding
-                        }
-                        text: MaterialIcons.fast_forward
-                        onClicked: {
-                            duplicateNode(true)
-                            nodeMenu.close()
+                    MenuItem {
+                        id: submitMenuItem
+
+                        text: nodeMenu.isSelectionFullyComputed ? "Re-Submit" : "Submit"
+                        visible: nodeMenu.isSelectionSubmittable
+                        height: visible ? implicitHeight : 0
+                        enabled: nodeMenu.canSelectionBeSubmitted
+
+                        onTriggered: {
+                            if (nodeMenu.isSelectionFullyComputed) {
+                                nodeMenuLoader.showDataDeletionDialog(
+                                    false, 
+                                    function(request, uigraph) {
+                                        request(uigraph.getSelectedNodes());
+                                    }.bind(null, submitRequest, uigraph)
+                                );
+                            } else {
+                                submitRequest(uigraph.getSelectedNodes());
+                            }
                         }
                     }
-                }
-                MenuItem {
-                    text: "Remove Node(s)" + (removeFollowingButton.hovered ? " From Here" : "")
-                    enabled: !nodeMenu.currentNode.locked
-                    onTriggered: uigraph.removeSelectedNodes()
-                    MaterialToolButton {
-                        id: removeFollowingButton
-                        height: parent.height
-                        anchors {
-                            right: parent.right
-                            rightMargin: parent.padding
-                        }
-                        text: MaterialIcons.fast_forward
-                        onClicked: {
-                            uigraph.removeNodesFrom(uigraph.getSelectedNodes())
-                            nodeMenu.close()
+                    MenuItem {
+                        text: "Stop Computation"
+                        enabled: nodeMenu.currentNode.canBeStopped()
+                        visible: enabled
+                        height: visible ? implicitHeight : 0
+                        onTriggered: uigraph.stopNodeComputation(nodeMenu.currentNode)
+                    }
+                    MenuItem {
+                        text: "Cancel Computation"
+                        enabled: nodeMenu.currentNode.canBeCanceled()
+                        visible: enabled
+                        height: visible ? implicitHeight : 0
+                        onTriggered: uigraph.cancelNodeComputation(nodeMenu.currentNode)
+                    }
+                    MenuItem {
+                        text: "Open Folder"
+                        visible: nodeMenu.currentNode.isComputable 
+                        height: visible ? implicitHeight : 0
+                        onTriggered: Qt.openUrlExternally(Filepath.stringToUrl(nodeMenu.currentNode.internalFolder))
+                    }
+                    MenuSeparator {
+                        visible: nodeMenu.currentNode.isComputable
+                    }
+                    MenuItem {
+                        text: "Cut Node(s)"
+                        enabled: true
+                        ToolTip.text: "Copy selection to the clipboard and remove it"
+                        ToolTip.visible: hovered
+                        onTriggered: {
+                            copyNodes()
+                            uigraph.removeSelectedNodes()
                         }
                     }
-                }
-                MenuSeparator {
-                    visible: nodeMenu.currentNode.isComputable
-                }
-                MenuItem {
-                    id: deleteDataMenuItem
-                    text: "Delete Data" + (deleteFollowingButton.hovered ? " From Here" : "" ) + "..."
-                    visible: nodeMenu.currentNode.isComputable
-                    height: visible ? implicitHeight : 0
-                    enabled: {
-                        if (!nodeMenu.currentNode)
-                            return false
-                        // Check if the current node is locked (needed because it does not belong to its own duplicates list)
-                        if (nodeMenu.currentNode.locked)
-                            return false
-                        // Check if at least one of the duplicate nodes is locked
-                        for (let i = 0; i < nodeMenu.currentNode.duplicates.count; ++i) {
-                            if (nodeMenu.currentNode.duplicates.at(i).locked)
+                    MenuItem {
+                        text: "Copy Node(s)"
+                        enabled: true
+                        ToolTip.text: "Copy selection to the clipboard"
+                        ToolTip.visible: hovered
+                        onTriggered: copyNodes()
+                    }
+                    MenuItem {
+                        text: "Paste Node(s)"
+                        enabled: true
+                        ToolTip.text: "Copy selection to the clipboard and immediately paste it"
+                        ToolTip.visible: hovered
+                        onTriggered: {
+                            copyNodes()
+                            pasteNodes()
+                        }
+                    }
+                    MenuItem {
+                        text: "Duplicate Node(s)" + (duplicateFollowingButton.hovered ? " From Here" : "")
+                        enabled: true
+                        onTriggered: duplicateNode(false)
+                        MaterialToolButton {
+                            id: duplicateFollowingButton
+                            height: parent.height
+                            anchors {
+                                right: parent.right
+                                rightMargin: parent.padding
+                            }
+                            text: MaterialIcons.fast_forward
+                            onClicked: {
+                                duplicateNode(true)
+                                nodeMenu.close()
+                            }
+                        }
+                    }
+                    MenuItem {
+                        text: "Remove Node(s)" + (removeFollowingButton.hovered ? " From Here" : "")
+                        enabled: !nodeMenu.currentNode.locked
+                        onTriggered: uigraph.removeSelectedNodes()
+                        MaterialToolButton {
+                            id: removeFollowingButton
+                            height: parent.height
+                            anchors {
+                                right: parent.right
+                                rightMargin: parent.padding
+                            }
+                            text: MaterialIcons.fast_forward
+                            onClicked: {
+                                uigraph.removeNodesFrom(uigraph.getSelectedNodes())
+                                nodeMenu.close()
+                            }
+                        }
+                    }
+                    MenuSeparator {
+                        visible: nodeMenu.currentNode.isComputable
+                    }
+                    MenuItem {
+                        id: deleteDataMenuItem
+                        text: "Delete Data" + (deleteFollowingButton.hovered ? " From Here" : "" ) + "..."
+                        visible: nodeMenu.currentNode.isComputable
+                        height: visible ? implicitHeight : 0
+                        enabled: {
+                            if (!nodeMenu.currentNode)
                                 return false
+                            // Check if the current node is locked (needed because it does not belong to its own duplicates list)
+                            if (nodeMenu.currentNode.locked)
+                                return false
+                            // Check if at least one of the duplicate nodes is locked
+                            for (let i = 0; i < nodeMenu.currentNode.duplicates.count; ++i) {
+                                if (nodeMenu.currentNode.duplicates.at(i).locked)
+                                    return false
+                            }
+                            return true
                         }
-                        return true
+
+                        onTriggered: nodeMenuLoader.showDataDeletionDialog(false)
+
+                        MaterialToolButton {
+                            id: deleteFollowingButton
+                            anchors {
+                                right: parent.right
+                                rightMargin: parent.padding
+                            }
+                            height: parent.height
+                            text: MaterialIcons.fast_forward
+                            onClicked: {
+                                nodeMenuLoader.showDataDeletionDialog(true);
+                                nodeMenu.close();
+                            }
+                        }
+
                     }
-
-                    onTriggered: nodeMenuLoader.showDataDeletionDialog(false)
-
-                    MaterialToolButton {
-                        id: deleteFollowingButton
-                        anchors {
-                            right: parent.right
-                            rightMargin: parent.padding
-                        }
-                        height: parent.height
-                        text: MaterialIcons.fast_forward
-                        onClicked: {
-                            nodeMenuLoader.showDataDeletionDialog(true);
-                            nodeMenu.close();
-                        }
-                    }
-
                 }
-            }
             }
 
             // Confirmation dialog for node cache deletion
@@ -821,7 +821,7 @@ Item {
             }
 
             // Nodes
-             Repeater {
+            Repeater {
                 id: nodeRepeater
 
                 model: root.graph ? root.graph.nodes : undefined

--- a/meshroom/ui/qml/GraphEditor/GraphEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/GraphEditor.qml
@@ -831,10 +831,6 @@ Item {
                 property bool updateSelectionOnClick: false
                 property var temporaryEdgeAboutToBeRemoved: undefined
 
-                function isNodeSelected(index: int) {
-                    return uigraph.nodeSelection.isRowSelected(index);
-                }
-
                 delegate: Node {
                     id: nodeDelegate
 
@@ -844,18 +840,11 @@ Item {
                     mainSelected: uigraph.selectedNode === node
                     hovered: uigraph.hoveredNode === node
 
-                    selected: nodeRepeater.isNodeSelected(index);
+                    // ItemSelectionModel.hasSelection triggers updates anytime the selectionChanged() signal is emitted.
+                    selected: uigraph.nodeSelection.hasSelection ? uigraph.nodeSelection.isRowSelected(index) : false
 
                     onAttributePinCreated: function(attribute, pin) { registerAttributePin(attribute, pin) }
                     onAttributePinDeleted: function(attribute, pin) { unregisterAttributePin(attribute, pin) }
-
-                    Connections {
-                        target: uigraph.nodeSelection
-
-                        function onSelectionChanged() {
-                            selected = nodeRepeater.isNodeSelected(index);
-                        }
-                    }
 
                     onPressed: function(mouse) {
                         nodeRepeater.updateSelectionOnClick = true;

--- a/meshroom/ui/qml/GraphEditor/GraphEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/GraphEditor.qml
@@ -861,7 +861,7 @@ Item {
                                 selectionMode = ItemSelectionModel.Select;
                             }
                             if(mouse.modifiers & Qt.ControlModifier) {
-                                selectionMode = ItemSelectionModel.Deselect;
+                                selectionMode = ItemSelectionModel.Toggle;
                             }
                             if(mouse.modifiers & Qt.AltModifier) {
                                 uigraph.selectFollowing(node);

--- a/meshroom/ui/qml/GraphEditor/GraphEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/GraphEditor.qml
@@ -140,13 +140,13 @@ Item {
             if (event.modifiers === Qt.AltModifier) {
                 uigraph.removeNodesFrom(uigraph.selectedNodes)
             } else {
-                uigraph.removeNodes(uigraph.selectedNodes)
+                uigraph.removeSelectedNodes()
             }
         } else if (event.key === Qt.Key_D) {
             duplicateNode(event.modifiers === Qt.AltModifier)
         } else if (event.key === Qt.Key_X && event.modifiers === Qt.ControlModifier) {
             copyNodes()
-            uigraph.removeNodes(uigraph.selectedNodes)
+            uigraph.removeSelectedNodes()
         } else if (event.key === Qt.Key_C) {
             if (event.modifiers === Qt.ControlModifier) {
                 copyNodes()
@@ -685,7 +685,7 @@ Item {
                     ToolTip.visible: hovered
                     onTriggered: {
                         copyNodes()
-                        uigraph.removeNodes(uigraph.selectedNodes)
+                        uigraph.removeSelectedNodes()
                     }
                 }
                 MenuItem {
@@ -726,7 +726,7 @@ Item {
                 MenuItem {
                     text: "Remove Node(s)" + (removeFollowingButton.hovered ? " From Here" : "")
                     enabled: nodeMenu.currentNode ? !nodeMenu.currentNode.locked : false
-                    onTriggered: uigraph.removeNodes(uigraph.selectedNodes)
+                    onTriggered: uigraph.removeSelectedNodes()
                     MaterialToolButton {
                         id: removeFollowingButton
                         height: parent.height

--- a/meshroom/ui/qml/GraphEditor/GraphEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/GraphEditor.qml
@@ -815,7 +815,7 @@ Item {
                         if (deleteFollowing)
                             uigraph.clearDataFrom(uigraph.selectedNodes);
                         else
-                            uigraph.clearData(uigraph.selectedNodes);
+                            uigraph.clearSelectedNodesData();
                         dataDeleted();
                     }
                     onClosed: destroy()

--- a/meshroom/ui/qml/GraphEditor/GraphEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/GraphEditor.qml
@@ -864,7 +864,12 @@ Item {
                                 selectionMode = ItemSelectionModel.Toggle;
                             }
                             if(mouse.modifiers & Qt.AltModifier) {
-                                uigraph.selectFollowing(node);
+                                let selectFollowingMode = ItemSelectionModel.ClearAndSelect;
+                                if(mouse.modifiers & Qt.ShiftModifier) {
+                                    selectFollowingMode = ItemSelectionModel.Select;
+                                }
+                                uigraph.selectFollowing(node, selectFollowingMode);
+                                // Indicate selection has been dealt with by setting conservative Select mode.
                                 selectionMode = ItemSelectionModel.Select;
                             }
                         }

--- a/meshroom/ui/qml/GraphEditor/GraphEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/GraphEditor.qml
@@ -572,11 +572,22 @@ Item {
                 
                 property var currentNode: nodeMenuLoader.currentNode
 
+                // Cache computatibility/submitability status of each selected node.
+                readonly property var nodeSubmitOrComputeStatus: {
+                    var collectedStatus = ({});
+                    uigraph.nodeSelection.selectedIndexes.forEach(function(idx) {
+                        const node = uigraph.graph.nodes.at(idx.row);
+                        collectedStatus[node] = uigraph.graph.canSubmitOrCompute(node);
+                    });
+                    return collectedStatus;
+                }
+
                 readonly property bool isSelectionFullyComputed: {
                     return uigraph.nodeSelection.selectedIndexes.every(function(idx) {
                         return uigraph.graph.nodes.at(idx.row).isComputed;
                     });
                 }
+
                 readonly property bool isSelectionOnlyComputableNodes: {
                     return uigraph.nodeSelection.selectedIndexes.every(function(idx) {
                         const node = uigraph.graph.nodes.at(idx.row);
@@ -586,6 +597,7 @@ Item {
                         );
                     });
                 }
+
                 readonly property bool canSelectionBeComputed: {
                     if(!isSelectionOnlyComputableNodes)
                         return false;
@@ -596,10 +608,11 @@ Item {
                         return (
                             node.isComputed
                             // canCompute if canSubmitOrCompute == 1(can compute) or 3(can compute & submit)
-                            || uigraph.graph.canSubmitOrCompute(node) % 2 == 1
+                            || nodeSubmitOrComputeStatus[node] % 2 == 1
                         );
                     });
                 }
+
                 readonly property bool isSelectionSubmittable: uigraph.canSubmit && isSelectionOnlyComputableNodes
 
                 readonly property bool canSelectionBeSubmitted: {
@@ -612,7 +625,7 @@ Item {
                         return (
                             node.isComputed
                             // canSubmit if canSubmitOrCompute == 2(can submit) or 3(can compute & submit)
-                            || uigraph.graph.canSubmitOrCompute(node) > 1
+                            || nodeSubmitOrComputeStatus[node] > 1
                         )
                     });
                 }

--- a/meshroom/ui/qml/GraphEditor/GraphEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/GraphEditor.qml
@@ -63,11 +63,10 @@ Item {
     function duplicateNode(duplicateFollowingNodes) {
         var nodes
         if (duplicateFollowingNodes) {
-            nodes = uigraph.duplicateNodesFrom(uigraph.selectedNodes)
+            nodes = uigraph.duplicateNodesFrom(uigraph.getSelectedNodes())
         } else {
-            nodes = uigraph.duplicateNodes(uigraph.selectedNodes)
+            nodes = uigraph.duplicateNodes(uigraph.getSelectedNodes())
         }
-        uigraph.clearNodeSelection()
         uigraph.selectedNode = nodes[0]
         uigraph.selectNodes(nodes)
     }
@@ -100,7 +99,6 @@ Item {
         var copiedContent = Clipboard.getText()
         var nodes = uigraph.pasteNodes(copiedContent, finalPosition, centerPosition)
         if (nodes.length > 0) {
-            uigraph.clearNodeSelection()
             uigraph.selectedNode = nodes[0]
             uigraph.selectNodes(nodes)
         }
@@ -116,7 +114,7 @@ Item {
             fit()
         } else if (event.key === Qt.Key_Delete) {
             if (event.modifiers === Qt.AltModifier) {
-                uigraph.removeNodesFrom(uigraph.selectedNodes)
+                uigraph.removeNodesFrom(uigraph.getSelectedNodes())
             } else {
                 uigraph.removeSelectedNodes()
             }
@@ -637,11 +635,11 @@ Item {
                             nodeMenuLoader.showDataDeletionDialog(
                                 false, 
                                 function(request, uigraph) {
-                                    request(uigraph.selectedNodes);
+                                    request(uigraph.getSelectedNodes());
                                 }.bind(null, computeRequest, uigraph)
                             );
                         } else {
-                            computeRequest(uigraph.selectedNodes);
+                            computeRequest(uigraph.getSelectedNodes());
                         }
                     }
                 }
@@ -658,11 +656,11 @@ Item {
                             nodeMenuLoader.showDataDeletionDialog(
                                 false, 
                                 function(request, uigraph) {
-                                    request(uigraph.selectedNodes);
+                                    request(uigraph.getSelectedNodes());
                                 }.bind(null, submitRequest, uigraph)
                             );
                         } else {
-                            submitRequest(uigraph.selectedNodes);
+                            submitRequest(uigraph.getSelectedNodes());
                         }
                     }
                 }
@@ -747,7 +745,7 @@ Item {
                         }
                         text: MaterialIcons.fast_forward
                         onClicked: {
-                            uigraph.removeNodesFrom(uigraph.selectedNodes)
+                            uigraph.removeNodesFrom(uigraph.getSelectedNodes())
                             nodeMenu.close()
                         }
                     }
@@ -807,13 +805,13 @@ Item {
                     modal: false
                     header.visible: false
 
-                    text: "Delete Data of '" + node.label + "'" + (uigraph.selectedNodes.count > 1 ? " and other selected Nodes" : "") + (deleteFollowing ?  " and following Nodes?" : "?")
+                    text: "Delete Data of '" + node.label + "'" + (uigraph.nodeSelection.selectedIndexes.length > 1 ? " and other selected Nodes" : "") + (deleteFollowing ?  " and following Nodes?" : "?")
                     helperText: "Warning: This operation cannot be undone."
                     standardButtons: Dialog.Yes | Dialog.Cancel
 
                     onAccepted: {
                         if (deleteFollowing)
-                            uigraph.clearDataFrom(uigraph.selectedNodes);
+                            uigraph.clearDataFrom(uigraph.getSelectedNodes());
                         else
                             uigraph.clearSelectedNodesData();
                         dataDeleted();

--- a/meshroom/ui/qml/GraphEditor/GraphEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/GraphEditor.qml
@@ -901,10 +901,9 @@ Item {
                         }
                         else if (mouse.button === Qt.RightButton) {
                             if(selected) {
-                                // Keep the full selection when right-clicking on a node.
+                                // Keep the full selection when right-clicking on an already selected node.
                                 nodeRepeater.updateSelectionOnClick = false;
                             }
-                            nodeMenuLoader.load(node)
                         }
 
                         if(selectionMode != ItemSelectionModel.NoUpdate) {
@@ -916,6 +915,12 @@ Item {
                         if(selected) {
                             uigraph.selectedNode = node;
                         }
+
+                        // Open the node context menu once selection has been updated.
+                        if(mouse.button == Qt.RightButton) {
+                            nodeMenuLoader.load(node)
+                        }
+
                     }
 
                     onReleased: function(mouse, wasDragged) {

--- a/meshroom/ui/qml/GraphEditor/Node.qml
+++ b/meshroom/ui/qml/GraphEditor/Node.qml
@@ -40,6 +40,8 @@ Item {
 
     // Mouse interaction related signals
     signal pressed(var mouse)
+    signal released(var mouse)
+    signal clicked(var mouse)
     signal doubleClicked(var mouse)
     signal moved(var position)
     signal entered()
@@ -125,8 +127,10 @@ Item {
         drag.threshold: 2
         hoverEnabled: true
         acceptedButtons: Qt.LeftButton | Qt.RightButton
-        onPressed: function(mouse) { root.pressed(mouse) }
-        onDoubleClicked: function(mouse) { root.doubleClicked(mouse) }
+        onPressed: (mouse) => root.pressed(mouse)
+        onReleased: (mouse) => root.released(mouse)
+        onClicked: (mouse) => root.clicked(mouse)
+        onDoubleClicked: (mouse) => root.doubleClicked(mouse)
         onEntered: root.entered()
         onExited: root.exited()
         drag.onActiveChanged: {


### PR DESCRIPTION
## Description
This PR addresses several issues related to the Node selection management, mostly related to performance and user experience.

### Selection performance
![selection_before_after](https://github.com/user-attachments/assets/92aa5893-4f9f-458e-b434-cf1aeb887ca9)

### Selection precision
![selection_precision_before_after](https://github.com/user-attachments/assets/f13d6b56-db69-4d2e-bfc9-0d57c2fd9ed7)

## Features list

- [X] Address performance degradation as the number of selected nodes increases.
- [X] Fix node selection precision issues.
- [X] Implement standard modifier controls (Shift to Add to Selection, Ctrl to Deselect).

## Implementation remarks

### Selection management

This PR changes the selection management backend to use QItemSelectionModel, instead of manually maintaining an extra QObjectListModel. This allows to rely on Qt to perform selection commands (ClearAndSelect, Deselect, Toggle..).  
It also fixes the main issue of having a lot of properties binding to the selection model, which was on top of that emitting its notify signal way to often.

### Node context menu
The node context menu was one of the most costly component, due to many direct bindings it had with the selection model.  
And it was created at application startup and living until application shutdown, even if unused.
It is now created dynamically only when explicitly required, and evaluate the computability status of selected nodes only on creation.

### Selection User Experience

#### Precision
The previous implementation was performing the box select on the Python side, only considering the default node sizes.
This led to imprecision in the interactive selection, where the varying visual size of the Node was never taken into account.
Now, the selection happens on the QML side.

#### Modifiers
This PR changes the use of some modifiers to lean towards more standard UX.
- Shift+Drag: box select add
- Ctrl+Drag: box deselect 

Note: To enable this change, the alternate view panning shortcut (Shift+Drag) has been moved to Alt+Drag.

