### PR TITLE
Add support for QML debugging/profiling

### DIFF
--- a/meshroom/env.py
+++ b/meshroom/env.py
@@ -4,8 +4,10 @@ Meshroom environment variable management.
 
 __all__ = [
     "EnvVar",
+    "EnvVarHelpAction",
 ]
 
+import argparse
 import os
 from dataclasses import dataclass
 from enum import Enum
@@ -51,3 +53,18 @@ class EnvVar(Enum):
             return value.lower() in {"true", "1", "on"}
         return valueType(value)
 
+    @classmethod
+    def help(cls) -> str:
+        """Return a formatted string with the details of each environment variables."""
+        return "\n".join([f"{var.name}: {var.value}" for var in cls])
+
+
+class EnvVarHelpAction(argparse.Action):
+    """Argparse action for printing Meshroom environment variables help and exit."""
+
+    DEFAULT_HELP = "Print Meshroom environment variables help and exit."
+
+    def __call__(self, parser, namespace, value, option_string=None):
+        print("Meshroom environment variables:")
+        print(EnvVar.help())
+        sys.exit(0)

--- a/meshroom/env.py
+++ b/meshroom/env.py
@@ -1,0 +1,53 @@
+"""
+Meshroom environment variable management.
+"""
+
+__all__ = [
+    "EnvVar",
+]
+
+import os
+from dataclasses import dataclass
+from enum import Enum
+import sys
+from typing import Any, Type
+
+
+@dataclass
+class VarDefinition:
+    """Environment variable definition."""
+
+    # The type to cast the value to.
+    valueType: Type
+    # Default value if the variable is not set in the environment.
+    default: str
+    # Description of the purpose of the variable.
+    description: str = ""
+
+    def __str__(self) -> str:
+        return f"{self.description} ({self.valueType.__name__}, default: '{self.default}')"
+
+
+class EnvVar(Enum):
+    """Meshroom environment variables catalog."""
+
+    # UI - Debug
+    MESHROOM_QML_DEBUG = VarDefinition(bool, "False", "Enable QML debugging")
+    MESHROOM_QML_DEBUG_PARAMS = VarDefinition(
+        str, "port:3768", "QML debugging params as expected by -qmljsdebugger"
+    )
+
+    @staticmethod
+    def get(envVar: "EnvVar") -> Any:
+        """Get the value of `envVar`, cast to the variable type."""
+        value = os.environ.get(envVar.name, envVar.value.default)
+        return EnvVar._cast(value, envVar.value.valueType)
+
+    @staticmethod
+    def _cast(value: str, valueType: Type) -> Any:
+        if valueType is str:
+            return value
+        elif valueType is bool:
+            return value.lower() in {"true", "1", "on"}
+        return valueType(value)
+

--- a/meshroom/ui/app.py
+++ b/meshroom/ui/app.py
@@ -8,6 +8,7 @@ from PySide6 import __version__ as PySideVersion
 from PySide6 import QtCore
 from PySide6.QtCore import Qt, QUrl, QJsonValue, qInstallMessageHandler, QtMsgType, QSettings
 from PySide6.QtGui import QIcon
+from PySide6.QtQuickControls2 import QQuickStyle
 from PySide6.QtWidgets import QApplication
 
 import meshroom
@@ -186,12 +187,11 @@ Additional Resources:
 
 class MeshroomApp(QApplication):
     """ Meshroom UI Application. """
-    def __init__(self, args):
+    def __init__(self, inputArgs):
         meshroom.core.initPipelines()
 
-        QtArgs = [args[0], '-style', 'Fusion'] + args[1:]  # force Fusion style by default
-
-        args = createMeshroomParser(args)
+        args = createMeshroomParser(inputArgs)
+        qtArgs = []
 
         logStringToPython = {
             'fatal': logging.FATAL,
@@ -203,7 +203,7 @@ class MeshroomApp(QApplication):
         }
         logging.getLogger().setLevel(logStringToPython[args.verbose])
 
-        super(MeshroomApp, self).__init__(QtArgs)
+        super(MeshroomApp, self).__init__(inputArgs[:1] + qtArgs)
 
         self.setOrganizationName('AliceVision')
         self.setApplicationName('Meshroom')
@@ -212,6 +212,9 @@ class MeshroomApp(QApplication):
         font = self.font()
         font.setPointSize(9)
         self.setFont(font)
