### PR TITLE
[ImageGallery] Intrinsics table: Always fully instantiate the model before populating it

### DIFF
--- a/meshroom/ui/qml/ImageGallery/ImageGallery.qml
+++ b/meshroom/ui/qml/ImageGallery/ImageGallery.qml
@@ -75,6 +75,11 @@ Panel {
     }
 
     function populate_model() {
+        if (!intrinsicModel.ready) {
+            // If the TableModel is not done being instantiated, do nothing
+            return
+        }
+
         intrinsicModel.clear()
         for (var intr in parsedIntrinsic) {
             intrinsicModel.appendRow(parsedIntrinsic[intr])
@@ -569,6 +574,8 @@ Panel {
 
             TableModel {
                 id : intrinsicModel
+                property bool ready: false
+
                 // Hardcoded default width per column
                 property var columnWidths: [105, 75, 75, 75, 60, 60, 60, 60, 200, 60, 60, 60]
                 property var columnNames: [
@@ -599,6 +606,13 @@ Panel {
                 TableModelColumn { display: function(modelIndex){return parsedIntrinsic[modelIndex.row][intrinsicModel.columnNames[10]]} }
                 TableModelColumn { display: function(modelIndex){return parsedIntrinsic[modelIndex.row][intrinsicModel.columnNames[11]]} }
                 //https://doc.qt.io/qt-5/qml-qt-labs-qmlmodels-tablemodel.html#appendRow-method
+
+                Component.onCompleted: {
+                    ready = true
+                    // Triggers "populate_model" in case the intrinsics have been filled while the model was
+                    // being instantiated
+                    root.populate_model()
+                }
             }
 
             //CODE FOR HEADERS

--- a/meshroom/ui/qml/ImageGallery/ImageGallery.qml
+++ b/meshroom/ui/qml/ImageGallery/ImageGallery.qml
@@ -557,8 +557,10 @@ Panel {
                 anchors.fill: parent
                 boundsMovement : Flickable.StopAtBounds
 
-                //Provide width for column
-                //Note no size provided for the last column (bool comp) so it uses its automated size
+                palette: root.palette
+
+                // Provide width for column
+                // Note no size provided for the last column (bool comp) so it uses its automated size
                 columnWidthProvider: function (column) { return intrinsicModel.columnWidths[column] }
 
                 model: intrinsicModel

--- a/meshroom/ui/qml/ImageGallery/ImageGallery.qml
+++ b/meshroom/ui/qml/ImageGallery/ImageGallery.qml
@@ -2,7 +2,7 @@ import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
 import QtQml.Models
-import Qt.labs.qmlmodels 1.0
+import Qt.labs.qmlmodels
 
 import Controls 1.0
 import MaterialIcons 2.2

--- a/meshroom/ui/qml/ImageGallery/IntrinsicDisplayDelegate.qml
+++ b/meshroom/ui/qml/ImageGallery/IntrinsicDisplayDelegate.qml
@@ -67,12 +67,12 @@ RowLayout {
             width: intrinsicModel.columnWidths[columnIndex]
             horizontalAlignment: TextInput.AlignRight
             readOnly: root.readOnly
-            color: 'white'
+            color: palette.text
 
             padding: 12
 
             selectByMouse: true
-            selectionColor: 'white'
+            selectionColor: palette.text
             selectedTextColor: Qt.darker(palette.window, 1.1)
 
             onEditingFinished: _reconstruction.setAttribute(attribute, text)
@@ -93,13 +93,13 @@ RowLayout {
             text: model.display.value
             width: intrinsicModel.columnWidths[columnIndex]
             horizontalAlignment: TextInput.AlignRight
-            color: 'white'
+            color: palette.text
             readOnly: root.readOnly
 
             padding: 12
 
             selectByMouse: true
-            selectionColor: 'white'
+            selectionColor: palette.text
             selectedTextColor: Qt.darker(palette.window, 1.1)
 
             IntValidator {
@@ -164,11 +164,11 @@ RowLayout {
             width: intrinsicModel.columnWidths[columnIndex]
             horizontalAlignment: TextInput.AlignRight
 
-            color: 'white'
+            color: palette.text
             padding: 12
 
             selectByMouse: true
-            selectionColor: 'white'
+            selectionColor: palette.text
             selectedTextColor: Qt.darker(palette.window, 1.1)
 
             readOnly: root.readOnly


### PR DESCRIPTION
## Description

This pull request fixes a crash that occurred when the Application view of Meshroom was being displayed without displaying the Homepage beforehand (e.g. when opening a file at Meshroom's launch with the command line, when switching from one color palette to another, when using the QML hot reload).

Under these conditions, the `TableModel` containing the intrinsics was being filled (with attempts to add rows) before the component itself had been fully instantiated.

We now forbid the model to be populated unless the component is ready. Additionally, we now use Meshroom's palette to set the color of the intrinsics attributes in the `TableView` instead of hardcoding them to "white".

## Implementations remarks

The `TableModel` for intrinsics now has a `ready` property that is set to `true` only once its `Component.onCompleted` has been triggered. 

At that moment, we manually call `populate_model()` to cover cases where the intrinsics have been fully parsed while the model was being instantiated and thus could not be populated.