### PR TITLE
[ui] Reconstruction: Restore the `Slot` status of the `clear` method

### DIFF
--- a/meshroom/ui/reconstruction.py
+++ b/meshroom/ui/reconstruction.py
@@ -518,6 +518,7 @@ class Reconstruction(UIGraph):
     def setActive(self, active):
         self._active = active
 
+    @Slot()
     def clear(self):
         self.clearActiveNodes()
         super().clear()


### PR DESCRIPTION
## Description

This PR fixes an issue introduced in cfd2b1e00aa7d99e7ed7a696395a53b2bee38aca which changes the `clear()` method from the `Reconstruction` class from a slot to a regular method. 

If `clear()` is not a slot, it cannot be called from the QML side. In practice, it made the "Home" button ineffective from the Application; once the Homepage had been left, it could not be returned to.