### PR TITLE
NodeAPI: Trigger node creation callback only for explicit new node creation

### DIFF
--- a/meshroom/core/desc/node.py
+++ b/meshroom/core/desc/node.py
@@ -68,6 +68,11 @@ class Node(object):
         return attrValues
 
     @classmethod
+    def onNodeCreated(cls, node):
+        """Called after a node instance had been created from this node descriptor and added to a Graph."""
+        pass
+
+    @classmethod
     def update(cls, node):
         """ Method call before node's internal update on invalidation.
 

--- a/meshroom/core/node.py
+++ b/meshroom/core/node.py
@@ -1467,33 +1467,6 @@ class Node(BaseNode):
             if attr.invalidate:
                 self.invalidatingAttributes.add(attr)
 
-        self.optionalCallOnDescriptor("onNodeCreated")
-
-    def optionalCallOnDescriptor(self, methodName, *args, **kwargs):
-        """ Call of optional method defined in the descriptor.
-        Available method names are:
-         - onNodeCreated
-        """
-        if hasattr(self.nodeDesc, methodName):
-            m = getattr(self.nodeDesc, methodName)
-            if callable(m):
-                try:
-                    m(self, *args, **kwargs)
-                except Exception:
-                    import traceback
-                    # Format error strings with all the provided arguments
-                    argsStr = ", ".join(str(arg) for arg in args)
-                    kwargsStr = ", ".join(str(key) + "=" + str(value) for key, value in kwargs.items())
-                    finalErrStr = argsStr
-                    if kwargsStr:
-                        if argsStr:
-                            finalErrStr += ", "
-                        finalErrStr += kwargsStr
-
-                    logging.error("Error on call to '{}' (with args: '{}') for node type {}".
-                                  format(methodName, finalErrStr, self.nodeType))
-                    logging.error(traceback.format_exc())
-
     def setAttributeValues(self, values):
         # initialize attribute values
         for k, v in values.items():

--- a/tests/test_nodeCallbacks.py
+++ b/tests/test_nodeCallbacks.py
@@ -1,0 +1,68 @@
+from meshroom.core import desc, registerNodeType, unregisterNodeType
+from meshroom.core.node import Node
+from meshroom.core.graph import Graph, loadGraph
+
+
+class NodeWithCreationCallback(desc.InputNode):
+    """Node defining an 'onNodeCreated' callback, triggered a new node is added to a Graph."""
+
+    inputs = [
+        desc.BoolParam(
+            name="triggered",
+            label="Triggered",
+            description="Attribute impacted by the `onNodeCreated` callback",
+            value=False,
+        ),
+    ]
+
+    @classmethod
+    def onNodeCreated(cls, node: Node):
+        """Triggered when a new node is created within a Graph."""
+        node.triggered.value = True
+
+
+class TestNodeCreationCallback:
+    @classmethod
+    def setup_class(cls):
+        registerNodeType(NodeWithCreationCallback)
+
+    @classmethod
+    def teardown_class(cls):
+        unregisterNodeType(NodeWithCreationCallback)
+
+    def test_notTriggeredOnNodeInstantiation(self):
+        node = Node(NodeWithCreationCallback.__name__)
+        assert node.triggered.value is False
+
+    def test_triggeredOnNewNodeCreationInGraph(self):
+        graph = Graph("")
+        node = graph.addNewNode(NodeWithCreationCallback.__name__)
+        assert node.triggered.value is True
+
+    def test_notTriggeredOnNodeDuplication(self):
+        graph = Graph("")
+        node = graph.addNewNode(NodeWithCreationCallback.__name__)
+        node.triggered.resetToDefaultValue()
+
+        duplicates = graph.duplicateNodes([node])
+        assert duplicates[node][0].triggered.value is False
+
+    def test_notTriggeredOnGraphLoad(self, graphSavedOnDisk):
+        graph: Graph = graphSavedOnDisk
+        node = graph.addNewNode(NodeWithCreationCallback.__name__)
+        node.triggered.resetToDefaultValue()
+        graph.save()
+
+        loadedGraph = loadGraph(graph.filepath)
+        assert loadedGraph.node(node.name).triggered.value is False
+
+    def test_triggeredOnGraphInitializationFromTemplate(self, graphSavedOnDisk):
+        graph: Graph = graphSavedOnDisk
+        node = graph.addNewNode(NodeWithCreationCallback.__name__)
+        node.triggered.resetToDefaultValue()
+        graph.save(template=True)
+
+        graphFromTemplate = Graph("")
+        graphFromTemplate.initFromTemplate(graph.filepath)
+
+        assert graphFromTemplate.node(node.name).triggered.value is True


### PR DESCRIPTION
## Description
This PR changes the logic of when node descriptors `onNodeCreated` callbacks are triggered.

`desc.Node.onCreated` callback is a hook in the Node API for developers to write custom behavior on a node first initialization. 
By being called in the core.Node constructor, this was triggered in several situations that don't match this idea and with unpredictable side effects (graph loading, node re-creation on undo...).
This changes this behavior to only trigger this callback for explicit node creation:
- when a new node is added to a graph
- for each node created when a graph is initialized from a template

## Features list
- [X] Trigger  `desc.Node.onCreated` only for explicit new node creation.

## Implementation remarks

* Make `onNodeCreated` callback an explicit method on desc.Node.
* Remove the call to node descriptor's `onNodeCreated` callback outside core.Node constructor.
* Trigger this callback on explicit node creation (adding new node to graph, init a graph from a template).
* Add new unit tests suite for this testing behavior.