### PR TITLE
[ui] app: Register components to QML before instantiating the engine

### DIFF
--- a/meshroom/ui/app.py
+++ b/meshroom/ui/app.py
@@ -250,6 +250,9 @@ class MeshroomApp(QApplication):
         # be retrievable
         self._updatedRecentProjectFilesThumbnails = True
 
+        # Register components for QML before instantiating the engine
+        components.registerTypes()
+
         # QML engine setup
         qmlDir = os.path.join(pwd, "qml")
         url = os.path.join(qmlDir, "main.qml")
@@ -263,7 +266,6 @@ class MeshroomApp(QApplication):
             qInstallMessageHandler(MessageHandler.handler)
 
         self.engine.addImportPath(qmlDir)
-        components.registerTypes()
 
         # expose available node types that can be instantiated
         self.engine.rootContext().setContextProperty("_nodeTypes", {n: {"category": nodesDesc[n].category} for n in sorted(nodesDesc.keys())})


### PR DESCRIPTION
## Description

This PR moves the QML registration of components before the instantiation of the QML engine. 

Functionally speaking, this does not change anything as Qt 6.6.x supports the registration of all types, including singleton, even after the instantiation of the engine, but this will not be the case anymore with Qt 6.7.x and above.