### PR TITLE
Create new pipeline for testing modular sfm

### DIFF
--- a/meshroom/nodes/aliceVision/SfMPoseInjecting.py
+++ b/meshroom/nodes/aliceVision/SfMPoseInjecting.py
@@ -50,6 +50,6 @@ Use a JSON file to inject poses inside the SfMData.
             name="output",
             label="SfMData",
             description="Path to the output SfM file.",
-            value=desc.Node.internalFolder + "sfmData.sfm",
+            value=desc.Node.internalFolder + "sfmData.abc",
         ),
     ]

--- a/meshroom/nodes/aliceVision/SfmBootstraping.py
+++ b/meshroom/nodes/aliceVision/SfmBootstraping.py
@@ -79,6 +79,6 @@ class SfMBootStraping(desc.AVCommandLineNode):
             name="output",
             label="SfMData",
             description="Path to the output SfMData file.",
-            value=desc.Node.internalFolder + "sfm.json",
+            value=desc.Node.internalFolder + "bootstrap.abc",
         ),
     ]

--- a/meshroom/nodes/aliceVision/SfmExpanding.py
+++ b/meshroom/nodes/aliceVision/SfmExpanding.py
@@ -170,6 +170,6 @@ class SfMExpanding(desc.AVCommandLineNode):
             name="output",
             label="SfMData",
             description="Path to the output SfMData file.",
-            value=desc.Node.internalFolder + "sfm.json",
+            value=desc.Node.internalFolder + "sfmExpanded.abc",
         ),
     ]

--- a/meshroom/nodes/aliceVision/SfmExpanding.py
+++ b/meshroom/nodes/aliceVision/SfmExpanding.py
@@ -172,4 +172,10 @@ class SfMExpanding(desc.AVCommandLineNode):
             description="Path to the output SfMData file.",
             value=desc.Node.internalFolder + "sfmExpanded.abc",
         ),
+        desc.File(
+            name="outputViewsAndPoses",
+            label="Views And Poses",
+            description="Path to the output SfMData file with cameras (views and poses).",
+            value=desc.Node.internalFolder + "cameras.sfm",
+        )
     ]

