### PR TITLE
[ui] Homepage: Project can be removed by right click

### DIFF
--- a/meshroom/ui/qml/Application.qml
+++ b/meshroom/ui/qml/Application.qml
@@ -737,6 +737,14 @@ Page {
                         }
                     }
                 }
+                Action {
+                    id: projectsPage
+                    text: "Projects ..."
+                    onTriggered: {
+                        const homepage = mainStack.replace("Homepage.qml")
+                        homepage.setCurrentTab("Projects")
+                    }
+                }
                 MenuSeparator { }
                 Action {
                     id: saveAction

--- a/meshroom/ui/qml/Homepage.qml
+++ b/meshroom/ui/qml/Homepage.qml
@@ -9,6 +9,14 @@ import Controls 1.0
 Page {
     id: root
 
+    function setCurrentTab(tabName) {
+        const tabIndex = tabPanel.tabs.indexOf(tabName)
+
+        if (tabIndex) {
+            tabPanel.currentTab = tabIndex
+        }
+    }
+
     onVisibleChanged: {
         logo.playing = false
         if (visible) {
@@ -369,9 +377,28 @@ Page {
 
                                 onClicked: function(mouse) {
                                     if (mouse.button === Qt.RightButton) {
+
+                                        if (!modelData["path"]) { return }
+
                                         projectContextMenu.x = mouse.x
                                         projectContextMenu.y = mouse.y
                                         projectContextMenu.open()
+                                        
+                                    }
+                                }
+
+                                onDoubleClicked: {
+                                    if (!modelData["path"]) {
+                                        initFileDialogFolder(openFileDialog)
+                                        openFileDialog.open()
+                                    } else {
+                                        // Open project
+                                        mainStack.push("Application.qml")
+                                        if (_reconstruction.load(modelData["path"])) {
+                                            MeshroomApp.addRecentProjectFile(modelData["path"])
+                                        } else {
+                                            MeshroomApp.removeRecentProjectFile(modelData["path"])
+                                        }
                                     }
                                 }
                             }
@@ -413,25 +440,8 @@ Page {
                                 anchors.centerIn: parent
                                 running: gridView.visible && modelData["thumbnail"] && thumbnail.status != Image.Ready
                                 visible: running
-                            }
+                            }                            
 
-                            Connections {
-                                target: projectDelegate
-                                function onClicked() {
-                                    if (!modelData["path"]) {
-                                        initFileDialogFolder(openFileDialog)
-                                        openFileDialog.open()
-                                    } else {
-                                        // Open project
-                                        mainStack.push("Application.qml")
-                                        if (_reconstruction.load(modelData["path"])) {
-                                            MeshroomApp.addRecentProjectFile(modelData["path"])
-                                        } else {
-                                            MeshroomApp.removeRecentProjectFile(modelData["path"])
-                                        }
-                                    }
-                                }
-                            }
                         }
                         Label {
                             id: project

--- a/meshroom/ui/qml/Homepage.qml
+++ b/meshroom/ui/qml/Homepage.qml
@@ -361,6 +361,41 @@ Page {
                             font.pointSize: 24
 
                             text: modelData["path"] ? (modelData["thumbnail"] ? "" : MaterialIcons.description) : MaterialIcons.folder_open
+                            
+                            MouseArea {
+                                anchors.fill: parent
+                                acceptedButtons: Qt.LeftButton | Qt.RightButton
+                                hoverEnabled: true
+
+                                onClicked: function(mouse) {
+                                    if (mouse.button === Qt.RightButton) {
+                                        projectContextMenu.x = mouse.x
+                                        projectContextMenu.y = mouse.y
+                                        projectContextMenu.open()
+                                    }
+                                }
+                            }
+
+                            Menu {
+                                id: projectContextMenu
+
+                                MenuItem {
+                                    text: "Open"
+                                    onTriggered: {                                        
+                                        if (_reconstruction.load(modelData["path"])) {
+                                            mainStack.push("Application.qml")
+                                            MeshroomApp.addRecentProjectFile(modelData["path"])
+                                        }
+                                    }
+                                }
+
+                                MenuItem {
+                                    text: "Delete"
+                                    onTriggered: {
+                                        MeshroomApp.removeRecentProjectFile(modelData["path"])
+                                    }
+                                }
+                            }
 
                             Image {
                                 id: thumbnail


### PR DESCRIPTION
<!-- Checklist before submission:

 - I have read the [contribution guidelines](../CONTRIBUTING.md).
 - I have updated the documentation, if applicable.
 - I have ensured that the change is tested somewhere.
 - I have followed the prevailing code style (for history readability and limit conflicts for maintainance).

-->
## Description

Add a context menu on the project to allow the deletion of a specific project

![image](https://github.com/user-attachments/assets/cdb4c30b-e2d8-455f-b928-4db2887c2bc5)

Add a 'Project ..." item in the main menu to allow navigation to the project page

![image](https://github.com/user-attachments/assets/25b9a6f7-51e1-4a63-bc6a-7070855a70aa)


## Features list

- [X] Homepage: ContextMenu to open/delete a project
- [X] MainMenu: Add `Projects ...` to have the possibility to list the projects when a project is already open

<!--
Explain main implementation choices.
It is also the right place to ask for feedback and help when you hesitate on the implementation.
-->
