### PR TITLE
[ui] Viewer2D: Add the pixel (x,y) values in the toolbar (editable)

### DIFF
--- a/meshroom/ui/qml/Viewer/HdrImageToolbar.qml
+++ b/meshroom/ui/qml/Viewer/HdrImageToolbar.qml
@@ -23,8 +23,12 @@ FloatingPane {
     property real gammaValue: Math.pow(gammaCtrl.value, slidersPowerValue)
     property alias channelModeValue: channelsCtrl.value
     property variant colorRGBA: null
+    property variant mousePosition: {return {x:0, y:0} }
 
     property bool colorPickerVisible: true
+
+    property int pixelX: 0
+    property int pixelY: 0
 
     background: Rectangle { color: root.palette.window }
 
@@ -136,6 +140,33 @@ FloatingPane {
             }
         }
 
+        RowLayout {
+
+            Label {
+                text: "x"
+            }
+            TextField {
+                id: xPixel
+                text: root.mousePosition.x
+                Layout.preferredWidth: 50
+                onTextEdited: {
+                    pixelX = parseInt(xPixel.text)
+                }
+            }
+            Label {
+                text: "y"
+            }
+            TextField {
+                id: yPixel
+                text: root.mousePosition.y
+                Layout.preferredWidth: 50
+                onTextEdited: {
+                    pixelY = parseInt(yPixel.text)
+                }
+            }
+
+        }
+
         Rectangle {
             visible: colorPickerVisible
             Layout.preferredWidth: 20
@@ -148,6 +179,7 @@ FloatingPane {
         RowLayout {
             spacing: 1
             visible: colorPickerVisible
+
             TextField {
                 id: red
                 property real value: root.colorRGBA ? root.colorRGBA.x : 0.0

--- a/meshroom/ui/qml/Viewer/Viewer2D.qml
+++ b/meshroom/ui/qml/Viewer/Viewer2D.qml
@@ -427,17 +427,30 @@ FocusScope {
             }
 
             colorRGBA: {
+                                                    
                 if (!floatImageViewerLoader.item ||
                     floatImageViewerLoader.item.imageStatus !== Image.Ready) {
                     return null
                 }
-                if (floatImageViewerLoader.item.containsMouse === false) {
-                    return null
+                
+                /// Get the pixel color value at mouse position (when mouse hover the image)
+                if (floatImageViewerLoader.item.containsMouse === true) {
+                    return floatImageViewerLoader.item.pixelValueAt( mousePosition.x, mousePosition.y )
                 }
-                var pix = floatImageViewerLoader.item.pixelValueAt(Math.floor(floatImageViewerLoader.item.mouseX),
-                                                                   Math.floor(floatImageViewerLoader.item.mouseY))
-                return pix
+
+                // Get the pixel color value from text field value (let the possibility to user to set the x,y from ui)
+                return floatImageViewerLoader.item.pixelValueAt( parseInt(pixelX) , parseInt(pixelY) )
+                
+
             }
+
+            mousePosition: {
+                return {
+                    x: Math.floor(floatImageViewerLoader.item.mouseX), 
+                    y: Math.floor(floatImageViewerLoader.item.mouseY)
+                }
+            }
+               
         }
 
         LensDistortionToolbar {


### PR DESCRIPTION
<!-- Checklist before submission:

 - I have read the [contribution guidelines](../CONTRIBUTING.md).
 - I have updated the documentation, if applicable.
 - I have ensured that the change is tested somewhere.
 - I have followed the prevailing code style (for history readability and limit conflicts for maintenance).

-->
## Description
Add the ability to display and edit `x, y` value of the current `rgba color` displayed in the viewer2D.

![viewer2d-xy](https://github.com/user-attachments/assets/5f27a777-045c-410f-abd6-6143d88e5f91)

## Features list

- [X] Add x and y text fields to `viewer2D` to display the pixel's coordinates 
- [X] x and y can be edited by user to select a specific pixel


<!--
Explain main implementation choices.
It is also the right place to ask for feedback and help when you hesitate on the implementation.
-->