--- a/meshroom/pipelines/cameraTrackingExperimental.mg
+++ b/meshroom/pipelines/cameraTrackingExperimental.mg
@@ -1,0 +1,572 @@
+{
+    "header": {
+        "releaseVersion": "2025.1.0-develop",
+        "fileVersion": "2.0",
+        "template": true,
+        "nodesVersions": {
+            "ApplyCalibration": "1.0",
+            "CameraInit": "12.0",
+            "CheckerboardDetection": "1.0",
+            "ConvertSfMFormat": "2.0",
+            "DepthMap": "5.0",
+            "DepthMapFilter": "4.0",
+            "DistortionCalibration": "5.0",
+            "ExportAnimatedCamera": "2.0",
+            "ExportDistortion": "2.0",
+            "FeatureExtraction": "1.3",
+            "FeatureMatching": "2.0",
+            "ImageDetectionPrompt": "0.1",
+            "ImageMatching": "2.0",
+            "ImageMatchingMultiSfM": "1.0",
+            "ImageSegmentationBox": "0.1",
+            "KeyframeSelection": "5.0",
+            "MeshDecimate": "1.0",
+            "MeshFiltering": "3.0",
+            "Meshing": "7.0",
+            "PrepareDenseScene": "3.1",
+            "Publish": "1.3",
+            "RelativePoseEstimating": "3.0",
+            "ScenePreview": "2.0",
+            "SfMBootStraping": "3.0",
+            "SfMExpanding": "2.0",
+            "SfMTransfer": "2.1",
+            "SfMTriangulation": "1.0",
+            "Texturing": "6.0",
+            "TracksBuilding": "1.0"
+        }
+    },
+    "graph": {
+        "ApplyCalibration_1": {
+            "nodeType": "ApplyCalibration",
+            "position": [
+                0,
+                0
+            ],
+            "inputs": {
+                "input": "{CameraInit_1.output}",
+                "calibration": "{DistortionCalibration_1.output}"
+            },
+            "internalInputs": {
+                "color": "#575963"
+            }
+        },
+        "CameraInit_1": {
+            "nodeType": "CameraInit",
+            "position": [
+                -200,
+                0
+            ],
+            "inputs": {},
+            "internalInputs": {
+                "color": "#575963"
+            }
+        },
+        "CameraInit_2": {
+            "nodeType": "CameraInit",
+            "position": [
+                -600,
+                -160
+            ],
+            "inputs": {},
+            "internalInputs": {
+                "label": "CameraInitLensGrid",
+                "color": "#302e2e"
+            }
+        },
+        "CheckerboardDetection_1": {
+            "nodeType": "CheckerboardDetection",
+            "position": [
+                -400,
+                -160
+            ],
+            "inputs": {
+                "input": "{CameraInit_2.output}",
+                "useNestedGrids": true,
+                "exportDebugImages": true
+            },
+            "internalInputs": {
+                "color": "#302e2e"
+            }
+        },
+        "ConvertSfMFormat_1": {
+            "nodeType": "ConvertSfMFormat",
+            "position": [
+                4140,
+                58
+            ],
+            "inputs": {
+                "input": "{ExportAnimatedCamera_1.input}",
+                "fileExt": "json",
+                "describerTypes": "{TracksBuilding_2.describerTypes}",
+                "structure": false,
+                "observations": false
+            },
+            "internalInputs": {
+                "color": "#4c594c"
+            }
+        },
+        "DepthMapFilter_1": {
+            "nodeType": "DepthMapFilter",
+            "position": [
+                3536,
+                -181
+            ],
+            "inputs": {
+                "input": "{DepthMap_1.input}",
+                "depthMapsFolder": "{DepthMap_1.output}"
+            },
+            "internalInputs": {
+                "color": "#3f3138"
+            }
+        },
+        "DepthMap_1": {
+            "nodeType": "DepthMap",
+            "position": [
+                3336,
+                -181
+            ],
+            "inputs": {
+                "input": "{PrepareDenseScene_1.input}",
+                "imagesFolder": "{PrepareDenseScene_1.output}",
+                "downscale": 1
+            },
+            "internalInputs": {
+                "color": "#3f3138"
+            }
+        },
+        "DistortionCalibration_1": {
+            "nodeType": "DistortionCalibration",
+            "position": [
+                -200,
+                -160
+            ],
+            "inputs": {
+                "input": "{CheckerboardDetection_1.input}",
+                "checkerboards": "{CheckerboardDetection_1.output}"
+            },
+            "internalInputs": {
+                "color": "#302e2e"
+            }
+        },
+        "ExportAnimatedCamera_1": {
+            "nodeType": "ExportAnimatedCamera",
+            "position": [
+                2748,
+                22
+            ],
+            "inputs": {
+                "input": "{SfMExpanding_2.output}",
+                "exportUndistortedImages": true
+            },
+            "internalInputs": {
+                "color": "#80766f"
+            }
+        },
+        "ExportDistortion_1": {
+            "nodeType": "ExportDistortion",
+            "position": [
+                0,
+                -160
+            ],
+            "inputs": {
+                "input": "{DistortionCalibration_1.output}"
+            },
+            "internalInputs": {
+                "color": "#302e2e"
+            }
+        },
+        "FeatureExtraction_1": {
+            "nodeType": "FeatureExtraction",
+            "position": [
+                400,
+                200
+            ],
+            "inputs": {
+                "input": "{ApplyCalibration_1.output}",
+                "masksFolder": "{ImageSegmentationBox_1.output}",
+                "maskExtension": "exr"
+            },
+            "internalInputs": {
+                "color": "#575963"
+            }
+        },
+        "FeatureMatching_1": {
+            "nodeType": "FeatureMatching",
+            "position": [
+                600,
+                0
+            ],
+            "inputs": {
+                "input": "{ImageMatching_1.input}",
+                "featuresFolders": "{ImageMatching_1.featuresFolders}",
+                "imagePairsList": "{ImageMatching_1.output}",
+                "describerTypes": "{FeatureExtraction_1.describerTypes}"
+            },
+            "internalInputs": {
+                "label": "FeatureMatchingKeyframes",
+                "color": "#575963"
+            }
+        },
+        "FeatureMatching_2": {
+            "nodeType": "FeatureMatching",
+            "position": [
+                1987,
+                186
+            ],
+            "inputs": {
+                "input": "{ImageMatching_2.input}",
+                "featuresFolders": "{ImageMatching_2.featuresFolders}",
+                "imagePairsList": "{ImageMatching_2.output}"
+            },
+            "internalInputs": {
+                "label": "FeatureMatchingAllFrames",
+                "color": "#80766f"
+            }
+        },
+        "FeatureMatching_3": {
+            "nodeType": "FeatureMatching",
+            "position": [
+                1987,
+                26
+            ],
+            "inputs": {
+                "input": "{ImageMatchingMultiSfM_1.outputCombinedSfM}",
+                "featuresFolders": "{ImageMatchingMultiSfM_1.featuresFolders}",
+                "imagePairsList": "{ImageMatchingMultiSfM_1.output}",
+                "describerTypes": "{FeatureExtraction_1.describerTypes}"
+            },
+            "internalInputs": {
+                "label": "FeatureMatchingFramesToKeyframes",
+                "color": "#80766f"
+            }
+        },
+        "ImageDetectionPrompt_1": {
+            "nodeType": "ImageDetectionPrompt",
+            "position": [
+                0,
+                200
+            ],
+            "inputs": {
+                "input": "{CameraInit_1.output}"
+            },
+            "internalInputs": {
+                "color": "#575963"
+            }
+        },
+        "ImageMatchingMultiSfM_1": {
+            "nodeType": "ImageMatchingMultiSfM",
+            "position": [
+                1787,
+                26
+            ],
+            "inputs": {
+                "input": "{KeyframeSelection_1.outputSfMDataFrames}",
+                "inputB": "{SfMExpanding_1.output}",
+                "featuresFolders": [
+                    "{FeatureExtraction_1.output}"
+                ],
+                "method": "VocabularyTree",
+                "matchingMode": "a/b",
+                "nbMatches": 20
+            },
+            "internalInputs": {
+                "color": "#80766f"
+            }
+        },
+        "ImageMatching_1": {
+            "nodeType": "ImageMatching",
+            "position": [
+                400,
+                0
+            ],
+            "inputs": {
+                "input": "{KeyframeSelection_1.outputSfMDataKeyframes}",
+                "featuresFolders": [
+                    "{FeatureExtraction_1.output}"
+                ],
+                "method": "Exhaustive"
+            },
+            "internalInputs": {
+                "label": "ImageMatchingKeyframes",
+                "color": "#575963"
+            }
+        },
+        "ImageMatching_2": {
+            "nodeType": "ImageMatching",
+            "position": [
+                1787,
+                186
+            ],
+            "inputs": {
+                "input": "{ApplyCalibration_1.output}",
+                "featuresFolders": [
+                    "{FeatureExtraction_1.output}"
+                ],
+                "method": "Sequential",
+                "nbNeighbors": 20
+            },
+            "internalInputs": {
+                "color": "#80766f"
+            }
+        },
+        "ImageSegmentationBox_1": {
+            "nodeType": "ImageSegmentationBox",
+            "position": [
+                200,
+                200
+            ],
+            "inputs": {
+                "input": "{ImageDetectionPrompt_1.input}",
+                "bboxFolder": "{ImageDetectionPrompt_1.output}",
+                "maskInvert": true,
+                "keepFilename": true
+            },
+            "internalInputs": {
+                "color": "#575963"
+            }
+        },
+        "KeyframeSelection_1": {
+            "nodeType": "KeyframeSelection",
+            "position": [
+                200,
+                0
+            ],
+            "inputs": {
+                "inputPaths": [
+                    "{ApplyCalibration_1.output}"
+                ]
+            },
+            "internalInputs": {
+                "color": "#575963"
+            }
+        },
+        "MeshDecimate_1": {
+            "nodeType": "MeshDecimate",
+            "position": [
+                4136,
+                -181
+            ],
+            "inputs": {
+                "input": "{MeshFiltering_1.outputMesh}",
+                "simplificationFactor": 0.05
+            },
+            "internalInputs": {
+                "color": "#3f3138"
+            }
+        },
+        "MeshFiltering_1": {
+            "nodeType": "MeshFiltering",
+            "position": [
+                3936,
+                -181
+            ],
+            "inputs": {
+                "inputMesh": "{Meshing_1.outputMesh}",
+                "filterLargeTrianglesFactor": 10.0
+            },
+            "internalInputs": {
+                "color": "#3f3138"
+            }
+        },
+        "Meshing_1": {
+            "nodeType": "Meshing",
+            "position": [
+                3736,
+                -181
+            ],
+            "inputs": {
+                "input": "{DepthMapFilter_1.input}",
+                "depthMapsFolder": "{DepthMapFilter_1.output}",
+                "estimateSpaceFromSfM": false,
+                "minStep": 1,
+                "fullWeight": 10.0,
+                "saveRawDensePointCloud": true
+            },
+            "internalInputs": {
+                "color": "#3f3138"
+            }
+        },
+        "PrepareDenseScene_1": {
+            "nodeType": "PrepareDenseScene",
+            "position": [
+                3136,
+                -181
+            ],
+            "inputs": {
+                "input": "{SfMTriangulation_1.output}",
+                "maskExtension": "exr"
+            },
+            "internalInputs": {
+                "color": "#3f3138"
+            }
+        },
+        "Publish_1": {
+            "nodeType": "Publish",
+            "position": [
+                4736,
+                -81
+            ],
+            "inputs": {
+                "inputFiles": [
+                    "{ExportAnimatedCamera_1.output}",
+                    "{Texturing_1.output}",
+                    "{ScenePreview_1.output}",
+                    "{ExportDistortion_1.output}"
+                ]
+            }
+        },
+        "RelativePoseEstimating_1": {
+            "nodeType": "RelativePoseEstimating",
+            "position": [
+                1012,
+                -1
+            ],
+            "inputs": {
+                "input": "{TracksBuilding_1.input}",
+                "tracksFilename": "{TracksBuilding_1.output}",
+                "countIterations": 50000,
+                "minInliers": 100
+            }
+        },
+        "ScenePreview_1": {
+            "nodeType": "ScenePreview",
+            "position": [
+                4357,
+                8
+            ],
+            "inputs": {
+                "cameras": "{ConvertSfMFormat_1.output}",
+                "model": "{MeshDecimate_1.output}",
+                "undistortedImages": "{ExportAnimatedCamera_1.outputUndistorted}",
+                "masks": "{ImageSegmentationBox_1.output}"
+            },
+            "internalInputs": {
+                "color": "#4c594c"
+            }
+        },
+        "SfMBootStraping_1": {
+            "nodeType": "SfMBootStraping",
+            "position": [
+                1215,
+                -7
+            ],
+            "inputs": {
+                "input": "{RelativePoseEstimating_1.input}",
+                "tracksFilename": "{RelativePoseEstimating_1.tracksFilename}",
+                "pairs": "{RelativePoseEstimating_1.output}"
+            }
+        },
+        "SfMExpanding_1": {
+            "nodeType": "SfMExpanding",
+            "position": [
+                1412,
+                -10
+            ],
+            "inputs": {
+                "input": "{SfMBootStraping_1.output}",
+                "tracksFilename": "{SfMBootStraping_1.tracksFilename}",
+                "minAngleForTriangulation": 1.0,
+                "minAngleForLandmark": 0.5
+            }
+        },
+        "SfMExpanding_2": {
+            "nodeType": "SfMExpanding",
+            "position": [
+                2469,
+                52
+            ],
+            "inputs": {
+                "input": "{TracksBuilding_2.input}",
+                "tracksFilename": "{TracksBuilding_2.output}",
+                "nbFirstUnstableCameras": 0,
+                "maxImagesPerGroup": 0,
+                "bundleAdjustmentMaxOutliers": 5000000,
+                "minNumberOfObservationsForTriangulation": 3,
+                "minAngleForTriangulation": 1.0,
+                "minAngleForLandmark": 0.5
+            }
+        },
+        "SfMTransfer_1": {
+            "nodeType": "SfMTransfer",
+            "position": [
+                2736,
+                -181
+            ],
+            "inputs": {
+                "input": "{KeyframeSelection_1.outputSfMDataKeyframes}",
+                "reference": "{SfMExpanding_2.output}",
+                "transferLandmarks": false
+            },
+            "internalInputs": {
+                "comment": "Transfer pose from final camera tracking into the keyframes-only scene.",
+                "color": "#3f3138"
+            }
+        },
+        "SfMTriangulation_1": {
+            "nodeType": "SfMTriangulation",
+            "position": [
+                2936,
+                -181
+            ],
+            "inputs": {
+                "input": "{SfMTransfer_1.output}",
+                "featuresFolders": "{TracksBuilding_1.featuresFolders}",
+                "matchesFolders": "{TracksBuilding_1.matchesFolders}",
+                "minAngleForTriangulation": 1.0,
+                "minAngleForLandmark": 0.5
+            },
+            "internalInputs": {
+                "color": "#3f3138"
+            }
+        },
+        "Texturing_1": {
+            "nodeType": "Texturing",
+            "position": [
+                4389,
+                -245
+            ],
+            "inputs": {
+                "input": "{Meshing_1.output}",
+                "imagesFolder": "{PrepareDenseScene_1.output}",
+                "inputMesh": "{MeshDecimate_1.output}"
+            },
+            "internalInputs": {
+                "color": "#3f3138"
+            }
+        },
+        "TracksBuilding_1": {
+            "nodeType": "TracksBuilding",
+            "position": [
+                826,
+                -2
+            ],
+            "inputs": {
+                "input": "{FeatureMatching_1.input}",
+                "featuresFolders": "{FeatureMatching_1.featuresFolders}",
+                "matchesFolders": [
+                    "{FeatureMatching_1.output}"
+                ],
+                "describerTypes": "{FeatureMatching_1.describerTypes}",
+                "filterTrackForks": true
+            }
+        },
+        "TracksBuilding_2": {
+            "nodeType": "TracksBuilding",
+            "position": [
+                2280,
+                34
+            ],
+            "inputs": {
+                "input": "{FeatureMatching_3.input}",
+                "featuresFolders": "{FeatureMatching_3.featuresFolders}",
+                "matchesFolders": [
+                    "{FeatureMatching_2.output}",
+                    "{FeatureMatching_3.output}"
+                ],
+                "describerTypes": "{FeatureMatching_3.describerTypes}",
+                "minInputTrackLength": 5,
+                "filterTrackForks": true
+            }
+        }
+    }
+}

