### PR TITLE
Fix Meshroom App CLI `latest` option

### DIFF
--- a/meshroom/ui/app.py
+++ b/meshroom/ui/app.py
@@ -303,7 +303,7 @@ class MeshroomApp(QApplication):
             self._activeProject.load(args.project)
             self.addRecentProjectFile(args.project)
         elif args.latest or args.latest2 or args.latest3:
-            projects = self._recentProjectFiles()
+            projects = self._recentProjectFiles
             if projects:
                 index = [args.latest, args.latest2, args.latest3].index(True)
                 project = os.path.abspath(projects[index]["path"])


### PR DESCRIPTION
## Description
Fix Meshroom app CLI `latest` option that was raising an error.


## Features list

- [X] Fix Meshroom app CLI `latest` option.

## Implementation remarks
Fix code that was not converted when _recentProjectFiles was converted from a function to a member variable. 
