### PR TITLE
[core] ListAttribute: fix methods not considering connected value

### DIFF
--- a/meshroom/core/attribute.py
+++ b/meshroom/core/attribute.py
@@ -502,12 +502,12 @@ class ListAttribute(Attribute):
         super(ListAttribute, self).__init__(node, attributeDesc, isOutput, root, parent)
 
     def __len__(self):
-        if self._value is None:
+        if self.value is None:
             return 0
-        return len(self._value)
+        return len(self.value)
 
     def __iter__(self):
-        return iter(self._value)
+        return iter(self.value)
 
     def getBaseType(self):
         return self.attributeDesc.elementDesc.__class__.__name__
@@ -516,10 +516,10 @@ class ListAttribute(Attribute):
         """ Returns child attribute at index 'idx' """
         # Implement 'at' rather than '__getitem__'
         # since the later is called spuriously when object is used in QML
-        return self._value.at(idx)
+        return self.value.at(idx)
 
     def index(self, item):
-        return self._value.indexOf(item)
+        return self.value.indexOf(item)
 
     def initValue(self):
         self.resetToDefaultValue()

--- a/tests/test_listAttribute.py
+++ b/tests/test_listAttribute.py
@@ -1,0 +1,63 @@
+from meshroom.core import desc
+from meshroom.core.graph import Graph
+from meshroom.core import registerNodeType, unregisterNodeType
+
+
+class NodeWithListAttribute(desc.Node):
+    inputs = [
+        desc.ListAttribute(
+            name="listInput",
+            label="List Input",
+            description="ListAttribute of StringParams.",
+            elementDesc=desc.StringParam(name="value", label="Value", description="", value=""),
+        )
+    ]
+
+
+class TestListAttribute:
+
+    @classmethod
+    def setup_class(cls):
+        registerNodeType(NodeWithListAttribute)
+
+    @classmethod
+    def teardown_class(cls):
+        unregisterNodeType(NodeWithListAttribute)
+
+    def test_lengthUsesLinkParam(self):
+        graph = Graph("")
+
+        nodeA = graph.addNewNode(NodeWithListAttribute.__name__)
+        nodeB = graph.addNewNode(NodeWithListAttribute.__name__)
+
+        graph.addEdge(nodeA.listInput, nodeB.listInput) 
+
+        nodeA.listInput.append("test")
+
+        assert len(nodeB.listInput) == 1
+
+    def test_iterationUsesLinkParam(self):
+        graph = Graph("")
+
+        nodeA = graph.addNewNode(NodeWithListAttribute.__name__)
+        nodeB = graph.addNewNode(NodeWithListAttribute.__name__)
+
+        graph.addEdge(nodeA.listInput, nodeB.listInput) 
+
+        nodeA.listInput.extend(["A", "B", "C"])
+
+        for value in nodeB.listInput:
+            assert value.node == nodeA
+
+    def test_elementAccessUsesLinkParam(self):
+        graph = Graph("")
+
+        nodeA = graph.addNewNode(NodeWithListAttribute.__name__)
+        nodeB = graph.addNewNode(NodeWithListAttribute.__name__)
+
+        graph.addEdge(nodeA.listInput, nodeB.listInput) 
+
+        nodeA.listInput.extend(["A", "B", "C"])
+
+        assert nodeB.listInput.at(0).node == nodeA
+        assert nodeB.listInput.index(nodeB.listInput.at(0)) == 0


### PR DESCRIPTION
## Description
Fix ListAttribute methods not considering linked ListAttribute value when connected.

## Features list

- [X] Fix `__len__`, `__iter__`, `at` and `index` methods to consider linked value.


## Implementation remarks
Use `value` property in those methods, that will consider the linked ListAttribute value if the attribute is connected.