### PR TITLE
Update sfm pipeline to accept meshes

### DIFF
--- a/meshroom/nodes/aliceVision/ExportMatches.py
+++ b/meshroom/nodes/aliceVision/ExportMatches.py
@@ -1,4 +1,4 @@
-__version__ = "1.1"
+__version__ = "2.0"
 
 from meshroom.core import desc
 from meshroom.core.utils import DESCRIBER_TYPES, VERBOSE_LEVEL
@@ -52,13 +52,13 @@ class ExportMatches(desc.AVCommandLineNode):
         ),
         desc.File(
             name="filterA",
-            label="filter A",
+            label="Filter A",
             description="One item of the pair must match this.",
             value="",
         ),
         desc.File(
             name="filterB",
-            label="filter B",
+            label="Filter B",
             description="One item of the pair must match this.",
             value="",
         ),

--- a/meshroom/nodes/aliceVision/ExportMatches.py
+++ b/meshroom/nodes/aliceVision/ExportMatches.py
@@ -50,6 +50,18 @@ class ExportMatches(desc.AVCommandLineNode):
             label="Matches Folders",
             description="Folder(s) in which computed matches are stored.",
         ),
+        desc.File(
+            name="filterA",
+            label="filter A",
+            description="One item of the pair must match this.",
+            value="",
+        ),
+        desc.File(
+            name="filterB",
+            label="filter B",
+            description="One item of the pair must match this.",
+            value="",
+        ),
         desc.ChoiceParam(
             name="verboseLevel",
             label="Verbose Level",

--- a/meshroom/nodes/aliceVision/RelativePoseEstimating.py
+++ b/meshroom/nodes/aliceVision/RelativePoseEstimating.py
@@ -42,6 +42,14 @@ Estimate relative pose between each pair of views that share tracks.
             range=(1024, 500000, 1),
             advanced=True,
         ),
+        desc.IntParam(
+            name="minInliers",
+            label="Ransac min inliers",
+            description="Minimal allowed inliers in two view relationship.",
+            value=35,
+            range=(1, 1000, 1),
+            advanced=True,
+        ),
         desc.ChoiceParam(
             name="verboseLevel",
             label="Verbose Level",

--- a/meshroom/nodes/aliceVision/RelativePoseEstimating.py
+++ b/meshroom/nodes/aliceVision/RelativePoseEstimating.py
@@ -36,7 +36,7 @@ Estimate relative pose between each pair of views that share tracks.
         ),
         desc.IntParam(
             name="countIterations",
-            label="Ransac max iterations",
+            label="Ransac Max Iterations",
             description="Maximal number of iterations.",
             value=1024,
             range=(1024, 500000, 1),
@@ -44,7 +44,7 @@ Estimate relative pose between each pair of views that share tracks.
         ),
         desc.IntParam(
             name="minInliers",
-            label="Ransac min inliers",
+            label="Ransac Min Inliers",
             description="Minimal allowed inliers in two view relationship.",
             value=35,
             range=(1, 1000, 1),

--- a/meshroom/nodes/aliceVision/RelativePoseEstimating.py
+++ b/meshroom/nodes/aliceVision/RelativePoseEstimating.py
@@ -1,4 +1,4 @@
-__version__ = "2.0"
+__version__ = "3.0"
 
 from meshroom.core import desc
 from meshroom.core.utils import DESCRIBER_TYPES, VERBOSE_LEVEL
@@ -33,6 +33,14 @@ Estimate relative pose between each pair of views that share tracks.
             label="Enforce pure rotation",
             description="Enforce pure rotation as a model",
             value=False,
+        ),
+        desc.IntParam(
+            name="countIterations",
+            label="Ransac max iterations",
+            description="Maximal number of iterations.",
+            value=1024,
+            range=(1024, 500000, 1),
+            advanced=True,
         ),
         desc.ChoiceParam(
             name="verboseLevel",

--- a/meshroom/nodes/aliceVision/SfmBootstraping.py
+++ b/meshroom/nodes/aliceVision/SfmBootstraping.py
@@ -1,7 +1,7 @@
-__version__ = "2.0"
+__version__ = "3.0"
 
 from meshroom.core import desc
-from meshroom.core.utils import DESCRIBER_TYPES, VERBOSE_LEVEL
+from meshroom.core.utils import VERBOSE_LEVEL
 
 
 class SfMBootStraping(desc.AVCommandLineNode):

--- a/meshroom/nodes/aliceVision/SfmBootstraping.py
+++ b/meshroom/nodes/aliceVision/SfmBootstraping.py
@@ -26,6 +26,12 @@ class SfMBootStraping(desc.AVCommandLineNode):
             value="",
         ),
         desc.File(
+            name="meshFilename",
+            label="Mesh File",
+            description="Mesh file (*.obj).",
+            value="",
+        ),
+        desc.File(
             name="pairs",
             label="Pairs File",
             description="Information on pairs.",

--- a/meshroom/nodes/aliceVision/SfmExpanding.py
+++ b/meshroom/nodes/aliceVision/SfmExpanding.py
@@ -28,6 +28,12 @@ class SfMExpanding(desc.AVCommandLineNode):
             description="Tracks file.",
             value="",
         ),
+        desc.File(
+            name="meshFilename",
+            label="Mesh File",
+            description="Mesh file (*.obj).",
+            value="",
+        ),
         desc.IntParam(
             name="localizerEstimatorMaxIterations",
             label="Localizer Max Ransac Iterations",

--- a/meshroom/nodes/aliceVision/SfmExpanding.py
+++ b/meshroom/nodes/aliceVision/SfmExpanding.py
@@ -1,7 +1,7 @@
-__version__ = "1.0"
+__version__ = "2.0"
 
 from meshroom.core import desc
-from meshroom.core.utils import DESCRIBER_TYPES, VERBOSE_LEVEL
+from meshroom.core.utils import VERBOSE_LEVEL
 
 
 class SfMExpanding(desc.AVCommandLineNode):

--- a/meshroom/pipelines/nodalCameraTracking.mg
+++ b/meshroom/pipelines/nodalCameraTracking.mg
@@ -18,7 +18,7 @@
             "ImageSegmentationBox": "0.1",
             "NodalSfM": "2.0",
             "Publish": "1.3",
-            "RelativePoseEstimating": "2.0",
+            "RelativePoseEstimating": "3.0",
             "ScenePreview": "2.0",
             "TracksBuilding": "1.0"
         }

--- a/meshroom/pipelines/nodalCameraTrackingWithoutCalibration.mg
+++ b/meshroom/pipelines/nodalCameraTrackingWithoutCalibration.mg
@@ -16,7 +16,7 @@
             "ImageSegmentationBox": "0.1",
             "NodalSfM": "2.0",
             "Publish": "1.3",
-            "RelativePoseEstimating": "2.0",
+            "RelativePoseEstimating": "3.0",
             "ScenePreview": "2.0",
             "TracksBuilding": "1.0"
         }


### PR DESCRIPTION
see https://github.com/alicevision/AliceVision/pull/1803

This PR add a set of features to enable use of lidar measures as smooth constraints on the landmark positions.

    Assumes one frame of the sequence is correclty aligned with the lidar geometric frame.
    Assumes the camera calibration is fully and precisely known.
    Use Mesh generated from lidar to fetch 3D point for a given 2D landmark by point back projection.

