### PR TITLE
[ui] Refactor the access to the list of recent project files

### DIFF
--- a/meshroom/ui/app.py
+++ b/meshroom/ui/app.py
@@ -413,8 +413,13 @@ class MeshroomApp(QApplication):
         available.
         """
         if not self._updatedRecentProjectFilesThumbnails:
-            self._recentProjectFiles = self._getRecentProjectFiles()
+            self._updateRecentProjectFilesThumbnails()
             self._updatedRecentProjectFilesThumbnails = True
+
+    def _updateRecentProjectFilesThumbnails(self) -> None:
+        for project in self._recentProjectFiles:
+            path = project["path"]
+            project["thumbnail"] = self._retrieveThumbnailPath(path)
 
     @Slot(str)
     @Slot(QUrl)

--- a/meshroom/ui/app.py
+++ b/meshroom/ui/app.py
@@ -245,6 +245,10 @@ class MeshroomApp(QApplication):
 
         # Initialize the list of recent project files
         self._recentProjectFiles = self._getRecentProjectFiles()
+        # Flag set to True if, for all the project files in the list, thumbnails have been retrieved when they
+        # are available. If set to False, then all the paths in the list are accurate, but some thumbnails might
+        # be retrievable
+        self._updatedRecentProjectFilesThumbnails = True
 
         # QML engine setup
         qmlDir = os.path.join(pwd, "qml")
@@ -388,6 +392,17 @@ class MeshroomApp(QApplication):
         settings.endGroup()
         return projects
 
+    @Slot()
+    def updateRecentProjectFilesThumbnails(self) -> None:
+        """
+        If there are thumbnails that may be retrievable (meaning the list of projects has been updated minimally),
+        update the list of recent project files by reading the QSettings and retrieving the thumbnails if they are
+        available.
+        """
+        if not self._updatedRecentProjectFilesThumbnails:
+            self._recentProjectFiles = self._getRecentProjectFiles()
+            self._updatedRecentProjectFilesThumbnails = True
+
     @Slot(str)
     @Slot(QUrl)
     def addRecentProjectFile(self, projectFile) -> None:
@@ -443,6 +458,7 @@ class MeshroomApp(QApplication):
 
         # Update the final list of recent projects
         self._recentProjectFiles = projects
+        self._updatedRecentProjectFilesThumbnails = False  # Thumbnails may not be up-to-date
         self.recentProjectFilesChanged.emit()
 
     @Slot(str)

--- a/meshroom/ui/app.py
+++ b/meshroom/ui/app.py
@@ -6,7 +6,7 @@ import json
 
 from PySide6 import __version__ as PySideVersion
 from PySide6 import QtCore
-from PySide6.QtCore import Qt, QUrl, QJsonValue, qInstallMessageHandler, QtMsgType, QSettings
+from PySide6.QtCore import QUrl, QJsonValue, qInstallMessageHandler, QtMsgType, QSettings
 from PySide6.QtGui import QIcon
 from PySide6.QtQml import QQmlDebuggingEnabler
 from PySide6.QtQuickControls2 import QQuickStyle

--- a/meshroom/ui/app.py
+++ b/meshroom/ui/app.py
@@ -244,7 +244,7 @@ class MeshroomApp(QApplication):
         meshroom.core.initSubmitters()
 
         # Initialize the list of recent project files
-        self._recentProjectFiles = self._getRecentProjectFiles()
+        self._recentProjectFiles = self._getRecentProjectFilesFromSettings()
         # Flag set to True if, for all the project files in the list, thumbnails have been retrieved when they
         # are available. If set to False, then all the paths in the list are accurate, but some thumbnails might
         # be retrievable
@@ -381,15 +381,14 @@ class MeshroomApp(QApplication):
 
         return thumbnail
 
-    def _getRecentProjectFiles(self) -> list[dict[str, str]]:
+    def _getRecentProjectFilesFromSettings(self) -> list[dict[str, str]]:
         """
         Read the list of recent project files from the QSettings, retrieve their filepath, and if it exists, their
         thumbnail.
 
         Returns:
