### PR TITLE
[ui]: Introduction of multiple ways to remove Node Edges

### DIFF
--- a/meshroom/ui/components/edge.py
+++ b/meshroom/ui/components/edge.py
@@ -110,16 +110,16 @@ class EdgeMouseArea(QQuickItem):
         self._containsMouse = value
         self.containsMouseChanged.emit()
 
-    @Slot(QRectF, result=bool)
-    def intersects(self, rect):
-        """ Checks whether the given rectangle's diagonal intersects with the Path. """
+    @Slot(QPointF, QPointF, result=bool)
+    def intersectsSegment(self, p1, p2):
+        """ Checks whether the given segment (p1, p2) intersects with the Path. """
         path = QPainterPath()
         # Starting point
-        path.moveTo(QPointF(rect.x(), rect.y()))
+        path.moveTo(p1)
         # Create a diagonal line to the other end of the rect
-        path.lineTo(QPointF(rect.width() + rect.x(), rect.height() + rect.y()))
-
-        return self._path.intersects(path)
+        path.lineTo(p2)
+        v = self._path.intersects(path)
+        return v
 
     thicknessChanged = Signal()
     thickness = Property(float, getThickness, setThickness, notify=thicknessChanged)

--- a/meshroom/ui/components/edge.py
+++ b/meshroom/ui/components/edge.py
@@ -110,6 +110,17 @@ class EdgeMouseArea(QQuickItem):
         self._containsMouse = value
         self.containsMouseChanged.emit()
 
+    @Slot(QRectF, result=bool)
+    def intersects(self, rect):
+        """ Checks whether the given rectangle's diagonal intersects with the Path. """
+        path = QPainterPath()
+        # Starting point
+        path.moveTo(QPointF(rect.x(), rect.y()))
+        # Create a diagonal line to the other end of the rect
+        path.lineTo(QPointF(rect.width() + rect.x(), rect.height() + rect.y()))
+
+        return self._path.intersects(path)
+
     thicknessChanged = Signal()
     thickness = Property(float, getThickness, setThickness, notify=thicknessChanged)
     curveScaleChanged = Signal()

--- a/meshroom/ui/components/edge.py
+++ b/meshroom/ui/components/edge.py
@@ -1,4 +1,4 @@
-from PySide6.QtCore import Signal, Property, QPointF, Qt, QObject
+from PySide6.QtCore import Signal, Property, QPointF, Qt, QObject, Slot, QRectF
 from PySide6.QtGui import QPainterPath, QVector2D
 from PySide6.QtQuick import QQuickItem
 

--- a/meshroom/ui/graph.py
+++ b/meshroom/ui/graph.py
@@ -870,6 +870,18 @@ class UIGraph(QObject):
         else:
             self.push(commands.RemoveEdgeCommand(self._graph, edge))
 
+    @Slot()
+    def disconnectSelectedNodes(self):
+        with self.groupedGraphModification("Disconnect Nodes"):
+            selectedNodes = self.getSelectedNodes()
+            for edge in self._graph.edges[:]:
+                # Remove only the edges which are coming or going out of the current selection
+                if edge.src.node in selectedNodes and edge.dst.node in selectedNodes:
+                    continue
+
+                if edge.dst.node in selectedNodes or edge.src.node in selectedNodes:
+                    self.removeEdge(edge)
+
     @Slot(Edge, Attribute, Attribute, result=Edge)
     def replaceEdge(self, edge, newSrc, newDst):
         with self.groupedGraphModification(f"Replace Edge '{edge.src.getFullNameToNode()}'->'{edge.dst.getFullNameToNode()}' with '{newSrc.getFullNameToNode()}'->'{newDst.getFullNameToNode()}'"):

--- a/meshroom/ui/graph.py
+++ b/meshroom/ui/graph.py
@@ -870,6 +870,13 @@ class UIGraph(QObject):
         else:
             self.push(commands.RemoveEdgeCommand(self._graph, edge))
 
+    @Slot(list)
+    def deleteEdgesByIndices(self, indices):
+        with self.groupedGraphModification("Remove Edges"):
+            copied = list(self._graph.edges)
+            for index in indices:
+                self.removeEdge(copied[index])
+
     @Slot()
     def disconnectSelectedNodes(self):
         with self.groupedGraphModification("Disconnect Nodes"):

