### PR TITLE
[ui] Minor UI stabilization fixes for Qt 6

### DIFF
--- a/meshroom/ui/qml/Controls/ExpandableGroup.qml
+++ b/meshroom/ui/qml/Controls/ExpandableGroup.qml
@@ -22,21 +22,24 @@ GroupBox {
     topPadding: label.height + padding
     background: Item {}
 
+    MouseArea {
+        parent: paneLabel
+        anchors.fill: parent
+        onClicked: function(mouse) {
+            expandButton.checked = !expandButton.checked
+        }
+    }
+
     label: Pane {
+        id: paneLabel
+        padding: 2
+        width: root.width
+
         background: Rectangle {
             id: labelBg
             color: palette.base
             opacity: 0.8
-
-            MouseArea {
-                anchors.fill: parent
-                onClicked: {
-                    expandButton.checked = !expandButton.checked
-                }
-            }
         }
-        padding: 2
-        width: root.width
 
         RowLayout {
             width: parent.width

--- a/meshroom/ui/qml/GraphEditor/Edge.qml
+++ b/meshroom/ui/qml/GraphEditor/Edge.qml
@@ -120,7 +120,7 @@ Item {
                 iconText: MaterialIcons.loop
                 label: (root.iteration + 1) + "/" + root.loopSize + " "
 
-                color: palette.base                
+                labelIconColor: palette.base
                 ToolTip.text: "Foreach Loop"
             }
 

--- a/meshroom/ui/qml/Homepage.qml
+++ b/meshroom/ui/qml/Homepage.qml
@@ -352,6 +352,7 @@ Page {
                             ToolTip.visible: hovered
                             ToolTip.text: modelData["path"] ? modelData["path"] : "Open browser to select a project file"
 
+                            font.family: MaterialIcons.fontFamily
                             font.pointSize: 24
 
                             text: modelData["path"] ? (modelData["thumbnail"] ? "" : MaterialIcons.description) : MaterialIcons.folder_open

--- a/meshroom/ui/qml/Homepage.qml
+++ b/meshroom/ui/qml/Homepage.qml
@@ -239,10 +239,15 @@ Page {
                     }
 
                     MaterialToolLabelButton {
+                        Layout.topMargin: 10
                         Layout.bottomMargin: 10
-                        Layout.fillWidth: true
-                        labelItem.horizontalAlignment: Text.AlignHCenter
-                        label: MaterialIcons.favorite + " Support AliceVision"
+                        Layout.alignment: Qt.AlignHCenter
+                        label: "Support AliceVision"
+                        iconText: MaterialIcons.favorite
+
+                        // Slightly "extend" the clickable area for the button while preserving the centered layout
+                        iconItem.leftPadding: 15
+                        labelItem.rightPadding: 15
 
                         onClicked: Qt.openUrlExternally("https://alicevision.org/association/#donate")
                     }

--- a/meshroom/ui/qml/MaterialIcons/MaterialToolLabel.qml
+++ b/meshroom/ui/qml/MaterialIcons/MaterialToolLabel.qml
@@ -12,7 +12,7 @@ Item {
     property alias iconText: iconItem.text
     property alias iconSize: iconItem.font.pointSize
     property alias label: labelItem.text
-    property var color: palette.text
+    property var labelIconColor: palette.text
     implicitWidth: childrenRect.width
     implicitHeight: childrenRect.height
     anchors.rightMargin: 5
@@ -24,12 +24,12 @@ Item {
             font.pointSize: 13
             padding: 0
             text: ""
-            color: color
+            color: labelIconColor
         }
         Label {
             id: labelItem
             text: ""
-            color: color
+            color: labelIconColor
         }
     }
 

--- a/meshroom/ui/qml/Viewer/SfmGlobalStats.qml
+++ b/meshroom/ui/qml/Viewer/SfmGlobalStats.qml
@@ -5,6 +5,8 @@ import QtQuick.Layouts
 
 import AliceVision 1.0 as AliceVision
 import Charts 1.0
+import Controls 1.0
+import Utils 1.0
 
 FloatingPane {
     id: root

--- a/meshroom/ui/qml/Viewer/SfmStatsView.qml
+++ b/meshroom/ui/qml/Viewer/SfmStatsView.qml
@@ -5,6 +5,8 @@ import QtQuick.Layouts
 
 import AliceVision 1.0 as AliceVision
 import Charts 1.0
+import Controls 1.0
+import Utils 1.0
 
 
 FloatingPane {

--- a/meshroom/ui/qml/Viewer3D/Inspector3D.qml
+++ b/meshroom/ui/qml/Viewer3D/Inspector3D.qml
@@ -229,6 +229,7 @@ FloatingPane {
 
                         Label {
                             text: resectionIdSlider.value + "/" + Viewer3DSettings.resectionIdCount
+                            color: palette.text
                             visible: Viewer3DSettings.displayResectionIds
                         }
                     }

--- a/meshroom/ui/qml/Viewer3D/Inspector3D.qml
+++ b/meshroom/ui/qml/Viewer3D/Inspector3D.qml
@@ -1,6 +1,5 @@
 import QtQuick
 import QtQuick.Controls
-import QtQuick.Controls.Material 2.12
 import QtQuick.Layouts
 import Qt3D.Core 2.6
 import Qt3D.Render 2.6

--- a/meshroom/ui/qml/Viewer3D/Inspector3D.qml
+++ b/meshroom/ui/qml/Viewer3D/Inspector3D.qml
@@ -252,6 +252,7 @@ FloatingPane {
                                 return 0
 
                             }
+                            labelIconColor: palette.text
                             ToolTip.text: "Number Of Cameras In Current Resection Group"
                             visible: Viewer3DSettings.displayResectionIds
                         }
@@ -269,6 +270,7 @@ FloatingPane {
 
                                 return currentCameras
                             }
+                            labelIconColor: palette.text
                             ToolTip.text: "Number Of Cumulated Cameras"
                             visible: Viewer3DSettings.displayResectionIds
                         }
@@ -285,6 +287,7 @@ FloatingPane {
 
                                 return totalCameras
                             }
+                            labelIconColor: palette.text
                             ToolTip.text: "Total Number Of Cameras"
                             visible: Viewer3DSettings.displayResectionIds
                         }

--- a/meshroom/ui/qml/WorkspaceView.qml
+++ b/meshroom/ui/qml/WorkspaceView.qml
@@ -258,7 +258,7 @@ Item {
                     Inspector3D {
                         id: inspector3d
                         SplitView.preferredWidth: 220
-                        SplitView.minimumWidth: 10
+                        SplitView.minimumWidth: 100
 
                         mediaLibrary: c_viewer3D.library
                         camera: c_viewer3D.mainCamera


### PR DESCRIPTION
## Description

This pull request fixes several minor UI issues following the merge of Qt 6:
- Correctly set the color of `MaterialToolLabels` (already existed before the merge of Qt 6);
- Explicitly set the color for the label of resectioned cameras in the Inspector3D;
- Fix the icon on the "Support AliceVision" button;
- Fix the icons in the grid view of projects on the Homepage;
- Use the correct style (Fusion) in the Inspector3D instead of Material;
- Add the missing imports to correctly display graphs related to the SfM statistics in the 2D Viewer;
- Fix the MouseArea located on the header of the expandable groups in the Inspector3D.