--- a/meshroom/pipelines/cameraTrackingExperimental.mg
+++ b/meshroom/pipelines/cameraTrackingExperimental.mg
@@ -465,8 +465,14 @@
             "inputs": {
                 "input": "{SfMBootStraping_1.output}",
                 "tracksFilename": "{SfMBootStraping_1.tracksFilename}",
+                "meshFilename": "{SfMBootStraping_1.meshFilename}",
                 "minAngleForTriangulation": 1.0,
                 "minAngleForLandmark": 0.5
+            },
+            "internalInputs": {
+                "comment": "Estimate cameras parameters for the keyframes.",
+                "label": "SfMExpandingKeys",
+                "color": "#80766f"
             }
         },
         "SfMExpanding_2": {
@@ -478,12 +484,18 @@
             "inputs": {
                 "input": "{TracksBuilding_2.input}",
                 "tracksFilename": "{TracksBuilding_2.output}",
+                "meshFilename": "{SfMExpanding_1.meshFilename}",
                 "nbFirstUnstableCameras": 0,
                 "maxImagesPerGroup": 0,
                 "bundleAdjustmentMaxOutliers": 5000000,
                 "minNumberOfObservationsForTriangulation": 3,
                 "minAngleForTriangulation": 1.0,
                 "minAngleForLandmark": 0.5
+            },
+            "internalInputs": {
+                "comment": "Estimate cameras parameters for the complete camera tracking sequence.",
+                "label": "SfMExpandingAll",
+                "color": "#80766f"
             }
         },
         "SfMTransfer_1": {

--- a/meshroom/pipelines/cameraTrackingWithoutCalibrationExperimental.mg
+++ b/meshroom/pipelines/cameraTrackingWithoutCalibrationExperimental.mg
@@ -1,0 +1,543 @@
+{
+    "header": {
+        "releaseVersion": "2025.1.0-develop",
+        "fileVersion": "2.0",
+        "template": true,
+        "nodesVersions": {
+            "ApplyCalibration": "1.0",
+            "CameraInit": "12.0",
+            "ConvertDistortion": "1.0",
+            "ConvertSfMFormat": "2.0",
+            "DepthMap": "5.0",
+            "DepthMapFilter": "4.0",
+            "ExportAnimatedCamera": "2.0",
+            "ExportDistortion": "2.0",
+            "FeatureExtraction": "1.3",
+            "FeatureMatching": "2.0",
+            "ImageDetectionPrompt": "0.1",
+            "ImageMatching": "2.0",
+            "ImageMatchingMultiSfM": "1.0",
+            "ImageSegmentationBox": "0.1",
+            "KeyframeSelection": "5.0",
+            "MeshDecimate": "1.0",
+            "MeshFiltering": "3.0",
+            "Meshing": "7.0",
+            "PrepareDenseScene": "3.1",
+            "Publish": "1.3",
+            "RelativePoseEstimating": "3.0",
+            "ScenePreview": "2.0",
+            "SfMBootStraping": "3.0",
+            "SfMExpanding": "2.0",
+            "SfMTransfer": "2.1",
+            "SfMTriangulation": "1.0",
+            "Texturing": "6.0",
+            "TracksBuilding": "1.0"
+        }
+    },
+    "graph": {
+        "ApplyCalibration_1": {
+            "nodeType": "ApplyCalibration",
+            "position": [
+                0,
+                0
+            ],
+            "inputs": {
+                "input": "{CameraInit_1.output}"
+            },
+            "internalInputs": {
+                "color": "#575963"
+            }
+        },
+        "CameraInit_1": {
+            "nodeType": "CameraInit",
+            "position": [
+                -200,
+                0
+            ],
+            "inputs": {},
+            "internalInputs": {
+                "color": "#575963"
+            }
+        },
+        "ConvertDistortion_1": {
+            "nodeType": "ConvertDistortion",
+            "position": [
+                2561,
+                222
+            ],
+            "inputs": {
+                "input": "{SfMExpanding_2.output}"
+            },
+            "internalInputs": {
+                "color": "#80766f"
+            }
+        },
+        "ConvertSfMFormat_1": {
+            "nodeType": "ConvertSfMFormat",
+            "position": [
+                3674,
+                23
+            ],
+            "inputs": {
+                "input": "{ExportAnimatedCamera_1.input}",
+                "fileExt": "json",
+                "describerTypes": "{TracksBuilding_2.describerTypes}",
+                "structure": false,
+                "observations": false
+            },
+            "internalInputs": {
+                "color": "#4c594c"
+            }
+        },
+        "DepthMapFilter_1": {
+            "nodeType": "DepthMapFilter",
+            "position": [
+                3074,
+                -177
+            ],
+            "inputs": {
+                "input": "{DepthMap_1.input}",
+                "depthMapsFolder": "{DepthMap_1.output}"
+            },
+            "internalInputs": {
+                "color": "#3f3138"
+            }
+        },
+        "DepthMap_1": {
+            "nodeType": "DepthMap",
+            "position": [
+                2874,
+                -177
+            ],
+            "inputs": {
+                "input": "{PrepareDenseScene_1.input}",
+                "imagesFolder": "{PrepareDenseScene_1.output}",
+                "downscale": 1
+            },
+            "internalInputs": {
+                "color": "#3f3138"
+            }
+        },
+        "ExportAnimatedCamera_1": {
+            "nodeType": "ExportAnimatedCamera",
+            "position": [
+                2754,
+                37
+            ],
+            "inputs": {
+                "input": "{SfMExpanding_2.output}",
+                "exportUndistortedImages": true
+            },
+            "internalInputs": {
+                "color": "#80766f"
+            }
+        },
+        "ExportDistortion_1": {
+            "nodeType": "ExportDistortion",
+            "position": [
+                2761,
+                222
+            ],
+            "inputs": {
+                "input": "{ConvertDistortion_1.output}",
+                "exportLensGridsUndistorted": false
+            },
+            "internalInputs": {
+                "color": "#80766f"
+            }
+        },
+        "FeatureExtraction_1": {
+            "nodeType": "FeatureExtraction",
+            "position": [
+                400,
+                200
+            ],
+            "inputs": {
+                "input": "{ApplyCalibration_1.output}",
+                "masksFolder": "{ImageSegmentationBox_1.output}",
+                "maskExtension": "exr"
+            },
+            "internalInputs": {
+                "color": "#575963"
+            }
+        },
+        "FeatureMatching_1": {
+            "nodeType": "FeatureMatching",
+            "position": [
+                600,
+                0
+            ],
+            "inputs": {
+                "input": "{ImageMatching_1.input}",
+                "featuresFolders": "{ImageMatching_1.featuresFolders}",
+                "imagePairsList": "{ImageMatching_1.output}",
+                "describerTypes": "{FeatureExtraction_1.describerTypes}"
+            },
+            "internalInputs": {
+                "label": "FeatureMatchingKeyframes",
+                "color": "#575963"
+            }
+        },
+        "FeatureMatching_2": {
+            "nodeType": "FeatureMatching",
+            "position": [
+                1874,
+                183
+            ],
+            "inputs": {
+                "input": "{ImageMatching_2.input}",
+                "featuresFolders": "{ImageMatching_2.featuresFolders}",
+                "imagePairsList": "{ImageMatching_2.output}"
+            },
+            "internalInputs": {
+                "label": "FeatureMatchingAllFrames",
+                "color": "#80766f"
+            }
+        },
+        "FeatureMatching_3": {
+            "nodeType": "FeatureMatching",
+            "position": [
+                1874,
+                23
+            ],
+            "inputs": {
+                "input": "{ImageMatchingMultiSfM_1.outputCombinedSfM}",
+                "featuresFolders": "{ImageMatchingMultiSfM_1.featuresFolders}",
+                "imagePairsList": "{ImageMatchingMultiSfM_1.output}",
+                "describerTypes": "{FeatureExtraction_1.describerTypes}"
+            },
+            "internalInputs": {
+                "label": "FeatureMatchingFramesToKeyframes",
+                "color": "#80766f"
+            }
+        },
+        "ImageDetectionPrompt_1": {
+            "nodeType": "ImageDetectionPrompt",
+            "position": [
+                0,
+                200
+            ],
+            "inputs": {
+                "input": "{CameraInit_1.output}"
+            },
+            "internalInputs": {
+                "color": "#575963"
+            }
+        },
+        "ImageMatchingMultiSfM_1": {
+            "nodeType": "ImageMatchingMultiSfM",
+            "position": [
+                1674,
+                23
+            ],
+            "inputs": {
+                "input": "{KeyframeSelection_1.outputSfMDataFrames}",
+                "inputB": "{SfMExpanding_1.output}",
+                "featuresFolders": [
+                    "{FeatureExtraction_1.output}"
+                ],
+                "method": "VocabularyTree",
+                "matchingMode": "a/b",
+                "nbMatches": 20
+            },
+            "internalInputs": {
+                "color": "#80766f"
+            }
+        },
+        "ImageMatching_1": {
+            "nodeType": "ImageMatching",
+            "position": [
+                400,
+                0
+            ],
+            "inputs": {
+                "input": "{KeyframeSelection_1.outputSfMDataKeyframes}",
+                "featuresFolders": [
+                    "{FeatureExtraction_1.output}"
+                ],
+                "method": "Exhaustive"
+            },
+            "internalInputs": {
+                "label": "ImageMatchingKeyframes",
+                "color": "#575963"
+            }
+        },
+        "ImageMatching_2": {
+            "nodeType": "ImageMatching",
+            "position": [
+                1674,
+                183
+            ],
+            "inputs": {
+                "input": "{ApplyCalibration_1.output}",
+                "featuresFolders": [
+                    "{FeatureExtraction_1.output}"
+                ],
+                "method": "Sequential",
+                "nbNeighbors": 20
+            },
+            "internalInputs": {
+                "color": "#80766f"
+            }
+        },
+        "ImageSegmentationBox_1": {
+            "nodeType": "ImageSegmentationBox",
+            "position": [
+                200,
+                200
+            ],
+            "inputs": {
+                "input": "{ImageDetectionPrompt_1.input}",
+                "bboxFolder": "{ImageDetectionPrompt_1.output}",
+                "maskInvert": true,
+                "keepFilename": true
+            },
+            "internalInputs": {
+                "color": "#575963"
+            }
+        },
+        "KeyframeSelection_1": {
+            "nodeType": "KeyframeSelection",
+            "position": [
+                200,
+                0
+            ],
+            "inputs": {
+                "inputPaths": [
+                    "{ApplyCalibration_1.output}"
+                ]
+            },
+            "internalInputs": {
+                "color": "#575963"
+            }
+        },
+        "MeshDecimate_1": {
+            "nodeType": "MeshDecimate",
+            "position": [
+                3674,
+                -177
+            ],
+            "inputs": {
+                "input": "{MeshFiltering_1.outputMesh}",
+                "simplificationFactor": 0.05
+            },
+            "internalInputs": {
+                "color": "#3f3138"
+            }
+        },
+        "MeshFiltering_1": {
+            "nodeType": "MeshFiltering",
+            "position": [
+                3474,
+                -177
+            ],
+            "inputs": {
+                "inputMesh": "{Meshing_1.outputMesh}",
+                "filterLargeTrianglesFactor": 10.0
+            },
+            "internalInputs": {
+                "color": "#3f3138"
+            }
+        },
+        "Meshing_1": {
+            "nodeType": "Meshing",
+            "position": [
+                3274,
+                -177
+            ],
+            "inputs": {
+                "input": "{DepthMapFilter_1.input}",
+                "depthMapsFolder": "{DepthMapFilter_1.output}",
+                "estimateSpaceFromSfM": false,
+                "minStep": 1,
+                "fullWeight": 10.0,
+                "saveRawDensePointCloud": true
+            },
+            "internalInputs": {
+                "color": "#3f3138"
+            }
+        },
+        "PrepareDenseScene_1": {
+            "nodeType": "PrepareDenseScene",
+            "position": [
+                2674,
+                -177
+            ],
+            "inputs": {
+                "input": "{SfMTriangulation_1.output}",
+                "maskExtension": "exr"
+            },
+            "internalInputs": {
+                "color": "#3f3138"
+            }
+        },
+        "Publish_1": {
+            "nodeType": "Publish",
+            "position": [
+                4274,
+                -77
+            ],
+            "inputs": {
+                "inputFiles": [
+                    "{ExportAnimatedCamera_1.output}",
+                    "{Texturing_1.output}",
+                    "{ScenePreview_1.output}",
+                    "{ExportDistortion_1.output}"
+                ]
+            }
+        },
+        "RelativePoseEstimating_1": {
+            "nodeType": "RelativePoseEstimating",
+            "position": [
+                1013,
+                4
+            ],
+            "inputs": {
+                "input": "{TracksBuilding_1.input}",
+                "tracksFilename": "{TracksBuilding_1.output}",
+                "countIterations": 50000,
+                "minInliers": 100
+            }
+        },
+        "ScenePreview_1": {
+            "nodeType": "ScenePreview",
+            "position": [
+                3874,
+                23
+            ],
+            "inputs": {
+                "cameras": "{ConvertSfMFormat_1.output}",
+                "model": "{MeshDecimate_1.output}",
+                "undistortedImages": "{ExportAnimatedCamera_1.outputUndistorted}",
+                "masks": "{ImageSegmentationBox_1.output}"
+            },
+            "internalInputs": {
+                "color": "#4c594c"
+            }
+        },
+        "SfMBootStraping_1": {
+            "nodeType": "SfMBootStraping",
+            "position": [
+                1216,
+                -2
+            ],
+            "inputs": {
+                "input": "{RelativePoseEstimating_1.input}",
+                "tracksFilename": "{RelativePoseEstimating_1.tracksFilename}",
+                "pairs": "{RelativePoseEstimating_1.output}"
+            }
+        },
+        "SfMExpanding_1": {
+            "nodeType": "SfMExpanding",
+            "position": [
+                1413,
+                -5
+            ],
+            "inputs": {
+                "input": "{SfMBootStraping_1.output}",
+                "tracksFilename": "{SfMBootStraping_1.tracksFilename}",
+                "minAngleForTriangulation": 1.0,
+                "minAngleForLandmark": 0.5
+            }
+        },
+        "SfMExpanding_2": {
+            "nodeType": "SfMExpanding",
+            "position": [
+                2309.5,
+                27.0
+            ],
+            "inputs": {
+                "input": "{TracksBuilding_2.input}",
+                "tracksFilename": "{TracksBuilding_2.output}",
+                "nbFirstUnstableCameras": 0,
+                "maxImagesPerGroup": 0,
+                "bundleAdjustmentMaxOutliers": 5000000,
+                "minNumberOfObservationsForTriangulation": 3,
+                "minAngleForTriangulation": 1.0,
+                "minAngleForLandmark": 0.5
+            }
+        },
+        "SfMTransfer_1": {
+            "nodeType": "SfMTransfer",
+            "position": [
+                2274,
+                -177
+            ],
+            "inputs": {
+                "input": "{KeyframeSelection_1.outputSfMDataKeyframes}",
+                "reference": "{SfMExpanding_2.output}",
+                "transferLandmarks": false
+            },
+            "internalInputs": {
+                "comment": "Transfer pose from final camera tracking into the keyframes-only scene.",
+                "color": "#3f3138"
+            }
+        },
+        "SfMTriangulation_1": {
+            "nodeType": "SfMTriangulation",
+            "position": [
+                2474,
+                -177
+            ],
+            "inputs": {
+                "input": "{SfMTransfer_1.output}",
+                "featuresFolders": "{TracksBuilding_1.featuresFolders}",
+                "matchesFolders": "{TracksBuilding_1.matchesFolders}",
+                "minAngleForTriangulation": 1.0,
+                "minAngleForLandmark": 0.5
+            },
+            "internalInputs": {
+                "color": "#3f3138"
+            }
+        },
+        "Texturing_1": {
+            "nodeType": "Texturing",
+            "position": [
+                3874,
+                -177
+            ],
+            "inputs": {
+                "input": "{Meshing_1.output}",
+                "imagesFolder": "{PrepareDenseScene_1.output}",
+                "inputMesh": "{MeshDecimate_1.output}"
+            },
+            "internalInputs": {
+                "color": "#3f3138"
+            }
+        },
+        "TracksBuilding_1": {
+            "nodeType": "TracksBuilding",
+            "position": [
+                827,
+                3
+            ],
+            "inputs": {
+                "input": "{FeatureMatching_1.input}",
+                "featuresFolders": "{FeatureMatching_1.featuresFolders}",
+                "matchesFolders": [
+                    "{FeatureMatching_1.output}"
+                ],
+                "describerTypes": "{FeatureMatching_1.describerTypes}",
+                "filterTrackForks": true
+            }
+        },
+        "TracksBuilding_2": {
+            "nodeType": "TracksBuilding",
+            "position": [
+                2103.5,
+                24.0
+            ],
+            "inputs": {
+                "input": "{FeatureMatching_3.input}",
+                "featuresFolders": "{FeatureMatching_3.featuresFolders}",
+                "matchesFolders": [
+                    "{FeatureMatching_2.output}",
+                    "{FeatureMatching_3.output}"
+                ],
+                "describerTypes": "{FeatureMatching_3.describerTypes}",
+                "minInputTrackLength": 5,
+                "filterTrackForks": true
+            }
+        }
+    }
+}

--- a/meshroom/pipelines/cameraTrackingWithoutCalibrationExperimental.mg
+++ b/meshroom/pipelines/cameraTrackingWithoutCalibrationExperimental.mg
@@ -436,8 +436,14 @@
             "inputs": {
                 "input": "{SfMBootStraping_1.output}",
                 "tracksFilename": "{SfMBootStraping_1.tracksFilename}",
+                "meshFilename": "{SfMBootStraping_1.meshFilename}",
                 "minAngleForTriangulation": 1.0,
                 "minAngleForLandmark": 0.5
+            },
+            "internalInputs": {
+                "comment": "Estimate cameras parameters for the keyframes.",
+                "label": "SfMExpandingKeys",
+                "color": "#80766f"
             }
         },
         "SfMExpanding_2": {
@@ -449,12 +455,18 @@
             "inputs": {
                 "input": "{TracksBuilding_2.input}",
                 "tracksFilename": "{TracksBuilding_2.output}",
+                "meshFilename": "{SfMExpanding_1.meshFilename}",
                 "nbFirstUnstableCameras": 0,
                 "maxImagesPerGroup": 0,
                 "bundleAdjustmentMaxOutliers": 5000000,
                 "minNumberOfObservationsForTriangulation": 3,
                 "minAngleForTriangulation": 1.0,
                 "minAngleForLandmark": 0.5
+            },
+            "internalInputs": {
+                "comment": "Estimate cameras parameters for the complete camera tracking sequence.",
+                "label": "SfMExpandingAll",
+                "color": "#80766f"
             }
         },
         "SfMTransfer_1": {

--- a/meshroom/pipelines/photogrammetryAndCameraTrackingExperimental.mg
+++ b/meshroom/pipelines/photogrammetryAndCameraTrackingExperimental.mg
@@ -1,0 +1,677 @@
+{
+    "header": {
+        "releaseVersion": "2025.1.0-develop",
+        "fileVersion": "2.0",
+        "template": true,
+        "nodesVersions": {
+            "ApplyCalibration": "1.0",
+            "CameraInit": "12.0",
+            "CheckerboardDetection": "1.0",
+            "ConvertSfMFormat": "2.0",
+            "DepthMap": "5.0",
+            "DepthMapFilter": "4.0",
+            "DistortionCalibration": "5.0",
+            "ExportAnimatedCamera": "2.0",
+            "ExportDistortion": "2.0",
+            "FeatureExtraction": "1.3",
+            "FeatureMatching": "2.0",
+            "ImageDetectionPrompt": "0.1",
+            "ImageMatching": "2.0",
+            "ImageMatchingMultiSfM": "1.0",
+            "ImageSegmentationBox": "0.1",
+            "KeyframeSelection": "5.0",
+            "MeshDecimate": "1.0",
+            "MeshFiltering": "3.0",
+            "Meshing": "7.0",
+            "PrepareDenseScene": "3.1",
+            "Publish": "1.3",
+            "RelativePoseEstimating": "3.0",
+            "ScenePreview": "2.0",
+            "SfMBootStraping": "3.0",
+            "SfMExpanding": "2.0",
+            "Texturing": "6.0",
+            "TracksBuilding": "1.0"
+        }
+    },
+    "graph": {
+        "ApplyCalibration_1": {
+            "nodeType": "ApplyCalibration",
+            "position": [
+                0,
+                0
+            ],
+            "inputs": {
+                "input": "{CameraInit_1.output}",
+                "calibration": "{DistortionCalibration_1.output}"
+            },
+            "internalInputs": {
+                "color": "#575963"
+            }
+        },
+        "CameraInit_1": {
+            "nodeType": "CameraInit",
+            "position": [
+                -200,
+                0
+            ],
+            "inputs": {},
+            "internalInputs": {
+                "label": "InitShot",
+                "color": "#575963"
+            }
+        },
+        "CameraInit_2": {
+            "nodeType": "CameraInit",
+            "position": [
+                -600,
+                -160
+            ],
+            "inputs": {},
+            "internalInputs": {
+                "label": "InitLensGrid",
+                "color": "#302e2e"
+            }
+        },
+        "CameraInit_3": {
+            "nodeType": "CameraInit",
+            "position": [
+                -600,
+                -500
+            ],
+            "inputs": {},
+            "internalInputs": {
+                "label": "InitPhotogrammetry",
+                "color": "#384a55"
+            }
+        },
+        "CheckerboardDetection_1": {
+            "nodeType": "CheckerboardDetection",
+            "position": [
+                -400,
+                -160
+            ],
+            "inputs": {
+                "input": "{CameraInit_2.output}",
+                "useNestedGrids": true,
+                "exportDebugImages": true
+            },
+            "internalInputs": {
+                "color": "#302e2e"
+            }
+        },
+        "ConvertSfMFormat_1": {
+            "nodeType": "ConvertSfMFormat",
+            "position": [
+                2638,
+                193
+            ],
+            "inputs": {
+                "input": "{ExportAnimatedCamera_1.input}",
+                "fileExt": "sfm",
+                "describerTypes": "{TracksBuilding_3.describerTypes}",
+                "structure": false,
+                "observations": false
+            },
+            "internalInputs": {
+                "color": "#4c594c"
+            }
+        },
+        "DepthMapFilter_2": {
+            "nodeType": "DepthMapFilter",
+            "position": [
+                1412,
+                -499
+            ],
+            "inputs": {
+                "input": "{DepthMap_2.input}",
+                "depthMapsFolder": "{DepthMap_2.output}"
+            },
+            "internalInputs": {
+                "color": "#384a55"
+            }
+        },
+        "DepthMap_2": {
+            "nodeType": "DepthMap",
+            "position": [
+                1212,
+                -499
+            ],
+            "inputs": {
+                "input": "{PrepareDenseScene_2.input}",
+                "imagesFolder": "{PrepareDenseScene_2.output}"
+            },
+            "internalInputs": {
+                "color": "#384a55"
+            }
+        },
+        "DistortionCalibration_1": {
+            "nodeType": "DistortionCalibration",
+            "position": [
+                -200,
+                -160
+            ],
+            "inputs": {
+                "input": "{CheckerboardDetection_1.input}",
+                "checkerboards": "{CheckerboardDetection_1.output}"
+            },
+            "internalInputs": {
+                "color": "#302e2e"
+            }
+        },
+        "ExportAnimatedCamera_1": {
+            "nodeType": "ExportAnimatedCamera",
+            "position": [
+                2450,
+                194
+            ],
+            "inputs": {
+                "input": "{SfMExpanding_3.output}",
+                "sfmDataFilter": "{ImageMatchingMultiSfM_2.inputB}",
+                "exportUndistortedImages": true
+            },
+            "internalInputs": {
+                "color": "#80766f"
+            }
+        },
+        "ExportDistortion_1": {
+            "nodeType": "ExportDistortion",
+            "position": [
+                0,
+                -160
+            ],
+            "inputs": {
+                "input": "{DistortionCalibration_1.output}"
+            },
+            "internalInputs": {
+                "color": "#302e2e"
+            }
+        },
+        "FeatureExtraction_1": {
+            "nodeType": "FeatureExtraction",
+            "position": [
+                400,
+                200
+            ],
+            "inputs": {
+                "input": "{ApplyCalibration_1.output}",
+                "masksFolder": "{ImageSegmentationBox_2.output}",
+                "maskExtension": "exr"
+            },
+            "internalInputs": {
+                "color": "#575963"
+            }
+        },
+        "FeatureExtraction_2": {
+            "nodeType": "FeatureExtraction",
+            "position": [
+                -400,
+                -500
+            ],
+            "inputs": {
+                "input": "{CameraInit_3.output}"
+            },
+            "internalInputs": {
+                "color": "#384a55"
+            }
+        },
+        "FeatureMatching_1": {
+            "nodeType": "FeatureMatching",
+            "position": [
+                600,
+                0
+            ],
+            "inputs": {
+                "input": "{ImageMatching_1.input}",
+                "featuresFolders": "{ImageMatching_1.featuresFolders}",
+                "imagePairsList": "{ImageMatching_1.output}",
+                "describerTypes": "{FeatureExtraction_1.describerTypes}"
+            },
+            "internalInputs": {
+                "label": "FeatureMatchingKeyframes",
+                "color": "#575963"
+            }
+        },
+        "FeatureMatching_2": {
+            "nodeType": "FeatureMatching",
+            "position": [
+                1838,
+                353
+            ],
+            "inputs": {
+                "input": "{ImageMatching_2.input}",
+                "featuresFolders": "{ImageMatching_2.featuresFolders}",
+                "imagePairsList": "{ImageMatching_2.output}"
+            },
+            "internalInputs": {
+                "label": "FeatureMatchingAllFrames",
+                "color": "#80766f"
+            }
+        },
+        "FeatureMatching_3": {
+            "nodeType": "FeatureMatching",
+            "position": [
+                1838,
+                193
+            ],
+            "inputs": {
+                "input": "{ImageMatchingMultiSfM_1.outputCombinedSfM}",
+                "featuresFolders": "{ImageMatchingMultiSfM_1.featuresFolders}",
+                "imagePairsList": "{ImageMatchingMultiSfM_1.output}",
+                "describerTypes": "{FeatureExtraction_1.describerTypes}"
+            },
+            "internalInputs": {
+                "label": "FeatureMatchingFramesToKeyframes",
+                "color": "#80766f"
+            }
+        },
+        "FeatureMatching_4": {
+            "nodeType": "FeatureMatching",
+            "position": [
+                0,
+                -500
+            ],
+            "inputs": {
+                "input": "{ImageMatching_3.input}",
+                "featuresFolders": "{ImageMatching_3.featuresFolders}",
+                "imagePairsList": "{ImageMatching_3.output}",
+                "describerTypes": "{FeatureExtraction_2.describerTypes}"
+            },
+            "internalInputs": {
+                "color": "#384a55"
+            }
+        },
+        "FeatureMatching_5": {
+            "nodeType": "FeatureMatching",
+            "position": [
+                600,
+                -300
+            ],
+            "inputs": {
+                "input": "{ImageMatchingMultiSfM_2.outputCombinedSfM}",
+                "featuresFolders": "{ImageMatchingMultiSfM_2.featuresFolders}",
+                "imagePairsList": "{ImageMatchingMultiSfM_2.output}",
+                "describerTypes": "{FeatureExtraction_1.describerTypes}"
+            },
+            "internalInputs": {
+                "color": "#575963"
+            }
+        },
+        "ImageDetectionPrompt_1": {
+            "nodeType": "ImageDetectionPrompt",
+            "position": [
+                0,
+                200
+            ],
+            "inputs": {
+                "input": "{CameraInit_1.output}"
+            },
+            "internalInputs": {
+                "color": "#575963"
+            }
+        },
+        "ImageMatchingMultiSfM_1": {
+            "nodeType": "ImageMatchingMultiSfM",
+            "position": [
+                1638,
+                193
+            ],
+            "inputs": {
+                "input": "{KeyframeSelection_1.outputSfMDataFrames}",
+                "inputB": "{SfMExpanding_2.output}",
+                "featuresFolders": [
+                    "{FeatureExtraction_1.output}"
+                ],
+                "method": "VocabularyTree",
+                "matchingMode": "a/b",
+                "nbMatches": 20
+            },
+            "internalInputs": {
+                "color": "#80766f"
+            }
+        },
+        "ImageMatchingMultiSfM_2": {
+            "nodeType": "ImageMatchingMultiSfM",
+            "position": [
+                400,
+                -300
+            ],
+            "inputs": {
+                "input": "{KeyframeSelection_1.outputSfMDataKeyframes}",
+                "inputB": "{SfMExpanding_1.output}",
+                "featuresFolders": [
+                    "{FeatureExtraction_1.output}"
+                ],
+                "method": "Exhaustive",
+                "matchingMode": "a/b"
+            },
+            "internalInputs": {
+                "color": "#575963"
+            }
+        },
+        "ImageMatching_1": {
+            "nodeType": "ImageMatching",
+            "position": [
+                400,
+                0
+            ],
+            "inputs": {
+                "input": "{KeyframeSelection_1.outputSfMDataKeyframes}",
+                "featuresFolders": [
+                    "{FeatureExtraction_1.output}"
+                ],
+                "method": "Exhaustive"
+            },
+            "internalInputs": {
+                "label": "ImageMatchingKeyframes",
+                "color": "#575963"
+            }
+        },
+        "ImageMatching_2": {
+            "nodeType": "ImageMatching",
+            "position": [
+                1638,
+                353
+            ],
+            "inputs": {
+                "input": "{ApplyCalibration_1.output}",
+                "featuresFolders": [
+                    "{FeatureExtraction_1.output}"
+                ],
+                "method": "Sequential",
+                "nbNeighbors": 20
+            },
+            "internalInputs": {
+                "color": "#80766f"
+            }
+        },
+        "ImageMatching_3": {
+            "nodeType": "ImageMatching",
+            "position": [
+                -200,
+                -500
+            ],
+            "inputs": {
+                "input": "{FeatureExtraction_2.input}",
+                "featuresFolders": [
+                    "{FeatureExtraction_2.output}"
+                ]
+            },
+            "internalInputs": {
+                "color": "#384a55"
+            }
+        },
+        "ImageSegmentationBox_2": {
+            "nodeType": "ImageSegmentationBox",
+            "position": [
+                200,
+                200
+            ],
+            "inputs": {
+                "input": "{ImageDetectionPrompt_1.input}",
+                "bboxFolder": "{ImageDetectionPrompt_1.output}",
+                "maskInvert": true,
+                "keepFilename": true
+            },
+            "internalInputs": {
+                "color": "#575963"
+            }
+        },
+        "KeyframeSelection_1": {
+            "nodeType": "KeyframeSelection",
+            "position": [
+                200,
+                0
+            ],
+            "inputs": {
+                "inputPaths": [
+                    "{ApplyCalibration_1.output}"
+                ]
+            },
+            "internalInputs": {
+                "color": "#575963"
+            }
+        },
+        "MeshDecimate_1": {
+            "nodeType": "MeshDecimate",
+            "position": [
+                2638,
+                93
+            ],
+            "inputs": {
+                "input": "{MeshFiltering_2.outputMesh}",
+                "simplificationFactor": 0.05
+            },
+            "internalInputs": {
+                "color": "#4c594c"
+            }
+        },
+        "MeshFiltering_2": {
+            "nodeType": "MeshFiltering",
+            "position": [
+                1812,
+                -499
+            ],
+            "inputs": {
+                "inputMesh": "{Meshing_2.outputMesh}"
+            },
+            "internalInputs": {
+                "color": "#384a55"
+            }
+        },
+        "Meshing_2": {
+            "nodeType": "Meshing",
+            "position": [
+                1612,
+                -499
+            ],
+            "inputs": {
+                "input": "{DepthMapFilter_2.input}",
+                "depthMapsFolder": "{DepthMapFilter_2.output}"
+            },
+            "internalInputs": {
+                "color": "#384a55"
+            }
+        },
+        "PrepareDenseScene_2": {
+            "nodeType": "PrepareDenseScene",
+            "position": [
+                1012,
+                -499
+            ],
+            "inputs": {
+                "input": "{SfMExpanding_1.output}"
+            },
+            "internalInputs": {
+                "color": "#384a55"
+            }
+        },
+        "Publish_1": {
+            "nodeType": "Publish",
+            "position": [
+                3130,
+                -22
+            ],
+            "inputs": {
+                "inputFiles": [
+                    "{ExportAnimatedCamera_1.output}",
+                    "{ScenePreview_1.output}",
+                    "{ExportDistortion_1.output}",
+                    "{Texturing_2.output}"
+                ]
+            }
+        },
+        "RelativePoseEstimating_1": {
+            "nodeType": "RelativePoseEstimating",
+            "position": [
+                419,
+                -495
+            ],
+            "inputs": {
+                "input": "{TracksBuilding_1.input}",
+                "tracksFilename": "{TracksBuilding_1.output}",
+                "minInliers": 100
+            }
+        },
+        "RelativePoseEstimating_2": {
+            "nodeType": "RelativePoseEstimating",
+            "position": [
+                1005,
+                1
+            ],
+            "inputs": {
+                "input": "{TracksBuilding_2.input}",
+                "tracksFilename": "{TracksBuilding_2.output}",
+                "countIterations": 50000,
+                "minInliers": 100
+            }
+        },
+        "ScenePreview_1": {
+            "nodeType": "ScenePreview",
+            "position": [
+                2838,
+                193
+            ],
+            "inputs": {
+                "cameras": "{ConvertSfMFormat_1.output}",
+                "model": "{MeshDecimate_1.output}",
+                "undistortedImages": "{ExportAnimatedCamera_1.outputUndistorted}",
+                "masks": "{ImageSegmentationBox_2.output}"
+            },
+            "internalInputs": {
+                "color": "#4c594c"
+            }
+        },
+        "SfMBootStraping_1": {
+            "nodeType": "SfMBootStraping",
+            "position": [
+                616,
+                -502
+            ],
+            "inputs": {
+                "input": "{RelativePoseEstimating_1.input}",
+                "tracksFilename": "{RelativePoseEstimating_1.tracksFilename}",
+                "pairs": "{RelativePoseEstimating_1.output}"
+            }
+        },
+        "SfMBootStraping_2": {
+            "nodeType": "SfMBootStraping",
+            "position": [
+                1208,
+                -5
+            ],
+            "inputs": {
+                "input": "{RelativePoseEstimating_2.input}",
+                "tracksFilename": "{RelativePoseEstimating_2.tracksFilename}",
+                "pairs": "{RelativePoseEstimating_2.output}"
+            }
+        },
+        "SfMExpanding_1": {
+            "nodeType": "SfMExpanding",
+            "position": [
+                806,
+                -502
+            ],
+            "inputs": {
+                "input": "{SfMBootStraping_1.output}",
+                "tracksFilename": "{SfMBootStraping_1.tracksFilename}",
+                "meshFilename": "{SfMBootStraping_1.meshFilename}"
+            }
+        },
+        "SfMExpanding_2": {
+            "nodeType": "SfMExpanding",
+            "position": [
+                1405,
+                -8
+            ],
+            "inputs": {
+                "input": "{SfMBootStraping_2.output}",
+                "tracksFilename": "{SfMBootStraping_2.tracksFilename}",
+                "lockScenePreviouslyReconstructed": true,
+                "minAngleForTriangulation": 1.0,
+                "minAngleForLandmark": 0.5
+            }
+        },
+        "SfMExpanding_3": {
+            "nodeType": "SfMExpanding",
+            "position": [
+                2243,
+                271
+            ],
+            "inputs": {
+                "input": "{TracksBuilding_3.input}",
+                "tracksFilename": "{TracksBuilding_3.output}",
+                "nbFirstUnstableCameras": 0,
+                "maxImagesPerGroup": 0,
+                "bundleAdjustmentMaxOutliers": 5000000,
+                "minNumberOfObservationsForTriangulation": 3,
+                "minAngleForTriangulation": 1.0,
+                "minAngleForLandmark": 0.5
+            }
+        },
+        "Texturing_2": {
+            "nodeType": "Texturing",
+            "position": [
+                2012,
+                -499
+            ],
+            "inputs": {
+                "input": "{Meshing_2.output}",
+                "imagesFolder": "{DepthMap_2.imagesFolder}",
+                "inputMesh": "{MeshFiltering_2.outputMesh}"
+            },
+            "internalInputs": {
+                "color": "#384a55"
+            }
+        },
+        "TracksBuilding_1": {
+            "nodeType": "TracksBuilding",
+            "position": [
+                223,
+                -495
+            ],
+            "inputs": {
+                "input": "{FeatureMatching_4.input}",
+                "featuresFolders": "{FeatureMatching_4.featuresFolders}",
+                "matchesFolders": [
+                    "{FeatureMatching_4.output}"
+                ],
+                "describerTypes": "{FeatureMatching_4.describerTypes}"
+            }
+        },
+        "TracksBuilding_2": {
+            "nodeType": "TracksBuilding",
+            "position": [
+                819,
+                0
+            ],
+            "inputs": {
+                "input": "{FeatureMatching_5.input}",
+                "featuresFolders": "{FeatureMatching_1.featuresFolders}",
+                "matchesFolders": [
+                    "{FeatureMatching_1.output}",
+                    "{FeatureMatching_5.output}"
+                ],
+                "describerTypes": "{FeatureMatching_1.describerTypes}",
+                "filterTrackForks": true
+            }
+        },
+        "TracksBuilding_3": {
+            "nodeType": "TracksBuilding",
+            "position": [
+                2049,
+                263
+            ],
+            "inputs": {
+                "input": "{FeatureMatching_3.input}",
+                "featuresFolders": "{FeatureMatching_3.featuresFolders}",
+                "matchesFolders": [
+                    "{FeatureMatching_3.output}",
+                    "{FeatureMatching_2.output}"
+                ],
+                "describerTypes": "{FeatureMatching_3.describerTypes}",
+                "minInputTrackLength": 5,
+                "filterTrackForks": true
+            }
+        }
+    }
+}

--- a/meshroom/pipelines/photogrammetryAndCameraTrackingExperimental.mg
+++ b/meshroom/pipelines/photogrammetryAndCameraTrackingExperimental.mg
@@ -575,6 +575,10 @@
                 "input": "{SfMBootStraping_1.output}",
                 "tracksFilename": "{SfMBootStraping_1.tracksFilename}",
                 "meshFilename": "{SfMBootStraping_1.meshFilename}"
+            },
+            "internalInputs": {
+                "label": "SfMExpandingPhotog",
+                "color": "#80766f"
             }
         },
         "SfMExpanding_2": {
@@ -589,6 +593,11 @@
                 "lockScenePreviouslyReconstructed": true,
                 "minAngleForTriangulation": 1.0,
                 "minAngleForLandmark": 0.5
+            },
+            "internalInputs": {
+                "label": "SfMExpandingKeys",
+                "comment": "Estimate cameras parameters for the keyframes.",
+                "color": "#80766f"
             }
         },
         "SfMExpanding_3": {
@@ -606,6 +615,11 @@
                 "minNumberOfObservationsForTriangulation": 3,
                 "minAngleForTriangulation": 1.0,
                 "minAngleForLandmark": 0.5
+            },
+            "internalInputs": {
+                "label": "SfMExpandingAll",
+                "comment": "Estimate cameras parameters for the complete camera tracking sequence.",
+                "color": "#80766f"
             }
         },
         "Texturing_2": {

--- a/meshroom/pipelines/photogrammetryExperimental.mg
+++ b/meshroom/pipelines/photogrammetryExperimental.mg
@@ -1,0 +1,200 @@
+{
+    "header": {
+        "releaseVersion": "2025.1.0-develop",
+        "fileVersion": "2.0",
+        "template": true,
+        "nodesVersions": {
+            "CameraInit": "12.0",
+            "DepthMap": "5.0",
+            "DepthMapFilter": "4.0",
+            "FeatureExtraction": "1.3",
+            "FeatureMatching": "2.0",
+            "ImageMatching": "2.0",
+            "MeshFiltering": "3.0",
+            "Meshing": "7.0",
+            "PrepareDenseScene": "3.1",
+            "Publish": "1.3",
+            "RelativePoseEstimating": "3.0",
+            "SfMBootStraping": "3.0",
+            "SfMExpanding": "2.0",
+            "Texturing": "6.0",
+            "TracksBuilding": "1.0"
+        }
+    },
+    "graph": {
+        "CameraInit_1": {
+            "nodeType": "CameraInit",
+            "position": [
+                0,
+                0
+            ],
+            "inputs": {}
+        },
+        "DepthMapFilter_1": {
+            "nodeType": "DepthMapFilter",
+            "position": [
+                1969,
+                0
+            ],
+            "inputs": {
+                "input": "{DepthMap_1.input}",
+                "depthMapsFolder": "{DepthMap_1.output}"
+            }
+        },
+        "DepthMap_1": {
+            "nodeType": "DepthMap",
+            "position": [
+                1769,
+                0
+            ],
+            "inputs": {
+                "input": "{PrepareDenseScene_1.input}",
+                "imagesFolder": "{PrepareDenseScene_1.output}"
+            }
+        },
+        "FeatureExtraction_1": {
+            "nodeType": "FeatureExtraction",
+            "position": [
+                200,
+                0
+            ],
+            "inputs": {
+                "input": "{CameraInit_1.output}"
+            }
+        },
+        "FeatureMatching_1": {
+            "nodeType": "FeatureMatching",
+            "position": [
+                600,
+                0
+            ],
+            "inputs": {
+                "input": "{ImageMatching_1.input}",
+                "featuresFolders": "{ImageMatching_1.featuresFolders}",
+                "imagePairsList": "{ImageMatching_1.output}",
+                "describerTypes": "{FeatureExtraction_1.describerTypes}"
+            }
+        },
+        "ImageMatching_1": {
+            "nodeType": "ImageMatching",
+            "position": [
+                400,
+                0
+            ],
+            "inputs": {
+                "input": "{FeatureExtraction_1.input}",
+                "featuresFolders": [
+                    "{FeatureExtraction_1.output}"
+                ]
+            }
+        },
+        "MeshFiltering_1": {
+            "nodeType": "MeshFiltering",
+            "position": [
+                2369,
+                0
+            ],
+            "inputs": {
+                "inputMesh": "{Meshing_1.outputMesh}"
+            }
+        },
+        "Meshing_1": {
+            "nodeType": "Meshing",
+            "position": [
+                2169,
+                0
+            ],
+            "inputs": {
+                "input": "{DepthMapFilter_1.input}",
+                "depthMapsFolder": "{DepthMapFilter_1.output}"
+            }
+        },
+        "PrepareDenseScene_1": {
+            "nodeType": "PrepareDenseScene",
+            "position": [
+                1569,
+                0
+            ],
+            "inputs": {
+                "input": "{SfMExpanding_1.output}"
+            }
+        },
+        "Publish_1": {
+            "nodeType": "Publish",
+            "position": [
+                2769,
+                0
+            ],
+            "inputs": {
+                "inputFiles": [
+                    "{Texturing_1.outputMesh}",
+                    "{Texturing_1.outputMaterial}",
+                    "{Texturing_1.outputTextures}"
+                ]
+            }
+        },
+        "RelativePoseEstimating_1": {
+            "nodeType": "RelativePoseEstimating",
+            "position": [
+                990,
+                -1
+            ],
+            "inputs": {
+                "input": "{TracksBuilding_1.input}",
+                "tracksFilename": "{TracksBuilding_1.output}",
+                "minInliers": 100
+            }
+        },
+        "SfMBootStraping_1": {
+            "nodeType": "SfMBootStraping",
+            "position": [
+                1187,
+                -8
+            ],
+            "inputs": {
+                "input": "{RelativePoseEstimating_1.input}",
+                "tracksFilename": "{RelativePoseEstimating_1.tracksFilename}",
+                "pairs": "{RelativePoseEstimating_1.output}"
+            }
+        },
+        "SfMExpanding_1": {
+            "nodeType": "SfMExpanding",
+            "position": [
+                1377,
+                -8
+            ],
+            "inputs": {
+                "input": "{SfMBootStraping_1.output}",
+                "tracksFilename": "{SfMBootStraping_1.tracksFilename}",
+                "meshFilename": "{SfMBootStraping_1.meshFilename}"
+            }
+        },
+        "Texturing_1": {
+            "nodeType": "Texturing",
+            "position": [
+                2569,
+                0
+            ],
+            "inputs": {
+                "input": "{Meshing_1.output}",
+                "imagesFolder": "{DepthMap_1.imagesFolder}",
+                "inputMesh": "{MeshFiltering_1.outputMesh}"
+            }
+        },
+        "TracksBuilding_1": {
+            "nodeType": "TracksBuilding",
+            "position": [
+                794,
+                -1
+            ],
+            "inputs": {
+                "input": "{FeatureMatching_1.input}",
+                "featuresFolders": "{FeatureMatching_1.featuresFolders}",
+                "matchesFolders": [
+                    "{FeatureMatching_1.output}"
+                ],
+                "describerTypes": "{FeatureMatching_1.describerTypes}"
+            }
+        }
+    }
+}

--- a/meshroom/ui/reconstruction.py
+++ b/meshroom/ui/reconstruction.py
@@ -436,11 +436,11 @@ class Reconstruction(UIGraph):
     activeNodeCategories = {
         # All nodes generating a sfm scene (3D reconstruction or panorama)
         "sfm": ["StructureFromMotion", "GlobalSfM", "PanoramaEstimation", "SfMTransform",
-                "SfMAlignment"],
+                "SfMAlignment", "SfMExpanding", "SfMBootstraping"],
         # All nodes generating a sfmData file
         "sfmData": ["CameraInit", "DistortionCalibration", "StructureFromMotion", "GlobalSfM",
                     "PanoramaEstimation", "SfMTransfer", "SfMTransform", "SfMAlignment",
-                    "ApplyCalibration"],
+                    "ApplyCalibration", "SfMExpanding", "SfMBootstraping"],
         # All nodes generating depth map files
         "allDepthMap": ["DepthMap", "DepthMapFilter"],
         # Nodes that can be used to provide features folders to the UI


### PR DESCRIPTION
- Create experimental pipelines templates for 

1. tracking
2. tracking without calibration
3. photogrammetry
4. photogrammetry with tracking

- Update meshroom to consider the new sfm Nodes as if it was the previous StructureFromMotion node

Requires https://github.com/alicevision/AliceVision/pull/1818