### PR TITLE
[ui] Edge: Workaround on the Crash due to Edge Connections

### DIFF
--- a/meshroom/ui/components/edge.py
+++ b/meshroom/ui/components/edge.py
@@ -1,4 +1,4 @@
-from PySide6.QtCore import Signal, Property, QPointF, Qt, QObject
+from PySide6.QtCore import Signal, Slot, Property, QPointF, Qt, QObject
 from PySide6.QtGui import QPainterPath, QVector2D
 from PySide6.QtQuick import QQuickItem
 
@@ -51,19 +51,6 @@ class EdgeMouseArea(QQuickItem):
         super(EdgeMouseArea, self).geometryChange(newGeometry, oldGeometry)
         self.updateShape()
 
-    def mousePressEvent(self, evt):
-        if not self.acceptedMouseButtons() & evt.button():
-            evt.setAccepted(False)
-            return
-        e = MouseEvent(evt)
-        self.pressed.emit(e)
-        e.deleteLater()
-
-    def mouseReleaseEvent(self, evt):
-        e = MouseEvent(evt)
-        self.released.emit(e)
-        e.deleteLater()
-
     def updateShape(self):
         p1 = QPointF(0, 0)
         p2 = QPointF(self.width(), self.height())
@@ -109,6 +96,10 @@ class EdgeMouseArea(QQuickItem):
             return
         self._containsMouse = value
         self.containsMouseChanged.emit()
+
+    @Slot(QPointF, result=bool)
+    def containsPoint(self, point):
+        return self.contains(point)
 
     thicknessChanged = Signal()
     thickness = Property(float, getThickness, setThickness, notify=thicknessChanged)

--- a/meshroom/ui/qml/GraphEditor/Edge.qml
+++ b/meshroom/ui/qml/GraphEditor/Edge.qml
@@ -139,12 +139,35 @@ Item {
         acceptedButtons: Qt.LeftButton | Qt.RightButton
         thickness: root.thickness + 4
         curveScale: cubic.ctrlPtDist / root.width  // Normalize by width
+    }
+
+    MouseArea {
+        x: Math.min(0, root.width)
+        y: Math.min(0, root.height)
+        height: Math.abs(root.height)
+        width: Math.abs(root.width)
+        acceptedButtons: Qt.LeftButton | Qt.RightButton
+
         onPressed: function(event) {
-            root.pressed(event)
-        }
-        onReleased: function(event) {
-            root.released(event)
+            let xpos = root.width < 0 ? root.height + event.x : event.x;
+            let ypos = root.height < 0 ? root.height + event.y: event.y;
+            if (edgeArea.containsPoint(Qt.point(xpos, ypos))) {
+                root.pressed(event);
+            }
+            else {
+                event.accepted = false;
+            }
         }
 
+        onReleased: function(event) {
+            let xpos = root.width < 0 ? root.height + event.x : event.x;
+            let ypos = root.height < 0 ? root.height + event.y: event.y;
+            if (edgeArea.containsPoint(Qt.point(xpos, ypos))) {
+                root.released(event);
+            }
+            else {
+                event.accepted = false;
+            }
+        }
     }
 }


### PR DESCRIPTION
## Description
This PR addresses a crash issue by working around the issue of querying buttons for the MouseEvent.
**MouseEvent::button()** or **MouseEvent::buttons()** on the `mousePressEvent` or in the `Custom MouseEvent` was causing crashes  some times when an event provided has issues.
While the underlying issues at this point are not clear, it is evident that the crash is happening due to the PySide binding.
A similar implementation was tested on the C++ side which seems to be working fine.


## Features list
[X] Workaround for edge crashing by implementing a Mouse Area which checks the pressed point to exist on the edge before emitting a pressed/released event.


## Implementation remarks
* This PR introduces a MouseArea which follows the edge, any clicks on the mouse area checks if the point exists on the edgeArea, if so a relevant pressed/released event gets triggered, else the event is ignored.

<!--
Explain main implementation choices.
It is also the right place to ask for feedback and help when you hesitate on the implementation.
-->