--- a/meshroom/ui/qml/Controls/DelegateSelectionLine.qml
+++ b/meshroom/ui/qml/Controls/DelegateSelectionLine.qml
@@ -1,0 +1,31 @@
+import QtQuick
+import Meshroom.Helpers
+
+/*
+A SelectionLine that can be used to select delegates in a model instantiator (Repeater, ListView...).
+Interesection test is done in the coordinate system of the container Item, using delegate's bounding boxes.
+The list of selected indices is emitted when the selection ends.
+*/
+
+SelectionLine {
+    id: root
+
+    // The Item instantiating the delegates.
+    property Item modelInstantiator
+    // The Item containing the delegates (used for coordinate mapping).
+    property Item container
+    // Emitted when the selection has ended, with the list of selected indices and modifiers.
+    signal delegateSelectionEnded(list<int> indices, int modifiers)
+
+    onSelectionEnded: function(selectionRect, modifiers) {
+        let selectedIndices = [];
+        const mappedSelectionRect = mapToItem(container, selectionRect);
+        for (var i = 0; i < modelInstantiator.count; ++i) {
+            const delegate = modelInstantiator.itemAt(i);
+            if (delegate.intersects(mappedSelectionRect)) {
+                selectedIndices.push(i);
+            }
+        }
+        delegateSelectionEnded(selectedIndices, modifiers);
+    }
+}