+
+        # Use Fusion style by default.
+        QQuickStyle.setStyle("Fusion")
 
         pwd = os.path.dirname(__file__)
         self.setWindowIcon(QIcon(os.path.join(pwd, "img/meshroom.svg")))

--- a/meshroom/ui/app.py
+++ b/meshroom/ui/app.py
@@ -8,6 +8,7 @@ from PySide6 import __version__ as PySideVersion
 from PySide6 import QtCore
 from PySide6.QtCore import Qt, QUrl, QJsonValue, qInstallMessageHandler, QtMsgType, QSettings
 from PySide6.QtGui import QIcon
+from PySide6.QtQml import QQmlDebuggingEnabler
 from PySide6.QtQuickControls2 import QQuickStyle
 from PySide6.QtWidgets import QApplication
 
@@ -15,6 +16,8 @@ import meshroom
 from meshroom.core import nodesDesc
 from meshroom.core.taskManager import TaskManager
 from meshroom.common import Property, Variant, Signal, Slot
+
+from meshroom.env import EnvVar
 
 from meshroom.ui import components
 from meshroom.ui.components.clipboard import ClipboardHelper
@@ -192,6 +195,11 @@ class MeshroomApp(QApplication):
 
         args = createMeshroomParser(inputArgs)
         qtArgs = []
+    
+        if EnvVar.get(EnvVar.MESHROOM_QML_DEBUG):
+            debuggerParams = EnvVar.get(EnvVar.MESHROOM_QML_DEBUG_PARAMS)
+            self.debugger = QQmlDebuggingEnabler(printWarning=True)
+            qtArgs = [f"-qmljsdebugger={debuggerParams}"]
 
         logStringToPython = {
             'fatal': logging.FATAL,

--- a/meshroom/ui/app.py
+++ b/meshroom/ui/app.py
@@ -17,7 +17,7 @@ from meshroom.core import nodesDesc
 from meshroom.core.taskManager import TaskManager
 from meshroom.common import Property, Variant, Signal, Slot
 
-from meshroom.env import EnvVar
+from meshroom.env import EnvVar, EnvVarHelpAction
 
 from meshroom.ui import components
 from meshroom.ui.components.clipboard import ClipboardHelper
@@ -183,6 +183,14 @@ Additional Resources:
         default=os.environ.get('MESHROOM_DEFAULT_PIPELINE', ''),
         help='Select the default Meshroom pipeline:\n'
         + '\n'.join(['    - ' + p for p in meshroom.core.pipelineTemplates]),
+    )
+
+    advanced_group = parser.add_argument_group("Advanced Options")
+    advanced_group.add_argument(
+        "--env-help",
+        action=EnvVarHelpAction,
+        nargs=0,
+        help=EnvVarHelpAction.DEFAULT_HELP,
     )
 
     return parser.parse_args(args[1:])


### PR DESCRIPTION
## Description
This PR adds the required setup to be able to attach the QML debugger/profiler to Meshroom.

QML debugging can be activated using the environment variable
```
MESHROOM_QML_DEBUG=1
```
And optionally configured using (with params as expected by [-qmljsdebugger](https://doc.qt.io/qt-6/qtquick-debugging.html#starting-applications)):
```
MESHROOM_QML_DEBUG_PARAMS=port:5555
```
The help of those environment variables can be accessed via CLI using:
```bash
> meshroom --env-help
Meshroom environment variables:
MESHROOM_QML_DEBUG: Enable QML debugging (bool, default: 'False')
MESHROOM_QML_DEBUG_PARAMS: QML debugging params as expected by -qmljsdebugger (str, default: 'port:3768')
```

### Usage
#### Debugger
This can be used to attach the QML debugger from Qt Creator, using:
```
Debug > Start Debugging > Attach to QML port...
```
#### Profiler
This setup can also be used to attach the QML profiler, either interactively from Qt Creator
```
Analyze > QML Profiler
```
or from command line:
```
qmlprofiler --attach localhost -p <port> --interactive
```

## Features list
- [X] Add support for enabling QML debugging
- [X] Add `--env-help` CLI option to Meshroom app to display env var help/documentation

## Implementation remarks
This PR also introduces an new class `EnvVar` (meshroom.env.EnvVar) that is designed to centralize the management of environment variables in Meshroom.

```python
from meshroom.env import EnvVar

EnvVar.get(EnvVar.MESHROOM_QML_DEBUG)
```
