### PR TITLE
[ui] GraphEditor: Address Key Event Conflicts in Node Menu

### DIFF
--- a/meshroom/ui/qml/GraphEditor/GraphEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/GraphEditor.qml
@@ -293,6 +293,8 @@ Item {
                                 searchBar.forceActiveFocus()
                         }
                     }
+                    // Set the priority ordering of the keys to be Item's own Key Handling > ForwardTo
+                    Keys.priority: Keys.AfterItem;
                     // Create node on mouse click
                     onClicked: newNodeMenu.createNode(modelData)
 


### PR DESCRIPTION
## Description
This PR addresses the Key Handling issue in the Node Creation Menu within the `GraphEditor`.
The changes ensure that the **Enter** and **Return** key events are correctly captured and handled by the Item first and then forwarded to the specified Item i.e. `SearchBar.textField`.

### Details
* Fixed the issue with Node creation Menu by setting the `Keys.priority` property to be `Keys.AfterItem`.
Quoting from https://doc.qt.io/qt-6/qml-qtquick-keys.html

```
Default priority ordering is Keys.BeforeItem and has the key event processing as:
1. Items specified in forwardTo
2. Specific key handlers, e.g. onReturnPressed, onPressed, onReleased handlers
3. Item specific key handling (Key handling of the parent item)

Keys.AfterItem has the key event processing as:
1. Item specific key handling (Key handling of the parent item)
2.  Items specified in forwardTo
3. Specific key handlers, e.g. onReturnPressed, onPressed, onReleased handlers
```
Thus, Keys.AfterItem as the priority ensures the Item's own key events are handled before Forwarding it to specified items. This handles all defined Enter and Return key presses and is more suitable for our use-case here.