--- a/meshroom/ui/qml/Controls/DelegateSelectionLine.qml
+++ b/meshroom/ui/qml/Controls/DelegateSelectionLine.qml
@@ -17,12 +17,13 @@ SelectionLine {
     // Emitted when the selection has ended, with the list of selected indices and modifiers.
     signal delegateSelectionEnded(list<int> indices, int modifiers)
 
-    onSelectionEnded: function(selectionRect, modifiers) {
+    onSelectionEnded: function(selectionP1, selectionP2, modifiers) {
         let selectedIndices = [];
-        const mappedSelectionRect = mapToItem(container, selectionRect);
+        const mappedP1 = mapToItem(container, selectionP1);
+        const mappedP2 = mapToItem(container, selectionP2);
         for (var i = 0; i < modelInstantiator.count; ++i) {
             const delegate = modelInstantiator.itemAt(i);
-            if (delegate.intersects(mappedSelectionRect)) {
+            if (delegate.intersectsSegment(mappedP1, mappedP2)) {
                 selectedIndices.push(i);
             }
         }

--- a/meshroom/ui/qml/Controls/SelectionLine.qml
+++ b/meshroom/ui/qml/Controls/SelectionLine.qml
@@ -1,0 +1,77 @@
+import QtQuick
+import QtQuick.Shapes
+
+/*
+Simple selection line that can be used by a MouseArea.
+
+Usage:
+1. Create a MouseArea and a selectionShape.
+2. Bind the selectionShape to the MouseArea by setting the `mouseArea` property.
+3. Call startSelection() with coordinates when the selection starts.
+4. Call endSelection() when the selection ends.
+5. Listen to the selectionEnded signal to get the rectangle whose Diagonal is the selection line.
+*/
+
+Item {
+    id: root
+
+    property MouseArea mouseArea
+
+    readonly property bool active: mouseArea.drag.target == dragTarget
+
+    signal selectionEnded(rect selectionRect, int modifiers)
+
+    function startSelection(mouse) {
+        dragTarget.startPos.x = dragTarget.x = mouse.x;
+        dragTarget.startPos.y = dragTarget.y = mouse.y;
+        dragTarget.modifiers = mouse.modifiers;
+        mouseArea.drag.target = dragTarget;
+    }
+
+    function endSelection() {
+        if (!active) {
+            return;
+        }
+        mouseArea.drag.target = null;
+        const rect = Qt.rect(selectionShape.x, selectionShape.y, selectionShape.width, selectionShape.height)
+        selectionEnded(rect, dragTarget.modifiers);
+    }
+
+    visible: active
+
+    Item {
+        id: selectionShape
+        x: dragTarget.startPos.x
+        y: dragTarget.startPos.y
+        width: dragTarget.x - dragTarget.startPos.x
+        height: dragTarget.y - dragTarget.startPos.y
+
+        Shape {
+            id: dynamicLine;
+            width: selectionShape.width;
+            height: selectionShape.height;
+            anchors.fill: parent;
+
+            ShapePath {
+                strokeWidth: 2;
+                strokeStyle: ShapePath.DashLine;
+                strokeColor: "#FF0000";
+                dashPattern: [3, 2];
+
+                startX: 0;
+                startY: 0;
+
+                PathLine {
+                    x: selectionShape.width;
+                    y: selectionShape.height;
+                }
+            }
+        }
+    }
+
+    Item {
+        id: dragTarget
+        property point startPos
+        property var modifiers
+    }
+}

--- a/meshroom/ui/qml/Controls/SelectionLine.qml
+++ b/meshroom/ui/qml/Controls/SelectionLine.qml
@@ -9,7 +9,7 @@ Usage:
 2. Bind the selectionShape to the MouseArea by setting the `mouseArea` property.
 3. Call startSelection() with coordinates when the selection starts.
 4. Call endSelection() when the selection ends.
-5. Listen to the selectionEnded signal to get the rectangle whose Diagonal is the selection line.
+5. Listen to the selectionEnded signal to get the segment (defined by 2 points).
 */
 
 Item {
@@ -19,7 +19,7 @@ Item {
 
     readonly property bool active: mouseArea.drag.target == dragTarget
 
-    signal selectionEnded(rect selectionRect, int modifiers)
+    signal selectionEnded(point selectionP1, point selectionP2, int modifiers)
 
     function startSelection(mouse) {
         dragTarget.startPos.x = dragTarget.x = mouse.x;
@@ -33,8 +33,9 @@ Item {
             return;
         }
         mouseArea.drag.target = null;
-        const rect = Qt.rect(selectionShape.x, selectionShape.y, selectionShape.width, selectionShape.height)
-        selectionEnded(rect, dragTarget.modifiers);
+        const p1 = Qt.point(selectionShape.x, selectionShape.y);
+        const p2 = Qt.point(selectionShape.x + selectionShape.width, selectionShape.y + selectionShape.height);
+        selectionEnded(p1, p2, dragTarget.modifiers);
     }
 
     visible: active

--- a/meshroom/ui/qml/Controls/SelectionLine.qml
+++ b/meshroom/ui/qml/Controls/SelectionLine.qml
@@ -56,7 +56,7 @@ Item {
             ShapePath {
                 strokeWidth: 2;
                 strokeStyle: ShapePath.DashLine;
-                strokeColor: "#FF0000";
+                strokeColor: "#CC3E3E";
                 dashPattern: [3, 2];
 
                 startX: 0;

--- a/meshroom/ui/qml/Controls/qmldir
+++ b/meshroom/ui/qml/Controls/qmldir
@@ -18,4 +18,6 @@ MScrollBar 1.0 MScrollBar.qml
 MSplitView 1.0 MSplitView.qml
 DirectionalLightPane 1.0 DirectionalLightPane.qml
 SelectionBox 1.0 SelectionBox.qml
+SelectionLine 1.0 SelectionLine.qml
 DelegateSelectionBox 1.0 DelegateSelectionBox.qml
+DelegateSelectionLine 1.0 DelegateSelectionLine.qml

--- a/meshroom/ui/qml/GraphEditor/Edge.qml
+++ b/meshroom/ui/qml/GraphEditor/Edge.qml
@@ -40,6 +40,17 @@ Item {
     property real endY: height
 
 
+    function intersects(rect) {
+        /**
+         * Detects whether a line along the given rects diagonal intersects with the edge mouse area.
+         */
+        // The edgeArea is within the parent Item and its bounds and position are relative to its parent
+        // Map the original rect to the coordinates of the edgeArea by subtracting the parent's coordinates from the rect
+        // This mapped rect would ensure that the rect coordinates map to 0 of the edge area
+        const mappedRect = Qt.rect(rect.x - x, rect.y - y, rect.width, rect.height);
+        return edgeArea.intersects(mappedRect);
+    }
+
     Shape {
         anchors.fill: parent
         // Cause rendering artifacts when enabled (and don't support hot reload really well)

--- a/meshroom/ui/qml/GraphEditor/Edge.qml
+++ b/meshroom/ui/qml/GraphEditor/Edge.qml
@@ -23,7 +23,7 @@ Item {
     property int loopSize: 0
     property int iteration: 0
 
-    // BUG: edgeArea is destroyed before path, need to test if not null to avoid warnings
+    // Note: edgeArea is destroyed before path, so we need to test if not null to avoid warnings.
     readonly property bool containsMouse: (loopArea && loopArea.containsMouse) || (edgeArea && edgeArea.containsMouse)
 
     signal pressed(var event)
@@ -40,15 +40,14 @@ Item {
     property real endY: height
 
 
-    function intersects(rect) {
+    function intersectsSegment(p1, p2) {
         /**
          * Detects whether a line along the given rects diagonal intersects with the edge mouse area.
          */
         // The edgeArea is within the parent Item and its bounds and position are relative to its parent
         // Map the original rect to the coordinates of the edgeArea by subtracting the parent's coordinates from the rect
         // This mapped rect would ensure that the rect coordinates map to 0 of the edge area
-        const mappedRect = Qt.rect(rect.x - x, rect.y - y, rect.width, rect.height);
-        return edgeArea.intersects(mappedRect);
+        return edgeArea.intersectsSegment(Qt.point(p1.x - x, p1.y - y), Qt.point(p2.x - x, p2.y - y));
     }
 
     Shape {

--- a/meshroom/ui/qml/GraphEditor/GraphEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/GraphEditor.qml
@@ -870,6 +870,10 @@ Item {
                     onAttributePinCreated: function(attribute, pin) { registerAttributePin(attribute, pin) }
                     onAttributePinDeleted: function(attribute, pin) { unregisterAttributePin(attribute, pin) }
 
+                    onShaked: {
+                        uigraph.disconnectSelectedNodes();
+                    }
+
                     onPressed: function(mouse) {
                         nodeRepeater.updateSelectionOnClick = true;
                         nodeRepeater.ongoingDrag = true;
@@ -965,6 +969,9 @@ Item {
                         if(!selected || !dragging) {
                             return;
                         }
+
+                        // Check for shake on the node
+                        checkForShake();
                         // Compute offset between the delegate and the stored node position.
                         const offset = Qt.point(x - node.x, y - node.y);
 

--- a/meshroom/ui/qml/GraphEditor/GraphEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/GraphEditor.qml
@@ -113,9 +113,14 @@ Item {
             }
         } else if (event.key === Qt.Key_D) {
             duplicateNode(event.modifiers === Qt.AltModifier)
-        } else if (event.key === Qt.Key_X && event.modifiers === Qt.ControlModifier) {
-            copyNodes()
-            uigraph.removeSelectedNodes()
+        } else if (event.key === Qt.Key_X) {
+            if (event.modifiers === Qt.ControlModifier) {
+                copyNodes()
+                uigraph.removeSelectedNodes()
+            }
+            else {
+                uigraph.disconnectSelectedNodes()
+            }
         } else if (event.key === Qt.Key_C) {
             if (event.modifiers === Qt.ControlModifier) {
                 copyNodes()

--- a/meshroom/ui/qml/GraphEditor/GraphEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/GraphEditor.qml
@@ -502,7 +502,7 @@ Item {
                         if (event.button) {
                             if (canEdit && (event.modifiers & Qt.AltModifier)) {
                                 uigraph.removeEdge(edge)
-                            } else {
+                            } else if (event.button == Qt.RightButton) {
                                 edgeMenu.currentEdge = edge
                                 edgeMenu.forLoop = forLoop
                                 var spawnPosition = mouseArea.mapToItem(draggable, mouseArea.mouseX, mouseArea.mouseY)
@@ -972,6 +972,7 @@ Item {
 
                         // Check for shake on the node
                         checkForShake();
+
                         // Compute offset between the delegate and the stored node position.
                         const offset = Qt.point(x - node.x, y - node.y);
 

--- a/meshroom/ui/qml/GraphEditor/GraphEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/GraphEditor.qml
@@ -732,6 +732,13 @@ Item {
                         }
                     }
                     MenuItem {
+                        text: "Disconnect Node(s)";
+                        enabled: true;
+                        ToolTip.text: "Disconnect all edges from the selected Node(s)";
+                        ToolTip.visible: hovered;
+                        onTriggered: uigraph.disconnectSelectedNodes();
+                    }
+                    MenuItem {
                         text: "Duplicate Node(s)" + (duplicateFollowingButton.hovered ? " From Here" : "")
                         enabled: true
                         onTriggered: duplicateNode(false)

--- a/meshroom/ui/qml/GraphEditor/Node.qml
+++ b/meshroom/ui/qml/GraphEditor/Node.qml
@@ -32,7 +32,7 @@ Item {
     property color baseColor: defaultColor
 
     /// Shake Relevance
-    readonly property double maxAmplitude: 300.0;
+    readonly property double maxAmplitude: 500.0;
     readonly property int shakeThreshold: 5;
     
     property int shakeCounter: 0;


### PR DESCRIPTION
## Description
This PR introduces various methods to remove Node edges within the Graph. These methods enhance the usability of the Node Graph by providing users with multiple options to managed node egde connections.

## Details of the Change:
The various methods include,
* Context Menu Change -> Right click on an edge now shows a popup.
* Fix -> Alt + Click on the Edge was not working after Qt6 Migration and is now fixed.
* Added functionality to remove all incoming and outgoing connections of nodes which are not present in the current selection
  * This feature can be accessed using various ways, Right click on Node > Disconnect Node(s)
  * Selecting Node(s) and Pressing `X` on the Keyboard
  * Selecting Node(s) and shaking them.
* Another way is to Press and Hold `Ctrl` and `Alt` on the Keyboard and Left click + Drag on the edges, this generates the EdgeSelectionLine and whatever edges this has intersected with will get removed.
