### PR TITLE
[ui] Fix: Improve UX for search by allowing Search focus to be removed when clicking outside box

### DIFF
--- a/meshroom/ui/qml/Application.qml
+++ b/meshroom/ui/qml/Application.qml
@@ -927,6 +927,13 @@ Page {
         }
 
         Rectangle {
+            id: menuSpacer
+            MouseArea {
+                anchors.fill: parent
+                onClicked: {
+                    menuSpacer.forceActiveFocus();
+                }
+            }
             Layout.fillWidth: true
             Layout.fillHeight: true
             color: Qt.darker(activePalette.window, 1.15)
@@ -973,6 +980,12 @@ Page {
         }
 
         Rectangle {
+            MouseArea {
+                anchors.fill: parent
+                onClicked: {
+                    menuSpacer.forceActiveFocus();
+                }
+            }
             Layout.fillWidth: true
             Layout.fillHeight: true
             color: Qt.darker(activePalette.window, 1.15)
@@ -1007,6 +1020,7 @@ Page {
         // Cache Folder
         RowLayout {
             spacing: 0
+            width: parent.width
             MaterialToolButton {
                 font.pointSize: 8
                 text: MaterialIcons.folder_open
@@ -1020,6 +1034,17 @@ Page {
                 text: _reconstruction ? _reconstruction.graph.cacheDir : "Unknown"
                 color: Qt.darker(palette.text, 1.2)
                 background: Item {}
+            }
+
+            Item {
+                Layout.fillWidth: true
+                Layout.fillHeight: true
+                MouseArea {
+                    anchors.fill: parent
+                    onClicked: {
+                        footer.forceActiveFocus();
+                    }
+                }
             }
         }
     }

--- a/meshroom/ui/qml/GraphEditor/NodeEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/NodeEditor.qml
@@ -255,6 +255,13 @@ Panel {
                 id: placeholder_component
 
                 Item {
+                    id: panel
+                    MouseArea {
+                        anchors.fill: parent
+                        onClicked: {
+                            panel.forceActiveFocus();
+                        }
+                    }
                     Column {
                         anchors.centerIn: parent
                         MaterialLabel {

--- a/meshroom/ui/qml/ImageGallery/ImageGallery.qml
+++ b/meshroom/ui/qml/ImageGallery/ImageGallery.qml
@@ -830,8 +830,15 @@ Panel {
         }
 
         Item {
+            id: spacer
             Layout.fillHeight: true
             Layout.fillWidth: true
+            MouseArea {
+                anchors.fill: parent
+                onClicked: {
+                    spacer.forceActiveFocus();
+                }
+            }
         }
 
         MaterialToolLabelButton {

--- a/meshroom/ui/qml/Viewer3D/Inspector3D.qml
+++ b/meshroom/ui/qml/Viewer3D/Inspector3D.qml
@@ -355,6 +355,14 @@ FloatingPane {
                         }
                     }
 
+                    MouseArea {
+                        anchors.fill: parent
+                        onClicked: {
+                            /// Steal focus from anything that may have
+                            mediaListView.forceActiveFocus();
+                        }
+                    }
+
                     model: SortFilterDelegateModel {
                         model: mediaLibrary.model
                         sortRole: ""


### PR DESCRIPTION
## Description
This PR addresses an issue where Search Text box focus was not getting stolen when clicking on few components in the Active UI.

## Features list
- [X] Mouse Area for Node Editor
- [X] Mouse Area for Inspector 3D List View
- [X] Mouse Area for Top Menu Bar
- [X] Mouse Area for Bottom Status Bar


## Implementation remarks
Added MouseArea(s) to components allowing clicks to force focus on the parent components thereby stealing focus from anything that may have it, including the Search Input Text.

<!--
Explain main implementation choices.
It is also the right place to ask for feedback and help when you hesitate on the implementation.
-->
