### PR TITLE
Extract more metadata using exifTool

### DIFF
--- a/meshroom/nodes/aliceVision/ExtractMetadata.py
+++ b/meshroom/nodes/aliceVision/ExtractMetadata.py
@@ -91,9 +91,8 @@ Using exifTool, this node extracts metadata of all images referenced in a sfmDat
             outFiles = self.resolvedPaths(chunk.node.input.value, chunk.node.output.value, chunk.node.keepFilename.value, chunk.node.extension.value)
 
             if not outFiles:
-                error = 'ExtractMetadata: input files listed, but no metadata to extract'
+                error = 'ExtractMetadata: No input files! Check that a sfmData is connected as input.'
                 chunk.logger.error(error)
-                chunk.logger.info('Listed input files: {}'.format([i.value for i in chunk.node.inputFiles.value]))
                 raise RuntimeError(error)
 
             if not os.path.exists(chunk.node.output.value):
@@ -107,17 +106,14 @@ Using exifTool, this node extracts metadata of all images referenced in a sfmDat
                 else: #xmp
                     cmd = 'exiftool -tagsfromfile ' + iFile + ' ' + chunk.node.arguments.value.strip() + ' ' + oFile
                 chunk.logger.debug(cmd)
-                os.system(cmd)
+                try:
+                    os.system(cmd)
+                except:
+                    chunk.logger.error("exifTool command failed ! Check that exifTool can be accessed on your system.")
+                    raise RuntimeError(error)
                 if not os.path.exists(oFile):
                     info = 'No metadata extracted for file ' + iFile
                     chunk.logger.info(info)
-                else:
-                    f = open(oFile)
-                    if f.readline().find('command not found') != -1:
-                        error = 'Metadata cannot be extracted, exiftool command not found'
-                        chunk.logger.error(error)
-                        raise RuntimeError(error)
-                    f.close()
             chunk.logger.info('Metadata extraction end')
             
         finally:

--- a/meshroom/nodes/aliceVision/ExtractMetadata.py
+++ b/meshroom/nodes/aliceVision/ExtractMetadata.py
@@ -7,6 +7,7 @@ import distutils.dir_util as du
 import shutil
 import glob
 import os
+import subprocess
 
 
 class ExtractMetadata(desc.Node):
@@ -106,10 +107,10 @@ Using exifTool, this node extracts metadata of all images referenced in a sfmDat
                 else: #xmp
                     cmd = 'exiftool -tagsfromfile ' + iFile + ' ' + chunk.node.arguments.value.strip() + ' ' + oFile
                 chunk.logger.debug(cmd)
-                try:
-                    os.system(cmd)
-                except:
-                    chunk.logger.error("exifTool command failed ! Check that exifTool can be accessed on your system.")
+                error = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE).stderr.read().decode()
+                chunk.logger.debug(error)
+                if error != "":
+                    chunk.logger.error(error)
                     raise RuntimeError(error)
                 if not os.path.exists(oFile):
                     info = 'No metadata extracted for file ' + iFile

