### PR TITLE
[ui] AttributeEditor: Feature/attribute navigation buttons

### DIFF
--- a/meshroom/core/attribute.py
+++ b/meshroom/core/attribute.py
@@ -325,10 +325,7 @@ class Attribute(BaseObject):
         # safety check to avoid evaluation errors
         if not self.node.graph or not self.node.graph.edges:
             return False
-        # if the attribute is a ListAttribute, we need to check if any of its elements has output connections
-        if isinstance(self, ListAttribute):
-            return next((edge for edge in self.node.graph.edges.values() if edge.src == self), None) is not None or \
-                any(attr.hasOutputConnections for attr in self._value if hasattr(attr, 'hasOutputConnections'))
+
         return next((edge for edge in self.node.graph.edges.values() if edge.src == self), None) is not None
 
     def getInputConnections(self) -> list["Edge"]:
@@ -733,12 +730,43 @@ class ListAttribute(Attribute):
         return self.isLink \
             or self.node.graph and self.isInput and self.node.graph._edges \
             and any(v in self.node.graph._edges.keys() for v in self._value)
+    
+    # override
+    @property
+    def hasOutputConnections(self):
+        """ Whether the attribute has output connections, i.e is the source of at least one edge. """
+
+        # safety check to avoid evaluation errors
+        if not self.node.graph or not self.node.graph.edges:
+            return False
+        
+        return next((edge for edge in self.node.graph.edges.values() if edge.src in self._value), None) is not None or \
+            any(attr.hasOutputConnections for attr in self._value if hasattr(attr, 'hasOutputConnections'))
+    
+    # override
+    def getInputConnections(self) -> list["Edge"]:
+
+        if not self.node.graph or not self.node.graph.edges:
+            return []
+        
+        return [edge for edge in self.node.graph.edges.values() if edge.dst in self._value]
+    
+    # override
+    def getOutputConnections(self) -> list["Edge"]:
+
+        if not self.node.graph or not self.node.graph.edges:
+            return []
+        
+        return [edge for edge in self.node.graph.edges.values() if edge.src in self._value]
+        
 
     # Override value property setter
     value = Property(Variant, Attribute._get_value, _set_value, notify=Attribute.valueChanged)
     isDefault = Property(bool, _isDefault, notify=Attribute.valueChanged)
     baseType = Property(str, getBaseType, constant=True)
     isLinkNested = Property(bool, isLinkNested.fget)
+    hasOutputConnections = Property(bool, hasOutputConnections.fget, notify=Attribute.hasOutputConnectionsChanged)
+
 
 
 class GroupAttribute(Attribute):

--- a/meshroom/core/attribute.py
+++ b/meshroom/core/attribute.py
@@ -347,13 +347,12 @@ class Attribute(BaseObject):
         
         return [edge for edge in self.node.graph.edges.values() if edge.src == self]
     
-    def getInputAttributes(self) -> list["Edge"]:
+    def getLinkedInAttributes(self) -> list["Attribute"]:
         """ Return the upstreams connected attributes  """
 
         return [edge.src for edge in self.getInputConnections()]
     
-
-    def getOutputAttributes(self):
+    def getLinkedOutAttributes(self) -> list["Attribute"]:
         """ Return the downstreams connected attributes """
         
         return [edge.dst for edge in self.getOutputConnections()]
@@ -481,8 +480,8 @@ class Attribute(BaseObject):
     isLinkNested = isLink
     hasOutputConnectionsChanged = Signal()
     hasOutputConnections = Property(bool, hasOutputConnections.fget, notify=hasOutputConnectionsChanged)
-    inputAttributes = Property(Variant, getInputAttributes)
-    outputAttributes = Property(Variant, getOutputAttributes)
+    linkedInAttributes = Property(Variant, getLinkedInAttributes)
+    linkedOutAttributes = Property(Variant, getLinkedOutAttributes)
     isDefault = Property(bool, _isDefault, notify=valueChanged)
     linkParam = Property(BaseObject, getLinkParam, notify=isLinkChanged)
     rootLinkParam = Property(BaseObject, lambda self: self.getLinkParam(recursive=True), notify=isLinkChanged)

--- a/meshroom/core/attribute.py
+++ b/meshroom/core/attribute.py
@@ -749,7 +749,7 @@ class ListAttribute(Attribute):
         if not self.node.graph or not self.node.graph.edges:
             return []
         
-        return [edge for edge in self.node.graph.edges.values() if edge.dst in self._value]
+        return [edge for edge in self.node.graph.edges.values() if edge.dst == self or edge.dst in self._value]
     
     # override
     def getOutputConnections(self) -> list["Edge"]:
@@ -757,9 +757,8 @@ class ListAttribute(Attribute):
         if not self.node.graph or not self.node.graph.edges:
             return []
         
-        return [edge for edge in self.node.graph.edges.values() if edge.src in self._value]
+        return [edge for edge in self.node.graph.edges.values() if edge.src == self or edge.src in self._value]
         
-
     # Override value property setter
     value = Property(Variant, Attribute._get_value, _set_value, notify=Attribute.valueChanged)
     isDefault = Property(bool, _isDefault, notify=Attribute.valueChanged)