-            list[dict[str, str]]: The list containing dictionaries of the form {"path": "/path/to/project/file",
-                                                                                "thumbnail": "/path/to/thumbnail"}
-                                  based on the recent projects stored in the QSettings.
+            The list containing dictionaries of the form {"path": "/path/to/project/file", "thumbnail":
+            "/path/to/thumbnail"} based on the recent projects stored in the QSettings.
         """
         projects = []
         settings = QSettings()

--- a/meshroom/ui/qml/Homepage.qml
+++ b/meshroom/ui/qml/Homepage.qml
@@ -311,7 +311,8 @@ Page {
 
                     model: {
                         // Request latest thumbnail paths
-                        MeshroomApp.updateRecentProjectFilesThumbnails()
+                        if (mainStack.currentItem instanceof Homepage)
+                            MeshroomApp.updateRecentProjectFilesThumbnails()
                         return [{"path": null, "thumbnail": null}].concat(MeshroomApp.recentProjectFiles)
                     }
 

--- a/meshroom/ui/qml/Homepage.qml
+++ b/meshroom/ui/qml/Homepage.qml
@@ -309,7 +309,11 @@ Page {
                     cellHeight: cellWidth
                     anchors.margins: 10
 
-                    model: [{ "path": null, "thumbnail": null}].concat(MeshroomApp.recentProjectFiles)
+                    model: {
+                        // Request latest thumbnail paths
+                        MeshroomApp.updateRecentProjectFilesThumbnails()
+                        return [{"path": null, "thumbnail": null}].concat(MeshroomApp.recentProjectFiles)
+                    }
 
                     // Update grid item when corresponding thumbnail is computed
                     Connections {


### PR DESCRIPTION
## Description

This pull request addresses some performance issues that were detected when interacting with the list of recent project files.

It mostly focuses on refactoring the access to the list of recent project files, which involved reading the QSettings every single time the content of the list was to be accessed, and accessing it far too many times. 

It also decouples the need for thumbnails between the homepage and the application: while the homepage needs access to thumbnails (if available) to set up the list of recent project files, the application has no use for them. When the list of project files is edited, there is no need to retrieve the corresponding thumbnail (if it exists) unless the current view is the homepage's.

Finally, it prevents the homepage from performing any such request for thumbnails unless it is actually being displayed.


### Performance Summary

**QSettings used to be read every single time `recentProjectFiles` was called:**

* When getting the list of project files to *add a project file*.
  * This includes "open file" and "save as" operations.
* When getting the list of project files to *remove a project file*.
* When getting the list of project files to *set the root folder of any file dialog*.
* When getting the list of project files to *fill the "Open Recent" menu*.
* When getting the list of project files to *set the model for the homepage*.
  * For this specific case, the model for the homepage was updated for every single update to the list (either adding or removing a project file) **as many times** as there were entries in the list. For example, if there were 30 project files in the list, QSettings were read 30 times just to setup the homepage at launch, and then 30 times again when a file was added (+ 1 time) or removed (-1 time).

**=> QSettings are now only read <ins>_once_</ins> throughout the lifetime of the Meshroom instance.**


## Features list

- [x] Reduce the reading of the QSettings to a single occurrence (upon Meshroom launch)
- [x] Refactor the accesses and interactions (addition/deletion) with the list of recent project files
- [x] Separate the update of the project files' path and thumbnail
- [X] Prevent the homepage from requesting updates when it is not the active view


## Implementation remarks

Prior to this PR, a call to the `recentProjectFiles` property necessarily involved a full reading of the QSettings, which provides for each entry both a path to the project file itself and a path to its thumbnail (if it exists). Upon the launch of Meshroom alone, if there were 40 project files in the QSettings, these QSettings were fully accessed and read 40 times just to set the homepage properly.

`recentProjectFiles` is now only an accessor to a list that is filled and edited in other calls, and which is initialized with a full reading of the QSettings when Meshroom is started, and never again during the lifetime of the instance. QSettings are thus only read once.

From there, any project file that is added or deleted leads to an update of the QSettings, but these settings are not read again to update the content of `recentProjectFiles`: `recentProjectFiles` is updated directly within these methods, ensuring it is always accurately reflecting the content of the QSettings.

When a project file is added, only the path to the project is added to the QSettings; there is no attempt to retrieve the thumbnail. However, a flag indicating that there may be some thumbnail paths to retrieve will be set.

When the homepage will become the current view again, it will request an update of the thumbnails. If the flag is set (meaning at least a file has been added to the list), all the project files in `recentProjectFiles` will be parsed in an attempt to retrieve their thumbnails. Otherwise (meaning that files have either been deleted or nothing has happened), nothing will happen.