--- a/meshroom/nodes/aliceVision/ExtractMetadata.py
+++ b/meshroom/nodes/aliceVision/ExtractMetadata.py
@@ -1,0 +1,124 @@
+__version__ = "0.1"
+
+from meshroom.core import desc
+from meshroom.core.utils import VERBOSE_LEVEL
+
+import distutils.dir_util as du
+import shutil
+import glob
+import os
+
+
+class ExtractMetadata(desc.Node):
+    size = desc.DynamicNodeSize("input")
+
+    category = 'Utils'
+    documentation = '''
+Using exifTool, this node extracts metadata of all images referenced in a sfmData and store them in appropriate files.
+'''
+
+    inputs = [
+        desc.File(
+            name="input",
+            label="Input",
+            description="SfMData file input.",
+            value="",
+        ),
+        desc.BoolParam(
+            name="keepFilename",
+            label="Keep Filename",
+            description="Keep the filename of the inputs for the outputs.",
+            value=False,
+        ),
+        desc.ChoiceParam(
+            name="extension",
+            label="Output File Extension",
+            description="Metadata file extension.",
+            value="txt",
+            values=["txt", "xml", "xmp"],
+            exclusive=True,
+        ),
+        desc.StringParam(
+            name="arguments",
+            label="Arguments",
+            description="ExifTool command arguments",
+            value="",
+        ),
+        desc.ChoiceParam(
+            name="verboseLevel",
+            label="Verbose Level",
+            description="Verbosity level (fatal, error, warning, info, debug, trace).",
+            values=VERBOSE_LEVEL,
+            value="info",
+        ),
+    ]
+
+    outputs = [
+        desc.File(
+            name="output",
+            label="Result Folder",
+            description="Output path for the resulting images.",
+            value=desc.Node.internalFolder,
+        ),
+    ]
+
+    def resolvedPaths(self, inputSfm, outDir, keepFilename, extension):
+        import pyalicevision as av
+        from pathlib import Path
+
+        paths = {}
+        dataAV = av.sfmData.SfMData()
+        if av.sfmDataIO.load(dataAV, inputSfm, av.sfmDataIO.ALL) and os.path.isdir(outDir):
+            views = dataAV.getViews()
+            for id, v in views.items():
+                inputFile = v.getImage().getImagePath()
+                if keepFilename:
+                    outputMetadata = os.path.join(outDir, Path(inputFile).stem + "." + extension)
+                else:
+                    outputMetadata = os.path.join(outDir, str(id) + "." + extension)
+                paths[inputFile] = outputMetadata
+
+        return paths
+
+    def processChunk(self, chunk):
+        try:
+            chunk.logManager.start(chunk.node.verboseLevel.value)
+            
+            if not chunk.node.input:
+                chunk.logger.warning('No image file to process')
+                return
+
+            outFiles = self.resolvedPaths(chunk.node.input.value, chunk.node.output.value, chunk.node.keepFilename.value, chunk.node.extension.value)
+
+            if not outFiles:
+                error = 'ExtractMetadata: input files listed, but no metadata to extract'
+                chunk.logger.error(error)
+                chunk.logger.info('Listed input files: {}'.format([i.value for i in chunk.node.inputFiles.value]))
+                raise RuntimeError(error)
+
+            if not os.path.exists(chunk.node.output.value):
+                os.mkdir(chunk.node.output.value)
+
+            for iFile, oFile in outFiles.items():
+                if chunk.node.extension.value == 'txt':
+                    cmd = 'exiftool ' + chunk.node.arguments.value.strip() + ' ' + iFile + ' > ' + oFile
+                elif chunk.node.extension.value == 'xml':
+                    cmd = 'exiftool -X ' + chunk.node.arguments.value.strip() + ' ' + iFile + ' > ' + oFile
+                else: #xmp
+                    cmd = 'exiftool -tagsfromfile ' + iFile + ' ' + chunk.node.arguments.value.strip() + ' ' + oFile
+                chunk.logger.debug(cmd)
+                os.system(cmd)
+                if not os.path.exists(oFile):
+                    info = 'No metadata extracted for file ' + iFile
+                    chunk.logger.info(info)
+                else:
+                    f = open(oFile)
+                    if f.readline().find('command not found') != -1:
+                        error = 'Metadata cannot be extracted, exiftool command not found'
+                        chunk.logger.error(error)
+                        raise RuntimeError(error)
+                    f.close()
+            chunk.logger.info('Metadata extraction end')
+            
+        finally:
+            chunk.logManager.end()

--- a/meshroom/nodes/aliceVision/ExtractMetadata.py
+++ b/meshroom/nodes/aliceVision/ExtractMetadata.py
@@ -89,6 +89,8 @@ Using exifTool, this node extracts metadata of all images referenced in a sfmDat
                 views = dataAV.getViews()
                 for id, v in views.items():
                     inputFile = v.getImage().getImagePath()
+                    chunk.logger.info(f"Processing {inputFile}")
+
                     if chunk.node.keepFilename.value:
                         outputMetadataFilename = os.path.join(chunk.node.output.value, Path(inputFile).stem + "." + chunk.node.extension.value)
                     else:
@@ -100,9 +102,12 @@ Using exifTool, this node extracts metadata of all images referenced in a sfmDat
                         cmd = 'exiftool -X ' + chunk.node.arguments.value.strip() + ' ' + inputFile + ' > ' + outputMetadataFilename
                     else: #xmp
                         cmd = 'exiftool -tagsfromfile ' + inputFile + ' ' + chunk.node.arguments.value.strip() + ' ' + outputMetadataFilename
+
                     chunk.logger.debug(cmd)
                     error = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE).stderr.read().decode()
+
                     chunk.logger.debug(error)
+                    
                     if error != "":
                         chunk.logger.error(error)
                         raise RuntimeError(error)


### PR DESCRIPTION
<!-- Checklist before submission:

 - I have read the [contribution guidelines](../CONTRIBUTING.md).
 - I have updated the documentation, if applicable.
 - I have ensured that the change is tested somewhere.
 - I have followed the prevailing code style (for history readability and limit conflicts for maintainance).

-->
## Description
This PR adds a pure python node dedicated to extract metadata from image files using exifTool. This node can be connected to the cameraInit node and for all images referenced in the "cameraInit.sfm" file, if exifTool is available, a file containing all metadata is generated. The file format can be selected amongst "txt", "xmp", "xml". Be aware that the "xmp" format cannot store all metadata contained in the image file.

## Features list

<!--
- [ ] Feature one. Fix #XXX
- [ ] Improve something else
- [ ] Connect to #3 (to declare link to issues without closing it when the PR is merged).
- [X] Add "X" when it is done.
-->


## Implementation remarks
The invocated exifTool command depends on the requested file format in the following way:

- "txt": `exiftool [args] imageFile > metadataFile.txt`
- "xml": `exiftool -X [args] imageFile > metadataFile.xml`
- "xmp": `exiftool -tagsfromfile imageFile [args] metadataFile.xmp`

Optional arguments 'args' can be defined through a string parameter of the meshroom node.
The boolean parameter "keepfilename" allows to keep the image file name for the metadata file but changing the file extension.

<!--
Explain main implementation choices.
It is also the right place to ask for feedback and help when you hesitate on the implementation.
-->
