### PR TITLE
UI: Redesign ChoiceParam UI component

### DIFF
--- a/meshroom/ui/qml/Controls/FilterComboBox.qml
+++ b/meshroom/ui/qml/Controls/FilterComboBox.qml
@@ -74,7 +74,6 @@ ComboBox {
 
     popup.contentItem: ColumnLayout {
         width: parent.width
-        Layout.maximumHeight: root.Window.height
         spacing: 0
 
         RowLayout {
@@ -120,6 +119,8 @@ ComboBox {
         ScrollView {
             Layout.fillWidth: true
             Layout.fillHeight: true
+            ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
+
             ListView {
                 implicitHeight: contentHeight
                 clip: true

--- a/meshroom/ui/qml/Controls/FilterComboBox.qml
+++ b/meshroom/ui/qml/Controls/FilterComboBox.qml
@@ -1,177 +1,134 @@
 import QtQuick
 import QtQuick.Controls
-
+import QtQuick.Layouts
 import Utils 1.0
 
+import MaterialIcons
+
 /**
-* ComboBox with filter text area
-*
-* @param inputModel - model to filter
-* @param editingFinished - signal emitted when editing is finished
-* @alias filterText - text to filter the model
+* ComboBox with filtering capabilities and support for custom values (i.e: outside the source model).
 */
 
 ComboBox {
-    id: combo
+    id: root
 
-    property var inputModel
+    // Model to populate the combobox.
+    required property var sourceModel
+    // Input value to use as the current combobox value.
+    property var inputValue
+    // The text to filter the combobox model when the choices are displayed.
+    property alias filterText: filterTextArea.text
+    // Whether the current input value is within the source model.
+    readonly property bool validValue: sourceModel.includes(inputValue)
+
     signal editingFinished(var value)
 
-    property alias filterText: filterTextArea
-    property bool validValue: true
+    function clearFilter() {
+        filterText = "";
+    }
 
-    enabled: root.editable
+    // Re-computing current index when source values are set.
+    Component.onCompleted: _updateCurrentIndex()
+    onInputValueChanged: _updateCurrentIndex()
+    onModelChanged: _updateCurrentIndex()
+
+    function _updateCurrentIndex() {
+        currentIndex = find(inputValue);
+    }
+
+    displayText: inputValue
+
     model: {
-        var filteredData = inputModel.filter(condition => {
-                                            if (filterTextArea.text.length > 0) return condition.toString().toLowerCase().includes(filterTextArea.text.toLowerCase())
-                                            return true
-                                        })
-        if (filteredData.length > 0) {
-            filterTextArea.background.color = Qt.lighter(palette.base, 2)
-            validValue = true
-
-            // order filtered data by relevance (results that start with the filter text come first)
-            filteredData.sort((a, b) => {
-                const nameA = a.toString().toLowerCase();
-                const nameB = b.toString().toLowerCase();
-                const filterText = filterTextArea.text.toLowerCase()
-                if (nameA.startsWith(filterText) && !nameB.startsWith(filterText))
-                    return -1
-                if (!nameA.startsWith(filterText) && nameB.startsWith(filterText))
-                    return 1
-                return 0
-            })
-        } else {
-            filterTextArea.background.color = Colors.red
-            validValue = false
-        }
-
-        if (filteredData.length == 0 || filterTextArea.length == 0) {
-            filteredData = inputModel
-        } 
-
-        return filteredData
+        return sourceModel.filter(item => {
+            return item.toString().toLowerCase().includes(filterText.toLowerCase());
+        });
     }
 
-    background: Rectangle {
-        implicitHeight: root.implicitHeight
-        color: {
-            if (validValue) {
-                return palette.mid
-            } else {
-                return Colors.red
-            }
+    popup.onClosed: clearFilter()
+
+    // Allows typing into the filter text area while the combobox has focus.
+    Keys.forwardTo: [filterTextArea]
+
+    onActivated: index => {
+        const isValidEntry = model.length > 0;
+        if (!isValidEntry) {
+            return;
         }
-        border.color: palette.base
+        editingFinished(model[index]);
     }
 
-    popup: Popup {
-        width: combo.width
-        implicitHeight: contentItem.implicitHeight 
-
-        onAboutToShow: {
-            filterTextArea.forceActiveFocus()
-
-            if (mapToGlobal(popup.x, popup.y).y + root.implicitHeight * (model.length + 1) > _window.contentItem.height) {
-                y = -((combo.height * (combo.model.length + 1) > _window.contentItem.height) ? _window.contentItem.height*2/3 : combo.height * (combo.model.length + 1))
-            } else {
-                y = 0
+    StateGroup {
+        id: filterState
+        // Override properties depending on filter text status.
+        states: [
+            State {
+                name: "Invalid"
+                when: root.delegateModel.count === 0
+                PropertyChanges {
+                    target: filterTextArea
+                    color: Colors.orange
+                }
             }
-        }
+        ]
+    }
 
-        contentItem: Item {
-            anchors.fill: parent
-            TextArea {
+    popup.contentItem: ColumnLayout {
+        width: parent.width
+        Layout.maximumHeight: root.Window.height
+        spacing: 0
+
+        RowLayout {
+            Layout.fillWidth: true
+            spacing: 2
+
+            TextField {
                 id: filterTextArea
-                leftPadding: 12
-                anchors.left: parent.left
-                anchors.right: parent.right
-                anchors.top: parent.top
-
-                selectByMouse: true
-                hoverEnabled: true
-                wrapMode: TextEdit.WrapAnywhere
-                placeholderText: "Filter"
-                background: Rectangle {}
-
-                onEditingFinished: {
-                    combo.popup.close()
-                    combo.editingFinished(displayText)
+                placeholderText: "Type to filter..."
+                Layout.fillWidth: true
+                leftPadding: 18
+                MouseArea {
+                    // Prevent textfield from stealing combobox's active focus, without disabling it.
+                    anchors.fill: parent
                 }
-
-                Keys.onEnterPressed: {
-                    if (!validValue) {
-                        displayText = filterTextArea.text
-                    } else {
-                        displayText = currentText
-                    }
-                    editingFinished()
-                }
-
-                Keys.onReturnPressed: {
-                    if (!validValue) {
-                        displayText = filterTextArea.text
-                    } else {
-                        displayText = currentText
-                    }
-                    editingFinished()
-                }
-
-                Keys.onUpPressed: {
-                    // if the current index is 0, the user wants to go to the last item
-                    if (combo.currentIndex == 0) {
-                        combo.currentIndex = combo.model.length - 1
-                    } else {
-                        combo.currentIndex--
+                background: Item {
+                    MaterialLabel {
+                        anchors.verticalCenter: parent.verticalCenter
+                        anchors.left: parent.left
+                        anchors.leftMargin: 2
+                        text: MaterialIcons.search
                     }
                 }
+            }
 
-                Keys.onDownPressed: {
-                    // if the current index is the last one, the user wants to go to the first item
-                    if (combo.currentIndex == combo.model.length - 1) {
-                        combo.currentIndex = 0
-                    } else {
-                        combo.currentIndex++
-                    }
+            MaterialToolButton {
+                enabled: root.filterText !== ""
+                text: MaterialIcons.add_task
+                ToolTip.text: "Force custom value"
+                onClicked: {
+                    editingFinished(root.filterText);
+                    root.popup.close();
                 }
             }
         }
 
-        ListView {
-            id: listView
-            clip: true
-            anchors.left: parent.left
-            anchors.right: parent.right
-            anchors.top: filterTextArea.bottom
-
-            implicitHeight: (combo.height * (combo.model.length + 1) > _window.contentItem.height) ? _window.contentItem.height*2/3 : contentHeight
-            model: combo.popup.visible ? combo.delegateModel : null
-
-            ScrollBar.vertical: MScrollBar {}
-        }
-    }
-
-    delegate: ItemDelegate {
-        width: combo.width
-        height: combo.height
-
-        contentItem: Text {
-            text: modelData
-            color: palette.text
+        Rectangle {
+            height: 1
+            Layout.fillWidth: true
+            color: Colors.sysPalette.mid
         }
 
-        highlighted: validValue ? combo.currentIndex === index : false
+        ScrollView {
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+            ListView {
+                implicitHeight: contentHeight
+                clip: true
 
-        hoverEnabled: true
-    }
-
-    onHighlightedIndexChanged: {
-        if (highlightedIndex >= 0) {
-            combo.currentIndex = highlightedIndex
+                model: root.delegateModel
+                highlightRangeMode: ListView.ApplyRange
+                currentIndex: root.highlightedIndex
+                ScrollBar.vertical: ScrollBar {}
+            }
         }
-    }
-
-    onCurrentTextChanged: {
-        displayText = currentText
     }
 }

--- a/meshroom/ui/qml/GraphEditor/AttributeControls/Choice.qml
+++ b/meshroom/ui/qml/GraphEditor/AttributeControls/Choice.qml
@@ -1,0 +1,34 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+import MaterialIcons
+import Controls
+
+/**
+ * A combobox-type control with a single current `value` and a list of possible `values`.
+ * Provides filtering capabilities and support for custom values (i.e: `value` not in `values`).
+ */
+RowLayout {
+    id: root
+
+    required property var value
+    required property var values
+
+    signal editingFinished(var value)
+
+    FilterComboBox {
+        id: comboBox
+
+        Layout.fillWidth: true
+        sourceModel: root.values
+        inputValue: root.value
+        onEditingFinished: value => root.editingFinished(value)
+    }
+
+    MaterialLabel {
+        visible: !comboBox.validValue
+        text: MaterialIcons.warning
+        ToolTip.text: "Custom value detected"
+    }
+}

--- a/meshroom/ui/qml/GraphEditor/AttributeControls/ChoiceMulti.qml
+++ b/meshroom/ui/qml/GraphEditor/AttributeControls/ChoiceMulti.qml
@@ -1,0 +1,41 @@
+import QtQuick
+import QtQuick.Controls
+import Controls
+
+/**
+ * A multi-checkboxes control with a current `value` (list of 0-N elements) and a list of possible `values`.
+ * Provides support for custom values (`value` elements not in `values`).
+ */
+Flow {
+    id: root
+
+    required property var value
+    required property var values
+    property color customValueColor: "orange"
+
+    signal toggled(var value, var checked)
+
+    // Predefined possible values.
+    Repeater {
+        model: root.values
+        delegate: CheckBox {
+            text: modelData
+            checked: root.value.includes(modelData)
+            onToggled: root.toggled(modelData, checked)
+        }
+    }
+
+    // Custom elements outside the predefined possible values.
+    Repeater {
+        model: root.value.filter(v => !root.values.includes(v))
+        delegate: CheckBox {
+            text: modelData
+            palette.text: root.customValueColor
+            font.italic: true
+            checked: true
+            ToolTip.text: "Custom value"
+            ToolTip.visible: hovered
+            onToggled: root.toggled(modelData, checked)
+        }
+    }
+}

--- a/meshroom/ui/qml/GraphEditor/AttributeItemDelegate.qml
+++ b/meshroom/ui/qml/GraphEditor/AttributeItemDelegate.qml
@@ -209,7 +209,7 @@ RowLayout {
                 case "PushButtonParam":
                     return pushButtonComponent
                 case "ChoiceParam":
-                    return attribute.desc.exclusive ? choiceComponent : multiChoiceComponent
+                    return attribute.desc.exclusive ? choiceComponent : choiceMultiComponent
                 case "IntParam": return sliderComponent
                 case "FloatParam":
                     if (attribute.desc.semantic === 'color/hue')
@@ -484,25 +484,21 @@ RowLayout {
         }
 
         Component {
-            id: multiChoiceComponent
-            Flow {
-                Repeater {
-                    id: checkboxRepeater
-                    model: attribute.values
-                    delegate: CheckBox {
-                        enabled: root.editable
-                        text: modelData
-                        checked: attribute.value.indexOf(modelData) >= 0
-                        onToggled: {
-                            var t = attribute.value
-                            if (!checked) {
-                                t.splice(t.indexOf(modelData), 1)  // Remove element
-                            } else {
-                                t.push(modelData)  // Add element
-                            }
-                            _reconstruction.setAttribute(attribute, t)
-                        }
+            id: choiceMultiComponent
+
+            AttributeControls.ChoiceMulti {
+                value: root.attribute.value
+                values: root.attribute.values
+                enabled: root.editable
+                customValueColor: Colors.orange
+                onToggled: (value, checked) => {
+                    var currentValue = root.attribute.value;
+                    if (!checked) {
+                        currentValue.splice(currentValue.indexOf(value), 1);
+                    } else {
+                        currentValue.push(value);
                     }
+                    _reconstruction.setAttribute(attribute, currentValue);
                 }
             }
         }

--- a/meshroom/ui/qml/GraphEditor/AttributeItemDelegate.qml
+++ b/meshroom/ui/qml/GraphEditor/AttributeItemDelegate.qml
@@ -6,6 +6,7 @@ import QtQuick.Dialogs
 import MaterialIcons 2.2
 import Utils 1.0
 import Controls 1.0
+import "AttributeControls" as AttributeControls
 
 /**
  * Instantiate a control to visualize and edit an Attribute based on its type.
@@ -208,7 +209,7 @@ RowLayout {
                 case "PushButtonParam":
                     return pushButtonComponent
                 case "ChoiceParam":
-                    return attribute.desc.exclusive ? comboBoxComponent : multiChoiceComponent
+                    return attribute.desc.exclusive ? choiceComponent : multiChoiceComponent
                 case "IntParam": return sliderComponent
                 case "FloatParam":
                     if (attribute.desc.semantic === 'color/hue')
@@ -469,26 +470,15 @@ RowLayout {
         }
 
         Component {
-            id: comboBoxComponent
+            id: choiceComponent
 
-            RowLayout {
-                FilterComboBox {
-                    id: comboBox
+            AttributeControls.Choice {
+                value: root.attribute.value
+                values: root.attribute.values
+                enabled: root.editable
 
-                    Layout.fillWidth: true
-
-                    enabled: root.editable
-                    sourceModel: attribute.values
-                    inputValue: attribute.value
-
-                    onEditingFinished: (value) => {
-                        _reconstruction.setAttribute(attribute, value)
-                    }
-                }
-                MaterialLabel {
-                    visible: !comboBox.validValue
-                    text: MaterialIcons.warning
-                    ToolTip.text: "Custom value detected"
+                onEditingFinished: (value) => {
+                    _reconstruction.setAttribute(root.attribute, value)
                 }
             }
         }

--- a/meshroom/ui/qml/GraphEditor/AttributeItemDelegate.qml
+++ b/meshroom/ui/qml/GraphEditor/AttributeItemDelegate.qml
@@ -471,41 +471,24 @@ RowLayout {
         Component {
             id: comboBoxComponent
 
-            FilterComboBox {
-                inputModel: attribute.values
+            RowLayout {
+                FilterComboBox {
+                    id: comboBox
 
-                Component.onCompleted: {
-                    // If value not in list, override the text and precise it is not valid
-                    var idx = find(attribute.value)
-                    if (idx === -1) {
-                        displayText = attribute.value
-                        validValue = false
-                    } else {
-                        currentIndex = idx
+                    Layout.fillWidth: true
+
+                    enabled: root.editable
+                    sourceModel: attribute.values
+                    inputValue: attribute.value
+
+                    onEditingFinished: (value) => {
+                        _reconstruction.setAttribute(attribute, value)
                     }
                 }
-
-                onEditingFinished: function(value) {
-                    _reconstruction.setAttribute(attribute, value)
-                }
-
-                Connections {
-                    target: attribute
-                    function onValueChanged() {
-                        // When reset, clear and find the current index
-                        // but if only reopen the combo box, keep the current value
-                        
-                        // Convert all values of desc values as string
-                        var valuesAsString = attribute.values.map(function(value) {
-                            return value.toString()
-                        })
-                        if (valuesAsString.includes(attribute.value) || attribute.value === attribute.desc.value) {
-                            filterText.clear()
-                            validValue = true
-                            displayText = currentText
-                            currentIndex = find(attribute.value) 
-                        }
-                    }
+                MaterialLabel {
+                    visible: !comboBox.validValue
+                    text: MaterialIcons.warning
+                    ToolTip.text: "Custom value detected"
                 }
             }
         }


### PR DESCRIPTION
## Description
Re-design the UI control for editing a ChoiceParam.

### Exclusive ChoiceParam
The exclusive ChoiceParam component has been resigned to address multiple issues with the current controls.

#### Before
##### Behavior
![combo_current](https://github.com/user-attachments/assets/50ebd60a-3bba-46aa-af2a-62a37985ada0)
##### Custom Value indicator
![image](https://github.com/user-attachments/assets/d52f5b19-ce2f-47be-9fe0-b2206c128861)

#### After (this PR)
##### Behavior
![combo_new](https://github.com/user-attachments/assets/62bd6383-5d2a-44e5-8951-8acbd2c7cc4c)

##### Custom value indicator
![image](https://github.com/user-attachments/assets/0e5381d1-61ed-4f6c-a662-24091cd09c00)

### Non-exclusive ChoiceParam
This component has been redesigned to display custom values outside the range of possible values.
That may happen when a node description is modified and potentially discard already serialized value in existing scenes.
![image](https://github.com/user-attachments/assets/891c11df-0b51-430f-8b7f-dc73fcfa8107)

This can be tried out by pasting this code snippet in Meshroom's script editor:
```python
from meshroom.ui import uiInstance

graph = uiInstance.activeProject
node = graph.addNewNode("FeatureExtraction")
graph.selectedNode = node

graph.setAttribute(node.describerTypes, ["other", "custom"])
```

## Features list

### Exclusive ChoiceParam
- [X] Make custom value setting from filter an explicit action.
- [X] Use a less error-looking UI for indicating the use of a custom value.
- [X] Fix value being changed on non explicit actions (eg: when clicking outside the selection popup to discard it).
- [X] Fix incorrect value being displayed in the UI compared to the actual attribute value (eg: after an undo).

### Non exclusive ChoiceParam
- [X] Enable support to display/edit value elements outside the list of possible values.

## Implementation remarks

### FilterComboBox
Rely as much as possible on the behaviors provided by the default ComboBox component to avoid custom logic for e.g keyboard navigation.
Move away from imperative code for handling value binding, simplifying the usage of the FilterComboBox component and making sure that the displayed value is always reflecting the actual attribute's value. 
Simplify the filtering logic.

### AttributeControls
Introduce a new subfolder (`AttributeControls`) to host the controls to view and edit attributes, in order to reduce the complexity of  `AttributeItemDelegate.qml`.