### PR TITLE
[GraphEditor] Only display "Pipelines" menu when templates are available

### DIFF
--- a/meshroom/ui/qml/GraphEditor/GraphEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/GraphEditor.qml
@@ -237,7 +237,9 @@ Item {
                 }
 
                 // Add a "Pipelines" category, filled with the list of templates to create pipelines from the menu
-                categories["Pipelines"] = MeshroomApp.pipelineTemplateNames
+                if (MeshroomApp.pipelineTemplateNames.length > 0) {
+                    categories["Pipelines"] = MeshroomApp.pipelineTemplateNames
+                }
 
                 return categories
             }


### PR DESCRIPTION
## Description

This PR adjusts the display of the "Pipelines" entry in the node menu depending on the number of available templates. If no template is available, the entry simply is not added to the node menu; if there is at least one template, then it is added to the node menu.

Before this change, in the node menu (displayed when pressing "Tab" or right-clicking in the Graph Editor), the "Pipelines" menu entry used to be displayed even if there was no available template (the entry would open to display an empty list).

If no template is available at the beginning of the session but the user saves one in one of the folders that are expected to contain templates, the entry will be added to the menu without restarting the session. 