### PR TITLE
Moved Auto-Layout Depth Settings under Graph Editor Menu

### DIFF
--- a/meshroom/ui/qml/Application.qml
+++ b/meshroom/ui/qml/Application.qml
@@ -1160,6 +1160,45 @@ Page {
                                 }
 
                                 Menu {
+                                    title: "Auto Layout Depth"
+
+                                    MenuItem {
+                                        id: autoLayoutMinimum
+                                        text: "Minimum"
+                                        checkable: true
+                                        checked: _reconstruction.layout.depthMode === 0
+                                        ToolTip.text: "Sets the Auto Layout Depth Mode to use Node's Minimum depth"
+                                        ToolTip.visible: hovered
+                                        ToolTip.delay: 200
+                                        onToggled: {
+                                            if (checked) {
+                                                _reconstruction.layout.depthMode = 0;
+                                                autoLayoutMaximum.checked = false;
+                                            }
+                                            // Prevents cases where the user unchecks the currently checked option
+                                            autoLayoutMinimum.checked = true;
+                                        }
+                                    }
+                                    MenuItem {
+                                        id: autoLayoutMaximum
+                                        text: "Maximum"
+                                        checkable: true
+                                        checked: _reconstruction.layout.depthMode === 1
+                                        ToolTip.text: "Sets the Auto Layout Depth Mode to use Node's Maximum depth"
+                                        ToolTip.visible: hovered
+                                        ToolTip.delay: 200
+                                        onToggled: {
+                                            if (checked) {
+                                                _reconstruction.layout.depthMode = 1;
+                                                autoLayoutMinimum.checked = false;
+                                            }
+                                            // Prevents cases where the user unchecks the currently checked option
+                                            autoLayoutMaximum.checked = true;
+                                        }
+                                    }
+                                }
+
+                                Menu {
                                     title: "Refresh Nodes Method"
 
                                     MenuItem {

--- a/meshroom/ui/qml/GraphEditor/GraphEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/GraphEditor.qml
@@ -1064,41 +1064,6 @@ Item {
                 implicitWidth: 1
                 color: activePalette.window
             }
-            // Settings
-            MaterialToolButton {
-                text: MaterialIcons.settings
-                font.pointSize: 11
-                onClicked: menu.open()
-                Menu {
-                    id: menu
-                    y: -height
-                    padding: 4
-                    RowLayout {
-                        spacing: 2
-                        Label {
-                            padding: 2
-                            text: "Auto-Layout Depth:"
-                        }
-                        ComboBox {
-                            flat: true
-                            model: ['Minimum', 'Maximum']
-                            implicitWidth: 85
-                            currentIndex: uigraph ? uigraph.layout.depthMode : -1
-                            onActivated: {
-                                uigraph.layout.depthMode = currentIndex
-                            }
-                        }
-                    }
-                }
-            }
-
-            // Separator
-            Rectangle {
-                Layout.fillHeight: true
-                Layout.margins: 2
-                implicitWidth: 1
-                color: activePalette.window
-            }
 
             ColorSelector {
                 id: colorSelector


### PR DESCRIPTION
## Description
This PR changes the placement of the Auto-Layout Depth setting and moving it under the Graph Editor Menu.
Removing the existing setting from the Floating panel makes the floating panel a little less obtrusive.
