### PR TITLE
[ui] Add Validation for Save file path accessibility

### DIFF
--- a/meshroom/ui/components/filepath.py
+++ b/meshroom/ui/components/filepath.py
@@ -59,6 +59,13 @@ class FilepathHelper(QObject):
 
     @Slot(str, result=bool)
     @Slot(QUrl, result=bool)
+    def accessible(self, path):
+        """ Returns whether a path is accessible for the user """
+        path = self.asStr(path)
+        return os.path.isdir(self.asStr(path)) and os.access(path, os.R_OK) and os.access(path, os.W_OK)
+
+    @Slot(str, result=bool)
+    @Slot(QUrl, result=bool)
     def isFile(self, path):
         """ Test whether a path is a regular file """
         return os.path.isfile(self.asStr(path))


### PR DESCRIPTION
## Description
This PR introduces a validation check to enhance the user experience by showing a warning popup when saving a file/template to a directory which is either not present or is not accessible to the user for writing to it.

## Features list

- [X] Added warning dialog for user considering the accessibility of the directory for the user before saving to it.

## Implementation remarks
Added an `accessible` helper to validate whether a given directory to save to is accessible for the user.
Updated the common `validateFilepathForSave` function to ensure the user has permission to save to the provided path.
This works in two ways, if either the directory the user is trying to save to does not exist it will return false, and the warning dialog shows up, or in case the user does not have access to writing to the directory also prompts the warning dialog.