### PR TITLE
[ui] NodeEditor: Don't allow to reduce split view size below 350

### DIFF
--- a/meshroom/ui/qml/Application.qml
+++ b/meshroom/ui/qml/Application.qml
@@ -1317,7 +1317,7 @@ Page {
                 NodeEditor {
                     id: nodeEditor
                     SplitView.preferredWidth: 500
-                    SplitView.minimumWidth: 80
+                    SplitView.minimumWidth: 350
 
                     node: _reconstruction ? _reconstruction.selectedNode : null
                     property bool computing: _reconstruction ? _reconstruction.computing : false


### PR DESCRIPTION
## Description

This prevents reducing the Node Editor up to the point where components within it (especially in its header) are disappearing from screen. 