### PR TITLE
[ui] NodeEditor: Addressed Tab Retention when switching Node selection

### DIFF
--- a/meshroom/core/graph.py
+++ b/meshroom/core/graph.py
@@ -255,7 +255,7 @@ class Graph(BaseObject):
     
     @property
     def isSaving(self):
-        """ Return True if the graph is currently being loaded. """
+        """ Return True if the graph is currently being saved. """
         return self._saving
 
     @Slot(str)

--- a/meshroom/ui/qml/Application.qml
+++ b/meshroom/ui/qml/Application.qml
@@ -20,6 +20,16 @@ Page {
     property alias unsavedDialog: unsavedDialog
     property alias workspaceView: workspaceView
 
+    readonly property var scenefile: _reconstruction ? _reconstruction.graph.filepath : "";
+
+    onScenefileChanged: {
+        // Check if we're not currently saving and emit the currentProjectChanged signal
+        if (! _reconstruction.graph.isSaving) {
+            // Refresh the NodeEditor
+            nodeEditor.refresh();
+        }
+    }
+
     Settings {
         id: settingsUILayout
         category: "UILayout"

--- a/meshroom/ui/qml/GraphEditor/NodeEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/NodeEditor.qml
@@ -372,6 +372,9 @@ Panel {
 
             property bool isComputable: root.node !== null && root.node.isComputable
 
+            // The indices of the tab bar which can be shown for incomputable nodes
+            readonly property var nonComputableTabIndices: [0, 4, 5];
+
             Layout.fillWidth: true
             width: childrenRect.width
             position: TabBar.Footer
@@ -415,9 +418,11 @@ Panel {
                 rightPadding: leftPadding
             }
 
-            onIsComputableChanged: {
-                if (!isComputable) {
-                    tabBar.currentIndex = 0
+            onVisibleChanged: {
+                // If we have a node selected and the node is not Computable
+                // Reset the currentIndex to 0, if the current index is not allowed for an incomputable node
+                if ((root.node && !root.node.isComputable) && (nonComputableTabIndices.indexOf(tabBar.currentIndex) === -1)) {
+                    tabBar.currentIndex = 0;
                 }
             }
         }

--- a/meshroom/ui/qml/GraphEditor/NodeEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/NodeEditor.qml
@@ -42,6 +42,14 @@ Panel {
         }
     }
 
+    function refresh() {
+        /**
+         * Refresh properties of the Node Editor.
+         */
+        // Reset tab bar's current index
+        tabBar.currentIndex = 0;
+    }
+
     headerBar: RowLayout {
         Label {
             id: computationInfo

--- a/meshroom/ui/qml/GraphEditor/StatViewer.qml
+++ b/meshroom/ui/qml/GraphEditor/StatViewer.qml
@@ -310,220 +310,208 @@ Item {
 ***       CPU UI        ***
 **************************/
 
-            ColumnLayout {
+            Button {
+                id: toggleCpuBtn
                 Layout.fillWidth: true
+                text: "Toggle CPU's"
+                state: "closed"
 
-                Button {
-                    id: toggleCpuBtn
-                    Layout.fillWidth: true
-                    text: "Toggle CPU's"
-                    state: "closed"
+                onClicked: state === "opened" ? state = "closed" : state = "opened"
 
-                    onClicked: state === "opened" ? state = "closed" : state = "opened"
-
-                    MaterialLabel {
-                        text: MaterialIcons.arrow_drop_down
-                        font.pointSize: 14
-                        anchors.right: parent.right
-                    }
-
-                    states: [
-                        State {
-                            name: "opened"
-                            PropertyChanges { target: cpuBtnContainer; visible: true }
-                            PropertyChanges { target: toggleCpuBtn; down: true }
-                        },
-                        State {
-                            name: "closed"
-                            PropertyChanges { target: cpuBtnContainer; visible: false }
-                            PropertyChanges { target: toggleCpuBtn; down: false }
-                        }
-                    ]
+                MaterialLabel {
+                    text: MaterialIcons.arrow_drop_down
+                    font.pointSize: 14
+                    anchors.right: parent.right
                 }
 
-                Item {
-                    id: cpuBtnContainer
+                states: [
+                    State {
+                        name: "opened"
+                        PropertyChanges { target: cpuBtnContainer; visible: true }
+                        PropertyChanges { target: toggleCpuBtn; down: true }
+                    },
+                    State {
+                        name: "closed"
+                        PropertyChanges { target: cpuBtnContainer; visible: false }
+                        PropertyChanges { target: toggleCpuBtn; down: false }
+                    }
+                ]
+            }
 
-                    Layout.fillWidth: true
-                    implicitHeight: childrenRect.height
-                    Layout.leftMargin: 25
+            Item {
+                id: cpuBtnContainer
 
-                    RowLayout {
-                        width: parent.width
-                        anchors.horizontalCenter: parent.horizontalCenter
+                Layout.fillWidth: true
+                implicitHeight: childrenRect.height
+                Layout.leftMargin: 25
 
-                        ChartViewCheckBox {
-                            id: allCPU
-                            text: "ALL"
-                            color: textColor
-                            checkState: cpuLegend.buttonGroup.checkState
-                            leftPadding: 0
-                            onClicked: {
-                                var _checked = checked;
-                                for (var i = 0; i < cpuChart.count; ++i) {
-                                    cpuChart.series(i).visible = _checked
-                                }
+                RowLayout {
+                    width: parent.width
+                    anchors.horizontalCenter: parent.horizontalCenter
+
+                    ChartViewCheckBox {
+                        id: allCPU
+                        text: "ALL"
+                        color: textColor
+                        checkState: cpuLegend.buttonGroup.checkState
+                        leftPadding: 0
+                        onClicked: {
+                            var _checked = checked;
+                            for (var i = 0; i < cpuChart.count; ++i) {
+                                cpuChart.series(i).visible = _checked
                             }
                         }
-
-                        ChartViewLegend {
-                            id: cpuLegend
-                            Layout.fillWidth: true
-                            Layout.fillHeight: true
-                            chartView: cpuChart
-                        }
-                    }
-                }
-
-                InteractiveChartView {
-                    id: cpuChart
-
-                    Layout.fillWidth: true
-                    Layout.preferredHeight: width / 2
-                    margins.top: 0
-                    margins.bottom: 0
-                    antialiasing: true
-
-                    legend.visible: false
-                    theme: ChartView.ChartThemeLight
-                    backgroundColor: "transparent"
-                    plotAreaColor: "transparent"
-                    titleColor: textColor
-
-                    visible: (root.fileVersion > 0.0)  // Only visible if we have valid information
-                    title: "CPU: " + root.nbCores + " cores, " + root.cpuFrequency + "MHz"
-
-                    ValueAxis {
-                        id: valueCpuY
-                        min: 0
-                        max: 100
-                        titleText: "<span style='color: " + textColor + "'>%</span>"
-                        color: textColor
-                        gridLineColor: textColor
-                        minorGridLineColor: textColor
-                        shadesColor: textColor
-                        shadesBorderColor: textColor
-                        labelsColor: textColor
                     }
 
-                    ValueAxis {
-                        id: valueCpuX
-                        min: 0
-                        max: root.deltaTime * Math.max(1, root.nbReads)
-                        titleText: "<span style='color: " + textColor + "'>Minutes</span>"
-                        color: textColor
-                        gridLineColor: textColor
-                        minorGridLineColor: textColor
-                        shadesColor: textColor
-                        shadesBorderColor: textColor
-                        labelsColor: textColor
+                    ChartViewLegend {
+                        id: cpuLegend
+                        Layout.fillWidth: true
+                        Layout.fillHeight: true
+                        chartView: cpuChart
                     }
                 }
             }
 
+            InteractiveChartView {
+                id: cpuChart
+
+                Layout.fillWidth: true
+                Layout.preferredHeight: width / 2
+                margins.top: 0
+                margins.bottom: 0
+                antialiasing: true
+
+                legend.visible: false
+                theme: ChartView.ChartThemeLight
+                backgroundColor: "transparent"
+                plotAreaColor: "transparent"
+                titleColor: textColor
+
+                visible: (root.fileVersion > 0.0)  // Only visible if we have valid information
+                title: "CPU: " + root.nbCores + " cores, " + root.cpuFrequency + "MHz"
+
+                ValueAxis {
+                    id: valueCpuY
+                    min: 0
+                    max: 100
+                    titleText: "<span style='color: " + textColor + "'>%</span>"
+                    color: textColor
+                    gridLineColor: textColor
+                    minorGridLineColor: textColor
+                    shadesColor: textColor
+                    shadesBorderColor: textColor
+                    labelsColor: textColor
+                }
+
+                ValueAxis {
+                    id: valueCpuX
+                    min: 0
+                    max: root.deltaTime * Math.max(1, root.nbReads)
+                    titleText: "<span style='color: " + textColor + "'>Minutes</span>"
+                    color: textColor
+                    gridLineColor: textColor
+                    minorGridLineColor: textColor
+                    shadesColor: textColor
+                    shadesBorderColor: textColor
+                    labelsColor: textColor
+                }
+            }
 
 /**************************
 ***       RAM UI        ***
 **************************/
 
-            ColumnLayout {
+            InteractiveChartView {
+                id: ramChart
+                margins.top: 0
+                margins.bottom: 0
+                Layout.fillWidth: true
+                Layout.preferredHeight: width / 2
+                antialiasing: true
+                legend.color: textColor
+                legend.labelColor: textColor
+                legend.visible: false
+                theme: ChartView.ChartThemeLight
+                backgroundColor: "transparent"
+                plotAreaColor: "transparent"
+                titleColor: textColor
 
-                InteractiveChartView {
-                    id: ramChart
-                    margins.top: 0
-                    margins.bottom: 0
-                    Layout.fillWidth: true
-                    Layout.preferredHeight: width / 2
-                    antialiasing: true
-                    legend.color: textColor
-                    legend.labelColor: textColor
-                    legend.visible: false
-                    theme: ChartView.ChartThemeLight
-                    backgroundColor: "transparent"
-                    plotAreaColor: "transparent"
-                    titleColor: textColor
+                visible: (root.fileVersion > 0.0)  // Only visible if we have valid information
+                title: root.ramLabel + root.ramTotal + "GB"
 
-                    visible: (root.fileVersion > 0.0)  // Only visible if we have valid information
-                    title: root.ramLabel + root.ramTotal + "GB"
+                ValueAxis {
+                    id: valueRamY
+                    min: 0
+                    max: 100
+                    titleText: "<span style='color: " + textColor + "'>%</span>"
+                    color: textColor
+                    gridLineColor: textColor
+                    minorGridLineColor: textColor
+                    shadesColor: textColor
+                    shadesBorderColor: textColor
+                    labelsColor: textColor
+                }
 
-                    ValueAxis {
-                        id: valueRamY
-                        min: 0
-                        max: 100
-                        titleText: "<span style='color: " + textColor + "'>%</span>"
-                        color: textColor
-                        gridLineColor: textColor
-                        minorGridLineColor: textColor
-                        shadesColor: textColor
-                        shadesBorderColor: textColor
-                        labelsColor: textColor
-                    }
-
-                    ValueAxis {
-                        id: valueRamX
-                        min: 0
-                        max: root.deltaTime * Math.max(1, root.nbReads)
-                        titleText: "<span style='color: " + textColor + "'>Minutes</span>"
-                        color: textColor
-                        gridLineColor: textColor
-                        minorGridLineColor: textColor
-                        shadesColor: textColor
-                        shadesBorderColor: textColor
-                        labelsColor: textColor
-                    }
+                ValueAxis {
+                    id: valueRamX
+                    min: 0
+                    max: root.deltaTime * Math.max(1, root.nbReads)
+                    titleText: "<span style='color: " + textColor + "'>Minutes</span>"
+                    color: textColor
+                    gridLineColor: textColor
+                    minorGridLineColor: textColor
+                    shadesColor: textColor
+                    shadesBorderColor: textColor
+                    labelsColor: textColor
                 }
             }
-
 
 /**************************
 ***       GPU UI        ***
 **************************/
 
-            ColumnLayout {
+            InteractiveChartView {
+                id: gpuChart
 
-                InteractiveChartView {
-                    id: gpuChart
+                Layout.fillWidth: true
+                Layout.preferredHeight: width/2
+                margins.top: 0
+                margins.bottom: 0
+                antialiasing: true
+                legend.color: textColor
+                legend.labelColor: textColor
+                theme: ChartView.ChartThemeLight
+                backgroundColor: "transparent"
+                plotAreaColor: "transparent"
+                titleColor: textColor
 
-                    Layout.fillWidth: true
-                    Layout.preferredHeight: width/2
-                    margins.top: 0
-                    margins.bottom: 0
-                    antialiasing: true
-                    legend.color: textColor
-                    legend.labelColor: textColor
-                    theme: ChartView.ChartThemeLight
-                    backgroundColor: "transparent"
-                    plotAreaColor: "transparent"
-                    titleColor: textColor
+                visible: (root.fileVersion >= 2.0)  // No GPU information was collected before stats 2.0 fileVersion
+                title: (root.gpuName || root.gpuTotalMemory) ? ("GPU: " + root.gpuName + ", " + root.gpuTotalMemory + "MB") : "No GPU"
 
-                    visible: (root.fileVersion >= 2.0)  // No GPU information was collected before stats 2.0 fileVersion
-                    title: (root.gpuName || root.gpuTotalMemory) ? ("GPU: " + root.gpuName + ", " + root.gpuTotalMemory + "MB") : "No GPU"
+                ValueAxis {
+                    id: valueGpuY
+                    min: 0
+                    max: root.gpuMaxAxis
+                    titleText: "<span style='color: " + textColor + "'>%, °C</span>"
+                    color: textColor
+                    gridLineColor: textColor
+                    minorGridLineColor: textColor
+                    shadesColor: textColor
+                    shadesBorderColor: textColor
+                    labelsColor: textColor
+                }
 
-                    ValueAxis {
-                        id: valueGpuY
-                        min: 0
-                        max: root.gpuMaxAxis
-                        titleText: "<span style='color: " + textColor + "'>%, °C</span>"
-                        color: textColor
-                        gridLineColor: textColor
-                        minorGridLineColor: textColor
-                        shadesColor: textColor
-                        shadesBorderColor: textColor
-                        labelsColor: textColor
-                    }
-
-                    ValueAxis {
-                        id: valueGpuX
-                        min: 0
-                        max: root.deltaTime * Math.max(1, root.nbReads)
-                        titleText: "<span style='color: " + textColor + "'>Minutes</span>"
-                        color: textColor
-                        gridLineColor: textColor
-                        minorGridLineColor: textColor
-                        shadesColor: textColor
-                        shadesBorderColor: textColor
-                        labelsColor: textColor
-                    }
+                ValueAxis {
+                    id: valueGpuX
+                    min: 0
+                    max: root.deltaTime * Math.max(1, root.nbReads)
+                    titleText: "<span style='color: " + textColor + "'>Minutes</span>"
+                    color: textColor
+                    gridLineColor: textColor
+                    minorGridLineColor: textColor
+                    shadesColor: textColor
+                    shadesBorderColor: textColor
+                    labelsColor: textColor
                 }
             }
         }


### PR DESCRIPTION
## Description
This PR addresses an issue with the Node Editor, where the selected tab was not getting retained when switching between selected nodes.

## Features list
- [x] Fixed Node Editor Switching to ensure the current tab retains when it can, depending on the node type.
- [x] Fixed issue with StatViewer causing the polish-loop during updates.
~- Introduced the `currentProjectChanged` signal which is meant to trigger update on various components when the scene is changed~
~- Currently the `onCurrentProjectChanged` slot is linked to refreshing the NodeEditor tabs.~

## Implementation remarks
Updated the event trigger to be `onVisibleChanged` rather than `onIsComputableChanged` as the latter does not get triggered when there is no node selected and then an incomputable node gets selected but the value of isComputable remains the same.

Visibility acts as a better trigger in my view, getting triggered when a node gets selected or deselected.
The condition is also updated to check if the current tab is not valid for the incomputable node before resetting it to 0.

This ensures that when documentation or such tab is selected, we don't end up resetting it back to 0 as it can exist in both the node types.

The available indices can be updated as we progress further with different types of nodes in the future.

