### PR TITLE
[core] attribute: Fix `hasOutputConnections` for ListAttributes

### DIFF
--- a/meshroom/core/attribute.py
+++ b/meshroom/core/attribute.py
@@ -765,7 +765,7 @@ class ListAttribute(Attribute):
         if not self.node.graph or not self.node.graph.edges:
             return False
         
-        return next((edge for edge in self.node.graph.edges.values() if edge.src in self._value), None) is not None or \
+        return next((edge for edge in self.node.graph.edges.values() if edge.src == self), None) is not None or \
             any(attr.hasOutputConnections for attr in self._value if hasattr(attr, 'hasOutputConnections'))
     
     # override


### PR DESCRIPTION
## Description

This PR fixes an issue seemingly introduced in cc4e1a2087392493d1acdd78325f8a96ac1101ab that generates errors and leaves a CompatibilityNode in an unstable state when upgrading it.

Below is an example of the generated error when upgrading a `StructureFromMotion` node that was in compatibility mode (in a generic photogrammetry graph):

```
An error occurred executing the property metacall 1 on property "hasOutputConnections" of ListAttribute(0x1f4cad31db0)
Traceback (most recent call last):
  File "C:\dev\meshroom\meshroom\core\attribute.py", line 768, in hasOutputConnections
    return next((edge for edge in self.node.graph.edges.values() if edge.src in self._value), None) is not None or \
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\dev\meshroom\meshroom\core\attribute.py", line 768, in <genexpr>
    return next((edge for edge in self.node.graph.edges.values() if edge.src in self._value), None) is not None or \
                                                                    ^^^^^^^^^^^^^^^^^^^^^^^
TypeError: 'in <string>' requires string as left operand, not Attribute
```

![image](https://github.com/user-attachments/assets/b52e8279-92d2-429a-a363-bbcc0610ad43)

This was caused by the comparison between an `Attribute` object (`edge.src`) and `self._value` with the `in` operator.  