### PR TITLE
[core] Node: Status should be `NONE` when there is no chunk

### DIFF
--- a/meshroom/core/node.py
+++ b/meshroom/core/node.py
@@ -1174,6 +1174,9 @@ class BaseNode(BaseObject):
         """
         if isinstance(self.nodeDesc, desc.InputNode):
             return Status.INPUT
+        if not self._chunks:
+            return Status.NONE
+
         chunksStatus = [chunk.status.status for chunk in self._chunks]
 
         anyOf = (Status.ERROR, Status.STOPPED, Status.KILLED,


### PR DESCRIPTION
## Description

Prior to this PR, nodes with a varying number of chunks were initialized with an empty list of chunks (as expected), but with a global status that was set to `SUCCESS` instead of `NONE`. 

This caused issues on the graphical side as `SUCCESS` is interpreted as the status for nodes that have been successfully computed. For nodes that had not been computed and whose number of chunks was not set yet, we thus ended up with computation times (set to "0.00s", as no actual computation had taken place) displayed as if said computation had been successful:
<div display="block" align="center"><img src="https://github.com/user-attachments/assets/32f36030-3a7a-4eb0-bb8f-bb8f6ca02e1c" /></div>

This PR addresses this issue by ensuring that the global status of a node with an empty list of chunks is always set to `NONE` instead of `SUCCESS`.