### PR TITLE
[ui] Application: fix save-as dialog not working properly (Qt6.7+)

### DIFF
--- a/meshroom/ui/qml/Application.qml
+++ b/meshroom/ui/qml/Application.qml
@@ -90,7 +90,7 @@ Page {
         }
     }
 
-    function validateFilepathForSave(filepath: string, sourceSaveDialog: Dialog): bool {
+    function validateFilepathForSave(filepath: string, sourceSaveDialog): bool {
         /**
          * Return true if `filepath` is valid for saving a file to disk.
          * Otherwise, show a warning dialog and returns false.


### PR DESCRIPTION
## Description
Since Qt 6.7, JS type annotations are enforced at runtime (see https://doc.qt.io/qt-6/qtqml-javascript-hostenvironment.html#type-annotations-and-assertions).
This PR removes a problematic annotation typing that is breaking the SaveAs file dialog.

## Features list

- [X] Fix SaveAs dialog for Qt 6.7+.


## Implementation remarks

Typing the `sourceSaveDialog` in `validateFilepathForSave` as Dialog (or Platform.FileDialog) breaks the value received by the function and its behavior.
