### PR TITLE
[pipelines] Experimental: Align and set colors for all nodes

### DIFF
--- a/meshroom/nodes/aliceVision/ExportMaya.py
+++ b/meshroom/nodes/aliceVision/ExportMaya.py
@@ -20,14 +20,14 @@ class ExportMaya(desc.Node):
         ),
         desc.File(
             name="alembic",
-            label="Alembic file",
+            label="Alembic File",
             description="Input alembic file.",
             value="",
         ),
         desc.File(
             name="mesh",
             label="Input Mesh",
-            description="Input Mesh file.",
+            description="Input mesh file.",
             value="",
         ),
         desc.File(
@@ -38,8 +38,8 @@ class ExportMaya(desc.Node):
         ),
         desc.BoolParam(
             name="generateMaya",
-            label="generate Maya scene",
-            description="Do we generate the scene or only export a mel script.",
+            label="Generate Maya Scene",
+            description="Select to generate the Maya scene in addition to the export of the mel script.",
             value=True,
         ),
         desc.ChoiceParam(
@@ -54,14 +54,14 @@ class ExportMaya(desc.Node):
     outputs = [
         desc.File(
             name="meloutput",
-            label="Mel script",
-            description="Generated mel script",
+            label="Mel Script",
+            description="Generated mel script.",
             value=desc.Node.internalFolder + "import.mel",
         ),
         desc.File(
             name="mayaoutput",
-            label="Maya scene",
-            description="Generated Maya scene",
+            label="Maya Scene",
+            description="Generated Maya scene.",
             value=desc.Node.internalFolder + "scene.mb",
             enabled=lambda node: node.generateMaya.value,
         ),
@@ -218,6 +218,5 @@ class ExportMaya(desc.Node):
                 raise RuntimeError()
             
             chunk.logger.info("Maya Scene generated")
-
 
         chunk.logManager.end()

--- a/meshroom/nodes/aliceVision/ExtractMetadata.py
+++ b/meshroom/nodes/aliceVision/ExtractMetadata.py
@@ -25,7 +25,7 @@ Using exifTool, this node extracts metadata of all images referenced in a sfmDat
         desc.File(
             name="input",
             label="Input",
-            description="SfMData file input.",
+            description="SfMData input file.",
             value="",
         ),
         desc.BoolParam(
@@ -45,7 +45,7 @@ Using exifTool, this node extracts metadata of all images referenced in a sfmDat
         desc.StringParam(
             name="arguments",
             label="Arguments",
-            description="ExifTool command arguments",
+            description="ExifTool command arguments.",
             value="",
         ),
         desc.BoolParam(

--- a/meshroom/nodes/aliceVision/MaskProcessing.py
+++ b/meshroom/nodes/aliceVision/MaskProcessing.py
@@ -44,7 +44,7 @@ class MaskProcessing(desc.AVCommandLineNode):
                 value="",
             ),
             name="inputs",
-            label="Input directories",
+            label="Input Directories",
             description="A set of directories containing masks with the same names.",
             exposed=True,
         ),
@@ -52,9 +52,9 @@ class MaskProcessing(desc.AVCommandLineNode):
             name="operator",
             label="Operator",
             description="Operator: Binary operator\n"
-                        "OR : applies binary OR between all the masks\n"
-                        "AND : applies binary AND between all the masks\n"
-                        "NOT : applies binary NOT to the first mask in the list\n",
+                        "OR: applies binary OR between all the masks\n"
+                        "AND: applies binary AND between all the masks\n"
+                        "NOT: applies binary NOT to the first mask in the list\n",
             value="and",
             values=["or", "and", "not"],
         ),

--- a/meshroom/pipelines/cameraTrackingExperimental.mg
+++ b/meshroom/pipelines/cameraTrackingExperimental.mg
@@ -2,7 +2,6 @@
     "header": {
         "releaseVersion": "2025.1.0-develop",
         "fileVersion": "2.0",
-        "template": true,
         "nodesVersions": {
             "ApplyCalibration": "1.0",
             "CameraInit": "12.0",
@@ -33,7 +32,8 @@
             "SfMTriangulation": "1.0",
             "Texturing": "6.0",
             "TracksBuilding": "1.0"
-        }
+        },
+        "template": true
     },
     "graph": {
         "ApplyCalibration_1": {
@@ -91,8 +91,8 @@
         "ConvertSfMFormat_1": {
             "nodeType": "ConvertSfMFormat",
             "position": [
-                4140,
-                58
+                3800,
+                200
             ],
             "inputs": {
                 "input": "{ExportAnimatedCamera_1.input}",
@@ -108,8 +108,8 @@
         "DepthMapFilter_1": {
             "nodeType": "DepthMapFilter",
             "position": [
-                3536,
-                -181
+                3200,
+                0
             ],
             "inputs": {
                 "input": "{DepthMap_1.input}",
@@ -122,8 +122,8 @@
         "DepthMap_1": {
             "nodeType": "DepthMap",
             "position": [
-                3336,
-                -181
+                3000,
+                0
             ],
             "inputs": {
                 "input": "{PrepareDenseScene_1.input}",
@@ -151,8 +151,8 @@
         "ExportAnimatedCamera_1": {
             "nodeType": "ExportAnimatedCamera",
             "position": [
-                2748,
-                22
+                2400,
+                200
             ],
             "inputs": {
                 "input": "{SfMExpanding_2.output}",
@@ -210,8 +210,8 @@
         "FeatureMatching_2": {
             "nodeType": "FeatureMatching",
             "position": [
-                1987,
-                186
+                1800,
+                400
             ],
             "inputs": {
                 "input": "{ImageMatching_2.input}",
@@ -226,8 +226,8 @@
         "FeatureMatching_3": {
             "nodeType": "FeatureMatching",
             "position": [
-                1987,
-                26
+                1800,
+                200
             ],
             "inputs": {
                 "input": "{ImageMatchingMultiSfM_1.outputCombinedSfM}",
@@ -256,8 +256,8 @@
         "ImageMatchingMultiSfM_1": {
             "nodeType": "ImageMatchingMultiSfM",
             "position": [
-                1787,
-                26
+                1600,
+                200
             ],
             "inputs": {
                 "input": "{KeyframeSelection_1.outputSfMDataFrames}",
@@ -294,8 +294,8 @@
         "ImageMatching_2": {
             "nodeType": "ImageMatching",
             "position": [
-                1787,
-                186
+                1600,
+                400
             ],
             "inputs": {
                 "input": "{ApplyCalibration_1.output}",
@@ -343,8 +343,8 @@
         "MeshDecimate_1": {
             "nodeType": "MeshDecimate",
             "position": [
-                4136,
-                -181
+                3800,
+                0
             ],
             "inputs": {
                 "input": "{MeshFiltering_1.outputMesh}",
@@ -357,8 +357,8 @@
         "MeshFiltering_1": {
             "nodeType": "MeshFiltering",
             "position": [
-                3936,
-                -181
+                3600,
+                0
             ],
             "inputs": {
                 "inputMesh": "{Meshing_1.outputMesh}",
@@ -371,8 +371,8 @@
         "Meshing_1": {
             "nodeType": "Meshing",
             "position": [
-                3736,
-                -181
+                3400,
+                0
             ],
             "inputs": {
                 "input": "{DepthMapFilter_1.input}",
@@ -389,8 +389,8 @@
         "PrepareDenseScene_1": {
             "nodeType": "PrepareDenseScene",
             "position": [
-                3136,
-                -181
+                2800,
+                0
             ],
             "inputs": {
                 "input": "{SfMTriangulation_1.output}",
@@ -403,8 +403,8 @@
         "Publish_1": {
             "nodeType": "Publish",
             "position": [
-                4736,
-                -81
+                4200,
+                100
             ],
             "inputs": {
                 "inputFiles": [
@@ -418,21 +418,24 @@
         "RelativePoseEstimating_1": {
             "nodeType": "RelativePoseEstimating",
             "position": [
-                1012,
-                -1
+                1000,
+                0
             ],
             "inputs": {
                 "input": "{TracksBuilding_1.input}",
                 "tracksFilename": "{TracksBuilding_1.output}",
                 "countIterations": 50000,
                 "minInliers": 100
+            },
+            "internalInputs": {
+                "color": "#575963"
             }
         },
         "ScenePreview_1": {
             "nodeType": "ScenePreview",
             "position": [
-                4357,
-                8
+                4000,
+                200
             ],
             "inputs": {
                 "cameras": "{ConvertSfMFormat_1.output}",
@@ -447,20 +450,23 @@
         "SfMBootStraping_1": {
             "nodeType": "SfMBootStraping",
             "position": [
-                1215,
-                -7
+                1200,
+                0
             ],
             "inputs": {
                 "input": "{RelativePoseEstimating_1.input}",
                 "tracksFilename": "{RelativePoseEstimating_1.tracksFilename}",
                 "pairs": "{RelativePoseEstimating_1.output}"
+            },
+            "internalInputs": {
+                "color": "#575963"
             }
         },
         "SfMExpanding_1": {
             "nodeType": "SfMExpanding",
             "position": [
-                1412,
-                -10
+                1400,
+                0
             ],
             "inputs": {
                 "input": "{SfMBootStraping_1.output}",
@@ -472,14 +478,14 @@
             "internalInputs": {
                 "comment": "Estimate cameras parameters for the keyframes.",
                 "label": "SfMExpandingKeys",
-                "color": "#80766f"
+                "color": "#575963"
             }
         },
         "SfMExpanding_2": {
             "nodeType": "SfMExpanding",
             "position": [
-                2469,
-                52
+                2200,
+                200
             ],
             "inputs": {
                 "input": "{TracksBuilding_2.input}",
@@ -501,8 +507,8 @@
         "SfMTransfer_1": {
             "nodeType": "SfMTransfer",
             "position": [
-                2736,
-                -181
+                2400,
+                0
             ],
             "inputs": {
                 "input": "{KeyframeSelection_1.outputSfMDataKeyframes}",
@@ -517,8 +523,8 @@
         "SfMTriangulation_1": {
             "nodeType": "SfMTriangulation",
             "position": [
-                2936,
-                -181
+                2600,
+                0
             ],
             "inputs": {
                 "input": "{SfMTransfer_1.output}",
@@ -534,8 +540,8 @@
         "Texturing_1": {
             "nodeType": "Texturing",
             "position": [
-                4389,
-                -245
+                4000,
+                0
             ],
             "inputs": {
                 "input": "{Meshing_1.output}",
@@ -549,8 +555,8 @@
         "TracksBuilding_1": {
             "nodeType": "TracksBuilding",
             "position": [
-                826,
-                -2
+                800,
+                0
             ],
             "inputs": {
                 "input": "{FeatureMatching_1.input}",
@@ -560,13 +566,16 @@
                 ],
                 "describerTypes": "{FeatureMatching_1.describerTypes}",
                 "filterTrackForks": true
+            },
+            "internalInputs": {
+                "color": "#575963"
             }
         },
         "TracksBuilding_2": {
             "nodeType": "TracksBuilding",
             "position": [
-                2280,
-                34
+                2000,
+                200
             ],
             "inputs": {
                 "input": "{FeatureMatching_3.input}",
@@ -578,6 +587,9 @@
                 "describerTypes": "{FeatureMatching_3.describerTypes}",
                 "minInputTrackLength": 5,
                 "filterTrackForks": true
+            },
+            "internalInputs": {
+                "color": "#80766f"
             }
         }
     }

--- a/meshroom/pipelines/cameraTrackingWithoutCalibrationExperimental.mg
+++ b/meshroom/pipelines/cameraTrackingWithoutCalibrationExperimental.mg
@@ -2,7 +2,6 @@
     "header": {
         "releaseVersion": "2025.1.0-develop",
         "fileVersion": "2.0",
-        "template": true,
         "nodesVersions": {
             "ApplyCalibration": "1.0",
             "CameraInit": "12.0",
@@ -32,7 +31,8 @@
             "SfMTriangulation": "1.0",
             "Texturing": "6.0",
             "TracksBuilding": "1.0"
-        }
+        },
+        "template": true
     },
     "graph": {
         "ApplyCalibration_1": {
@@ -62,8 +62,8 @@
         "ConvertDistortion_1": {
             "nodeType": "ConvertDistortion",
             "position": [
-                2561,
-                222
+                2400,
+                360
             ],
             "inputs": {
                 "input": "{SfMExpanding_2.output}"
@@ -75,8 +75,8 @@
         "ConvertSfMFormat_1": {
             "nodeType": "ConvertSfMFormat",
             "position": [
-                3674,
-                23
+                3800,
+                200
             ],
             "inputs": {
                 "input": "{ExportAnimatedCamera_1.input}",
@@ -92,8 +92,8 @@
         "DepthMapFilter_1": {
             "nodeType": "DepthMapFilter",
             "position": [
-                3074,
-                -177
+                3200,
+                0
             ],
             "inputs": {
                 "input": "{DepthMap_1.input}",
@@ -106,8 +106,8 @@
         "DepthMap_1": {
             "nodeType": "DepthMap",
             "position": [
-                2874,
-                -177
+                3000,
+                0
             ],
             "inputs": {
                 "input": "{PrepareDenseScene_1.input}",
@@ -121,8 +121,8 @@
         "ExportAnimatedCamera_1": {
             "nodeType": "ExportAnimatedCamera",
             "position": [
-                2754,
-                37
+                2600,
+                200
             ],
             "inputs": {
                 "input": "{SfMExpanding_2.output}",
@@ -135,8 +135,8 @@
         "ExportDistortion_1": {
             "nodeType": "ExportDistortion",
             "position": [
-                2761,
-                222
+                2600,
+                360
             ],
             "inputs": {
                 "input": "{ConvertDistortion_1.output}",
@@ -181,8 +181,8 @@
         "FeatureMatching_2": {
             "nodeType": "FeatureMatching",
             "position": [
-                1874,
-                183
+                1800,
+                360
             ],
             "inputs": {
                 "input": "{ImageMatching_2.input}",
@@ -197,8 +197,8 @@
         "FeatureMatching_3": {
             "nodeType": "FeatureMatching",
             "position": [
-                1874,
-                23
+                1800,
+                200
             ],
             "inputs": {
                 "input": "{ImageMatchingMultiSfM_1.outputCombinedSfM}",
@@ -227,8 +227,8 @@
         "ImageMatchingMultiSfM_1": {
             "nodeType": "ImageMatchingMultiSfM",
             "position": [
-                1674,
-                23
+                1600,
+                200
             ],
             "inputs": {
                 "input": "{KeyframeSelection_1.outputSfMDataFrames}",
@@ -265,8 +265,8 @@
         "ImageMatching_2": {
             "nodeType": "ImageMatching",
             "position": [
-                1674,
-                183
+                1600,
+                360
             ],
             "inputs": {
                 "input": "{ApplyCalibration_1.output}",
@@ -314,8 +314,8 @@
         "MeshDecimate_1": {
             "nodeType": "MeshDecimate",
             "position": [
-                3674,
-                -177
+                3800,
+                0
             ],
             "inputs": {
                 "input": "{MeshFiltering_1.outputMesh}",
@@ -328,8 +328,8 @@
         "MeshFiltering_1": {
             "nodeType": "MeshFiltering",
             "position": [
-                3474,
-                -177
+                3600,
+                0
             ],
             "inputs": {
                 "inputMesh": "{Meshing_1.outputMesh}",
@@ -342,8 +342,8 @@
         "Meshing_1": {
             "nodeType": "Meshing",
             "position": [
-                3274,
-                -177
+                3400,
+                0
             ],
             "inputs": {
                 "input": "{DepthMapFilter_1.input}",
@@ -360,8 +360,8 @@
         "PrepareDenseScene_1": {
             "nodeType": "PrepareDenseScene",
             "position": [
-                2674,
-                -177
+                2800,
+                0
             ],
             "inputs": {
                 "input": "{SfMTriangulation_1.output}",
@@ -374,8 +374,8 @@
         "Publish_1": {
             "nodeType": "Publish",
             "position": [
-                4274,
-                -77
+                4400,
+                100
             ],
             "inputs": {
                 "inputFiles": [
@@ -389,21 +389,24 @@
         "RelativePoseEstimating_1": {
             "nodeType": "RelativePoseEstimating",
             "position": [
-                1013,
-                4
+                1000,
+                0
             ],
             "inputs": {
                 "input": "{TracksBuilding_1.input}",
                 "tracksFilename": "{TracksBuilding_1.output}",
                 "countIterations": 50000,
                 "minInliers": 100
+            },
+            "internalInputs": {
+                "color": "#575963"
             }
         },
         "ScenePreview_1": {
             "nodeType": "ScenePreview",
             "position": [
-                3874,
-                23
+                4000,
+                200
             ],
             "inputs": {
                 "cameras": "{ConvertSfMFormat_1.output}",
@@ -418,20 +421,23 @@
         "SfMBootStraping_1": {
             "nodeType": "SfMBootStraping",
             "position": [
-                1216,
-                -2
+                1200,
+                0
             ],
             "inputs": {
                 "input": "{RelativePoseEstimating_1.input}",
                 "tracksFilename": "{RelativePoseEstimating_1.tracksFilename}",
                 "pairs": "{RelativePoseEstimating_1.output}"
+            },
+            "internalInputs": {
+                "color": "#575963"
             }
         },
         "SfMExpanding_1": {
             "nodeType": "SfMExpanding",
             "position": [
-                1413,
-                -5
+                1400,
+                0
             ],
             "inputs": {
                 "input": "{SfMBootStraping_1.output}",
@@ -443,14 +449,14 @@
             "internalInputs": {
                 "comment": "Estimate cameras parameters for the keyframes.",
                 "label": "SfMExpandingKeys",
-                "color": "#80766f"
+                "color": "#575963"
             }
         },
         "SfMExpanding_2": {
             "nodeType": "SfMExpanding",
             "position": [
-                2309.5,
-                27.0
+                2200,
+                200
             ],
             "inputs": {
                 "input": "{TracksBuilding_2.input}",
@@ -472,8 +478,8 @@
         "SfMTransfer_1": {
             "nodeType": "SfMTransfer",
             "position": [
-                2274,
-                -177
+                2400,
+                0
             ],
             "inputs": {
                 "input": "{KeyframeSelection_1.outputSfMDataKeyframes}",
@@ -488,8 +494,8 @@
         "SfMTriangulation_1": {
             "nodeType": "SfMTriangulation",
             "position": [
-                2474,
-                -177
+                2600,
+                0
             ],
             "inputs": {
                 "input": "{SfMTransfer_1.output}",
@@ -505,8 +511,8 @@
         "Texturing_1": {
             "nodeType": "Texturing",
             "position": [
-                3874,
-                -177
+                4000,
+                0
             ],
             "inputs": {
                 "input": "{Meshing_1.output}",
@@ -520,8 +526,8 @@
         "TracksBuilding_1": {
             "nodeType": "TracksBuilding",
             "position": [
-                827,
-                3
+                800,
+                0
             ],
             "inputs": {
                 "input": "{FeatureMatching_1.input}",
@@ -531,13 +537,16 @@
                 ],
                 "describerTypes": "{FeatureMatching_1.describerTypes}",
                 "filterTrackForks": true
+            },
+            "internalInputs": {
+                "color": "#575963"
             }
         },
         "TracksBuilding_2": {
             "nodeType": "TracksBuilding",
             "position": [
-                2103.5,
-                24.0
+                2000,
+                200
             ],
             "inputs": {
                 "input": "{FeatureMatching_3.input}",
@@ -549,6 +558,9 @@
                 "describerTypes": "{FeatureMatching_3.describerTypes}",
                 "minInputTrackLength": 5,
                 "filterTrackForks": true
+            },
+            "internalInputs": {
+                "color": "#80766f"
             }
         }
     }

--- a/meshroom/pipelines/photogrammetryAndCameraTrackingExperimental.mg
+++ b/meshroom/pipelines/photogrammetryAndCameraTrackingExperimental.mg
@@ -2,7 +2,6 @@
     "header": {
         "releaseVersion": "2025.1.0-develop",
         "fileVersion": "2.0",
-        "template": true,
         "nodesVersions": {
             "ApplyCalibration": "1.0",
             "CameraInit": "12.0",
@@ -31,7 +30,8 @@
             "SfMExpanding": "2.0",
             "Texturing": "6.0",
             "TracksBuilding": "1.0"
-        }
+        },
+        "template": true
     },
     "graph": {
         "ApplyCalibration_1": {
@@ -102,8 +102,8 @@
         "ConvertSfMFormat_1": {
             "nodeType": "ConvertSfMFormat",
             "position": [
-                2638,
-                193
+                2600,
+                200
             ],
             "inputs": {
                 "input": "{ExportAnimatedCamera_1.input}",
@@ -119,8 +119,8 @@
         "DepthMapFilter_2": {
             "nodeType": "DepthMapFilter",
             "position": [
-                1412,
-                -499
+                1400,
+                -500
             ],
             "inputs": {
                 "input": "{DepthMap_2.input}",
@@ -133,8 +133,8 @@
         "DepthMap_2": {
             "nodeType": "DepthMap",
             "position": [
-                1212,
-                -499
+                1200,
+                -500
             ],
             "inputs": {
                 "input": "{PrepareDenseScene_2.input}",
@@ -161,8 +161,8 @@
         "ExportAnimatedCamera_1": {
             "nodeType": "ExportAnimatedCamera",
             "position": [
-                2450,
-                194
+                2400,
+                200
             ],
             "inputs": {
                 "input": "{SfMExpanding_3.output}",
@@ -234,8 +234,8 @@
         "FeatureMatching_2": {
             "nodeType": "FeatureMatching",
             "position": [
-                1838,
-                353
+                1800,
+                400
             ],
             "inputs": {
                 "input": "{ImageMatching_2.input}",
@@ -250,8 +250,8 @@
         "FeatureMatching_3": {
             "nodeType": "FeatureMatching",
             "position": [
-                1838,
-                193
+                1800,
+                200
             ],
             "inputs": {
                 "input": "{ImageMatchingMultiSfM_1.outputCombinedSfM}",
@@ -283,7 +283,7 @@
         "FeatureMatching_5": {
             "nodeType": "FeatureMatching",
             "position": [
-                600,
+                1200,
                 -300
             ],
             "inputs": {
@@ -312,8 +312,8 @@
         "ImageMatchingMultiSfM_1": {
             "nodeType": "ImageMatchingMultiSfM",
             "position": [
-                1638,
-                193
+                1600,
+                200
             ],
             "inputs": {
                 "input": "{KeyframeSelection_1.outputSfMDataFrames}",
@@ -332,7 +332,7 @@
         "ImageMatchingMultiSfM_2": {
             "nodeType": "ImageMatchingMultiSfM",
             "position": [
-                400,
+                1000,
                 -300
             ],
             "inputs": {
@@ -369,8 +369,8 @@
         "ImageMatching_2": {
             "nodeType": "ImageMatching",
             "position": [
-                1638,
-                353
+                1600,
+                400
             ],
             "inputs": {
                 "input": "{ApplyCalibration_1.output}",
@@ -434,8 +434,8 @@
         "MeshDecimate_1": {
             "nodeType": "MeshDecimate",
             "position": [
-                2638,
-                93
+                2600,
+                0
             ],
             "inputs": {
                 "input": "{MeshFiltering_2.outputMesh}",
@@ -448,8 +448,8 @@
         "MeshFiltering_2": {
             "nodeType": "MeshFiltering",
             "position": [
-                1812,
-                -499
+                1800,
+                -500
             ],
             "inputs": {
                 "inputMesh": "{Meshing_2.outputMesh}"
@@ -461,8 +461,8 @@
         "Meshing_2": {
             "nodeType": "Meshing",
             "position": [
-                1612,
-                -499
+                1600,
+                -500
             ],
             "inputs": {
                 "input": "{DepthMapFilter_2.input}",
@@ -475,8 +475,8 @@
         "PrepareDenseScene_2": {
             "nodeType": "PrepareDenseScene",
             "position": [
-                1012,
-                -499
+                1000,
+                -500
             ],
             "inputs": {
                 "input": "{SfMExpanding_1.output}"
@@ -488,8 +488,8 @@
         "Publish_1": {
             "nodeType": "Publish",
             "position": [
-                3130,
-                -22
+                3000,
+                -100
             ],
             "inputs": {
                 "inputFiles": [
@@ -503,33 +503,39 @@
         "RelativePoseEstimating_1": {
             "nodeType": "RelativePoseEstimating",
             "position": [
-                419,
-                -495
+                400,
+                -500
             ],
             "inputs": {
                 "input": "{TracksBuilding_1.input}",
                 "tracksFilename": "{TracksBuilding_1.output}",
                 "minInliers": 100
+            },
+            "internalInputs": {
+                "color": "#384a55"
             }
         },
         "RelativePoseEstimating_2": {
             "nodeType": "RelativePoseEstimating",
             "position": [
-                1005,
-                1
+                1000,
+                0
             ],
             "inputs": {
                 "input": "{TracksBuilding_2.input}",
                 "tracksFilename": "{TracksBuilding_2.output}",
                 "countIterations": 50000,
                 "minInliers": 100
+            },
+            "internalInputs": {
+                "color": "#575963"
             }
         },
         "ScenePreview_1": {
             "nodeType": "ScenePreview",
             "position": [
-                2838,
-                193
+                2800,
+                200
             ],
             "inputs": {
                 "cameras": "{ConvertSfMFormat_1.output}",
@@ -544,32 +550,38 @@
         "SfMBootStraping_1": {
             "nodeType": "SfMBootStraping",
             "position": [
-                616,
-                -502
+                600,
+                -500
             ],
             "inputs": {
                 "input": "{RelativePoseEstimating_1.input}",
                 "tracksFilename": "{RelativePoseEstimating_1.tracksFilename}",
                 "pairs": "{RelativePoseEstimating_1.output}"
+            },
+            "internalInputs": {
+                "color": "#384a55"
             }
         },
         "SfMBootStraping_2": {
             "nodeType": "SfMBootStraping",
             "position": [
-                1208,
-                -5
+                1200,
+                0
             ],
             "inputs": {
                 "input": "{RelativePoseEstimating_2.input}",
                 "tracksFilename": "{RelativePoseEstimating_2.tracksFilename}",
                 "pairs": "{RelativePoseEstimating_2.output}"
+            },
+            "internalInputs": {
+                "color": "#575963"
             }
         },
         "SfMExpanding_1": {
             "nodeType": "SfMExpanding",
             "position": [
-                806,
-                -502
+                800,
+                -500
             ],
             "inputs": {
                 "input": "{SfMBootStraping_1.output}",
@@ -578,14 +590,14 @@
             },
             "internalInputs": {
                 "label": "SfMExpandingPhotog",
-                "color": "#80766f"
+                "color": "#384a55"
             }
         },
         "SfMExpanding_2": {
             "nodeType": "SfMExpanding",
             "position": [
-                1405,
-                -8
+                1400,
+                0
             ],
             "inputs": {
                 "input": "{SfMBootStraping_2.output}",
@@ -595,16 +607,16 @@
                 "minAngleForLandmark": 0.5
             },
             "internalInputs": {
-                "label": "SfMExpandingKeys",
                 "comment": "Estimate cameras parameters for the keyframes.",
-                "color": "#80766f"
+                "label": "SfMExpandingKeys",
+                "color": "#575963"
             }
         },
         "SfMExpanding_3": {
             "nodeType": "SfMExpanding",
             "position": [
-                2243,
-                271
+                2200,
+                200
             ],
             "inputs": {
                 "input": "{TracksBuilding_3.input}",
@@ -617,16 +629,16 @@
                 "minAngleForLandmark": 0.5
             },
             "internalInputs": {
-                "label": "SfMExpandingAll",
                 "comment": "Estimate cameras parameters for the complete camera tracking sequence.",
+                "label": "SfMExpandingAll",
                 "color": "#80766f"
             }
         },
         "Texturing_2": {
             "nodeType": "Texturing",
             "position": [
-                2012,
-                -499
+                2000,
+                -500
             ],
             "inputs": {
                 "input": "{Meshing_2.output}",
@@ -640,8 +652,8 @@
         "TracksBuilding_1": {
             "nodeType": "TracksBuilding",
             "position": [
-                223,
-                -495
+                200,
+                -500
             ],
             "inputs": {
                 "input": "{FeatureMatching_4.input}",
@@ -650,12 +662,15 @@
                     "{FeatureMatching_4.output}"
                 ],
                 "describerTypes": "{FeatureMatching_4.describerTypes}"
+            },
+            "internalInputs": {
+                "color": "#384a55"
             }
         },
         "TracksBuilding_2": {
             "nodeType": "TracksBuilding",
             "position": [
-                819,
+                800,
                 0
             ],
             "inputs": {
@@ -667,13 +682,16 @@
                 ],
                 "describerTypes": "{FeatureMatching_1.describerTypes}",
                 "filterTrackForks": true
+            },
+            "internalInputs": {
+                "color": "#575963"
             }
         },
         "TracksBuilding_3": {
             "nodeType": "TracksBuilding",
             "position": [
-                2049,
-                263
+                2000,
+                200
             ],
             "inputs": {
                 "input": "{FeatureMatching_3.input}",
@@ -685,6 +703,9 @@
                 "describerTypes": "{FeatureMatching_3.describerTypes}",
                 "minInputTrackLength": 5,
                 "filterTrackForks": true
+            },
+            "internalInputs": {
+                "color": "#80766f"
             }
         }
     }

--- a/meshroom/pipelines/photogrammetryExperimental.mg
+++ b/meshroom/pipelines/photogrammetryExperimental.mg
@@ -33,7 +33,7 @@
         "DepthMapFilter_1": {
             "nodeType": "DepthMapFilter",
             "position": [
-                1969,
+                2000,
                 0
             ],
             "inputs": {
@@ -44,7 +44,7 @@
         "DepthMap_1": {
             "nodeType": "DepthMap",
             "position": [
-                1769,
+                1800,
                 0
             ],
             "inputs": {
@@ -91,7 +91,7 @@
         "MeshFiltering_1": {
             "nodeType": "MeshFiltering",
             "position": [
-                2369,
+                2400,
                 0
             ],
             "inputs": {
@@ -101,7 +101,7 @@
         "Meshing_1": {
             "nodeType": "Meshing",
             "position": [
-                2169,
+                2200,
                 0
             ],
             "inputs": {
@@ -112,7 +112,7 @@
         "PrepareDenseScene_1": {
             "nodeType": "PrepareDenseScene",
             "position": [
-                1569,
+                1600,
                 0
             ],
             "inputs": {
@@ -122,7 +122,7 @@
         "Publish_1": {
             "nodeType": "Publish",
             "position": [
-                2769,
+                2800,
                 0
             ],
             "inputs": {
@@ -136,8 +136,8 @@
         "RelativePoseEstimating_1": {
             "nodeType": "RelativePoseEstimating",
             "position": [
-                990,
-                -1
+                1000,
+                0
             ],
             "inputs": {
                 "input": "{TracksBuilding_1.input}",
@@ -148,8 +148,8 @@
         "SfMBootStraping_1": {
             "nodeType": "SfMBootStraping",
             "position": [
-                1187,
-                -8
+                1200,
+                0
             ],
             "inputs": {
                 "input": "{RelativePoseEstimating_1.input}",
@@ -160,8 +160,8 @@
         "SfMExpanding_1": {
             "nodeType": "SfMExpanding",
             "position": [
-                1377,
-                -8
+                1400,
+                0
             ],
             "inputs": {
                 "input": "{SfMBootStraping_1.output}",
@@ -172,7 +172,7 @@
         "Texturing_1": {
             "nodeType": "Texturing",
             "position": [
-                2569,
+                2600,
                 0
             ],
             "inputs": {
@@ -184,8 +184,8 @@
         "TracksBuilding_1": {
             "nodeType": "TracksBuilding",
             "position": [
-                794,
-                -1
+                800,
+                0
             ],
             "inputs": {
                 "input": "{FeatureMatching_1.input}",


### PR DESCRIPTION
## Description

This PR realigns all nodes and applies the correct colors on them for the following experimental pipelines:
- Camera Tracking
- Camera Tracking without calibration
- Photogrammetry
- Photogrammetry & Camera Tracking

Additionally, the labels and descriptions of some attributes for the `ExportMaya` and `ExtractMetadata` nodes are improved. 