### PR TITLE
Use shutil to load nvidia-smi

### DIFF
--- a/meshroom/core/stats.py
+++ b/meshroom/core/stats.py
@@ -51,9 +51,9 @@ class ComputerStatistics:
         self.ramTotal = psutil.virtual_memory().total / (1024*1024*1024)
 
         if platform.system() == "Windows":
-            from distutils import spawn
+            import shutil
             # If the platform is Windows and nvidia-smi
-            self.nvidia_smi = spawn.find_executable('nvidia-smi')
+            self.nvidia_smi = shutil.which('nvidia-smi')
             if self.nvidia_smi is None:
                 # Could not be found from the environment path,
                 # try to find it from system drive with default installation path


### PR DESCRIPTION
<!-- Checklist before submission:

 - I have read the [contribution guidelines](../CONTRIBUTING.md).
 - I have updated the documentation, if applicable.
 - I have ensured that the change is tested somewhere.
 - I have followed the prevailing code style (for history readability and limit conflicts for maintainance).

-->
## Description
The `spawn.find_executable` method is deprecated from Python3.10 and removed in Python3.12. This PR replaces it with the recommended `shutil.which` method:
```python
DeprecationWarning: Use shutil.which instead of find_executable
```

## Features list

<!--
- [ ] Feature one. Fix #XXX
- [ ] Improve something else
- [ ] Connect to #3 (to declare link to issues without closing it when the PR is merged).
- [X] Add "X" when it is done.
-->


## Implementation remarks


<!--
Explain main implementation choices.
It is also the right place to ask for feedback and help when you hesitate on the implementation.
-->
