### PR TITLE
[desc] Import `CREATE_NEW_PROCESS_GROUP` flag from `subprocess`

### DIFF
--- a/meshroom/core/desc/node.py
+++ b/meshroom/core/desc/node.py
@@ -155,7 +155,8 @@ class BaseNode(object):
                 # Change the process group to avoid Meshroom main process being killed if the
                 # subprocess gets terminated by the user or an Out Of Memory (OOM kill).
                 if sys.platform == "win32":
-                    platformArgs = {"creationflags": psutil.CREATE_NEW_PROCESS_GROUP}
+                    from subprocess import CREATE_NEW_PROCESS_GROUP
+                    platformArgs = {"creationflags": CREATE_NEW_PROCESS_GROUP}
                     # Note: DETACHED_PROCESS means fully detached process.
                     # We don't want a fully detached process to ensure that if Meshroom is killed,
                     # the subprocesses are killed too.


### PR DESCRIPTION
## Description

This PR fixes an issue that occurs only on Windows when executing nodes, following #2703.

The `CREATE_NEW_PROCESS_GROUP` flag must be added to the list of creation flags when doing the `Popen` to ensure that the process to execute will not be fully detached (and hence will be killable). However, `psutil` does not contain any creation flags, instead supporting those from `subprocess` (https://psutil.readthedocs.io/en/stable/#psutil.Popen).

Prior to this PR, attempting to use `psutil.CREATE_NEW_PROCESS_GROUP` would cause an error on the execution for all the node processes as it did not exist. This PR replaces it by `subprocess.CREATE_NEW_PROCESS_GROUP`, effectively creating the process with the correct status. It is worth noting that `subprocess.CREATE_NEW_PROCESS_GROUP` is imported within the `if sys.platform == "win32"` condition as this flag only exists for Windows platforms.