### PR TITLE
[GraphEditor] AttributeItemDelegate: Use MaterialLabel for uncomputed attributes

### DIFF
--- a/meshroom/ui/qml/GraphEditor/AttributeItemDelegate.qml
+++ b/meshroom/ui/qml/GraphEditor/AttributeItemDelegate.qml
@@ -233,11 +233,12 @@ RowLayout {
 
         Component {
             id: notComputedComponent
-            Label {
+            MaterialLabel {
                 anchors.fill: parent
                 text: MaterialIcons.do_not_disturb_alt
                 horizontalAlignment: Text.AlignHCenter
                 verticalAlignment: Text.AlignVCenter
+                padding: 4
                 background: Rectangle {
                     anchors.fill: parent
                     border.width: 0


### PR DESCRIPTION
## Description

This PR fixes an issue with the MaterialIcon label of attributes with dynamic values that have not yet been computed. Following the migration to Qt 6, labels that used the MaterialIcon font without being properly declared as `MaterialLabel` were not correctly displayed. 

<div align="center">Before this PR:<br/>
<img src="https://github.com/user-attachments/assets/0cd8469b-e96b-4d2b-bfb1-018c8f6931e9" /></div>

<div align="center">After:<br/><img src="https://github.com/user-attachments/assets/40ed3239-4f41-4a2c-a587-8230edc3075c" /></div>

