### PR TITLE
[ui][fix] Edge: Fixing an issue with mouse event on Custom EdgeMouseArea causing Crash

### DIFF
--- a/meshroom/ui/components/edge.py
+++ b/meshroom/ui/components/edge.py
@@ -17,7 +17,7 @@ class MouseEvent(QObject):
     x = Property(float, lambda self: self._x, constant=True)
     y = Property(float, lambda self: self._y, constant=True)
     button = Property(Qt.MouseButton, lambda self: self._button, constant=True)
-    modifiers = Property(int, lambda self: self._modifiers, constant=True)
+    modifiers = Property(Qt.KeyboardModifier, lambda self: self._modifiers, constant=True)
 
 
 class EdgeMouseArea(QQuickItem):
@@ -47,8 +47,8 @@ class EdgeMouseArea(QQuickItem):
         self.setContainsMouse(False)
         super(EdgeMouseArea, self).hoverLeaveEvent(evt)
 
-    def geometryChanged(self, newGeometry, oldGeometry):
-        super(EdgeMouseArea, self).geometryChanged(newGeometry, oldGeometry)
+    def geometryChange(self, newGeometry, oldGeometry):
+        super(EdgeMouseArea, self).geometryChange(newGeometry, oldGeometry)
         self.updateShape()
 
     def mousePressEvent(self, evt):

--- a/meshroom/ui/qml/GraphEditor/Edge.qml
+++ b/meshroom/ui/qml/GraphEditor/Edge.qml
@@ -138,6 +138,7 @@ Item {
         anchors.fill: parent
         acceptedButtons: Qt.LeftButton | Qt.RightButton
         thickness: root.thickness + 4
+        curveScale: cubic.ctrlPtDist / root.width  // Normalize by width
         onPressed: function(event) {
             root.pressed(event)
         }
@@ -145,11 +146,5 @@ Item {
             root.released(event)
         }
 
-        Component.onCompleted: {
-            /* The curve scale must be set only once the component has been fully created, so
-             * that all the events following the update of the curve scale can be taken into
-             * account. */
-            curveScale = cubic.ctrlPtDist / root.width  // Normalize by width
-        }
     }
 }

--- a/meshroom/ui/qml/GraphEditor/Edge.qml
+++ b/meshroom/ui/qml/GraphEditor/Edge.qml
@@ -149,7 +149,7 @@ Item {
             /* The curve scale must be set only once the component has been fully created, so
              * that all the events following the update of the curve scale can be taken into
              * account. */
-            curveScale = Qt.binding(() => cubic.ctrlPtDist / root.width)  // Normalize by width
+            curveScale = cubic.ctrlPtDist / root.width  // Normalize by width
         }
     }
 }


### PR DESCRIPTION
~~Event::button() was sometimes causing a crash, copying the event and using event.buttons() from the copied event seems to be stable before calling event.button() eventually~~
## Description
This PR addresses a known crash issue with the EdgeMouseArea (QQuickItem)'s mousePressEvent.
The crash occurs when querying button() from the event.
The event is not null and is able to provide other data correctly before ending up crashing when queried for button.

## Features list
- [X] Fix UpdateShape to get invoked on geometryChange
- [X] Fix Alt + Mouse Click to Remove an Edge due to a change in data type for Keyboard Modifiers from int to enum.Flag
- [ ] Fix Crash on clicking egde multiple times


## Implementation remarks
~~Current Fix is based on copying the provided event and calling event.buttons() to check if the buttons are supported and then calling button() is the custom MouseEvent constructor.~~
This seems to have stopped the crashes for now, but still testing on larger scale is pending before we confirm anything.
<!--
Explain main implementation choices.
It is also the right place to ask for feedback and help when you hesitate on the implementation.
-->
