### PR TITLE
change git clone link to use https link in "get the project"

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ If you want to build it yourself, see [**INSTALL.md**](INSTALL.md) to setup the 
 
 Get the source code and install runtime requirements:
 ```bash
-git clone --recursive git://github.com/alicevision/meshroom
+git clone --recursive https://github.com/alicevision/Meshroom.git
 cd meshroom
 pip install -r requirements.txt
 ```


### PR DESCRIPTION
## Description

Change the git clone link under the "get the project" section to use the https github link, as the git link will not work in many circumstances. The https link should work universally

## Features list

No features have been added

## Implementation remarks

No remarks
