### PR TITLE
Node: Propagate attribute change via `valueChanged` signal

### DIFF
--- a/meshroom/core/node.py
+++ b/meshroom/core/node.py
@@ -980,7 +980,7 @@ class BaseNode(BaseObject):
         if self.graph:
             # If we are in a graph, propagate the notification to the connected output attributes
             for edge in self.graph.outEdges(attr):
-                edge.dst.node._onAttributeChanged(edge.dst)
+                edge.dst.valueChanged.emit()
 
     def onAttributeClicked(self, attr):
         """ When an attribute is clicked, a specific function can be defined in the descriptor and be called.


### PR DESCRIPTION
## Description
Improve propagation of attribute value change signals to get proper UI update.

### Before
![attribute_update_downstream](https://github.com/user-attachments/assets/f0ccf0d3-a938-4a69-a851-f51cf13e7644)
### After
![attribute_update_downstream_new](https://github.com/user-attachments/assets/04551649-9ecf-43cf-9de3-bdaccbb3e2c8)

### Alternative node debug display to better visualize what problem is being solved:
![attribute_update_downstream_before_after](https://github.com/user-attachments/assets/766c4505-7396-4c72-9649-192ce79ae5da)

## Features list

<!--
- [ ] Feature one. Fix #XXX
- [ ] Improve something else
- [ ] Connect to #3 (to declare link to issues without closing it when the PR is merged).
- [X] Add "X" when it is done.
-->


## Implementation remarks

Propagate attribute value changes downstream using `valueChanged` signal emission, instead of calling `_onAttributeChanged` directly. 
This does not change the current core behavior, but it triggers the property notification signal when in UI mode.
This makes changes happening upstream properly reflected in downstream nodes.

