### PR TITLE
Fix: Improve large project file loading performance

### DIFF
--- a/meshroom/core/attribute.py
+++ b/meshroom/core/attribute.py
@@ -31,7 +31,12 @@ def attributeFactory(description, value, isOutput, node, root=None, parent=None)
     else:
         attr.resetToDefaultValue()
 
-    attr.valueChanged.connect(lambda attr=attr: node._onAttributeChanged(attr))
+    # Only connect slot that reacts to value change once initial value has been set.
+    # NOTE: This should be handled by the Node class, but we're currently limited by our core
+    #       signal implementation that does not support emitting parameters.
+    #       And using a lambda here to send the attribute as a parameter causes
+    #       performance issues when using the pyside backend.
+    attr.valueChanged.connect(attr._onValueChanged)
 
     return attr
 
@@ -212,6 +217,10 @@ class Attribute(BaseObject):
 
         self.valueChanged.emit()
         self.validValueChanged.emit()
+
+    @Slot()
+    def _onValueChanged(self):
+        self.node._onAttributeChanged(self)
 
     def _set_label(self, label):
         if self._label == label:


### PR DESCRIPTION
## Description
This PR adresses performance issues when loading large project files (in UI mode), introduced as part of #2586.
It changes the way a Node is notified of an Attribute value change, which has a great impact on Attribute creation time.
The figures below shows the before and after for a project with a large number of attributes.

**Before**
![meshroom_connect_lambda](https://github.com/user-attachments/assets/4f7a7be6-1d58-43b6-9789-053d9c56c97e)
Overall attribute creation time: 146s

**After**
![meshroom_connect_slot](https://github.com/user-attachments/assets/50231101-2f63-4b4e-a29a-f2c33bcf5e11)
Overall attribute creation time: 1.24s


## Features list
- [X] Improve large project file loading performance.

## Implementation remarks

The notification of attribute value change to the owning node has been reworked to use a Signal/Slot connection, rather than a Signal/lambda.
This leads to much better performance, while preserving the same behavior.