### PR TITLE
[GraphEditor] Edge: Correctly update the `EdgeMouseArea` when moving nodes

### DIFF
--- a/meshroom/ui/qml/GraphEditor/Edge.qml
+++ b/meshroom/ui/qml/GraphEditor/Edge.qml
@@ -148,8 +148,8 @@ Item {
         Component.onCompleted: {
             /* The curve scale must be set only once the component has been fully created, so
              * that all the events following the update of the curve scale can be taken into
-             * account */
-            curveScale = cubic.ctrlPtDist / root.width  // Normalize by width
+             * account. */
+            curveScale = Qt.binding(() => cubic.ctrlPtDist / root.width)  // Normalize by width
         }
     }
 }


### PR DESCRIPTION
## Description

This pull request correctly updates the mouse area over edges when nodes these edges are connected to have been moved. 

Prior to it, the mouse area of each edge was set once and never updated afterwards, meaning the edge remained selectable if and only if it did not move too much from its original position. The curve scale of the mouse area is now recomputed every single time the size of its edge has changed (i.e. whenever a node it is connected to has been moved).