--- a/meshroom/ui/qml/Application.qml
+++ b/meshroom/ui/qml/Application.qml
@@ -1335,7 +1335,9 @@ Page {
                     SplitView.minimumWidth: 80
 
                     node: _reconstruction ? _reconstruction.selectedNode : null
-                    property bool computing: _reconstruction ? _reconstruction.computing : false
+                    property bool computing: _reconstruction ? _reconstruction.computing : false       
+                    property var currentAttributes: []
+
                     // Make NodeEditor readOnly when computing
                     readOnly: node ? node.locked : false
 
@@ -1344,8 +1346,22 @@ Page {
                         _reconstruction.selectedNode = n
                     }                   
 
-                    onInAttributeClicked: function(mouse, inAttributes) {
-                        selectNodesFromAttributes(inAttributes)
+                    onInAttributeClicked: function(srcItem, mouse, inAttributes) {
+
+                        nodeEditor.currentAttributes = inAttributes
+
+                        if (mouse.button === Qt.RightButton) {
+
+                            const srcGlobal = srcItem.mapToGlobal(0, 0)
+                            const nodeEditorGlobal = nodeEditor.mapToGlobal(0, 0)
+                            contextMenu.x = srcGlobal.x - nodeEditorGlobal.x
+                            contextMenu.y = srcGlobal.y - nodeEditorGlobal.y - 14 // TODO: Couldn't found a way to avoid padding in position. 14 = navButtonIn.paddingTop * 2
+                            contextMenu.open()
+
+                            return
+                        }
+
+                        nodeEditor.selectNodesFromAttributes(nodeEditor.currentAttributes)
 
                         if (mouse.button === Qt.MiddleButton) {
                             graphEditor.fit()
@@ -1353,11 +1369,41 @@ Page {
                         
                     }
 
-                    onOutAttributeClicked: function(mouse, outAttributes) {                        
-                        selectNodesFromAttributes(outAttributes)
+                    onOutAttributeClicked: function(srcItem, mouse, outAttributes) {     
+
+                        nodeEditor.currentAttributes = outAttributes
+
+                        if (mouse.button === Qt.RightButton) {
+                            
+                            const srcGlobal = srcItem.mapToGlobal(0, 0)
+                            const nodeEditorGlobal = nodeEditor.mapToGlobal(0, 0)
+                            contextMenu.x = srcGlobal.x - nodeEditorGlobal.x
+                            contextMenu.y = srcGlobal.y - nodeEditorGlobal.y - 14 // TODO: Couldn't found a way to avoid padding in position. 14 = navButtonOut.paddingTop * 2
+                            contextMenu.open()
+
+                            return
+                        }
+
+                        nodeEditor.selectNodesFromAttributes(nodeEditor.currentAttributes)
 
                         if (mouse.button === Qt.MiddleButton) {
                             graphEditor.fit()
+                        }
+
+                    }
+
+                    Menu {
+                        id: contextMenu
+
+                        Repeater {
+                            model: nodeEditor.currentAttributes
+
+                            delegate: MenuItem {
+                                text: `${modelData.node.label}.${modelData.label}`
+                                onTriggered: {
+                                    nodeEditor.selectNodesFromAttributes([nodeEditor.currentAttributes[index]])
+                                }
+                            }
                         }
 
                     }

--- a/meshroom/ui/qml/Application.qml
+++ b/meshroom/ui/qml/Application.qml
@@ -1354,14 +1354,21 @@ Page {
                         _handleNavButtonClick(srcItem, mouse, outAttributes)
                     }
 
+                    // NavButtonContextMenu
                     Menu {
-                        id: contextMenu
+                        id: navButtonContextMenu
 
                         Repeater {
                             model: nodeEditor.currentAttributes
 
                             delegate: MenuItem {
-                                text: `${modelData.node.label}.${modelData.label}`
+
+                                contentItem: Text {
+                                    text: `${modelData.node.label}.${modelData.label}`
+                                    elide: Text.ElideLeft
+                                    color: Colors.sysPalette.text
+                                }
+                                
                                 onTriggered: {
                                     nodeEditor._selectNodesFromAttributes([nodeEditor.currentAttributes[index]])
                                 }

--- a/meshroom/ui/qml/Application.qml
+++ b/meshroom/ui/qml/Application.qml
@@ -1346,10 +1346,20 @@ Page {
 
                     onInAttributeClicked: function(mouse, inAttributes) {
                         selectNodesFromAttributes(inAttributes)
+
+                        if (mouse.button === Qt.MiddleButton) {
+                            graphEditor.fit()
+                        }
+                        
                     }
 
                     onOutAttributeClicked: function(mouse, outAttributes) {                        
                         selectNodesFromAttributes(outAttributes)
+
+                        if (mouse.button === Qt.MiddleButton) {
+                            graphEditor.fit()
+                        }
+
                     }
 
                     function selectNodesFromAttributes(attributes) {

--- a/meshroom/ui/qml/Application.qml
+++ b/meshroom/ui/qml/Application.qml
@@ -1346,50 +1346,12 @@ Page {
                         _reconstruction.selectedNode = n
                     }                   
 
-                    onInAttributeClicked: function(srcItem, mouse, inAttributes) {
-
-                        nodeEditor.currentAttributes = inAttributes
-
-                        if (mouse.button === Qt.RightButton) {
-
-                            const srcGlobal = srcItem.mapToGlobal(0, 0)
-                            const nodeEditorGlobal = nodeEditor.mapToGlobal(0, 0)
-                            contextMenu.x = srcGlobal.x - nodeEditorGlobal.x
-                            contextMenu.y = srcGlobal.y - nodeEditorGlobal.y - 14 // TODO: Couldn't found a way to avoid padding in position. 14 = navButtonIn.paddingTop * 2
-                            contextMenu.open()
-
-                            return
-                        }
-
-                        nodeEditor.selectNodesFromAttributes(nodeEditor.currentAttributes)
-
-                        if (mouse.button === Qt.MiddleButton) {
-                            graphEditor.fit()
-                        }
-                        
+                    onInAttributeClicked: function(srcItem, mouse, inAttributes) {                        
+                        _handleNavButtonClick(srcItem, mouse, inAttributes)                        
                     }
 
-                    onOutAttributeClicked: function(srcItem, mouse, outAttributes) {     
-
-                        nodeEditor.currentAttributes = outAttributes
-
-                        if (mouse.button === Qt.RightButton) {
-                            
-                            const srcGlobal = srcItem.mapToGlobal(0, 0)
-                            const nodeEditorGlobal = nodeEditor.mapToGlobal(0, 0)
-                            contextMenu.x = srcGlobal.x - nodeEditorGlobal.x
-                            contextMenu.y = srcGlobal.y - nodeEditorGlobal.y - 14 // TODO: Couldn't found a way to avoid padding in position. 14 = navButtonOut.paddingTop * 2
-                            contextMenu.open()
-
-                            return
-                        }
-
-                        nodeEditor.selectNodesFromAttributes(nodeEditor.currentAttributes)
-
-                        if (mouse.button === Qt.MiddleButton) {
-                            graphEditor.fit()
-                        }
-
+                    onOutAttributeClicked: function(srcItem, mouse, outAttributes) {
+                        _handleNavButtonClick(srcItem, mouse, outAttributes)
                     }
 
                     Menu {
@@ -1401,14 +1363,14 @@ Page {
                             delegate: MenuItem {
                                 text: `${modelData.node.label}.${modelData.label}`
                                 onTriggered: {
-                                    nodeEditor.selectNodesFromAttributes([nodeEditor.currentAttributes[index]])
+                                    nodeEditor._selectNodesFromAttributes([nodeEditor.currentAttributes[index]])
                                 }
                             }
                         }
 
                     }
 
-                    function selectNodesFromAttributes(attributes) {
+                    function _selectNodesFromAttributes(attributes) {
                         /*
                             Retrieve the nodes from given attributes, and select its 
                         */
@@ -1424,6 +1386,29 @@ Page {
                         }
                         graphEditor.uigraph.selectNodes(nodes)
                     } 
+
+                    function _openLinkAttributesContextMenu(srcItem, mouse, attributes) {
+                        nodeEditor.currentAttributes = attributes
+                        const srcGlobal = srcItem.mapToGlobal(0, 0)
+                        const nodeEditorGlobal = nodeEditor.mapToGlobal(0, 0)
+                        navButtonContextMenu.x = srcGlobal.x - nodeEditorGlobal.x
+                        navButtonContextMenu.y = srcGlobal.y - nodeEditorGlobal.y - 14 // TODO: Couldn't found a way to avoid padding in position. 14 = navButtonOut.paddingTop * 2
+                        navButtonContextMenu.open()
+                    }
+
+                    function _handleNavButtonClick(srcItem, mouse, attributes) {
+
+                        if (mouse.button === Qt.RightButton) {
+                            nodeEditor._openLinkAttributesContextMenu(srcItem, mouse, attributes)
+                            return
+                        }
+
+                        nodeEditor._selectNodesFromAttributes(nodeEditor.currentAttributes)
+
+                        if (mouse.button === Qt.MiddleButton) {
+                            graphEditor.fit()
+                        }
+                    }
 
                 }
             }

--- a/meshroom/ui/qml/Application.qml
+++ b/meshroom/ui/qml/Application.qml
@@ -1354,10 +1354,8 @@ Page {
 
                     function selectNodesFromAttributes(attributes) {
                         /*
-                            Retrieve the nodes from givn attributes, and select its 
+                            Retrieve the nodes from given attributes, and select its 
                         */
-
-                        console.log("attributes", attributes)
 
                         if ( !attributes || attributes.length == 0) { return }
 

--- a/meshroom/ui/qml/Application.qml
+++ b/meshroom/ui/qml/Application.qml
@@ -1403,7 +1403,7 @@ Page {
                             return
                         }
 
-                        nodeEditor._selectNodesFromAttributes(nodeEditor.currentAttributes)
+                        nodeEditor._selectNodesFromAttributes(attributes)
 
                         if (mouse.button === Qt.MiddleButton) {
                             graphEditor.fit()

--- a/meshroom/ui/qml/Application.qml
+++ b/meshroom/ui/qml/Application.qml
@@ -1342,7 +1342,35 @@ Page {
                     onUpgradeRequest: {
                         var n = _reconstruction.upgradeNode(node)
                         _reconstruction.selectedNode = n
+                    }                   
+
+                    onInAttributeClicked: function(mouse, inAttributes) {
+                        selectNodesFromAttributes(inAttributes)
                     }
+
+                    onOutAttributeClicked: function(mouse, outAttributes) {                        
+                        selectNodesFromAttributes(outAttributes)
+                    }
+
+                    function selectNodesFromAttributes(attributes) {
+                        /*
+                            Retrieve the nodes from givn attributes, and select its 
+                        */
+
+                        console.log("attributes", attributes)
+
+                        if ( !attributes || attributes.length == 0) { return }
+
+                        graphEditor.uigraph.clearNodeSelection()
+                        
+                        const nodes = attributes.map( attr => attr.node)
+
+                        if (attributes.length == 1) {
+                            _reconstruction.selectedNode = attributes[0].node
+                        }
+                        graphEditor.uigraph.selectNodes(nodes)
+                    } 
+
                 }
             }
         }

--- a/meshroom/ui/qml/GraphEditor/AttributeEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/AttributeEditor.qml
@@ -16,6 +16,8 @@ ListView {
 
     signal upgradeRequest()
     signal attributeDoubleClicked(var mouse, var attribute)
+    signal inAttributeClicked(var mouse, var inAttributes)
+    signal outAttributeClicked(var mouse, var outAttributes)
 
     implicitHeight: contentHeight
 
@@ -40,9 +42,17 @@ ListView {
             filterText: root.filterText
             objectsHideable: root.objectsHideable
             attribute: object
+
             onDoubleClicked: function(mouse, attr) {
                 root.attributeDoubleClicked(mouse, attr)
             }
+            onInAttributeClicked: function(mouse, inAttributes) {
+                root.inAttributeClicked(mouse, inAttributes)
+            }
+            onOutAttributeClicked: function(mouse, outAttributes) {
+                root.outAttributeClicked(mouse, outAttributes)
+            }
+
         }
 
         onActiveChanged: height = active ? item.implicitHeight : -spacing

--- a/meshroom/ui/qml/GraphEditor/AttributeEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/AttributeEditor.qml
@@ -16,8 +16,8 @@ ListView {
 
     signal upgradeRequest()
     signal attributeDoubleClicked(var mouse, var attribute)
-    signal inAttributeClicked(var mouse, var inAttributes)
-    signal outAttributeClicked(var mouse, var outAttributes)
+    signal inAttributeClicked(var srcItem, var mouse, var inAttributes)
+    signal outAttributeClicked(var srcItem, var mouse, var outAttributes)
 
     implicitHeight: contentHeight
 
@@ -46,11 +46,11 @@ ListView {
             onDoubleClicked: function(mouse, attr) {
                 root.attributeDoubleClicked(mouse, attr)
             }
-            onInAttributeClicked: function(mouse, inAttributes) {
-                root.inAttributeClicked(mouse, inAttributes)
+            onInAttributeClicked: function(srcItem, mouse, inAttributes) {
+                root.inAttributeClicked(srcItem, mouse, inAttributes)
             }
-            onOutAttributeClicked: function(mouse, outAttributes) {
-                root.outAttributeClicked(mouse, outAttributes)
+            onOutAttributeClicked: function(srcItem, mouse, outAttributes) {
+                root.outAttributeClicked(srcItem, mouse, outAttributes)
             }
 
         }

--- a/meshroom/ui/qml/GraphEditor/AttributeItemDelegate.qml
+++ b/meshroom/ui/qml/GraphEditor/AttributeItemDelegate.qml
@@ -26,6 +26,8 @@ RowLayout {
     readonly property bool editable: !attribute.isOutput && !attribute.isLink && !readOnly
 
     signal doubleClicked(var mouse, var attr)
+    signal inAttributeClicked(var mouse, var inAttributes)
+    signal outAttributeClicked(var mouse, var outAttributes)
 
     spacing: 2
 
@@ -55,6 +57,18 @@ RowLayout {
             spacing: 0
             width: parent.width
             height: parent.height
+
+            // In connection
+            MaterialToolButton {
+                text: (object != undefined && object.isLink) ? MaterialIcons.login : " "
+                enabled: (object != undefined && object.isLink)
+                font.pointSize: 8
+                ToolTip.text: (object != undefined && object.isLink) ? object.linkParam.label : ""
+                onClicked: function(mouse) {
+                    root.inAttributeClicked(mouse, object.inputAttributes)               
+                }
+                
+            }
 
             Label {
                 id: parameterLabel
@@ -167,6 +181,18 @@ RowLayout {
                     }
                 }
             }
+
+            MaterialToolButton {
+                text: (attribute != undefined && attribute.hasOutputConnections) ? MaterialIcons.logout : ""
+                font.pointSize: 8
+                enabled: (attribute != undefined && attribute.hasOutputConnections)
+                
+                onClicked: function(mouse) {
+                    root.outAttributeClicked(mouse, attribute.outputAttributes)               
+                }
+
+            }
+
             MaterialLabel {
                 visible: attribute.desc.advanced
                 text: MaterialIcons.build

--- a/meshroom/ui/qml/GraphEditor/AttributeItemDelegate.qml
+++ b/meshroom/ui/qml/GraphEditor/AttributeItemDelegate.qml
@@ -63,6 +63,9 @@ RowLayout {
                 text: (object != undefined && object.isLink) ? MaterialIcons.login : " "
                 enabled: (object != undefined && object.isLink)
                 font.pointSize: 8
+                anchors.top: parent.top
+                anchors.left: parent.left
+                topPadding: 7
                 ToolTip.text: (object != undefined && object.isLink) ? object.linkParam.label : ""
                 onClicked: function(mouse) {
                     root.inAttributeClicked(mouse, object.inputAttributes)               
@@ -186,7 +189,10 @@ RowLayout {
                 text: (attribute != undefined && attribute.hasOutputConnections) ? MaterialIcons.logout : ""
                 font.pointSize: 8
                 enabled: (attribute != undefined && attribute.hasOutputConnections)
-                
+                anchors.top: parent.top
+                anchors.right: parent.right
+                topPadding: 7
+
                 onClicked: function(mouse) {
                     root.outAttributeClicked(mouse, attribute.outputAttributes)               
                 }

--- a/meshroom/ui/qml/GraphEditor/AttributeItemDelegate.qml
+++ b/meshroom/ui/qml/GraphEditor/AttributeItemDelegate.qml
@@ -71,7 +71,7 @@ RowLayout {
                 ToolTip.text: shouldBeVisible ? object.linkParam.label : ""
 
                 onClicked: function(mouse) {
-                    root.inAttributeClicked(mouse, object.inputAttributes)               
+                    root.inAttributeClicked(mouse, object.linkedInAttributes)               
                 }
                 
             }
@@ -199,7 +199,7 @@ RowLayout {
                 topPadding: 7
 
                 onClicked: function(mouse) {
-                    root.outAttributeClicked(mouse, attribute.outputAttributes)               
+                    root.outAttributeClicked(mouse, attribute.linkedOutAttributes)               
                 }
 
             }

--- a/meshroom/ui/qml/GraphEditor/AttributeItemDelegate.qml
+++ b/meshroom/ui/qml/GraphEditor/AttributeItemDelegate.qml
@@ -60,7 +60,7 @@ RowLayout {
 
             // In connection
             MaterialToolButton {
-                property var shouldBeVisible: (object != undefined && object.isLink)
+                property var shouldBeVisible: (object != undefined && object.isLinkNested)
 
                 text: shouldBeVisible ? MaterialIcons.login : " "
                 enabled: shouldBeVisible

--- a/meshroom/ui/qml/GraphEditor/AttributeItemDelegate.qml
+++ b/meshroom/ui/qml/GraphEditor/AttributeItemDelegate.qml
@@ -69,8 +69,13 @@ RowLayout {
                 topPadding: 7
                 ToolTip.text: shouldBeVisible ? object.linkParam.label : ""
 
-                onClicked: function(mouse) {
-                    root.inAttributeClicked(mouse, object.linkedInAttributes)               
+                MouseArea {
+                    anchors.fill: parent
+                    acceptedButtons: Qt.LeftButton | Qt.MiddleButton
+
+                    onClicked: function(mouse) {
+                        root.inAttributeClicked(mouse, object.linkedInAttributes)               
+                    }
                 }
                 
             }
@@ -196,9 +201,15 @@ RowLayout {
                 Layout.alignment: Qt.AlignTop | Qt.AlignRight
                 topPadding: 7
 
-                onClicked: function(mouse) {
-                    root.outAttributeClicked(mouse, attribute.linkedOutAttributes)               
+                MouseArea {
+                    anchors.fill: parent
+                    acceptedButtons: Qt.LeftButton | Qt.MiddleButton
+
+                    onClicked: function(mouse) {
+                        root.outAttributeClicked(mouse, attribute.linkedOutAttributes)               
+                    }
                 }
+                
 
             }
 

--- a/meshroom/ui/qml/GraphEditor/AttributeItemDelegate.qml
+++ b/meshroom/ui/qml/GraphEditor/AttributeItemDelegate.qml
@@ -60,6 +60,7 @@ RowLayout {
 
             // In connection
             MaterialToolButton {
+                id: navButtonIn
                 property var shouldBeVisible: (object != undefined && object.isLinkNested)
 
                 text: shouldBeVisible ? MaterialIcons.login : " "
@@ -193,6 +194,7 @@ RowLayout {
             }
 
             MaterialToolButton {
+                id: navButtonOut
                 property var shouldBeVisible: (attribute != undefined && attribute.hasOutputConnections)
 
                 text: shouldBeVisible ? MaterialIcons.logout : ""

--- a/meshroom/ui/qml/GraphEditor/AttributeItemDelegate.qml
+++ b/meshroom/ui/qml/GraphEditor/AttributeItemDelegate.qml
@@ -65,8 +65,7 @@ RowLayout {
                 text: shouldBeVisible ? MaterialIcons.login : " "
                 enabled: shouldBeVisible
                 font.pointSize: 8
-                anchors.top: parent.top
-                anchors.left: parent.left
+                Layout.alignment: Qt.AlignTop | Qt.AlignLeft 
                 topPadding: 7
                 ToolTip.text: shouldBeVisible ? object.linkParam.label : ""
 
@@ -194,8 +193,7 @@ RowLayout {
                 text: shouldBeVisible ? MaterialIcons.logout : ""
                 font.pointSize: 8
                 enabled: shouldBeVisible
-                anchors.top: parent.top
-                anchors.right: parent.right
+                Layout.alignment: Qt.AlignTop | Qt.AlignRight
                 topPadding: 7
 
                 onClicked: function(mouse) {

--- a/meshroom/ui/qml/GraphEditor/AttributeItemDelegate.qml
+++ b/meshroom/ui/qml/GraphEditor/AttributeItemDelegate.qml
@@ -62,7 +62,7 @@ RowLayout {
             MaterialToolButton {
                 id: navButtonIn
 
-                property var shouldBeVisible: (object != undefined && object.isLinkNested)
+                property bool shouldBeVisible: (object != undefined && object.isLinkNested)
 
                 text: shouldBeVisible ? MaterialIcons.login : " "
                 enabled: shouldBeVisible
@@ -196,7 +196,7 @@ RowLayout {
             MaterialToolButton {
                 id: navButtonOut
 
-                property var shouldBeVisible: (attribute != undefined && attribute.hasOutputConnections)
+                property bool shouldBeVisible: (attribute != undefined && attribute.hasOutputConnections)
 
                 text: shouldBeVisible ? MaterialIcons.logout : ""
                 font.pointSize: 8

--- a/meshroom/ui/qml/GraphEditor/AttributeItemDelegate.qml
+++ b/meshroom/ui/qml/GraphEditor/AttributeItemDelegate.qml
@@ -64,7 +64,7 @@ RowLayout {
 
                 property bool shouldBeVisible: (object != undefined && object.isLinkNested)
 
-                text: shouldBeVisible ? MaterialIcons.login : " "
+                text: shouldBeVisible ? MaterialIcons.login : "  "
                 enabled: shouldBeVisible
                 font.pointSize: 8
                 Layout.alignment: Qt.AlignTop | Qt.AlignLeft 
@@ -198,7 +198,7 @@ RowLayout {
 
                 property bool shouldBeVisible: (attribute != undefined && attribute.hasOutputConnections)
 
-                text: shouldBeVisible ? MaterialIcons.logout : ""
+                text: shouldBeVisible ? MaterialIcons.logout : " "
                 font.pointSize: 8
                 enabled: shouldBeVisible
                 Layout.alignment: Qt.AlignTop | Qt.AlignRight

--- a/meshroom/ui/qml/GraphEditor/AttributeItemDelegate.qml
+++ b/meshroom/ui/qml/GraphEditor/AttributeItemDelegate.qml
@@ -26,8 +26,8 @@ RowLayout {
     readonly property bool editable: !attribute.isOutput && !attribute.isLink && !readOnly
 
     signal doubleClicked(var mouse, var attr)
-    signal inAttributeClicked(var mouse, var inAttributes)
-    signal outAttributeClicked(var mouse, var outAttributes)
+    signal inAttributeClicked(var srcItem, var mouse, var inAttributes)
+    signal outAttributeClicked(var srcItem, var mouse, var outAttributes)
 
     spacing: 2
 
@@ -61,6 +61,7 @@ RowLayout {
             // In connection
             MaterialToolButton {
                 id: navButtonIn
+
                 property var shouldBeVisible: (object != undefined && object.isLinkNested)
 
                 text: shouldBeVisible ? MaterialIcons.login : " "
@@ -68,17 +69,16 @@ RowLayout {
                 font.pointSize: 8
                 Layout.alignment: Qt.AlignTop | Qt.AlignLeft 
                 topPadding: 7
-                ToolTip.text: shouldBeVisible ? object.linkParam.label : ""
 
                 MouseArea {
                     anchors.fill: parent
-                    acceptedButtons: Qt.LeftButton | Qt.MiddleButton
+                    acceptedButtons: Qt.LeftButton | Qt.MiddleButton | Qt.RightButton
 
                     onClicked: function(mouse) {
-                        root.inAttributeClicked(mouse, object.linkedInAttributes)               
+                        root.inAttributeClicked(navButtonIn, mouse, object.linkedInAttributes)
                     }
                 }
-                
+                                
             }
 
             Label {
@@ -195,6 +195,7 @@ RowLayout {
 
             MaterialToolButton {
                 id: navButtonOut
+
                 property var shouldBeVisible: (attribute != undefined && attribute.hasOutputConnections)
 
                 text: shouldBeVisible ? MaterialIcons.logout : ""
@@ -205,10 +206,10 @@ RowLayout {
 
                 MouseArea {
                     anchors.fill: parent
-                    acceptedButtons: Qt.LeftButton | Qt.MiddleButton
+                    acceptedButtons: Qt.LeftButton | Qt.MiddleButton | Qt.RightButton
 
-                    onClicked: function(mouse) {
-                        root.outAttributeClicked(mouse, attribute.linkedOutAttributes)               
+                    onClicked: function(mouse) {        
+                        root.outAttributeClicked(navButtonOut, mouse, attribute.linkedOutAttributes)               
                     }
                 }
                 
@@ -714,8 +715,8 @@ RowLayout {
                                 obj.label.horizontalAlignment = Text.AlignHCenter
                                 obj.label.verticalAlignment = Text.AlignVCenter
                                 obj.doubleClicked.connect(function(attr) { root.doubleClicked(attr) })
-                                obj.inAttributeClicked.connect(function(mouse, inAttributes) { root.inAttributeClicked(mouse, inAttributes) })
-                                obj.outAttributeClicked.connect(function(mouse, outAttributes) { root.outAttributeClicked(mouse, outAttributes) })
+                                obj.inAttributeClicked.connect(function(srcItem, mouse, inAttributes) { root.inAttributeClicked(srcItem, mouse, inAttributes) })
+                                obj.outAttributeClicked.connect(function(srcItem, mouse, outAttributes) { root.outAttributeClicked(srcItem, mouse, outAttributes) })
                             }
                             ToolButton {
                                 enabled: root.editable

--- a/meshroom/ui/qml/GraphEditor/AttributeItemDelegate.qml
+++ b/meshroom/ui/qml/GraphEditor/AttributeItemDelegate.qml
@@ -692,6 +692,8 @@ RowLayout {
                                 obj.label.horizontalAlignment = Text.AlignHCenter
                                 obj.label.verticalAlignment = Text.AlignVCenter
                                 obj.doubleClicked.connect(function(attr) { root.doubleClicked(attr) })
+                                obj.inAttributeClicked.connect(function(mouse, inAttributes) { root.inAttributeClicked(mouse, inAttributes) })
+                                obj.outAttributeClicked.connect(function(mouse, outAttributes) { root.outAttributeClicked(mouse, outAttributes) })
                             }
                             ToolButton {
                                 enabled: root.editable

--- a/meshroom/ui/qml/GraphEditor/AttributeItemDelegate.qml
+++ b/meshroom/ui/qml/GraphEditor/AttributeItemDelegate.qml
@@ -60,13 +60,16 @@ RowLayout {
 
             // In connection
             MaterialToolButton {
-                text: (object != undefined && object.isLink) ? MaterialIcons.login : " "
-                enabled: (object != undefined && object.isLink)
+                property var shouldBeVisible: (object != undefined && object.isLink)
+
+                text: shouldBeVisible ? MaterialIcons.login : " "
+                enabled: shouldBeVisible
                 font.pointSize: 8
                 anchors.top: parent.top
                 anchors.left: parent.left
                 topPadding: 7
-                ToolTip.text: (object != undefined && object.isLink) ? object.linkParam.label : ""
+                ToolTip.text: shouldBeVisible ? object.linkParam.label : ""
+
                 onClicked: function(mouse) {
                     root.inAttributeClicked(mouse, object.inputAttributes)               
                 }
@@ -186,9 +189,11 @@ RowLayout {
             }
 
             MaterialToolButton {
-                text: (attribute != undefined && attribute.hasOutputConnections) ? MaterialIcons.logout : ""
+                property var shouldBeVisible: (attribute != undefined && attribute.hasOutputConnections)
+
+                text: shouldBeVisible ? MaterialIcons.logout : ""
                 font.pointSize: 8
-                enabled: (attribute != undefined && attribute.hasOutputConnections)
+                enabled: shouldBeVisible
                 anchors.top: parent.top
                 anchors.right: parent.right
                 topPadding: 7

--- a/meshroom/ui/qml/GraphEditor/NodeEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/NodeEditor.qml
@@ -21,6 +21,8 @@ Panel {
     property string nodeStartDateTime: ""
 
     signal attributeDoubleClicked(var mouse, var attribute)
+    signal inAttributeClicked(var mouse, var inAttributes)
+    signal outAttributeClicked(var mouse, var outAttributes)
     signal upgradeRequest()
 
     title: "Node" + (node !== null ? " - <b>" + node.label + "</b>" + (node.label !== node.defaultLabel ? " (" + node.defaultLabel + ")" : "") : "")
@@ -301,6 +303,13 @@ Panel {
                             onAttributeDoubleClicked: function(mouse, attribute) { root.attributeDoubleClicked(mouse, attribute) }
                             onUpgradeRequest: root.upgradeRequest()
                             filterText: searchBar.text
+
+                            onInAttributeClicked: function(mouse, inAttributes) {
+                                root.inAttributeClicked(mouse, inAttributes)
+                            }
+                            onOutAttributeClicked: function(mouse, outAttributes) {
+                                root.outAttributeClicked(mouse, outAttributes)
+                            }
                         }
 
                         Loader {

--- a/meshroom/ui/qml/GraphEditor/NodeEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/NodeEditor.qml
@@ -21,8 +21,8 @@ Panel {
     property string nodeStartDateTime: ""
 
     signal attributeDoubleClicked(var mouse, var attribute)
-    signal inAttributeClicked(var mouse, var inAttributes)
-    signal outAttributeClicked(var mouse, var outAttributes)
+    signal inAttributeClicked(var srcItem, var mouse, var inAttributes)
+    signal outAttributeClicked(var srcItem, var mouse, var outAttributes)
     signal upgradeRequest()
 
     title: "Node" + (node !== null ? " - <b>" + node.label + "</b>" + (node.label !== node.defaultLabel ? " (" + node.defaultLabel + ")" : "") : "")
@@ -304,11 +304,11 @@ Panel {
                             onUpgradeRequest: root.upgradeRequest()
                             filterText: searchBar.text
 
-                            onInAttributeClicked: function(mouse, inAttributes) {
-                                root.inAttributeClicked(mouse, inAttributes)
+                            onInAttributeClicked: function(srcItem, mouse, inAttributes) {
+                                root.inAttributeClicked(srcItem, mouse, inAttributes)
                             }
-                            onOutAttributeClicked: function(mouse, outAttributes) {
-                                root.outAttributeClicked(mouse, outAttributes)
+                            onOutAttributeClicked: function(srcItem, mouse, outAttributes) {
+                                root.outAttributeClicked(srcItem, mouse, outAttributes)
                             }
                         }
 

--- a/tests/test_attributes.py
+++ b/tests/test_attributes.py
@@ -1,0 +1,29 @@
+from meshroom.core.graph import Graph
+
+
+def test_attribute_retrieve_linked_input_and_output_attributes():
+    """
+    Check that an attribute can retrieve the linked input and output attributes
+    """
+
+    # n0 -- n1 -- n2
+    #   \          \
+    #    ---------- n3
+
+    g = Graph('')
+    n0 = g.addNewNode('Ls', input='/tmp')
+    n1 = g.addNewNode('Ls', input=n0.output)
+    n2 = g.addNewNode('Ls', input=n1.output)
+    n3 = g.addNewNode('AppendFiles', input=n1.output, input2=n2.output)
+
+    # check that the attribute can retrieve its linked input attributes
+    assert len(n0.input.getInputAttributes()) == 0
+    assert len(n1.input.getInputAttributes()) == 1
+    assert n1.input.getInputAttributes()[0] == n0.output
+    
+    assert len(n1.output.getOutputAttributes()) == 2
+    
+    assert n1.output.getOutputAttributes()[0] == n2.input
+    assert n1.output.getOutputAttributes()[1] == n3.input
+
+    

--- a/tests/test_attributes.py
+++ b/tests/test_attributes.py
@@ -11,7 +11,7 @@ def test_attribute_retrieve_linked_input_and_output_attributes():
     #    ---------- n3
 
     g = Graph('')
-    n0 = g.addNewNode('Ls', input='/tmp')
+    n0 = g.addNewNode('Ls', input='')
     n1 = g.addNewNode('Ls', input=n0.output)
     n2 = g.addNewNode('Ls', input=n1.output)
     n3 = g.addNewNode('AppendFiles', input=n1.output, input2=n2.output)

--- a/tests/test_attributes.py
+++ b/tests/test_attributes.py
@@ -17,13 +17,13 @@ def test_attribute_retrieve_linked_input_and_output_attributes():
     n3 = g.addNewNode('AppendFiles', input=n1.output, input2=n2.output)
 
     # check that the attribute can retrieve its linked input attributes
-    assert len(n0.input.getInputAttributes()) == 0
-    assert len(n1.input.getInputAttributes()) == 1
-    assert n1.input.getInputAttributes()[0] == n0.output
+    assert len(n0.input.getLinkedInAttributes()) == 0
+    assert len(n1.input.getLinkedInAttributes()) == 1
+    assert n1.input.getLinkedInAttributes()[0] == n0.output
     
-    assert len(n1.output.getOutputAttributes()) == 2
+    assert len(n1.output.getLinkedOutAttributes()) == 2
     
-    assert n1.output.getOutputAttributes()[0] == n2.input
-    assert n1.output.getOutputAttributes()[1] == n3.input
+    assert n1.output.getLinkedOutAttributes()[0] == n2.input
+    assert n1.output.getLinkedOutAttributes()[1] == n3.input
 
     

--- a/tests/test_attributes.py
+++ b/tests/test_attributes.py
@@ -17,6 +17,10 @@ def test_attribute_retrieve_linked_input_and_output_attributes():
     n3 = g.addNewNode('AppendFiles', input=n1.output, input2=n2.output)
 
     # check that the attribute can retrieve its linked input attributes
+
+    assert n0.output.hasOutputConnections
+    assert not n3.output.hasOutputConnections
+
     assert len(n0.input.getLinkedInAttributes()) == 0
     assert len(n1.input.getLinkedInAttributes()) == 1
     assert n1.input.getLinkedInAttributes()[0] == n0.output
@@ -26,4 +30,10 @@ def test_attribute_retrieve_linked_input_and_output_attributes():
     assert n1.output.getLinkedOutAttributes()[0] == n2.input
     assert n1.output.getLinkedOutAttributes()[1] == n3.input
 
+    n0.graph = None
+
+    # Bounding cases
+    assert not n0.output.hasOutputConnections
+    assert len(n0.input.getLinkedInAttributes()) == 0
+    assert len(n0.output.getLinkedOutAttributes()) == 0
     


### PR DESCRIPTION
<!-- Checklist before submission:

 - I have read the [contribution guidelines](../CONTRIBUTING.md).
 - I have updated the documentation, if applicable.
 - I have ensured that the change is tested somewhere.
 - I have followed the prevailing code style (for history readability and limit conflicts for maintainance).

-->
## Description

Add navigation buttons around attributes label in the `AttributeEditor`

![nav_buttons](https://github.com/user-attachments/assets/d40b3160-8e7a-4d40-9514-d73aa8f49235)


If an attribute have linked attributes:
 - a button appear on the left of the label, for input attributes
 - a button appear on the right of the label, for output attributes

## Features list

- [X] Add navigation buttons on linked attributes, in the `AttributeEditor`
- [X] On clicked, the linked attributes nodes are selected in the `GraphEditor`
- [X]  MiddleClick select the linked nodes and fit the view _(not by default, because it can break current user workflow)_ 
- [X] When many attributes are connected, a context menu present the list of attributes to let the user choose the connection he wants to go through.
![image](https://github.com/user-attachments/assets/311a3407-a6bb-4ff7-b065-b979cff95b8c)



