### PR TITLE
[GraphEditor] Fix injections into signal handlers with JS functions

### DIFF
--- a/meshroom/ui/qml/GraphEditor/AttributeItemDelegate.qml
+++ b/meshroom/ui/qml/GraphEditor/AttributeItemDelegate.qml
@@ -103,7 +103,7 @@ RowLayout {
                     anchors.fill: parent
                     hoverEnabled: true
                     acceptedButtons: Qt.AllButtons
-                    onDoubleClicked: root.doubleClicked(mouse, root.attribute)
+                    onDoubleClicked: function(mouse) { root.doubleClicked(mouse, root.attribute) }
 
                     property Component menuComp: Menu {
                         id: paramMenu

--- a/meshroom/ui/qml/GraphEditor/NodeEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/NodeEditor.qml
@@ -290,7 +290,7 @@ Panel {
                             Layout.fillWidth: true
                             model: root.node.attributes
                             readOnly: root.readOnly || root.isCompatibilityNode
-                            onAttributeDoubleClicked: root.attributeDoubleClicked(mouse, attribute)
+                            onAttributeDoubleClicked: function(mouse, attribute) { root.attributeDoubleClicked(mouse, attribute) }
                             onUpgradeRequest: root.upgradeRequest()
                             filterText: searchBar.text
                         }
@@ -357,7 +357,7 @@ Panel {
                             Layout.fillWidth: true
                             model: root.node.internalAttributes
                             readOnly: root.readOnly || root.isCompatibilityNode
-                            onAttributeDoubleClicked: root.attributeDoubleClicked(mouse, attribute)
+                            onAttributeDoubleClicked: function(mouse, attribute) { root.attributeDoubleClicked(mouse, attribute) }
                             onUpgradeRequest: root.upgradeRequest()
                             filterText: searchBar.text
                         }

--- a/meshroom/ui/qml/GraphEditor/ScriptEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/ScriptEditor.qml
@@ -118,7 +118,7 @@ Item {
                 ToolTip.text: "Execute Script"
 
                 onClicked: {
-                    processScript()
+                    root.processScript()
                 }
             }
 
@@ -285,9 +285,9 @@ Item {
                             root.forceActiveFocus()
                         }
 
-                        Keys.onPressed: {
+                        Keys.onPressed: function(event) {
                             if ((event.key === Qt.Key_Enter || event.key === Qt.Key_Return) && event.modifiers === Qt.ControlModifier) {
-                                processScript()
+                                root.processScript()
                             }
                         }
                     }


### PR DESCRIPTION
## Description

Minor fixes related to the injection of parameters into signal handlers, which is not supported anymore on Qt6.