### PR TITLE
[qml] Fix QML warnings when dropping project files into the Graph Editor

### DIFF
--- a/meshroom/ui/qml/Application.qml
+++ b/meshroom/ui/qml/Application.qml
@@ -1281,7 +1281,7 @@ Page {
                             _reconstruction.forceNodesStatusUpdate();
                             computeManager.submit(nodes)
                         }
-                        onFilesDropped: {
+                        onFilesDropped: function(drop, mousePosition) {
                             var filesByType = _reconstruction.getFilesByTypeFromDrop(drop.urls)
                             if (filesByType["meshroomScenes"].length == 1) {
                                 ensureSaved(function() {

--- a/meshroom/ui/qml/GraphEditor/GraphEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/GraphEditor.qml
@@ -987,7 +987,7 @@ Item {
             id: dropArea
             anchors.fill: parent
             keys: ["text/uri-list"]
-            onEntered: {
+            onEntered: function(drag) {
                 nbMeshroomScenes = 0
                 nbDraggedFiles = drag.urls.length
 

--- a/meshroom/ui/qml/GraphEditor/GraphEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/GraphEditor.qml
@@ -992,7 +992,7 @@ Item {
                 nbDraggedFiles = drag.urls.length
 
                 drag.urls.forEach(function(file) {
-                    if (file.endsWith(".mg")) {
+                    if (String(file).endsWith(".mg")) {
                         nbMeshroomScenes++
                     }
                 })


### PR DESCRIPTION
## Description

This PR fixes QML warnings that are generated when project files are dropped into the Graph Editor.


## Features list

- [x] Fix "injections into signal handlers" warnings when dropping project files into the GraphEditor
- [x] Ensure filenames are converted to strings before testing their extension


