### PR TITLE
New Plugin Architecture for Node Registration

### DIFF
--- a/meshroom/common/qt.py
+++ b/meshroom/common/qt.py
@@ -305,7 +305,8 @@ class QObjectListModel(QtCore.QAbstractListModel):
         key = getattr(item, self._keyAttrName, None)
         if key is None:
             return
-        assert key in self._objectByKey
+        if key not in self._objectByKey:
+            raise RuntimeError(f"{key} is not in the Model: {self._objectByKey.keys()}")
         del self._objectByKey[key]
 
     def onRequestDeletion(self, item):

--- a/meshroom/core/__init__.py
+++ b/meshroom/core/__init__.py
@@ -19,7 +19,7 @@ try:
 except Exception:
     pass
 
-from meshroom.core.plugins import ProcessEnv
+from meshroom.core.plugins import validateNodeDesc, ProcessEnv
 from meshroom.core.submitter import BaseSubmitter
 from meshroom.env import EnvVar, meshroomFolder
 from . import desc
@@ -126,40 +126,6 @@ def loadClasses(folder, packageName, classType):
                         '{errorMsg}\n'
                         .format(package=packageName, errorMsg='\n'.join(errors)))
     return classes
-
-
-def validateNodeDesc(nodeDesc: desc.Node) -> list:
-    """
-    Check that the node has a valid description before being loaded. For the description
-    to be valid, the default value of every parameter needs to correspond to the type
-    of the parameter.
-    An empty returned list means that every parameter is valid, and so is the node's description.
-    If it is not valid, the returned list contains the names of the invalid parameters. In case
-    of nested parameters (parameters in groups or lists, for example), the name of the parameter
-    follows the name of the parent attributes. For example, if the attribute "x", contained in group
-    "group", is invalid, then it will be added to the list as "group:x".
-
-    Args:
-        nodeDesc: description of the node
-
-    Returns:
-        errors: the list of invalid parameters if there are any, empty list otherwise
-    """
-    errors = []
-
-    for param in nodeDesc.inputs:
-        err = param.checkValueTypes()
-        if err:
-            errors.append(err)
-
-    for param in nodeDesc.outputs:
-        if param.value is None:
-            continue
-        err = param.checkValueTypes()
-        if err:
-            errors.append(err)
-
-    return errors
 
 
 class Version:

--- a/meshroom/core/__init__.py
+++ b/meshroom/core/__init__.py
@@ -353,7 +353,6 @@ def loadPluginFolder(folder):
     if plugins:
         for plugin in plugins:
             pluginManager.addPlugin(plugin)
-            pluginManager.registerPlugin(plugin.name)
             pipelineTemplates.update(plugin.templates)
 
     return plugins
@@ -399,7 +398,6 @@ def initNodes():
         if plugins:
             for plugin in plugins:
                 pluginManager.addPlugin(plugin)
-                pluginManager.registerPlugin(plugin.name)
 
 
 def initSubmitters():

--- a/meshroom/core/__init__.py
+++ b/meshroom/core/__init__.py
@@ -257,7 +257,8 @@ class Version:
         status = ''
         # If there is a status, it is placed after a "-"
         splitComponents = versionName.split("-", maxsplit=1)
-        if (len(splitComponents) > 1):  # If there is no status, splitComponents is equal to [versionName]
+        # If there is no status, splitComponents is equal to [versionName]
+        if len(splitComponents) > 1:
             status = splitComponents[-1]
         return tuple([int(v) for v in splitComponents[0].split(".")]), status
 
@@ -354,6 +355,7 @@ def loadPluginFolder(folder):
             pluginManager.addPlugin(plugin)
             pluginManager.registerPlugin(plugin.name)
             pipelineTemplates.update(plugin.templates)
+
     return plugins
 
 
@@ -404,7 +406,7 @@ def initSubmitters():
     additionalPaths = EnvVar.getList(EnvVar.MESHROOM_SUBMITTERS_PATH)
     allSubmittersFolders = [meshroomFolder] + additionalPaths
     for folder in allSubmittersFolders:
-        subs = loadSubmitters(folder, 'submitters')
+        subs = loadSubmitters(folder, "submitters")
         for sub in subs:
             registerSubmitter(sub())
 
@@ -413,7 +415,7 @@ def initPipelines():
     # Load pipeline templates: check in the default folder and any folder the user might have
     # added to the environment variable
     additionalPipelinesPath = EnvVar.getList(EnvVar.MESHROOM_PIPELINE_TEMPLATES_PATH)
-    pipelineTemplatesFolders = [os.path.join(meshroomFolder, 'pipelines')] + additionalPipelinesPath
+    pipelineTemplatesFolders = [os.path.join(meshroomFolder, "pipelines")] + additionalPipelinesPath
     for f in pipelineTemplatesFolders:
         loadPipelineTemplates(f)
     for plugin in pluginManager.getPlugins().values():
@@ -422,6 +424,6 @@ def initPipelines():
 
 def initPlugins():
     additionalpluginsPath = EnvVar.getList(EnvVar.MESHROOM_PLUGINS_PATH)
-    nodesFolders = [os.path.join(meshroomFolder, 'plugins')] + additionalpluginsPath
+    nodesFolders = [os.path.join(meshroomFolder, "plugins")] + additionalpluginsPath
     for f in nodesFolders:
         loadPluginFolder(folder=f)

--- a/meshroom/core/__init__.py
+++ b/meshroom/core/__init__.py
@@ -128,7 +128,7 @@ def loadClasses(folder, packageName, classType):
     return classes
 
 
-def validateNodeDesc(nodeDesc):
+def validateNodeDesc(nodeDesc: desc.Node) -> list:
     """
     Check that the node has a valid description before being loaded. For the description
     to be valid, the default value of every parameter needs to correspond to the type
@@ -140,10 +140,10 @@ def validateNodeDesc(nodeDesc):
     "group", is invalid, then it will be added to the list as "group:x".
 
     Args:
-        nodeDesc (desc.Node): description of the node
+        nodeDesc: description of the node
 
     Returns:
-        errors (list): the list of invalid parameters if there are any, empty list otherwise
+        errors: the list of invalid parameters if there are any, empty list otherwise
     """
     errors = []
 
@@ -280,7 +280,7 @@ class Version:
         return self.components[2]
 
 
-def moduleVersion(moduleName, default=None):
+def moduleVersion(moduleName: str, default=None):
     """ Return the version of a module indicated with '__version__' keyword.
 
     Args:
@@ -293,7 +293,7 @@ def moduleVersion(moduleName, default=None):
     return getattr(sys.modules[moduleName], "__version__", default)
 
 
-def nodeVersion(nodeDesc, default=None):
+def nodeVersion(nodeDesc: desc.Node, default=None):
     """ Return node type version for the given node description class.
 
     Args:
@@ -306,7 +306,7 @@ def nodeVersion(nodeDesc, default=None):
     return moduleVersion(nodeDesc.__module__, default)
 
 
-def registerNodeType(nodeType):
+def registerNodeType(nodeType: desc.Node):
     """ Register a Node Type based on a Node Description class.
 
     After registration, nodes of this type can be instantiated in a Graph.
@@ -316,7 +316,7 @@ def registerNodeType(nodeType):
     nodesDesc[nodeType.__name__] = nodeType
 
 
-def unregisterNodeType(nodeType):
+def unregisterNodeType(nodeType: desc.Node):
     """ Remove 'nodeType' from the list of register node types. """
     assert nodeType.__name__ in nodesDesc
     del nodesDesc[nodeType.__name__]
@@ -367,7 +367,7 @@ def loadPluginsFolder(folder):
             loadPluginFolder(subFolder)
 
 
-def registerSubmitter(s):
+def registerSubmitter(s: BaseSubmitter):
     if s.name in submitters:
         logging.error(f"Submitter {s.name} is already registered.")
     submitters[s.name] = s

--- a/meshroom/core/__init__.py
+++ b/meshroom/core/__init__.py
@@ -312,22 +312,6 @@ def nodeVersion(nodeDesc: desc.Node, default=None):
     return moduleVersion(nodeDesc.__module__, default)
 
 
-def registerNodeType(nodeType: desc.Node):
-    """ Register a Node Type based on a Node Description class.
-
-    After registration, nodes of this type can be instantiated in a Graph.
-    """
-    if nodeType.__name__ in nodesDesc:
-        logging.error(f"Node Desc {nodeType.__name__} is already registered.")
-    nodesDesc[nodeType.__name__] = nodeType
-
-
-def unregisterNodeType(nodeType: desc.Node):
-    """ Remove 'nodeType' from the list of register node types. """
-    assert nodeType.__name__ in nodesDesc
-    del nodesDesc[nodeType.__name__]
-
-
 def loadNodes(folder, packageName) -> list[NodePlugin]:
     if not os.path.isdir(folder):
         logging.error(f"Node folder '{folder}' does not exist.")

--- a/meshroom/core/__init__.py
+++ b/meshroom/core/__init__.py
@@ -19,6 +19,7 @@ try:
 except Exception:
     pass
 
+from meshroom.core.plugins import ProcessEnv
 from meshroom.core.submitter import BaseSubmitter
 from meshroom.env import EnvVar, meshroomFolder
 from . import desc
@@ -349,9 +350,7 @@ def loadPluginFolder(folder):
         logging.info(f"Plugin folder '{folder}' does not contain a 'meshroom' folder.")
         return
 
-    binFolders = [Path(folder, 'bin')]
-    libFolders = [Path(folder, 'lib'), Path(folder, 'lib64')]
-    pythonPathFolders = [Path(folder)] + binFolders
+    processEnv = ProcessEnv(folder)
 
     loadAllNodes(folder=mrFolder)
     loadPipelineTemplates(folder=mrFolder)
@@ -361,7 +360,7 @@ def loadPluginsFolder(folder):
     if not os.path.isdir(folder):
         logging.debug(f"PluginSet folder '{folder}' does not exist.")
         return
-    
+
     for file in os.listdir(folder):
         if os.path.isdir(file):
             subFolder = os.path.join(folder, file)

--- a/meshroom/core/__init__.py
+++ b/meshroom/core/__init__.py
@@ -32,7 +32,6 @@ logging.basicConfig(format='[%(asctime)s][%(levelname)s] %(message)s', level=log
 sessionUid = str(uuid.uuid1())
 
 cacheFolderName = 'MeshroomCache'
-nodesDesc: dict[str, desc.BaseNode] = {}
 pluginManager: NodePluginManager = NodePluginManager()
 submitters: dict[str, BaseSubmitter] = {}
 pipelineTemplates: dict[str, str] = {}
@@ -408,7 +407,7 @@ def loadPipelineTemplates(folder: str):
 
 def initNodes():
     additionalNodesPath = EnvVar.getList(EnvVar.MESHROOM_NODES_PATH)
-    nodesFolders = [os.path.join(meshroomFolder, 'nodes')] + additionalNodesPath
+    nodesFolders = [os.path.join(meshroomFolder, "nodes")] + additionalNodesPath
     for f in nodesFolders:
         plugins = loadAllNodes(folder=f)
         if plugins:

--- a/meshroom/core/__init__.py
+++ b/meshroom/core/__init__.py
@@ -100,7 +100,11 @@ def loadClasses(folder: str, packageName: str, classType: type) -> list[type]:
                            and issubclass(plugin, classType)]
 
                 if not plugins:
-                    logging.warning(f"No class defined in plugin: {pluginModuleName}")
+                    # Only packages/folders have __path__, single module/file do not have it.
+                    isPackage = hasattr(pluginMod, "__path__")
+                    # Sub-folders/Packages should not raise a warning
+                    if not isPackage:
+                        logging.warning(f"No class defined in plugin: {package.__name__}.{pluginName} ('{pluginMod.__file__}')")
 
                 for p in plugins:
                     p.packageName = packageName

--- a/meshroom/core/__init__.py
+++ b/meshroom/core/__init__.py
@@ -19,7 +19,7 @@ try:
 except Exception:
     pass
 
-from meshroom.core.plugins import validateNodeDesc, ProcessEnv
+from meshroom.core.plugins import validateNodeDesc, ProcessEnv, NodePluginManager
 from meshroom.core.submitter import BaseSubmitter
 from meshroom.env import EnvVar, meshroomFolder
 from . import desc
@@ -33,6 +33,7 @@ sessionUid = str(uuid.uuid1())
 
 cacheFolderName = 'MeshroomCache'
 nodesDesc: dict[str, desc.BaseNode] = {}
+pluginManager: NodePluginManager = NodePluginManager()
 submitters: dict[str, BaseSubmitter] = {}
 pipelineTemplates: dict[str, str] = {}
 

--- a/meshroom/core/__init__.py
+++ b/meshroom/core/__init__.py
@@ -324,7 +324,7 @@ def loadNodes(folder, packageName) -> list[NodePlugin]:
 
 def loadAllNodes(folder) -> list[Plugin]:
     plugins = []
-    for _, package, ispkg in pkgutil.walk_packages([folder]):
+    for _, package, ispkg in pkgutil.iter_modules([folder]):
         if ispkg:
             plugin = Plugin(package, folder)
             nodePlugins = loadNodes(folder, package)

--- a/meshroom/core/desc/node.py
+++ b/meshroom/core/desc/node.py
@@ -39,8 +39,10 @@ class BaseNode(object):
             name="invalidation",
             label="Invalidation Message",
             description="A message that will invalidate the node's output folder.\n"
-                        "This is useful for development, we can invalidate the output of the node when we modify the code.\n"
-                        "It is displayed in bold font in the invalidation/comment messages tooltip.",
+                        "This is useful for development, we can invalidate the output of the node "
+                        "when we modify the code.\n"
+                        "It is displayed in bold font in the invalidation/comment messages "
+                        "tooltip.",
             value="",
             semantic="multiline",
             advanced=True,
@@ -50,7 +52,8 @@ class BaseNode(object):
             name="comment",
             label="Comments",
             description="User comments describing this specific node instance.\n"
-                        "It is displayed in regular font in the invalidation/comment messages tooltip.",
+                        "It is displayed in regular font in the invalidation/comment messages "
+                        "tooltip.",
             value="",
             semantic="multiline",
             invalidate=False,
@@ -58,7 +61,8 @@ class BaseNode(object):
         StringParam(
             name="label",
             label="Node's Label",
-            description="Customize the default label (to replace the technical name of the node instance).",
+            description="Customize the default label (to replace the technical name of the node "
+                        "instance).",
             value="",
             invalidate=False,
         ),

--- a/meshroom/core/graph.py
+++ b/meshroom/core/graph.py
@@ -759,16 +759,24 @@ class Graph(BaseObject):
             for nodeName in nodeNames:
                 self.upgradeNode(nodeName)
 
-    def reloadAllNodes(self):
+    def reloadAllNodes(self, nodeTypes: list[str]):
         """
-        Replace all the node instances in the current graph with new node instances of the same
-        type. If the description of the nodes has changed, the reloaded nodes will reflect theses
-        changes.
+        Replace all the node instances of "nodeTypes" in the current graph with new node instances of the
+        same type. If the description of the nodes has changed, the reloaded nodes will reflect theses
+        changes. If "nodeTypes" is empty, then the function returns immediately.
+
+        Args:
+            nodeTypes: the list of node types that will be reloaded.
         """
+        if not nodeTypes:
+            # No updated node to replace in the graph, nothing to do
+            return
+
         newNodes: dict[str, BaseNode] = {}
         for node in self._nodes.values():
-            newNode = nodeFactory(node.toDict(), node.nodeType, expectedUid=node._uid)
-            newNodes[node.name] = newNode
+            if node.nodeType in nodeTypes:
+                newNode = nodeFactory(node.toDict(), node.nodeType, expectedUid=node._uid)
+                newNodes[node.name] = newNode
 
         # Replace in a different loop to ensure all the nodes have been looped over: when looping
         # over self._nodes and replacing nodes at the same time, some nodes might not be reached

--- a/meshroom/core/graph.py
+++ b/meshroom/core/graph.py
@@ -764,7 +764,7 @@ class Graph(BaseObject):
             for nodeName in nodeNames:
                 self.upgradeNode(nodeName)
 
-    def reloadAllNodes(self, nodeTypes: list[str]):
+    def reloadNodePlugins(self, nodeTypes: list[str]):
         """
         Replace all the node instances of "nodeTypes" in the current graph with new node instances of the
         same type. If the description of the nodes has changed, the reloaded nodes will reflect theses

--- a/meshroom/core/graph.py
+++ b/meshroom/core/graph.py
@@ -765,9 +765,15 @@ class Graph(BaseObject):
         type. If the description of the nodes has changed, the reloaded nodes will reflect theses
         changes.
         """
+        newNodes: dict[str, BaseNode] = {}
         for node in self._nodes.values():
             newNode = nodeFactory(node.toDict(), node.nodeType, expectedUid=node._uid)
-            self.replaceNode(node.name, newNode)
+            newNodes[node.name] = newNode
+
+        # Replace in a different loop to ensure all the nodes have been looped over: when looping
+        # over self._nodes and replacing nodes at the same time, some nodes might not be reached
+        for name, node in newNodes.items():
+            self.replaceNode(name, node)
 
     @Slot(str, result=Attribute)
     def attribute(self, fullName):

--- a/meshroom/core/graph.py
+++ b/meshroom/core/graph.py
@@ -759,6 +759,16 @@ class Graph(BaseObject):
             for nodeName in nodeNames:
                 self.upgradeNode(nodeName)
 
+    def reloadAllNodes(self):
+        """
+        Replace all the node instances in the current graph with new node instances of the same
+        type. If the description of the nodes has changed, the reloaded nodes will reflect theses
+        changes.
+        """
+        for node in self._nodes.values():
+            newNode = nodeFactory(node.toDict(), node.nodeType, expectedUid=node._uid)
+            self.replaceNode(node.name, newNode)
+
     @Slot(str, result=Attribute)
     def attribute(self, fullName):
         # type: (str) -> Attribute

--- a/meshroom/core/graph.py
+++ b/meshroom/core/graph.py
@@ -748,7 +748,12 @@ class Graph(BaseObject):
             if dstName in outListAttributes:
                 _recreateTargetListAttributeChildren(*outListAttributes[dstName])
             try:
-                self.addEdge(self.attribute(srcName), self.attribute(dstName))
+                srcAttr = self.attribute(srcName)
+                dstAttr = self.attribute(dstName)
+                if srcAttr is None or dstAttr is None:
+                    logging.warning(f"Failed to restore edge {srcName}{' (missing)' if srcAttr is None else ''} -> {dstName}{' (missing)' if dstAttr is None else ''}")
+                    continue
+                self.addEdge(srcAttr, dstAttr)
             except (KeyError, ValueError) as e:
                 logging.warning(f"Failed to restore edge {srcName} -> {dstName}: {e}")
 

--- a/meshroom/core/node.py
+++ b/meshroom/core/node.py
@@ -18,7 +18,7 @@ from typing import Callable, Optional
 
 import meshroom
 from meshroom.common import Signal, Variant, Property, BaseObject, Slot, ListModel, DictModel
-from meshroom.core import desc, stats, hashValue, nodeVersion, Version, MrNodeType
+from meshroom.core import desc, plugins, stats, hashValue, nodeVersion, Version, MrNodeType
 from meshroom.core.attribute import attributeFactory, ListAttribute, GroupAttribute, Attribute
 from meshroom.core.exception import NodeUpgradeError, UnknownNodeTypeError
 
@@ -201,7 +201,7 @@ class StatusData(BaseObject):
         self.mrNodeType = d.get("mrNodeType", MrNodeType.NONE)
         if not isinstance(self.mrNodeType, MrNodeType):
             self.mrNodeType = MrNodeType[self.mrNodeType]
-        
+
         self.nodeName = d.get("nodeName", "")
         self.nodeType = d.get("nodeType", "")
         self.packageName = d.get("packageName", "")
@@ -639,10 +639,12 @@ class BaseNode(BaseObject):
         super().__init__(parent)
         self._nodeType: str = nodeType
         self.nodeDesc: desc.BaseNode = None
+        self.nodePlugin: plugins.Plugin = None
 
         # instantiate node description if nodeType is valid
-        if nodeType in meshroom.core.nodesDesc:
-            self.nodeDesc = meshroom.core.nodesDesc[nodeType]()
+        if meshroom.core.pluginManager.getNodePlugin(nodeType):
+            self.nodeDesc = meshroom.core.pluginManager.getNodePlugin(nodeType).nodeDescriptor()
+            self.nodePlugin = meshroom.core.pluginManager.getNodePlugin(nodeType)
 
         self.packageName: str = ""
         self.packageVersion: str = ""

--- a/meshroom/core/node.py
+++ b/meshroom/core/node.py
@@ -642,9 +642,9 @@ class BaseNode(BaseObject):
         self.nodePlugin: plugins.Plugin = None
 
         # instantiate node description if nodeType is valid
-        if meshroom.core.pluginManager.getNodePlugin(nodeType):
-            self.nodeDesc = meshroom.core.pluginManager.getNodePlugin(nodeType).nodeDescriptor()
-            self.nodePlugin = meshroom.core.pluginManager.getNodePlugin(nodeType)
+        if meshroom.core.pluginManager.getRegisteredNodePlugin(nodeType):
+            self.nodeDesc = meshroom.core.pluginManager.getRegisteredNodePlugin(nodeType).nodeDescriptor()
+            self.nodePlugin = meshroom.core.pluginManager.getRegisteredNodePlugin(nodeType)
 
         self.packageName: str = ""
         self.packageVersion: str = ""

--- a/meshroom/core/node.py
+++ b/meshroom/core/node.py
@@ -1816,6 +1816,7 @@ class CompatibilityIssue(Enum):
     VersionConflict = 2  # mismatch between node's description version and serialized node data
     DescriptionConflict = 3  # mismatch between node's description attributes and serialized node data
     UidConflict = 4  # mismatch between computed UIDs and UIDs stored in serialized node data
+    PluginIssue = 5  # issue when loading the associated plugin
 
 
 class CompatibilityNode(BaseNode):

--- a/meshroom/core/nodeFactory.py
+++ b/meshroom/core/nodeFactory.py
@@ -123,13 +123,14 @@ class _NodeCreator:
     def _checkAttributesAreCompatibleWithDescription(self) -> bool:
         return (
             self._checkAttributesCompatibility(self.nodeDesc.inputs, self.inputs)
-            and self._checkAttributesCompatibility(self.nodeDesc.internalInputs, self.internalInputs)
+            and self._checkAttributesCompatibility(self.nodeDesc.internalInputs,
+                                                   self.internalInputs)
             and self._checkAttributesCompatibility(self.nodeDesc.outputs, self.outputs)
         )
 
     def _checkInputAttributesNames(self) -> bool:
         def serializedInput(attr: desc.Attribute) -> bool:
-            """Filter that excludes not-serialized desc input attributes."""
+            """ Filter that excludes not-serialized desc input attributes. """
             if isinstance(attr, desc.PushButtonParam):
                 # PushButtonParam are not serialized has they do not hold a value.
                 return False
@@ -140,7 +141,7 @@ class _NodeCreator:
 
     def _checkOutputAttributesNames(self) -> bool:
         def serializedOutput(attr: desc.Attribute) -> bool:
-            """Filter that excludes not-serialized desc output attributes."""
+            """ Filter that excludes not-serialized desc output attributes. """
             if attr.isDynamicValue:
                 # Dynamic outputs values are not serialized with the node,
                 # as their value is written in the computed output data.

--- a/meshroom/core/nodeFactory.py
+++ b/meshroom/core/nodeFactory.py
@@ -56,7 +56,7 @@ class _NodeCreator:
         self.uid = self.nodeData.get("uid", None)
         self.nodeDesc = None
         if meshroom.core.pluginManager.isRegistered(self.nodeType):
-            self.nodeDesc = meshroom.core.pluginManager.getNodePlugin(self.nodeType).nodeDescriptor
+            self.nodeDesc = meshroom.core.pluginManager.getRegisteredNodePlugin(self.nodeType).nodeDescriptor
 
     def create(self) -> Union[Node, CompatibilityNode]:
         compatibilityIssue = self._checkCompatibilityIssues()

--- a/meshroom/core/nodeFactory.py
+++ b/meshroom/core/nodeFactory.py
@@ -54,7 +54,9 @@ class _NodeCreator:
         self.internalFolder = self.nodeData.get("internalFolder")
         self.position = Position(*self.nodeData.get("position", []))
         self.uid = self.nodeData.get("uid", None)
-        self.nodeDesc = meshroom.core.nodesDesc.get(self.nodeType, None)
+        self.nodeDesc = None
+        if meshroom.core.pluginManager.isRegistered(self.nodeType):
+            self.nodeDesc = meshroom.core.pluginManager.getNodePlugin(self.nodeType).nodeDescriptor
 
     def create(self) -> Union[Node, CompatibilityNode]:
         compatibilityIssue = self._checkCompatibilityIssues()

--- a/meshroom/core/nodeFactory.py
+++ b/meshroom/core/nodeFactory.py
@@ -76,6 +76,8 @@ class _NodeCreator:
 
     def _checkCompatibilityIssues(self) -> Optional[CompatibilityIssue]:
         if self.nodeDesc is None:
+            if meshroom.core.pluginManager.belongsToPlugin(self.nodeType) is not None:
+                return CompatibilityIssue.PluginIssue
             return CompatibilityIssue.UnknownNodeType
 
         if not self._checkUidCompatibility():

--- a/meshroom/core/plugins.py
+++ b/meshroom/core/plugins.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+
+from meshroom.common import BaseObject
+
+class ProcessEnv(BaseObject):
+    """
+    Describes the environment required by a node's process.
+    """
+
+    def __init__(self, folder: str):
+        super().__init__()
+        self.binPaths: list = [Path(folder, "bin")]
+        self.libPaths: list = [Path(folder, "lib"), Path(folder, "lib64")]
+        self.pythonPathFolders: list = [Path(folder)] + self.binPaths

--- a/meshroom/core/plugins.py
+++ b/meshroom/core/plugins.py
@@ -148,6 +148,16 @@ class Plugin(BaseObject):
             if file.endswith(".mg"):
                 self._templates[os.path.splitext(file)[0]] = os.path.join(self.path, file)
 
+    def containsNodePlugin(self, name: str) -> bool:
+        """
+        Return whether the node plugin "name" is part of the plugin, independently from its
+        status.
+
+        Args:
+            name: the name of the node plugin to be checked.
+        """
+        return name in self._nodePlugins
+
 
 class NodePlugin(BaseObject):
     """
@@ -230,6 +240,22 @@ class NodePluginManager(BaseObject):
             name: the name of the node plugin whose registration needs to be checked.
         """
         return name in self._nodePlugins
+
+    def belongsToPlugin(self, name: str) -> Plugin:
+        """
+        Check whether the node plugin belongs to a loaded plugin, independently from
+        whether it has been registered or not.
+
+        Args:
+            name: the name of the node plugin that needs to be searched for across plugins.
+
+        Returns:
+            Plugin | None: the Plugin the node belongs to if it exists, None otherwise.
+        """
+        for plugin in self._plugins.values():
+            if plugin.containsNodePlugin(name):
+                return plugin
+        return None
 
     def getPlugins(self) -> dict[str: Plugin]:
         """

--- a/meshroom/core/plugins.py
+++ b/meshroom/core/plugins.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 
+from enum import Enum
 from pathlib import Path
 
 from meshroom.common import BaseObject
@@ -17,6 +18,16 @@ class ProcessEnv(BaseObject):
         self.binPaths: list = [Path(folder, "bin")]
         self.libPaths: list = [Path(folder, "lib"), Path(folder, "lib64")]
         self.pythonPathFolders: list = [Path(folder)] + self.binPaths
+
+
+class NodePluginStatus(Enum):
+    """
+    Loading status for NodePlugin objects.
+    """
+    NOT_LOADED = 0  # The node plugin exists but is not loaded and cannot be used (not registered)
+    LOADED = 1  # The node plugin is currently loaded and functional (it has been registered)
+    DESC_ERROR = 2  # The node plugin exists but has an invalid description
+    ERROR = 3  # The node plugin exists and is valid but could not be successfully loaded
 
 
 class Plugin(BaseObject):

--- a/meshroom/core/plugins.py
+++ b/meshroom/core/plugins.py
@@ -333,7 +333,8 @@ class NodePluginManager(BaseObject):
         if not self.getPlugin(plugin.name):
             self._plugins[plugin.name] = plugin
             if registerNodePlugins:
-                self.registerPlugin(plugin.name)
+                for node in plugin.nodes:
+                    self.registerNode(plugin.nodes[node])
 
     def removePlugin(self, plugin: Plugin, unregisterNodePlugins: bool = True):
         """
@@ -348,7 +349,8 @@ class NodePluginManager(BaseObject):
         """
         if self.getPlugin(plugin.name):
             if unregisterNodePlugins:
-                self.unregisterPlugin(plugin.name)
+                for node in plugin.nodes.values():
+                    self.unregisterNode(node)
             del self._plugins[plugin.name]
 
     def getRegisteredNodePlugins(self) -> dict[str: NodePlugin]:
@@ -371,33 +373,6 @@ class NodePluginManager(BaseObject):
         if self.isRegistered(name):
             return self._nodePlugins[name]
         return None
-
-    def registerPlugin(self, name: str):
-        """
-        Register all the NodePlugins contained in the Plugin loaded as "name".
-
-        Args:
-            name: the name of the Plugin whose NodePlugins will be registered.
-        """
-        plugin = self.getPlugin(name)
-        if plugin:
-            for node in plugin.nodes:
-                self.registerNode(plugin.nodes[node])
-        else:
-            logging.error(f"No loaded Plugin named {name}.")
-
-    def unregisterPlugin(self, name: str):
-        """
-        Unregister all the NodePlugins contained in the Plugin loaded as "name"
-        that are currently registered.
-
-        Args:
-            name: the name of the Plugin whose NodePlugins will be unregistered.
-        """
-        plugin = self.getPlugin(name)
-        if plugin:
-            for node in plugin.nodes.values():
-                self.unregisterNode(node)
 
     def registerNode(self, nodePlugin: NodePlugin):
         """

--- a/meshroom/core/plugins.py
+++ b/meshroom/core/plugins.py
@@ -262,14 +262,14 @@ class NodePluginManager(BaseObject):
         if not self.getPlugin(plugin.name):
             self._plugins[plugin.name] = plugin
 
-    def getNodePlugins(self) -> dict[str: NodePlugin]:
+    def getRegisteredNodePlugins(self) -> dict[str: NodePlugin]:
         """
         Return a dictionary containing all the registered NodePlugins, with
         {key, value} = {name, NodePlugin}.
         """
         return self._nodePlugins
 
-    def getNodePlugin(self, name: str) -> NodePlugin:
+    def getRegisteredNodePlugin(self, name: str) -> NodePlugin:
         """
         Return the NodePlugin object that has been registered under the name "name" if it exists.
 

--- a/meshroom/core/plugins.py
+++ b/meshroom/core/plugins.py
@@ -1,6 +1,11 @@
+from __future__ import annotations
+
+import logging
+
 from pathlib import Path
 
 from meshroom.common import BaseObject
+from meshroom.core import desc
 
 class ProcessEnv(BaseObject):
     """
@@ -12,3 +17,73 @@ class ProcessEnv(BaseObject):
         self.binPaths: list = [Path(folder, "bin")]
         self.libPaths: list = [Path(folder, "lib"), Path(folder, "lib64")]
         self.pythonPathFolders: list = [Path(folder)] + self.binPaths
+
+
+class Plugin(BaseObject):
+    """
+    A collection of node plugins.
+
+    Members:
+        name: the name of the plugin (e.g. name of the Python module containing the node plugins)
+        path: the absolute path of the plugin
+        _nodePlugins: dictionary mapping the name of a node plugin to its corresponding
+                      NodePlugin object
+        processEnv: the environment required for the nodes' processes to be correctly executed
+    """
+
+    def __init__(self, name: str, path: str):
+        super().__init__()
+
+        self._name: str = name
+        self._path: str = path
+
+        self._nodePlugins: dict[str: NodePlugin] = {}
+        self._processEnv: ProcessEnv = ProcessEnv(path)
+
+    @property
+    def name(self):
+        """ Return the name of the plugin. """
+        return self._name
+
+    @property
+    def path(self):
+        """ Return the absolute path of the plugin. """
+        return self._path
+
+    @property
+    def processEnv(self):
+        """ Return the environment required to successfully execute processes. """
+        return self._processEnv
+
+    def addNodePlugin(self, nodePlugin: NodePlugin):
+        """
+        Add a node plugin to the current plugin object and assign it as its containing plugin.
+        The node plugin is added to the dictionary of node plugins with the name of the node
+        descriptor as its key.
+
+        Args:
+            nodePlugin: the NodePlugin object to add to the Plugin.
+        """
+        self._nodePlugins[nodePlugin.nodeDescriptor.__name__] = nodePlugin
+        nodePlugin.plugin = self
+
+    def removeNodePlugin(self, name: str):
+        """
+        Remove a node plugin from the current plugin object and delete any container relationship.
+
+        Args:
+            name: the name of the NodePlugin to remove.
+        """
+        if name in self._nodePlugins:
+            self._nodePlugins[name].plugin = None
+            del self._nodePlugins[name]
+        else:
+            logging.warning(f"Node plugin {name} is not part of the plugin {self.name}.")
+
+
+
+class NodePlugin(BaseObject):
+    """
+    """
+    def __init__(self, nodeDesc: desc.Node, plugin: Plugin = None):
+        super().__init__()

--- a/meshroom/core/plugins.py
+++ b/meshroom/core/plugins.py
@@ -8,6 +8,40 @@ from pathlib import Path
 from meshroom.common import BaseObject
 from meshroom.core import desc
 
+def validateNodeDesc(nodeDesc: desc.Node) -> list:
+    """
+    Check that the node has a valid description before being loaded. For the description
+    to be valid, the default value of every parameter needs to correspond to the type
+    of the parameter.
+    An empty returned list means that every parameter is valid, and so is the node's description.
+    If it is not valid, the returned list contains the names of the invalid parameters. In case
+    of nested parameters (parameters in groups or lists, for example), the name of the parameter
+    follows the name of the parent attributes. For example, if the attribute "x", contained in group
+    "group", is invalid, then it will be added to the list as "group:x".
+
+    Args:
+        nodeDesc: description of the node.
+
+    Returns:
+        errors: the list of invalid parameters if there are any, empty list otherwise
+    """
+    errors = []
+
+    for param in nodeDesc.inputs:
+        err = param.checkValueTypes()
+        if err:
+            errors.append(err)
+
+    for param in nodeDesc.outputs:
+        if param.value is None:
+            continue
+        err = param.checkValueTypes()
+        if err:
+            errors.append(err)
+
+    return errors
+
+
 class ProcessEnv(BaseObject):
     """
     Describes the environment required by a node's process.

--- a/meshroom/core/test.py
+++ b/meshroom/core/test.py
@@ -31,7 +31,7 @@ def checkTemplateVersions(path: str, nodesAlreadyLoaded: bool = False) -> bool:
             if not meshroom.core.pluginManager.isRegistered(nodeType):
                 return False
 
-            nodeDesc = meshroom.core.pluginManager.getNodePlugin(nodeType)
+            nodeDesc = meshroom.core.pluginManager.getRegisteredNodePlugin(nodeType)
             currentNodeVersion = meshroom.core.nodeVersion(nodeDesc)
 
             inputs = nodeData.get("inputs", {})
@@ -60,7 +60,7 @@ def checkTemplateVersions(path: str, nodesAlreadyLoaded: bool = False) -> bool:
 
     finally:
         if not nodesAlreadyLoaded:
-            nodePlugins = meshroom.core.pluginManager.getNodePlugins()
+            nodePlugins = meshroom.core.pluginManager.getRegisteredNodePlugins()
             for node in nodePlugins:
                 meshroom.core.pluginManager.unregisterNode(node)
 

--- a/meshroom/core/test.py
+++ b/meshroom/core/test.py
@@ -28,10 +28,10 @@ def checkTemplateVersions(path: str, nodesAlreadyLoaded: bool = False) -> bool:
 
         for _, nodeData in graphData.items():
             nodeType = nodeData["nodeType"]
-            if not nodeType in meshroom.core.nodesDesc:
+            if not meshroom.core.pluginManager.isRegistered(nodeType):
                 return False
 
-            nodeDesc = meshroom.core.nodesDesc[nodeType]
+            nodeDesc = meshroom.core.pluginManager.getNodePlugin(nodeType)
             currentNodeVersion = meshroom.core.nodeVersion(nodeDesc)
 
             inputs = nodeData.get("inputs", {})
@@ -60,9 +60,9 @@ def checkTemplateVersions(path: str, nodesAlreadyLoaded: bool = False) -> bool:
 
     finally:
         if not nodesAlreadyLoaded:
-            nodeTypes = [nodeType for _, nodeType in meshroom.core.nodesDesc.items()]
-            for nodeType in nodeTypes:
-                unregisterNodeType(nodeType)
+            nodePlugins = meshroom.core.pluginManager.getNodePlugins()
+            for node in nodePlugins:
+                meshroom.core.pluginManager.unregisterNode(node)
 
 
 def checkAllTemplatesVersions() -> bool:

--- a/meshroom/ui/app.py
+++ b/meshroom/ui/app.py
@@ -13,7 +13,7 @@ from PySide6.QtQuickControls2 import QQuickStyle
 from PySide6.QtWidgets import QApplication
 
 import meshroom
-from meshroom.core import nodesDesc
+from meshroom.core import pluginManager
 from meshroom.core.taskManager import TaskManager
 from meshroom.common import Property, Variant, Signal, Slot
 
@@ -261,7 +261,7 @@ class MeshroomApp(QApplication):
         self.engine.addImportPath(qmlDir)
 
         # expose available node types that can be instantiated
-        self.engine.rootContext().setContextProperty("_nodeTypes", {n: {"category": nodesDesc[n].category} for n in sorted(nodesDesc.keys())})
+        self.engine.rootContext().setContextProperty("_nodeTypes", {n: {"category": pluginManager.getNodePlugins()[n].nodeDescriptor.category} for n in sorted(pluginManager.getNodePlugins().keys())})
 
         # instantiate Reconstruction object
         self._undoStack = commands.UndoStack(self)

--- a/meshroom/ui/app.py
+++ b/meshroom/ui/app.py
@@ -261,7 +261,7 @@ class MeshroomApp(QApplication):
         self.engine.addImportPath(qmlDir)
 
         # expose available node types that can be instantiated
-        self.engine.rootContext().setContextProperty("_nodeTypes", {n: {"category": pluginManager.getNodePlugins()[n].nodeDescriptor.category} for n in sorted(pluginManager.getNodePlugins().keys())})
+        self.engine.rootContext().setContextProperty("_nodeTypes", {n: {"category": pluginManager.getRegisteredNodePlugins()[n].nodeDescriptor.category} for n in sorted(pluginManager.getRegisteredNodePlugins().keys())})
 
         # instantiate Reconstruction object
         self._undoStack = commands.UndoStack(self)

--- a/meshroom/ui/components/thumbnail.py
+++ b/meshroom/ui/components/thumbnail.py
@@ -129,7 +129,7 @@ class ThumbnailCache(QObject):
             # Compute storage duration since last usage of thumbnail
             lastUsage = f_stat.st_mtime
             storageTime = now - lastUsage
-            logging.debug(f'[ThumbnailCache] Thumbnail {f_name} has been stored for {storageTime}s')
+            # logging.debug(f'[ThumbnailCache] Thumbnail {f_name} has been stored for {storageTime}s')
 
             if storageTime > ThumbnailCache.storageTimeLimit * 3600 * 24:
                 # Mark as removable if storage time exceeds limit

--- a/meshroom/ui/qml/Application.qml
+++ b/meshroom/ui/qml/Application.qml
@@ -553,6 +553,15 @@ Page {
     }
 
     Action {
+        id: reloadAllNodesAction
+        property string tooltip: "Reload all the node descriptions for all the registered plugins"
+        text: "Reload All Nodes"
+        onTriggered: {
+            _reconstruction.reloadAllNodes()
+        }
+    }
+
+    Action {
         id: undoAction
 
         property string tooltip: 'Undo "' + (_reconstruction ? _reconstruction.undoStack.undoText : "Unknown") + '"'
@@ -829,6 +838,12 @@ Page {
                         action: removeImagesFromAllGroupsAction
                         ToolTip.visible: hovered
                         ToolTip.text: removeImagesFromAllGroupsAction.tooltip
+                    }
+
+                    MenuItem {
+                        action: reloadAllNodesAction
+                        ToolTip.visible: hovered
+                        ToolTip.text: reloadAllNodesAction.tooltip
                     }
                 }
                 MenuSeparator { }

--- a/meshroom/ui/qml/Application.qml
+++ b/meshroom/ui/qml/Application.qml
@@ -556,6 +556,7 @@ Page {
         id: reloadAllNodesAction
         property string tooltip: "Reload all the node descriptions for all the registered plugins"
         text: "Reload All Nodes"
+        shortcut: "Ctrl+Shift+R"
         onTriggered: {
             _reconstruction.reloadAllNodes()
         }

--- a/meshroom/ui/qml/Application.qml
+++ b/meshroom/ui/qml/Application.qml
@@ -553,12 +553,12 @@ Page {
     }
 
     Action {
-        id: reloadAllNodesAction
-        property string tooltip: "Reload all the node descriptions for all the registered plugins"
-        text: "Reload All Nodes"
+        id: reloadPluginsAction
+        property string tooltip: "Reload the source code for all nodes from all registered plugins"
+        text: "Reload Plugins Source Code"
         shortcut: "Ctrl+Shift+R"
         onTriggered: {
-            _reconstruction.reloadAllNodes()
+            _reconstruction.reloadPlugins()
         }
     }
 
@@ -842,9 +842,9 @@ Page {
                     }
 
                     MenuItem {
-                        action: reloadAllNodesAction
+                        action: reloadPluginsAction
                         ToolTip.visible: hovered
-                        ToolTip.text: reloadAllNodesAction.tooltip
+                        ToolTip.text: reloadPluginsAction.tooltip
                     }
                 }
                 MenuSeparator { }

--- a/meshroom/ui/reconstruction.py
+++ b/meshroom/ui/reconstruction.py
@@ -537,7 +537,7 @@ class Reconstruction(UIGraph):
         # For all nodes declared to be accessed by the UI
         usedNodeTypes = {j for i in self.activeNodeCategories.values() for j in i}
         allUiNodes = set(self.uiNodes) | usedNodeTypes
-        allLoadedNodeTypes = set(meshroom.core.nodesDesc.keys())
+        allLoadedNodeTypes = set(meshroom.core.pluginManager.getNodePlugins().keys())
         for nodeType in allUiNodes:
             self._activeNodes.add(ActiveNode(nodeType, parent=self))
 
@@ -684,7 +684,7 @@ class Reconstruction(UIGraph):
         if not sfmFile or not os.path.isfile(sfmFile):
             self.tempCameraInit = None
             return
-        nodeDesc = meshroom.core.nodesDesc["CameraInit"]()
+        nodeDesc = meshroom.core.pluginManager.getNodePlugin("CameraInit")
         views, intrinsics = nodeDesc.readSfMData(sfmFile)
         tmpCameraInit = Node("CameraInit", viewpoints=views, intrinsics=intrinsics)
         tmpCameraInit.locked = True

--- a/meshroom/ui/reconstruction.py
+++ b/meshroom/ui/reconstruction.py
@@ -559,11 +559,13 @@ class Reconstruction(UIGraph):
         The nodes in the graph will be updated to match the changes in the description, if
         there was any.
         """
+        nodeTypes: list[str] = []
         for plugin in meshroom.core.pluginManager.getPlugins().values():
             for node in plugin.nodes.values():
-                node.reload()
+                if node.reload():
+                    nodeTypes.append(node.nodeDescriptor.__name__)
 
-        self._graph.reloadAllNodes()
+        self._graph.reloadAllNodes(nodeTypes)
 
     @Slot()
     @Slot(str)

--- a/meshroom/ui/reconstruction.py
+++ b/meshroom/ui/reconstruction.py
@@ -553,7 +553,7 @@ class Reconstruction(UIGraph):
         self.setActiveNodes(nodes)
 
     @Slot()
-    def reloadAllNodes(self):
+    def reloadPlugins(self):
         """
         Reload all the NodePlugins from all the registered plugins.
         The nodes in the graph will be updated to match the changes in the description, if
@@ -565,7 +565,7 @@ class Reconstruction(UIGraph):
                 if node.reload():
                     nodeTypes.append(node.nodeDescriptor.__name__)
 
-        self._graph.reloadAllNodes(nodeTypes)
+        self._graph.reloadNodePlugins(nodeTypes)
 
     @Slot()
     @Slot(str)

--- a/meshroom/ui/reconstruction.py
+++ b/meshroom/ui/reconstruction.py
@@ -553,6 +553,19 @@ class Reconstruction(UIGraph):
         self.setActiveNodes(nodes)
 
     @Slot()
+    def reloadAllNodes(self):
+        """
+        Reload all the NodePlugins from all the registered plugins.
+        The nodes in the graph will be updated to match the changes in the description, if
+        there was any.
+        """
+        for plugin in meshroom.core.pluginManager.getPlugins().values():
+            for node in plugin.nodes.values():
+                node.reload()
+
+        self._graph.reloadAllNodes()
+
+    @Slot()
     @Slot(str)
     def new(self, pipeline=None):
         """ Create a new pipeline. """

--- a/meshroom/ui/reconstruction.py
+++ b/meshroom/ui/reconstruction.py
@@ -736,14 +736,16 @@ class Reconstruction(UIGraph):
         """
         if not startNode:
             return None
-        nodes = self._graph.dfsOnDiscover(startNodes=[startNode], filterTypes=nodeTypes, reverse=True)[0]
+        nodes = self._graph.dfsOnDiscover(startNodes=[startNode],
+                                          filterTypes=nodeTypes, reverse=True)[0]
         if not nodes:
             return None
         # order the nodes according to their depth in the graph, then according to their name
         nodes.sort(key=lambda n: (n.depth, n.name))
         node = nodes[-1]
         if preferredStatus:
-            node = next((n for n in reversed(nodes) if n.getGlobalStatus() == preferredStatus), node)
+            node = next((n for n in reversed(nodes)
+                         if n.getGlobalStatus() == preferredStatus), node)
         return node
 
     def addSfmAugmentation(self, withMVS=False):
@@ -800,7 +802,8 @@ class Reconstruction(UIGraph):
         This method allows to reduce process time by doing it on Python side.
 
         Args:
-            {images, videos, panoramaInfo, meshroomScenes, otherFiles}: Map containing the lists of paths for recognized images, videos, Meshroom scenes and other files.
+            {images, videos, panoramaInfo, meshroomScenes, otherFiles}: Map containing the
+                lists of paths for recognized images, videos, Meshroom scenes and other files.
             Node: cameraInit node used to add new images to it
             QPoint: position to locate the node (usually the mouse position)
         """
@@ -821,7 +824,8 @@ class Reconstruction(UIGraph):
                     else:
                         p = position
                     cameraInit = self.addNewNode("CameraInit", position=p)
-            self._workerThreads.apply_async(func=self.importImagesSync, args=(filesByType["images"], cameraInit,))
+            self._workerThreads.apply_async(func=self.importImagesSync,
+                                            args=(filesByType["images"], cameraInit,))
         if filesByType["videos"]:
             if self.nodes:
                 boundingBox = self.layout.boundingBox()
@@ -840,7 +844,8 @@ class Reconstruction(UIGraph):
                     newVideoNodeMessage,
                     "Warning: You need to manually compute the KeyframeSelection node \n"
                     "and then reimport the created images into Meshroom for the reconstruction.\n\n"
-                    "If you know the Camera Make/Model, it is highly recommended to declare them in the Node."
+                    "If you know the Camera Make/Model, it is highly recommended to declare "
+                    "them in the Node."
                 ))
 
         if filesByType["panoramaInfo"]:
@@ -848,15 +853,15 @@ class Reconstruction(UIGraph):
                 self.error.emit(
                     Message(
                         "Multiple XML files in input",
-                        "Ignore the xml Panorama files:\n\n'{}'.".format(',\n'.join(filesByType["panoramaInfo"])),
+                        "Ignore the XML Panorama files:\n\n'{}'.".format(',\n'.join(filesByType["panoramaInfo"])),
                         "",
                     ))
             else:
-                panoramaInitNodes = self.graph.nodesOfType('PanoramaInit')
+                panoramaInitNodes = self.graph.nodesOfType("PanoramaInit")
                 for panoramaInfoFile in filesByType["panoramaInfo"]:
                     for panoramaInitNode in panoramaInitNodes:
-                        panoramaInitNode.attribute('initializeCameras').value = 'File'
-                        panoramaInitNode.attribute('config').value = panoramaInfoFile
+                        panoramaInitNode.attribute("initializeCameras").value = "File"
+                        panoramaInitNode.attribute("config").value = panoramaInfoFile
                 if panoramaInitNodes:
                     self.info.emit(
                         Message(
@@ -918,7 +923,11 @@ class Reconstruction(UIGraph):
                 filesByType.extend(multiview.findFilesByTypeInFolder(localFile))
             else:
                 filesByType.addFile(localFile)
-        return {"images": filesByType.images, "videos": filesByType.videos, "panoramaInfo": filesByType.panoramaInfo, "meshroomScenes": filesByType.meshroomScenes, "other": filesByType.other}
+        return {"images": filesByType.images,
+                "videos": filesByType.videos,
+                "panoramaInfo": filesByType.panoramaInfo,
+                "meshroomScenes": filesByType.meshroomScenes,
+                "other": filesByType.other}
 
     def importImagesFromFolder(self, path, recursive=False):
         """

--- a/meshroom/ui/reconstruction.py
+++ b/meshroom/ui/reconstruction.py
@@ -537,7 +537,7 @@ class Reconstruction(UIGraph):
         # For all nodes declared to be accessed by the UI
         usedNodeTypes = {j for i in self.activeNodeCategories.values() for j in i}
         allUiNodes = set(self.uiNodes) | usedNodeTypes
-        allLoadedNodeTypes = set(meshroom.core.pluginManager.getNodePlugins().keys())
+        allLoadedNodeTypes = set(meshroom.core.pluginManager.getRegisteredNodePlugins().keys())
         for nodeType in allUiNodes:
             self._activeNodes.add(ActiveNode(nodeType, parent=self))
 
@@ -684,7 +684,7 @@ class Reconstruction(UIGraph):
         if not sfmFile or not os.path.isfile(sfmFile):
             self.tempCameraInit = None
             return
-        nodeDesc = meshroom.core.pluginManager.getNodePlugin("CameraInit")
+        nodeDesc = meshroom.core.pluginManager.getRegisteredNodePlugin("CameraInit")
         views, intrinsics = nodeDesc.readSfMData(sfmFile)
         tmpCameraInit = Node("CameraInit", viewpoints=views, intrinsics=intrinsics)
         tmpCameraInit.locked = True

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -6,7 +6,6 @@ from meshroom.core import pluginManager
 plugins = loadAllNodes(os.path.join(os.path.dirname(__file__), "nodes"))
 for plugin in plugins:
     pluginManager.addPlugin(plugin)
-    pluginManager.registerPlugin(plugin.name)
 
 if os.getenv("MESHROOM_PIPELINE_TEMPLATES_PATH", False):
     os.environ["MESHROOM_PIPELINE_TEMPLATES_PATH"] += os.pathsep + os.path.dirname(os.path.realpath(__file__))

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,8 +1,13 @@
 import os
 
-from meshroom.core import loadAllNodes, initPipelines
+from meshroom.core import loadAllNodes
+from meshroom.core import pluginManager
 
-loadAllNodes(os.path.join(os.path.dirname(__file__), "nodes"))
+plugins = loadAllNodes(os.path.join(os.path.dirname(__file__), "nodes"))
+for plugin in plugins:
+    pluginManager.addPlugin(plugin)
+    pluginManager.registerPlugin(plugin.name)
+
 if os.getenv("MESHROOM_PIPELINE_TEMPLATES_PATH", False):
     os.environ["MESHROOM_PIPELINE_TEMPLATES_PATH"] += os.pathsep + os.path.dirname(os.path.realpath(__file__))
 else:

--- a/tests/nodes/test/appendFiles.py
+++ b/tests/nodes/test/appendFiles.py
@@ -39,4 +39,3 @@ class AppendFiles(desc.CommandLineNode):
             value='{nodeCacheFolder}/appendText.txt',
         )
     ]
-

--- a/tests/nodes/test/ls.py
+++ b/tests/nodes/test/ls.py
@@ -2,21 +2,21 @@ from meshroom.core import desc
 
 
 class Ls(desc.CommandLineNode):
-    commandLine = 'ls {inputValue} > {outputValue}'
+    commandLine = "ls {inputValue} > {outputValue}"
     inputs = [
         desc.File(
-            name='input',
-            label='Input',
-            description='''''',
-            value='',
+            name="input",
+            label="Input",
+            description="",
+            value="",
         )
     ]
 
     outputs = [
         desc.File(
-            name='output',
-            label='Output',
-            description='''''',
-            value='{nodeCacheFolder}/ls.txt',
+            name="output",
+            label="Output",
+            description="",
+            value="{nodeCacheFolder}/ls.txt",
         )
     ]

--- a/tests/plugins/meshroom/pluginA/PluginANodeA.py
+++ b/tests/plugins/meshroom/pluginA/PluginANodeA.py
@@ -1,0 +1,22 @@
+__version__ = "1.0"
+
+from meshroom.core import desc
+
+class PluginANodeA(desc.Node):
+    inputs = [
+        desc.File(
+            name="input",
+            label="Input",
+            description="",
+            value="",
+        ),
+    ]
+
+    outputs = [
+        desc.File(
+            name="output",
+            label="Output",
+            description="",
+            value="",
+        ),
+    ]

--- a/tests/plugins/meshroom/pluginA/PluginANodeB.py
+++ b/tests/plugins/meshroom/pluginA/PluginANodeB.py
@@ -1,0 +1,28 @@
+__version__ = "1.0"
+
+from meshroom.core import desc
+
+class PluginANodeB(desc.Node):
+    inputs = [
+        desc.File(
+            name="input",
+            label="Input",
+            description="",
+            value="",
+        ),
+        desc.IntParam(
+            name="int",
+            label="Integer",
+            description="",
+            value=1,
+        ),
+    ]
+
+    outputs = [
+        desc.File(
+            name="output",
+            label="Output",
+            description="",
+            value="",
+        ),
+    ]

--- a/tests/plugins/meshroom/pluginB/PluginBNodeA.py
+++ b/tests/plugins/meshroom/pluginB/PluginBNodeA.py
@@ -1,0 +1,22 @@
+__version__ = "1.0"
+
+from meshroom.core import desc
+
+class PluginBNodeA(desc.Node):
+    inputs = [
+        desc.File(
+            name="input",
+            label="Input",
+            description="",
+            value="",
+        ),
+    ]
+
+    outputs = [
+        desc.File(
+            name="output",
+            label="Output",
+            description="",
+            value="",
+        ),
+    ]

--- a/tests/plugins/meshroom/pluginB/PluginBNodeB.py
+++ b/tests/plugins/meshroom/pluginB/PluginBNodeB.py
@@ -1,0 +1,28 @@
+__version__ = "1.0"
+
+from meshroom.core import desc
+
+class PluginBNodeB(desc.Node):
+    inputs = [
+        desc.File(
+            name="input",
+            label="Input",
+            description="",
+            value="",
+        ),
+        desc.IntParam(
+            name="int",
+            label="Integer",
+            description="",
+            value="not an integer",
+        ),
+    ]
+
+    outputs = [
+        desc.File(
+            name="output",
+            label="Output",
+            description="",
+            value="",
+        ),
+    ]

--- a/tests/plugins/meshroom/sharedTemplate.mg
+++ b/tests/plugins/meshroom/sharedTemplate.mg
@@ -1,0 +1,10 @@
+{
+    "header": {
+        "releaseVersion": "2025.1.0-develop",
+        "fileVersion": "2.0",
+        "nodesVersions": {},
+        "template": true
+    },
+    "graph": {
+    }
+}

--- a/tests/test_attributeChoiceParam.py
+++ b/tests/test_attributeChoiceParam.py
@@ -1,4 +1,5 @@
-from meshroom.core import desc, registerNodeType, unregisterNodeType
+from meshroom.core import desc, pluginManager
+from meshroom.core.plugins import NodePlugin
 from meshroom.core.graph import Graph, loadGraph
 
 
@@ -52,13 +53,15 @@ class NodeWithChoiceParamsSavingValuesOverride(desc.Node):
 
 
 class TestChoiceParam:
+    nodePlugin = NodePlugin(NodeWithChoiceParams)
+
     @classmethod
     def setup_class(cls):
-        registerNodeType(NodeWithChoiceParams)
+        pluginManager.registerNode(cls.nodePlugin)
 
     @classmethod
     def teardown_class(cls):
-        unregisterNodeType(NodeWithChoiceParams)
+        pluginManager.unregisterNode(cls.nodePlugin)
 
     def test_customValueIsSerialized(self, graphSavedOnDisk):
         graph: Graph = graphSavedOnDisk
@@ -117,13 +120,15 @@ class TestChoiceParam:
 
 
 class TestChoiceParamSavingCustomValues:
+    nodePlugin = NodePlugin(NodeWithChoiceParamsSavingValuesOverride)
+
     @classmethod
     def setup_class(cls):
-        registerNodeType(NodeWithChoiceParamsSavingValuesOverride)
+        pluginManager.registerNode(cls.nodePlugin)
 
     @classmethod
     def teardown_class(cls):
-        unregisterNodeType(NodeWithChoiceParamsSavingValuesOverride)
+        pluginManager.unregisterNode(cls.nodePlugin)
 
     def test_customValueIsSerialized(self, graphSavedOnDisk):
         graph: Graph = graphSavedOnDisk

--- a/tests/test_attributeChoiceParam.py
+++ b/tests/test_attributeChoiceParam.py
@@ -1,7 +1,7 @@
 from meshroom.core import desc, pluginManager
-from meshroom.core.plugins import NodePlugin
 from meshroom.core.graph import Graph, loadGraph
 
+from .utils import registerNodeDesc, unregisterNodeDesc
 
 class NodeWithChoiceParams(desc.Node):
     inputs = [
@@ -53,15 +53,14 @@ class NodeWithChoiceParamsSavingValuesOverride(desc.Node):
 
 
 class TestChoiceParam:
-    nodePlugin = NodePlugin(NodeWithChoiceParams)
 
     @classmethod
     def setup_class(cls):
-        pluginManager.registerNode(cls.nodePlugin)
+        registerNodeDesc(NodeWithChoiceParams)
 
     @classmethod
     def teardown_class(cls):
-        pluginManager.unregisterNode(cls.nodePlugin)
+        unregisterNodeDesc(NodeWithChoiceParams)
 
     def test_customValueIsSerialized(self, graphSavedOnDisk):
         graph: Graph = graphSavedOnDisk
@@ -120,15 +119,14 @@ class TestChoiceParam:
 
 
 class TestChoiceParamSavingCustomValues:
-    nodePlugin = NodePlugin(NodeWithChoiceParamsSavingValuesOverride)
 
     @classmethod
     def setup_class(cls):
-        pluginManager.registerNode(cls.nodePlugin)
+        registerNodeDesc(NodeWithChoiceParamsSavingValuesOverride)
 
     @classmethod
     def teardown_class(cls):
-        pluginManager.unregisterNode(cls.nodePlugin)
+        unregisterNodeDesc(NodeWithChoiceParamsSavingValuesOverride)
 
     def test_customValueIsSerialized(self, graphSavedOnDisk):
         graph: Graph = graphSavedOnDisk

--- a/tests/test_attributeChoiceParam.py
+++ b/tests/test_attributeChoiceParam.py
@@ -84,7 +84,7 @@ class TestChoiceParam:
         graph: Graph = graphSavedOnDisk
         node = graph.addNewNode(NodeWithChoiceParams.__name__)
         node.choice.values = ["D", "E", "F"]
-        
+
         graph.save()
         loadedGraph = loadGraph(graph.filepath)
 
@@ -143,7 +143,7 @@ class TestChoiceParamSavingCustomValues:
         node = graph.addNewNode(NodeWithChoiceParamsSavingValuesOverride.__name__)
         node.choice.values = ["D", "E", "F"]
         node.choiceMulti.values = ["D", "E", "F"]
-        
+
         graph.save()
         loadedGraph = loadGraph(graph.filepath)
 

--- a/tests/test_compatibility.py
+++ b/tests/test_compatibility.py
@@ -20,7 +20,8 @@ SampleGroupV1 = [
     desc.IntParam(name="a", label="a", description="", value=0, range=None),
     desc.ListAttribute(
         name="b",
-        elementDesc=desc.FloatParam(name="p", label="", description="", value=0.0, range=None),
+        elementDesc=desc.FloatParam(name="p", label="",
+                                    description="", value=0.0, range=None),
         label="b",
         description="",
     )
@@ -30,7 +31,8 @@ SampleGroupV2 = [
     desc.IntParam(name="a", label="a", description="", value=0, range=None),
     desc.ListAttribute(
         name="b",
-        elementDesc=desc.GroupAttribute(name="p", label="", description="", groupDesc=SampleGroupV1),
+        elementDesc=desc.GroupAttribute(name="p", label="",
+                                        description="", groupDesc=SampleGroupV1),
         label="b",
         description="",
     )
@@ -39,10 +41,12 @@ SampleGroupV2 = [
 # SampleGroupV3 is SampleGroupV2 with one more int parameter
 SampleGroupV3 = [
     desc.IntParam(name="a", label="a", description="", value=0, range=None),
-    desc.IntParam(name="notInSampleGroupV2", label="notInSampleGroupV2", description="", value=0, range=None),
+    desc.IntParam(name="notInSampleGroupV2", label="notInSampleGroupV2",
+                  description="", value=0, range=None),
     desc.ListAttribute(
         name="b",
-        elementDesc=desc.GroupAttribute(name="p", label="", description="", groupDesc=SampleGroupV1),
+        elementDesc=desc.GroupAttribute(name="p", label="",
+                                        description="", groupDesc=SampleGroupV1),
         label="b",
         description="",
     )
@@ -52,11 +56,12 @@ SampleGroupV3 = [
 class SampleNodeV1(desc.Node):
     """ Version 1 Sample Node """
     inputs = [
-        desc.File(name='input', label='Input', description='', value='',),
-        desc.StringParam(name='paramA', label='ParamA', description='', value='', invalidate=False)  # No impact on UID
+        desc.File(name="input", label="Input", description="", value=""),
+        desc.StringParam(name="paramA", label="ParamA", description="",
+                         value="", invalidate=False)  # No impact on UID
     ]
     outputs = [
-        desc.File(name='output', label='Output', description='', value="{nodeCacheFolder}")
+        desc.File(name="output", label="Output", description="", value="{nodeCacheFolder}")
     ]
 
 
@@ -65,11 +70,12 @@ class SampleNodeV2(desc.Node):
         * 'input' has been renamed to 'in'
     """
     inputs = [
-        desc.File(name='in', label='Input', description='', value='',),
-        desc.StringParam(name='paramA', label='ParamA', description='', value='', invalidate=False),  # No impact on UID
+        desc.File(name="in", label="Input", description="", value=""),
+        desc.StringParam(name="paramA", label="ParamA", description="",
+                         value="", invalidate=False),  # No impact on UID
     ]
     outputs = [
-        desc.File(name='output', label='Output', description='', value="{nodeCacheFolder}")
+        desc.File(name="output", label="Output", description="", value="{nodeCacheFolder}")
     ]
 
 
@@ -79,10 +85,10 @@ class SampleNodeV3(desc.Node):
         * 'paramA' has been removed'
     """
     inputs = [
-        desc.File(name='in', label='Input', description='', value='',),
+        desc.File(name="in", label="Input", description="", value=""),
     ]
     outputs = [
-        desc.File(name='output', label='Output', description='', value="{nodeCacheFolder}")
+        desc.File(name="output", label="Output", description="", value="{nodeCacheFolder}")
     ]
 
 
@@ -92,14 +98,14 @@ class SampleNodeV4(desc.Node):
         * 'paramA' has been added
     """
     inputs = [
-        desc.File(name='in', label='Input', description='', value='',),
-        desc.ListAttribute(name='paramA', label='ParamA',
+        desc.File(name="in", label="Input", description="", value=""),
+        desc.ListAttribute(name="paramA", label="ParamA",
                            elementDesc=desc.GroupAttribute(
-                               groupDesc=SampleGroupV1, name='gA', label='gA', description=''),
-                           description='')
+                               groupDesc=SampleGroupV1, name="gA", label="gA", description=""),
+                           description="")
     ]
     outputs = [
-        desc.File(name='output', label='Output', description='', value="{nodeCacheFolder}")
+        desc.File(name="output", label="Output", description="", value="{nodeCacheFolder}")
     ]
 
 
@@ -109,14 +115,14 @@ class SampleNodeV5(desc.Node):
         * 'paramA' elementDesc has changed from SampleGroupV1 to SampleGroupV2
     """
     inputs = [
-        desc.File(name='in', label='Input', description='', value=''),
-        desc.ListAttribute(name='paramA', label='ParamA',
+        desc.File(name="in", label="Input", description="", value=""),
+        desc.ListAttribute(name="paramA", label="ParamA",
                            elementDesc=desc.GroupAttribute(
-                               groupDesc=SampleGroupV2, name='gA', label='gA', description=''),
-                           description='')
+                               groupDesc=SampleGroupV2, name="gA", label="gA", description=""),
+                           description="")
     ]
     outputs = [
-        desc.File(name='output', label='Output', description='', value="{nodeCacheFolder}")
+        desc.File(name="output", label="Output", description="", value="{nodeCacheFolder}")
     ]
 
 
@@ -126,24 +132,25 @@ class SampleNodeV6(desc.Node):
         * 'paramA' elementDesc has changed from SampleGroupV2 to SampleGroupV3
     """
     inputs = [
-        desc.File(name='in', label='Input', description='', value=''),
-        desc.ListAttribute(name='paramA', label='ParamA',
+        desc.File(name="in", label="Input", description="", value=""),
+        desc.ListAttribute(name="paramA", label="ParamA",
                            elementDesc=desc.GroupAttribute(
-                               groupDesc=SampleGroupV3, name='gA', label='gA', description=''),
-                           description='')
+                               groupDesc=SampleGroupV3, name="gA", label="gA", description=""),
+                           description="")
     ]
     outputs = [
-        desc.File(name='output', label='Output', description='', value="{nodeCacheFolder}")
+        desc.File(name="output", label="Output", description="", value="{nodeCacheFolder}")
     ]
 
 
 class SampleInputNodeV1(desc.InputNode):
     """ Version 1 Sample Input Node """
     inputs = [
-        desc.StringParam(name='path', label='path', description='', value='', invalidate=False)  # No impact on UID
+        desc.StringParam(name="path", label="Path", description="",
+                         value="", invalidate=False)  # No impact on UID
     ]
     outputs = [
-        desc.File(name='output', label='Output', description='', value="{nodeCacheFolder}")
+        desc.File(name="output", label="Output", description="", value="{nodeCacheFolder}")
     ]
 
 
@@ -152,10 +159,11 @@ class SampleInputNodeV2(desc.InputNode):
         * 'path' has been renamed to 'in'
     """
     inputs = [
-        desc.StringParam(name='in', label='path', description='', value='', invalidate=False)  # No impact on UID
+        desc.StringParam(name="in", label="path", description="",
+                         value="", invalidate=False)  # No impact on UID
     ]
     outputs = [
-        desc.File(name='output', label='Output', description='', value="{nodeCacheFolder}")
+        desc.File(name="output", label="Output", description="", value="{nodeCacheFolder}")
     ]
 
 
@@ -170,7 +178,7 @@ def test_unknown_node_type():
     Test compatibility behavior for unknown node type.
     """
     registerNodeType(SampleNodeV1)
-    g = Graph('')
+    g = Graph("")
     n = g.addNewNode("SampleNodeV1", input="/dev/null", paramA="foo")
     graphFile = os.path.join(tempfile.mkdtemp(), "test_unknown_node_type.mg")
     g.save(graphFile)
@@ -178,24 +186,25 @@ def test_unknown_node_type():
     nodeName = n.name
     unregisterNodeType(SampleNodeV1)
 
-    # reload file
+
+    # Reload file
     g = loadGraph(graphFile)
     os.remove(graphFile)
 
     assert len(g.nodes) == 1
     n = g.node(nodeName)
     # SampleNodeV1 is now an unknown type
-    # check node instance type and compatibility issue type
+    # Check node instance type and compatibility issue type
     assert isinstance(n, CompatibilityNode)
     assert n.issue == CompatibilityIssue.UnknownNodeType
-    # check if attributes are properly restored
+    # Check if attributes are properly restored
     assert len(n.attributes) == 3
     assert n.input.isInput
     assert n.output.isOutput
-    # check if internal folder
+    # Check if internal folder
     assert n.internalFolder == internalFolder
 
-    # upgrade can't be perform on unknown node types
+    # Upgrade can't be perform on unknown node types
     assert not n.canUpgrade
     with pytest.raises(NodeUpgradeError):
         g.upgradeNode(nodeName)
@@ -205,20 +214,20 @@ def test_description_conflict():
     """
     Test compatibility behavior for conflicting node descriptions.
     """
-    # copy registered node types to be able to restore them
-    originalNodeTypes = copy.copy(meshroom.core.nodesDesc)
+    # Copy registered node types to be able to restore them
+    originalNodeTypes = copy.deepcopy(pluginManager.getNodePlugins())
 
     nodeTypes = [SampleNodeV1, SampleNodeV2, SampleNodeV3, SampleNodeV4, SampleNodeV5]
     nodes = []
-    g = Graph('')
+    g = Graph("")
 
-    # register and instantiate instances of all node types except last one
+    # Register and instantiate instances of all node types except last one
     for nt in nodeTypes[:-1]:
-        registerNodeType(nt)
+        pluginManager.registerNode(NodePlugin(nt))
         n = g.addNewNode(nt.__name__)
 
         if nt == SampleNodeV4:
-            # initialize list attribute with values to create a conflict with V5
+            # Initialize list attribute with values to create a conflict with V5
             n.paramA.value = [{'a': 0, 'b': [1.0, 2.0]}]
 
         nodes.append(n)
@@ -226,15 +235,15 @@ def test_description_conflict():
     graphFile = os.path.join(tempfile.mkdtemp(), "test_description_conflict.mg")
     g.save(graphFile)
 
-    # reload file as-is, ensure no compatibility issue is detected (no CompatibilityNode instances)
+    # Reload file as-is, ensure no compatibility issue is detected (no CompatibilityNode instances)
     loadGraph(graphFile, strictCompatibility=True)
 
-    # offset node types register to create description conflicts
-    # each node type name now reference the next one's implementation
+    # Offset node types register to create description conflicts
+    # Each node type name now reference the next one's implementation
     for i, nt in enumerate(nodeTypes[:-1]):
-        meshroom.core.nodesDesc[nt.__name__] = nodeTypes[i+1]
+        pluginManager.getNodePlugins()[nt.__name__] = NodePlugin(nodeTypes[i + 1])
 
-    # reload file
+    # Reload file
     g = loadGraph(graphFile)
     os.remove(graphFile)
 
@@ -246,7 +255,7 @@ def test_description_conflict():
         assert isinstance(compatNode, CompatibilityNode)
         assert srcNode.internalFolder == compatNode.internalFolder
 
-        # case by case description conflict verification
+        # Case by case description conflict verification
         if isinstance(srcNode.nodeDesc, SampleNodeV1):
             # V1 => V2: 'input' has been renamed to 'in'
             assert len(compatNode.attributes) == 3
@@ -254,27 +263,29 @@ def test_description_conflict():
             assert hasattr(compatNode, "input")
             assert not hasattr(compatNode, "in")
 
-            # perform upgrade
+            # Perform upgrade
             upgradedNode = g.upgradeNode(nodeName)
-            assert isinstance(upgradedNode, Node) and isinstance(upgradedNode.nodeDesc, SampleNodeV2)
+            assert isinstance(upgradedNode, Node) and \
+                isinstance(upgradedNode.nodeDesc, SampleNodeV2)
 
             assert list(upgradedNode.attributes.keys()) == ["in", "paramA", "output"]
             assert not hasattr(upgradedNode, "input")
             assert hasattr(upgradedNode, "in")
-            # check uid has changed (not the same set of attributes)
+            # Check UID has changed (not the same set of attributes)
             assert upgradedNode.internalFolder != srcNode.internalFolder
 
         elif isinstance(srcNode.nodeDesc, SampleNodeV2):
-            # V2 => V3: 'paramA' has been removed'
+            # V2 => V3: 'paramA' has been removed
             assert len(compatNode.attributes) == 3
             assert hasattr(compatNode, "paramA")
 
-            # perform upgrade
+            # Perform upgrade
             upgradedNode = g.upgradeNode(nodeName)
-            assert isinstance(upgradedNode, Node) and isinstance(upgradedNode.nodeDesc, SampleNodeV3)
+            assert isinstance(upgradedNode, Node) and \
+                isinstance(upgradedNode.nodeDesc, SampleNodeV3)
 
             assert not hasattr(upgradedNode, "paramA")
-            # check uid is identical (paramA not part of uid)
+            # Check UID is identical (paramA not part of UID)
             assert upgradedNode.internalFolder == srcNode.internalFolder
 
         elif isinstance(srcNode.nodeDesc, SampleNodeV3):
@@ -282,9 +293,10 @@ def test_description_conflict():
             assert len(compatNode.attributes) == 2
             assert not hasattr(compatNode, "paramA")
 
-            # perform upgrade
+            # Perform upgrade
             upgradedNode = g.upgradeNode(nodeName)
-            assert isinstance(upgradedNode, Node) and isinstance(upgradedNode.nodeDesc, SampleNodeV4)
+            assert isinstance(upgradedNode, Node) and \
+                isinstance(upgradedNode.nodeDesc, SampleNodeV4)
 
             assert hasattr(upgradedNode, "paramA")
             assert isinstance(upgradedNode.paramA.attributeDesc, desc.ListAttribute)
@@ -298,22 +310,24 @@ def test_description_conflict():
             groupAttribute = compatNode.paramA.attributeDesc.elementDesc
 
             assert isinstance(groupAttribute, desc.GroupAttribute)
-            # check that Compatibility node respect SampleGroupV1 description
+            # Check that Compatibility node respect SampleGroupV1 description
             for elt in groupAttribute.groupDesc:
-                assert isinstance(elt, next(a for a in SampleGroupV1 if a.name == elt.name).__class__)
+                assert isinstance(elt,
+                                  next(a for a in SampleGroupV1 if a.name == elt.name).__class__)
 
-            # perform upgrade
+            # Perform upgrade
             upgradedNode = g.upgradeNode(nodeName)
-            assert isinstance(upgradedNode, Node) and isinstance(upgradedNode.nodeDesc, SampleNodeV5)
+            assert isinstance(upgradedNode, Node) and \
+                isinstance(upgradedNode.nodeDesc, SampleNodeV5)
 
             assert hasattr(upgradedNode, "paramA")
-            # parameter was incompatible, value could not be restored
+            # Parameter was incompatible, value could not be restored
             assert upgradedNode.paramA.isDefault
             assert upgradedNode.internalFolder != srcNode.internalFolder
         else:
             raise ValueError("Unexpected node type: " + srcNode.nodeType)
 
-    # restore original node types
+    # Restore original node types
     meshroom.core.nodesDesc = originalNodeTypes
 
 
@@ -323,7 +337,7 @@ def test_upgradeAllNodes():
     registerNodeType(SampleInputNodeV1)
     registerNodeType(SampleInputNodeV2)
 
-    g = Graph('')
+    g = Graph("")
     n1 = g.addNewNode("SampleNodeV1")
     n2 = g.addNewNode("SampleNodeV2")
     n3 = g.addNewNode("SampleInputNodeV1")
@@ -335,28 +349,28 @@ def test_upgradeAllNodes():
     graphFile = os.path.join(tempfile.mkdtemp(), "test_description_conflict.mg")
     g.save(graphFile)
 
-    # make SampleNodeV2 and SampleInputNodeV2 an unknown type
+    # Make SampleNodeV2 and SampleInputNodeV2 an unknown type
     unregisterNodeType(SampleNodeV2)
     unregisterNodeType(SampleInputNodeV2)
-    # replace SampleNodeV1 by SampleNodeV2 and SampleInputNodeV1 by SampleInputNodeV2
     meshroom.core.nodesDesc[SampleNodeV1.__name__] = SampleNodeV2
     meshroom.core.nodesDesc[SampleInputNodeV1.__name__] = SampleInputNodeV2
+    # Replace SampleNodeV1 by SampleNodeV2 and SampleInputNodeV1 by SampleInputNodeV2
 
-    # reload file
+    # Reload file
     g = loadGraph(graphFile)
     os.remove(graphFile)
 
-    # both nodes are CompatibilityNodes
+    # Both nodes are CompatibilityNodes
     assert len(g.compatibilityNodes) == 4
     assert g.node(n1Name).canUpgrade      # description conflict
     assert not g.node(n2Name).canUpgrade  # unknown type
     assert g.node(n3Name).canUpgrade      # description conflict
     assert not g.node(n4Name).canUpgrade  # unknown type
 
-    # upgrade all upgradable nodes
+    # Upgrade all upgradable nodes
     g.upgradeAllNodes()
 
-    # only the nodes with an unknown type have not been upgraded
+    # Only the nodes with an unknown type have not been upgraded
     assert len(g.compatibilityNodes) == 2
     assert n2Name in g.compatibilityNodes.keys()
     assert n4Name in g.compatibilityNodes.keys()
@@ -369,36 +383,36 @@ def test_conformUpgrade():
     registerNodeType(SampleNodeV5)
     registerNodeType(SampleNodeV6)
 
-    g = Graph('')
+    g = Graph("")
     n1 = g.addNewNode("SampleNodeV5")
-    n1.paramA.value = [{'a': 0, 'b': [{'a': 0, 'b': [1.0, 2.0]}, {'a': 1, 'b': [1.0, 2.0]}]}]
+    n1.paramA.value = [{"a": 0, "b": [{"a": 0, "b": [1.0, 2.0]}, {"a": 1, "b": [1.0, 2.0]}]}]
     n1Name = n1.name
     graphFile = os.path.join(tempfile.mkdtemp(), "test_conform_upgrade.mg")
     g.save(graphFile)
 
-    # replace SampleNodeV5 by SampleNodeV6
+    # Replace SampleNodeV5 by SampleNodeV6
     meshroom.core.nodesDesc[SampleNodeV5.__name__] = SampleNodeV6
 
-    # reload file
+    # Reload file
     g = loadGraph(graphFile)
     os.remove(graphFile)
 
-    # node is a CompatibilityNode
+    # Node is a CompatibilityNode
     assert len(g.compatibilityNodes) == 1
     assert g.node(n1Name).canUpgrade
 
-    # upgrade all upgradable nodes
+    # Upgrade all upgradable nodes
     g.upgradeAllNodes()
 
-    # only the node with an unknown type has not been upgraded
+    # Only the node with an unknown type has not been upgraded
     assert len(g.compatibilityNodes) == 0
 
     upgradedNode = g.node(n1Name)
 
-    # check upgrade
+    # Check upgrade
     assert isinstance(upgradedNode, Node) and isinstance(upgradedNode.nodeDesc, SampleNodeV6)
 
-    # check conformation
+    # Check conformation
     assert len(upgradedNode.paramA.value) == 1
 
     unregisterNodeType(SampleNodeV5)
@@ -482,7 +496,7 @@ class TestVersionConflict:
             with overrideNodeTypeVersion(SampleNodeV1, "1.0"):
                 node = graph.addNewNode(SampleNodeV1.__name__)
                 graph.save()
-            
+
             with overrideNodeTypeVersion(SampleNodeV1, "2.0"):
                 otherGraph = Graph("")
                 otherGraph.load(graph.filepath)
@@ -496,7 +510,7 @@ class TestVersionConflict:
         with registeredNodeTypes([SampleNodeV1]):
             graph.addNewNode(SampleNodeV1.__name__)
             graph.save()
-            
+
             with overrideNodeTypeVersion(SampleNodeV1, "2.0"):
                 otherGraph = Graph("")
                 otherGraph.load(graph.filepath)
@@ -508,7 +522,8 @@ class UidTestingNodeV1(desc.Node):
     inputs = [
         desc.File(name="input", label="Input", description="", value="", invalidate=True),
     ]
-    outputs = [desc.File(name="output", label="Output", description="", value="{nodeCacheFolder}")]
+    outputs = [desc.File(name="output", label="Output",
+                         description="", value="{nodeCacheFolder}")]
 
 
 class UidTestingNodeV2(desc.Node):
@@ -554,7 +569,8 @@ class UidTestingNodeV3(desc.Node):
             description="",
         ),
     ]
-    outputs = [desc.File(name="output", label="Output", description="", value="{nodeCacheFolder}")]
+    outputs = [desc.File(name="output", label="Output",
+                         description="", value="{nodeCacheFolder}")]
 
 
 class TestUidConflict:
@@ -626,7 +642,8 @@ class TestUidConflict:
             assert len(loadedGraph.compatibilityNodes) == 0
 
 
-    def test_uidConflictDoesNotPropagateToValidDownstreamNodeThroughConnection(self, graphSavedOnDisk):
+    def test_uidConflictDoesNotPropagateToValidDownstreamNodeThroughConnection(
+            self, graphSavedOnDisk):
         with registeredNodeTypes([UidTestingNodeV1, UidTestingNodeV2]):
             graph: Graph = graphSavedOnDisk
             nodeA = graph.addNewNode(UidTestingNodeV2.__name__)
@@ -640,7 +657,8 @@ class TestUidConflict:
             loadedGraph = loadGraph(graph.filepath)
             assert len(loadedGraph.compatibilityNodes) == 1
 
-    def test_uidConflictDoesNotPropagateToValidDownstreamNodeThroughListConnection(self, graphSavedOnDisk):
+    def test_uidConflictDoesNotPropagateToValidDownstreamNodeThroughListConnection(
+            self,graphSavedOnDisk):
         with registeredNodeTypes([UidTestingNodeV2, UidTestingNodeV3]):
             graph: Graph = graphSavedOnDisk
             nodeA = graph.addNewNode(UidTestingNodeV2.__name__)

--- a/tests/test_compatibility.py
+++ b/tests/test_compatibility.py
@@ -170,7 +170,7 @@ class SampleInputNodeV2(desc.InputNode):
 
 def replaceNodeTypeDesc(nodeType: str, nodeDesc: Type[desc.Node]):
     """Change the `nodeDesc` associated to `nodeType`."""
-    pluginManager.getNodePlugins()[nodeType] = NodePlugin(nodeDesc)
+    pluginManager.getRegisteredNodePlugins()[nodeType] = NodePlugin(nodeDesc)
 
 
 def test_unknown_node_type():
@@ -216,7 +216,7 @@ def test_description_conflict():
     Test compatibility behavior for conflicting node descriptions.
     """
     # Copy registered node types to be able to restore them
-    originalNodeTypes = copy.deepcopy(pluginManager.getNodePlugins())
+    originalNodeTypes = copy.deepcopy(pluginManager.getRegisteredNodePlugins())
 
     nodeTypes = [SampleNodeV1, SampleNodeV2, SampleNodeV3, SampleNodeV4, SampleNodeV5]
     nodes = []
@@ -242,7 +242,7 @@ def test_description_conflict():
     # Offset node types register to create description conflicts
     # Each node type name now reference the next one's implementation
     for i, nt in enumerate(nodeTypes[:-1]):
-        pluginManager.getNodePlugins()[nt.__name__] = NodePlugin(nodeTypes[i + 1])
+        pluginManager.getRegisteredNodePlugins()[nt.__name__] = NodePlugin(nodeTypes[i + 1])
 
     # Reload file
     g = loadGraph(graphFile)
@@ -359,8 +359,8 @@ def test_upgradeAllNodes():
     pluginManager.unregisterNode(nodePluginSampleInputV2)
 
     # Replace SampleNodeV1 by SampleNodeV2 and SampleInputNodeV1 by SampleInputNodeV2
-    pluginManager.getNodePlugins()[nodePluginSampleV1.nodeDescriptor.__name__] = nodePluginSampleV2
-    pluginManager.getNodePlugins()[nodePluginSampleInputV1.nodeDescriptor.__name__] = \
+    pluginManager.getRegisteredNodePlugins()[nodePluginSampleV1.nodeDescriptor.__name__] = nodePluginSampleV2
+    pluginManager.getRegisteredNodePlugins()[nodePluginSampleInputV1.nodeDescriptor.__name__] = \
         nodePluginSampleInputV2
 
     # Reload file
@@ -400,7 +400,7 @@ def test_conformUpgrade():
     g.save(graphFile)
 
     # Replace SampleNodeV5 by SampleNodeV6
-    pluginManager.getNodePlugins()[nodePluginSampleV5.nodeDescriptor.__name__] = nodePluginSampleV6
+    pluginManager.getRegisteredNodePlugins()[nodePluginSampleV5.nodeDescriptor.__name__] = nodePluginSampleV6
 
     # Reload file
     g = loadGraph(graphFile)

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -2,11 +2,11 @@ from meshroom.core.graph import Graph
 
 
 def test_depth():
-    graph = Graph('Tests tasks depth')
+    graph = Graph("Tests tasks depth")
 
-    tA = graph.addNewNode('Ls', input='/tmp')
-    tB = graph.addNewNode('AppendText', inputText='echo B')
-    tC = graph.addNewNode('AppendText', inputText='echo C')
+    tA = graph.addNewNode("Ls", input="/tmp")
+    tB = graph.addNewNode("AppendText", inputText="echo B")
+    tC = graph.addNewNode("AppendText", inputText="echo C")
 
     graph.addEdges(
         (tA.output, tB.input),
@@ -19,19 +19,19 @@ def test_depth():
 
 
 def test_depth_diamond_graph():
-    graph = Graph('Tests tasks depth')
+    graph = Graph("Tests tasks depth")
 
-    tA = graph.addNewNode('Ls', input='/tmp')
-    tB = graph.addNewNode('AppendText', inputText='echo B')
-    tC = graph.addNewNode('AppendText', inputText='echo C')
-    tD = graph.addNewNode('AppendFiles')
+    tA = graph.addNewNode("Ls", input="/tmp")
+    tB = graph.addNewNode("AppendText", inputText="echo B")
+    tC = graph.addNewNode("AppendText", inputText="echo C")
+    tD = graph.addNewNode("AppendFiles")
 
     graph.addEdges(
         (tA.output, tB.input),
         (tA.output, tC.input),
         (tB.output, tD.input),
         (tC.output, tD.input2),
-        )
+    )
 
     assert tA.depth == 0
     assert tB.depth == 1
@@ -58,13 +58,13 @@ def test_depth_diamond_graph():
 
 
 def test_depth_diamond_graph2():
-    graph = Graph('Tests tasks depth')
+    graph = Graph("Tests tasks depth")
 
-    tA = graph.addNewNode('Ls', input='/tmp')
-    tB = graph.addNewNode('AppendText', inputText='echo B')
-    tC = graph.addNewNode('AppendText', inputText='echo C')
-    tD = graph.addNewNode('AppendText', inputText='echo D')
-    tE = graph.addNewNode('AppendFiles')
+    tA = graph.addNewNode("Ls", input="/tmp")
+    tB = graph.addNewNode("AppendText", inputText="echo B")
+    tC = graph.addNewNode("AppendText", inputText="echo C")
+    tD = graph.addNewNode("AppendText", inputText="echo D")
+    tE = graph.addNewNode("AppendFiles")
     #         C
     #       /   \
     #  /---/---->\
@@ -81,7 +81,7 @@ def test_depth_diamond_graph2():
         (tB.output, tE.input2),
         (tC.output, tE.input3),
         (tD.output, tE.input4),
-        )
+    )
 
     assert tA.depth == 0
     assert tB.depth == 1
@@ -116,14 +116,13 @@ def test_depth_diamond_graph2():
 
 
 def test_transitive_reduction():
+    graph = Graph("Tests tasks depth")
 
-    graph = Graph('Tests tasks depth')
-
-    tA = graph.addNewNode('Ls', input='/tmp')
-    tB = graph.addNewNode('AppendText', inputText='echo B')
-    tC = graph.addNewNode('AppendText', inputText='echo C')
-    tD = graph.addNewNode('AppendText', inputText='echo D')
-    tE = graph.addNewNode('AppendFiles')
+    tA = graph.addNewNode("Ls", input="/tmp")
+    tB = graph.addNewNode("AppendText", inputText="echo B")
+    tC = graph.addNewNode("AppendText", inputText="echo C")
+    tD = graph.addNewNode("AppendText", inputText="echo D")
+    tE = graph.addNewNode("AppendFiles")
     #         C
     #       /   \
     #  /---/---->\
@@ -141,7 +140,7 @@ def test_transitive_reduction():
         (tB.output, tE.input4),
         (tC.output, tE.input3),
         (tD.output, tE.input2),
-        )
+    )
 
     flowEdges = graph.flowEdges()
     flowEdgesRes = [(tB, tA),
@@ -153,24 +152,24 @@ def test_transitive_reduction():
     assert set(flowEdgesRes) == set(flowEdges)
 
     assert len(graph._nodesMinMaxDepths) == len(graph.nodes)
-    for node, (minDepth, maxDepth) in graph._nodesMinMaxDepths.items():
+    for node, (_, maxDepth) in graph._nodesMinMaxDepths.items():
         assert node.depth == maxDepth
 
 
 def test_graph_reverse_dfsOnDiscover():
-    graph = Graph('Test dfsOnDiscover(reverse=True)')
+    graph = Graph("Test dfsOnDiscover(reverse=True)")
 
     #    ------------\
     #   /   ~ C - E - F
     # A - B
     #      ~ D
 
-    A = graph.addNewNode('Ls', input='/tmp')
-    B = graph.addNewNode('AppendText', inputText=A.output)
-    C = graph.addNewNode('AppendText', inputText=B.output)
-    D = graph.addNewNode('AppendText', inputText=B.output)
-    E = graph.addNewNode('Ls', input=C.output)
-    F = graph.addNewNode('AppendText', input=A.output, inputText=E.output)
+    A = graph.addNewNode("Ls", input="/tmp")
+    B = graph.addNewNode("AppendText", inputText=A.output)
+    C = graph.addNewNode("AppendText", inputText=B.output)
+    D = graph.addNewNode("AppendText", inputText=B.output)
+    E = graph.addNewNode("Ls", input=C.output)
+    F = graph.addNewNode("AppendText", input=A.output, inputText=E.output)
 
     # Get all nodes from A (use set, order not guaranteed)
     nodes = graph.dfsOnDiscover(startNodes=[A], reverse=True)[0]
@@ -179,7 +178,7 @@ def test_graph_reverse_dfsOnDiscover():
     nodes = graph.dfsOnDiscover(startNodes=[B], reverse=True)[0]
     assert set(nodes) == {B, D, C, E, F}
     # Get all nodes of type AppendText from B
-    nodes = graph.dfsOnDiscover(startNodes=[B], filterTypes=['AppendText'], reverse=True)[0]
+    nodes = graph.dfsOnDiscover(startNodes=[B], filterTypes=["AppendText"], reverse=True)[0]
     assert set(nodes) == {B, D, C, F}
     # Get all nodes from C (order guaranteed)
     nodes = graph.dfsOnDiscover(startNodes=[C], reverse=True)[0]
@@ -190,7 +189,7 @@ def test_graph_reverse_dfsOnDiscover():
 
 
 def test_graph_dfsOnDiscover():
-    graph = Graph('Test dfsOnDiscover(reverse=False)')
+    graph = Graph("Test dfsOnDiscover(reverse=False)")
 
     #    ------------\
     #   /   ~ C - E - F
@@ -198,13 +197,13 @@ def test_graph_dfsOnDiscover():
     #      ~ D
     #    G
 
-    G = graph.addNewNode('Ls', input='/tmp')
-    A = graph.addNewNode('Ls', input='/tmp')
-    B = graph.addNewNode('AppendText', inputText=A.output)
-    C = graph.addNewNode('AppendText', inputText=B.output)
-    D = graph.addNewNode('AppendText', input=G.output, inputText=B.output)
-    E = graph.addNewNode('Ls', input=C.output)
-    F = graph.addNewNode('AppendText', input=A.output, inputText=E.output)
+    G = graph.addNewNode("Ls", input="/tmp")
+    A = graph.addNewNode("Ls", input="/tmp")
+    B = graph.addNewNode("AppendText", inputText=A.output)
+    C = graph.addNewNode("AppendText", inputText=B.output)
+    D = graph.addNewNode("AppendText", input=G.output, inputText=B.output)
+    E = graph.addNewNode("Ls", input=C.output)
+    F = graph.addNewNode("AppendText", input=A.output, inputText=E.output)
 
     # Get all nodes from A (use set, order not guaranteed)
     nodes = graph.dfsOnDiscover(startNodes=[A], reverse=False)[0]
@@ -219,7 +218,7 @@ def test_graph_dfsOnDiscover():
     nodes = graph.dfsOnDiscover(startNodes=[F], reverse=False)[0]
     assert set(nodes) == {A, B, C, E, F}
     # Get all nodes of type AppendText from C
-    nodes = graph.dfsOnDiscover(startNodes=[C], filterTypes=['AppendText'], reverse=False)[0]
+    nodes = graph.dfsOnDiscover(startNodes=[C], filterTypes=["AppendText"], reverse=False)[0]
     assert set(nodes) == {B, C}
     # Get all nodes from D (order guaranteed)
     nodes = graph.dfsOnDiscover(startNodes=[D], longestPathFirst=True, reverse=False)[0]
@@ -230,21 +229,21 @@ def test_graph_dfsOnDiscover():
 
 
 def test_graph_nodes_sorting():
-    graph = Graph('')
+    graph = Graph("")
 
-    ls0 = graph.addNewNode('Ls')
-    ls1 = graph.addNewNode('Ls')
-    ls2 = graph.addNewNode('Ls')
+    ls0 = graph.addNewNode("Ls")
+    ls1 = graph.addNewNode("Ls")
+    ls2 = graph.addNewNode("Ls")
 
-    assert graph.nodesOfType('Ls', sortedByIndex=True) == [ls0, ls1, ls2]
+    assert graph.nodesOfType("Ls", sortedByIndex=True) == [ls0, ls1, ls2]
 
-    graph = Graph('')
+    graph = Graph("")
     # 'Random' creation order (what happens when loading a file)
-    ls2 = graph.addNewNode('Ls', name='Ls_2')
-    ls0 = graph.addNewNode('Ls', name='Ls_0')
-    ls1 = graph.addNewNode('Ls', name='Ls_1')
+    ls2 = graph.addNewNode("Ls", name="Ls_2")
+    ls0 = graph.addNewNode("Ls", name="Ls_0")
+    ls1 = graph.addNewNode("Ls", name="Ls_1")
 
-    assert graph.nodesOfType('Ls', sortedByIndex=True) == [ls0, ls1, ls2]
+    assert graph.nodesOfType("Ls", sortedByIndex=True) == [ls0, ls1, ls2]
 
 
 def test_duplicate_nodes():
@@ -256,24 +255,25 @@ def test_duplicate_nodes():
     #   \          \
     #    ---------- n3
 
-    g = Graph('')
-    n0 = g.addNewNode('Ls', input='/tmp')
-    n1 = g.addNewNode('Ls', input=n0.output)
-    n2 = g.addNewNode('Ls', input=n1.output)
-    n3 = g.addNewNode('AppendFiles', input=n1.output, input2=n2.output)
+    g = Graph("")
+    n0 = g.addNewNode("Ls", input="/tmp")
+    n1 = g.addNewNode("Ls", input=n0.output)
+    n2 = g.addNewNode("Ls", input=n1.output)
+    n3 = g.addNewNode("AppendFiles", input=n1.output, input2=n2.output)
 
-    # duplicate from n1
+    # Duplicate from n1
     nodes_to_duplicate, _ = g.dfsOnDiscover(startNodes=[n1], reverse=True, dependenciesOnly=True)
     nMap = g.duplicateNodes(srcNodes=nodes_to_duplicate)
     for s, duplicated in nMap.items():
         for d in duplicated:
             assert s.nodeType == d.nodeType
 
-    # check number of duplicated nodes and that every parent node has been duplicated once
-    assert len(nMap) == 3 and all([len(nMap[i]) == 1 for i in nMap.keys()])
+    # Check number of duplicated nodes and that every parent node has been duplicated once
+    assert len(nMap) == 3 and \
+        all([len(nMap[i]) == 1 for i in nMap.keys()])
 
-    # check connections
-    # access directly index 0 because we know there is a single duplicate for each parent node
+    # Check connections
+    # Access directly index 0 because we know there is a single duplicate for each parent node
     assert nMap[n1][0].input.getLinkParam() == n0.output
     assert nMap[n2][0].input.getLinkParam() == nMap[n1][0].output
     assert nMap[n3][0].input.getLinkParam() == nMap[n1][0].output

--- a/tests/test_graphIO.py
+++ b/tests/test_graphIO.py
@@ -255,7 +255,8 @@ class TestGraphPartialSerialization:
             otherGraph = Graph("")
             otherGraph._deserialize(graph.serializePartial([nodeA, nodeB]))
 
-            assert otherGraph.node(nodeB.name).listInput.linkParam == otherGraph.node(nodeA.name).listInput
+            assert otherGraph.node(nodeB.name).listInput.linkParam == \
+                otherGraph.node(nodeA.name).listInput
 
     def test_singleNodeWithInputConnectionFromNonSerializedNodeRemovesEdge(self):
         graph = Graph("")

--- a/tests/test_invalidation.py
+++ b/tests/test_invalidation.py
@@ -7,8 +7,10 @@ from meshroom.core import desc, registerNodeType
 class SampleNode(desc.Node):
     """ Sample Node for unit testing """
     inputs = [
-        desc.File(name='input', label='Input', description='', value='',),
-        desc.StringParam(name='paramA', label='ParamA', description='', value='', invalidate=False)  # No impact on UID
+        desc.File(name="input", label="Input", description="", value="",),
+        desc.StringParam(name="paramA", label="ParamA",
+                         description="", value="",
+                         invalidate=False)  # No impact on UID
     ]
     outputs = [
         desc.File(name='output', label='Output', description='', value="{nodeCacheFolder}")
@@ -19,10 +21,10 @@ registerNodeType(SampleNode)
 
 
 def test_output_invalidation():
-    graph = Graph('')
-    n1 = graph.addNewNode('SampleNode', input='/tmp')
-    n2 = graph.addNewNode('SampleNode')
-    n3 = graph.addNewNode('SampleNode')
+    graph = Graph("")
+    n1 = graph.addNewNode("SampleNode", input="/tmp")
+    n2 = graph.addNewNode("SampleNode")
+    n3 = graph.addNewNode("SampleNode")
 
     graph.addEdges(
         (n1.output, n2.input),
@@ -52,9 +54,9 @@ def test_inputLinkInvalidation():
     """
     Input links should not change the invalidation.
     """
-    graph = Graph('')
-    n1 = graph.addNewNode('SampleNode')
-    n2 = graph.addNewNode('SampleNode')
+    graph = Graph("")
+    n1 = graph.addNewNode("SampleNode")
+    n2 = graph.addNewNode("SampleNode")
 
     graph.addEdges((n1.input, n2.input))
     assert n1.input.uid() == n2.input.uid()

--- a/tests/test_invalidation.py
+++ b/tests/test_invalidation.py
@@ -2,7 +2,8 @@
 # coding:utf-8
 from meshroom.core.graph import Graph
 from meshroom.core import desc, pluginManager
-from meshroom.core.plugins import NodePlugin
+
+from .utils import registerNodeDesc
 
 
 class SampleNode(desc.Node):
@@ -17,8 +18,7 @@ class SampleNode(desc.Node):
         desc.File(name='output', label='Output', description='', value="{nodeCacheFolder}")
     ]
 
-nodePlugin = NodePlugin(SampleNode)
-pluginManager.registerNode(nodePlugin)  # register standalone NodePlugin
+registerNodeDesc(SampleNode)  # register standalone NodePlugin
 
 def test_output_invalidation():
     graph = Graph("")

--- a/tests/test_invalidation.py
+++ b/tests/test_invalidation.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 # coding:utf-8
 from meshroom.core.graph import Graph
-from meshroom.core import desc, registerNodeType
+from meshroom.core import desc, pluginManager
+from meshroom.core.plugins import NodePlugin
 
 
 class SampleNode(desc.Node):
@@ -16,9 +17,8 @@ class SampleNode(desc.Node):
         desc.File(name='output', label='Output', description='', value="{nodeCacheFolder}")
     ]
 
-
-registerNodeType(SampleNode)
-
+nodePlugin = NodePlugin(SampleNode)
+pluginManager.registerNode(nodePlugin)  # register standalone NodePlugin
 
 def test_output_invalidation():
     graph = Graph("")

--- a/tests/test_nodeAttributeChangedCallback.py
+++ b/tests/test_nodeAttributeChangedCallback.py
@@ -3,7 +3,8 @@
 from meshroom.core.graph import Graph, loadGraph, executeGraph
 from meshroom.core import desc, pluginManager
 from meshroom.core.node import Node
-from meshroom.core.plugins import NodePlugin
+
+from .utils import registerNodeDesc, unregisterNodeDesc
 
 
 class NodeWithAttributeChangedCallback(desc.BaseNode):
@@ -38,15 +39,14 @@ class NodeWithAttributeChangedCallback(desc.BaseNode):
 
 
 class TestNodeWithAttributeChangedCallback:
-    nodePlugin = NodePlugin(NodeWithAttributeChangedCallback)
 
     @classmethod
     def setup_class(cls):
-        pluginManager.registerNode(cls.nodePlugin)
+        registerNodeDesc(NodeWithAttributeChangedCallback)
 
     @classmethod
     def teardown_class(cls):
-        pluginManager.unregisterNode(cls.nodePlugin)
+        unregisterNodeDesc(NodeWithAttributeChangedCallback)
 
     def test_assignValueTriggersCallback(self):
         node = Node(NodeWithAttributeChangedCallback.__name__)
@@ -71,15 +71,14 @@ class TestNodeWithAttributeChangedCallback:
 
 
 class TestAttributeCallbackTriggerInGraph:
-    nodePlugin = NodePlugin(NodeWithAttributeChangedCallback)
 
     @classmethod
     def setup_class(cls):
-        pluginManager.registerNode(cls.nodePlugin)
+        registerNodeDesc(NodeWithAttributeChangedCallback)
 
     @classmethod
     def teardown_class(cls):
-        pluginManager.unregisterNode(cls.nodePlugin)
+        unregisterNodeDesc(NodeWithAttributeChangedCallback)
 
     def test_connectionTriggersCallback(self):
         graph = Graph("")
@@ -246,18 +245,16 @@ class NodeWithCompoundAttributes(desc.BaseNode):
 
 
 class TestAttributeCallbackBehaviorWithUpstreamCompoundAttributes:
-    nodePluginAttributeChangedCallback = NodePlugin(NodeWithAttributeChangedCallback)
-    nodePluginCompoundAttributes = NodePlugin(NodeWithCompoundAttributes)
 
     @classmethod
     def setup_class(cls):
-        pluginManager.registerNode(cls.nodePluginAttributeChangedCallback)
-        pluginManager.registerNode(cls.nodePluginCompoundAttributes)
+        registerNodeDesc(NodeWithAttributeChangedCallback)
+        registerNodeDesc(NodeWithCompoundAttributes)
 
     @classmethod
     def teardown_class(cls):
-        pluginManager.unregisterNode(cls.nodePluginAttributeChangedCallback)
-        pluginManager.unregisterNode(cls.nodePluginCompoundAttributes)
+        unregisterNodeDesc(NodeWithAttributeChangedCallback)
+        unregisterNodeDesc(NodeWithCompoundAttributes)
 
     def test_connectionToListElement(self):
         graph = Graph("")
@@ -349,18 +346,18 @@ class NodeWithDynamicOutputValue(desc.BaseNode):
 
 
 class TestAttributeCallbackBehaviorWithUpstreamDynamicOutputs:
-    nodePluginAttributeChangedCallback = NodePlugin(NodeWithAttributeChangedCallback)
-    nodePluginDynamicOutputValue = NodePlugin(NodeWithDynamicOutputValue)
+    # nodePluginAttributeChangedCallback = NodePlugin(NodeWithAttributeChangedCallback)
+    # nodePluginDynamicOutputValue = NodePlugin(NodeWithDynamicOutputValue)
 
     @classmethod
     def setup_class(cls):
-        pluginManager.registerNode(cls.nodePluginAttributeChangedCallback)
-        pluginManager.registerNode(cls.nodePluginDynamicOutputValue)
+        registerNodeDesc(NodeWithAttributeChangedCallback)
+        registerNodeDesc(NodeWithDynamicOutputValue)
 
     @classmethod
     def teardown_class(cls):
-        pluginManager.unregisterNode(cls.nodePluginAttributeChangedCallback)
-        pluginManager.unregisterNode(cls.nodePluginDynamicOutputValue)
+        unregisterNodeDesc(NodeWithAttributeChangedCallback)
+        unregisterNodeDesc(NodeWithDynamicOutputValue)
 
     def test_connectingUncomputedDynamicOutputDoesNotTriggerDownstreamAttributeChangedCallback(
         self,
@@ -443,15 +440,13 @@ class TestAttributeCallbackBehaviorWithUpstreamDynamicOutputs:
 
 
 class TestAttributeCallbackBehaviorOnGraphImport:
-    nodePlugin = NodePlugin(NodeWithAttributeChangedCallback)
-
     @classmethod
     def setup_class(cls):
-        pluginManager.registerNode(cls.nodePlugin)
+        registerNodeDesc(NodeWithAttributeChangedCallback)
 
     @classmethod
     def teardown_class(cls):
-        pluginManager.unregisterNode(cls.nodePlugin)
+        unregisterNodeDesc(NodeWithAttributeChangedCallback)
 
     def test_importingGraphDoesNotTriggerAttributeChangedCallbacks(self):
         graph = Graph("")

--- a/tests/test_nodeAttributeChangedCallback.py
+++ b/tests/test_nodeAttributeChangedCallback.py
@@ -313,7 +313,8 @@ class TestAttributeCallbackBehaviorWithUpstreamCompoundAttributes:
 
 class NodeWithDynamicOutputValue(desc.BaseNode):
     """
-    A Node containing an output attribute which value is computed dynamically during graph execution.
+    A Node containing an output attribute which value is computed dynamically
+    during graph execution.
     """
 
     inputs = [
@@ -390,7 +391,6 @@ class TestAttributeCallbackBehaviorWithUpstreamDynamicOutputs:
         assert nodeB.input.value == 20
         assert nodeB.affectedInput.value == 0
 
-        
     def test_clearingDynamicOutputValueDoesNotTriggerDownstreamAttributeChangedCallback(
         self, graphSavedOnDisk
     ):
@@ -450,9 +450,8 @@ class TestAttributeCallbackBehaviorOnGraphImport:
 
         nodeA.input.value = 5
         nodeB.affectedInput.value = 2
-        
+
         otherGraph = Graph("")
         otherGraph.importGraphContent(graph)
 
         assert otherGraph.node(nodeB.name).affectedInput.value == 2
-

--- a/tests/test_nodeAttributeChangedCallback.py
+++ b/tests/test_nodeAttributeChangedCallback.py
@@ -1,8 +1,9 @@
 # coding:utf-8
 
 from meshroom.core.graph import Graph, loadGraph, executeGraph
-from meshroom.core import desc, registerNodeType, unregisterNodeType
+from meshroom.core import desc, pluginManager
 from meshroom.core.node import Node
+from meshroom.core.plugins import NodePlugin
 
 
 class NodeWithAttributeChangedCallback(desc.BaseNode):
@@ -37,13 +38,15 @@ class NodeWithAttributeChangedCallback(desc.BaseNode):
 
 
 class TestNodeWithAttributeChangedCallback:
+    nodePlugin = NodePlugin(NodeWithAttributeChangedCallback)
+
     @classmethod
     def setup_class(cls):
-        registerNodeType(NodeWithAttributeChangedCallback)
+        pluginManager.registerNode(cls.nodePlugin)
 
     @classmethod
     def teardown_class(cls):
-        unregisterNodeType(NodeWithAttributeChangedCallback)
+        pluginManager.unregisterNode(cls.nodePlugin)
 
     def test_assignValueTriggersCallback(self):
         node = Node(NodeWithAttributeChangedCallback.__name__)
@@ -68,13 +71,15 @@ class TestNodeWithAttributeChangedCallback:
 
 
 class TestAttributeCallbackTriggerInGraph:
+    nodePlugin = NodePlugin(NodeWithAttributeChangedCallback)
+
     @classmethod
     def setup_class(cls):
-        registerNodeType(NodeWithAttributeChangedCallback)
+        pluginManager.registerNode(cls.nodePlugin)
 
     @classmethod
     def teardown_class(cls):
-        unregisterNodeType(NodeWithAttributeChangedCallback)
+        pluginManager.unregisterNode(cls.nodePlugin)
 
     def test_connectionTriggersCallback(self):
         graph = Graph("")
@@ -219,7 +224,7 @@ class NodeWithCompoundAttributes(desc.BaseNode):
                     desc.IntParam(
                         name="int", label="Int", description="", value=0, range=None
                     )
-                ],  
+                ],
             )
         ),
         desc.GroupAttribute(
@@ -241,15 +246,18 @@ class NodeWithCompoundAttributes(desc.BaseNode):
 
 
 class TestAttributeCallbackBehaviorWithUpstreamCompoundAttributes:
+    nodePluginAttributeChangedCallback = NodePlugin(NodeWithAttributeChangedCallback)
+    nodePluginCompoundAttributes = NodePlugin(NodeWithCompoundAttributes)
+
     @classmethod
     def setup_class(cls):
-        registerNodeType(NodeWithAttributeChangedCallback)
-        registerNodeType(NodeWithCompoundAttributes)
+        pluginManager.registerNode(cls.nodePluginAttributeChangedCallback)
+        pluginManager.registerNode(cls.nodePluginCompoundAttributes)
 
     @classmethod
     def teardown_class(cls):
-        unregisterNodeType(NodeWithAttributeChangedCallback)
-        unregisterNodeType(NodeWithCompoundAttributes)
+        pluginManager.unregisterNode(cls.nodePluginAttributeChangedCallback)
+        pluginManager.unregisterNode(cls.nodePluginCompoundAttributes)
 
     def test_connectionToListElement(self):
         graph = Graph("")
@@ -341,15 +349,18 @@ class NodeWithDynamicOutputValue(desc.BaseNode):
 
 
 class TestAttributeCallbackBehaviorWithUpstreamDynamicOutputs:
+    nodePluginAttributeChangedCallback = NodePlugin(NodeWithAttributeChangedCallback)
+    nodePluginDynamicOutputValue = NodePlugin(NodeWithDynamicOutputValue)
+
     @classmethod
     def setup_class(cls):
-        registerNodeType(NodeWithAttributeChangedCallback)
-        registerNodeType(NodeWithDynamicOutputValue)
+        pluginManager.registerNode(cls.nodePluginAttributeChangedCallback)
+        pluginManager.registerNode(cls.nodePluginDynamicOutputValue)
 
     @classmethod
     def teardown_class(cls):
-        unregisterNodeType(NodeWithAttributeChangedCallback)
-        unregisterNodeType(NodeWithDynamicOutputValue)
+        pluginManager.unregisterNode(cls.nodePluginAttributeChangedCallback)
+        pluginManager.unregisterNode(cls.nodePluginDynamicOutputValue)
 
     def test_connectingUncomputedDynamicOutputDoesNotTriggerDownstreamAttributeChangedCallback(
         self,
@@ -432,13 +443,15 @@ class TestAttributeCallbackBehaviorWithUpstreamDynamicOutputs:
 
 
 class TestAttributeCallbackBehaviorOnGraphImport:
+    nodePlugin = NodePlugin(NodeWithAttributeChangedCallback)
+
     @classmethod
     def setup_class(cls):
-        registerNodeType(NodeWithAttributeChangedCallback)
+        pluginManager.registerNode(cls.nodePlugin)
 
     @classmethod
     def teardown_class(cls):
-        unregisterNodeType(NodeWithAttributeChangedCallback)
+        pluginManager.unregisterNode(cls.nodePlugin)
 
     def test_importingGraphDoesNotTriggerAttributeChangedCallbacks(self):
         graph = Graph("")

--- a/tests/test_nodeCallbacks.py
+++ b/tests/test_nodeCallbacks.py
@@ -1,6 +1,7 @@
-from meshroom.core import desc, registerNodeType, unregisterNodeType
+from meshroom.core import desc, pluginManager
 from meshroom.core.node import Node
 from meshroom.core.graph import Graph, loadGraph
+from meshroom.core.plugins import NodePlugin
 
 
 class NodeWithCreationCallback(desc.InputNode):
@@ -22,13 +23,15 @@ class NodeWithCreationCallback(desc.InputNode):
 
 
 class TestNodeCreationCallback:
+    nodePlugin = NodePlugin(NodeWithCreationCallback)
+
     @classmethod
     def setup_class(cls):
-        registerNodeType(NodeWithCreationCallback)
+        pluginManager.registerNode(cls.nodePlugin)
 
     @classmethod
     def teardown_class(cls):
-        unregisterNodeType(NodeWithCreationCallback)
+        pluginManager.unregisterNode(cls.nodePlugin)
 
     def test_notTriggeredOnNodeInstantiation(self):
         node = Node(NodeWithCreationCallback.__name__)

--- a/tests/test_nodeCallbacks.py
+++ b/tests/test_nodeCallbacks.py
@@ -1,7 +1,8 @@
 from meshroom.core import desc, pluginManager
 from meshroom.core.node import Node
 from meshroom.core.graph import Graph, loadGraph
-from meshroom.core.plugins import NodePlugin
+
+from .utils import registerNodeDesc, unregisterNodeDesc
 
 
 class NodeWithCreationCallback(desc.InputNode):
@@ -23,15 +24,14 @@ class NodeWithCreationCallback(desc.InputNode):
 
 
 class TestNodeCreationCallback:
-    nodePlugin = NodePlugin(NodeWithCreationCallback)
 
     @classmethod
     def setup_class(cls):
-        pluginManager.registerNode(cls.nodePlugin)
+        registerNodeDesc(NodeWithCreationCallback)
 
     @classmethod
     def teardown_class(cls):
-        pluginManager.unregisterNode(cls.nodePlugin)
+        unregisterNodeDesc(NodeWithCreationCallback)
 
     def test_notTriggeredOnNodeInstantiation(self):
         node = Node(NodeWithCreationCallback.__name__)

--- a/tests/test_nodeCommandLineFormatting.py
+++ b/tests/test_nodeCommandLineFormatting.py
@@ -8,7 +8,8 @@ from meshroom.core.node import Node
 
 class NodeWithAttributesNeedingFormatting(desc.Node):
     """
-    A node containing list, file, choice and group attributes in order to test the formatting of the command line.
+    A node containing list, file, choice and group attributes in order to test the
+    formatting of the command line.
     """
     inputs = [
         desc.ListAttribute(
@@ -128,23 +129,28 @@ class TestCommandLineFormatting:
 
         # Assert that extending values when the list is not empty is working
         node.images.extend(inputImages)
-        assert node.images.getValueStr() == '"single value with space" "{}" "{}"'.format(inputImages[0],
-                                                                                         inputImages[1])
+        assert node.images.getValueStr() == \
+            '"single value with space" "{}" "{}"'.format(inputImages[0],
+                                                         inputImages[1])
 
-        # Values are not retrieved as strings in the command line, so quotes around them are not expected
-        assert node._cmdVars["imagesValue"] == 'single value with space {} {}'.format(inputImages[0],
-                                                                                      inputImages[1])
+        # Values are not retrieved as strings in the command line, so quotes around them are
+        # not expected
+        assert node._cmdVars["imagesValue"] == \
+            'single value with space {} {}'.format(inputImages[0],
+                                                   inputImages[1])
 
     def test_formatting_strings(self):
         graph = Graph("")
         node = graph.addNewNode("NodeWithAttributesNeedingFormatting")
         node._buildCmdVars()
 
-        # Assert an empty File attribute generates empty quotes when requesting its value as a string
+        # Assert an empty File attribute generates empty quotes when requesting its value as
+        # a string
         assert node.input.getValueStr() == '""'
         assert node._cmdVars["inputValue"] == ""
 
-        # Assert a Choice attribute with a non-empty default value is surrounded with quotes when requested as a string
+        # Assert a Choice attribute with a non-empty default value is surrounded with quotes
+        # when requested as a string
         assert node.method.getValueStr() == '"MethodC"'
         assert node._cmdVars["methodValue"] == "MethodC"
 
@@ -154,14 +160,18 @@ class TestCommandLineFormatting:
 
         # Assert that the list with one empty value generates empty quotes
         node.images.extend("")
-        assert node.images.getValueStr() == '""', "A list with one empty string should generate empty quotes"
-        assert node._cmdVars["imagesValue"] == "", "The value is always only the value, so empty here"
+        assert node.images.getValueStr() == '""', \
+            "A list with one empty string should generate empty quotes"
+        assert node._cmdVars["imagesValue"] == "", \
+            "The value is always only the value, so empty here"
 
         # Assert that a list with 2 empty strings generates quotes
         node.images.extend("")
-        assert node.images.getValueStr() == '"" ""', "A list with 2 empty strings should generate quotes"
+        assert node.images.getValueStr() == '"" ""', \
+            "A list with 2 empty strings should generate quotes"
         assert node._cmdVars["imagesValue"] == ' ', \
-            "The value is always only the value, so 2 empty strings with the space separator in the middle"
+            "The value is always only the value, so 2 empty strings with the " \
+            "space separator in the middle"
 
     def test_formatting_groups(self):
         graph = Graph("")

--- a/tests/test_nodeCommandLineFormatting.py
+++ b/tests/test_nodeCommandLineFormatting.py
@@ -2,8 +2,9 @@
 # coding:utf-8
 
 from meshroom.core.graph import Graph, loadGraph, executeGraph
-from meshroom.core import desc, registerNodeType, unregisterNodeType
+from meshroom.core import desc, pluginManager
 from meshroom.core.node import Node
+from meshroom.core.plugins import NodePlugin
 
 
 class NodeWithAttributesNeedingFormatting(desc.Node):
@@ -100,13 +101,15 @@ class NodeWithAttributesNeedingFormatting(desc.Node):
     ]
 
 class TestCommandLineFormatting:
+    nodePlugin = NodePlugin(NodeWithAttributesNeedingFormatting)
+
     @classmethod
     def setup_class(cls):
-        registerNodeType(NodeWithAttributesNeedingFormatting)
+        pluginManager.registerNode(cls.nodePlugin)
 
     @classmethod
     def teardown_class(cls):
-        unregisterNodeType(NodeWithAttributesNeedingFormatting)
+        pluginManager.unregisterNode(cls.nodePlugin)
 
     def test_formatting_listOfFiles(self):
         inputImages = ["/non/existing/fileA", "/non/existing/with space/fileB"]

--- a/tests/test_nodeCommandLineFormatting.py
+++ b/tests/test_nodeCommandLineFormatting.py
@@ -4,7 +4,8 @@
 from meshroom.core.graph import Graph, loadGraph, executeGraph
 from meshroom.core import desc, pluginManager
 from meshroom.core.node import Node
-from meshroom.core.plugins import NodePlugin
+
+from .utils import registerNodeDesc, unregisterNodeDesc
 
 
 class NodeWithAttributesNeedingFormatting(desc.Node):
@@ -101,15 +102,14 @@ class NodeWithAttributesNeedingFormatting(desc.Node):
     ]
 
 class TestCommandLineFormatting:
-    nodePlugin = NodePlugin(NodeWithAttributesNeedingFormatting)
 
     @classmethod
     def setup_class(cls):
-        pluginManager.registerNode(cls.nodePlugin)
+        registerNodeDesc(NodeWithAttributesNeedingFormatting)
 
     @classmethod
     def teardown_class(cls):
-        pluginManager.unregisterNode(cls.nodePlugin)
+        unregisterNodeDesc(NodeWithAttributesNeedingFormatting)
 
     def test_formatting_listOfFiles(self):
         inputImages = ["/non/existing/fileA", "/non/existing/with space/fileB"]

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -44,7 +44,7 @@ def test_pipeline():
             if attr.isOutput and attr.enabled:
                 otherAttr = otherNode.attribute(key)
                 assert attr.uid() != otherAttr.uid()
-    
+
     # Test serialization/deserialization on both graphs
     for graph in [graph1, graph2]:
         filename = tempfile.mktemp()

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -4,6 +4,7 @@ from meshroom.core import desc, pluginManager, loadClassesNodes
 from meshroom.core.plugins import NodePluginStatus, Plugin
 
 import os
+import time
 
 class TestPluginWithValidNodesOnly:
     plugin = None
@@ -185,10 +186,23 @@ class TestPluginWithInvalidNodes:
         # Attempt to register node plugin
         pluginManager.registerNode(node)
         assert pluginManager.isRegistered(nodeName)
+
+        # Reload the node again without any change
+        node.reload()
+        assert pluginManager.isRegistered(nodeName)
         
+        # Hack to ensure that the timestamp of the file will be different after being rewritten
+        # Without it, on some systems, the operation is too fast and the timestamp does not change,
+        # cause the test to fail
+        time.sleep(0.1)
+
         # Restore the node file to its original state (with a description error)
         with open(node.path, "w") as f:
             f.write(originalFileContent)
+
+        timestampOr2 = os.path.getmtime(node.path)
+        print(f"New timestamp: {timestampOr2}")
+        print(os.stat(node.path))
         
         # Reload the node and assert it is invalid while still registered
         node.reload()

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -3,7 +3,6 @@
 from meshroom.core import desc, pluginManager, loadClassesNodes
 from meshroom.core.plugins import NodePluginStatus, Plugin
 
-from itertools import islice
 import os
 
 class TestPluginWithValidNodesOnly:
@@ -21,7 +20,8 @@ class TestPluginWithValidNodesOnly:
 
     @classmethod
     def teardown_class(cls):
-        pluginManager.unregisterPlugin(cls.plugin)
+        for node in cls.plugin.nodes.values():
+            pluginManager.unregisterNode(node)
         cls.plugin = None
 
     def test_loadedPlugin(self):
@@ -127,7 +127,8 @@ class TestPluginWithInvalidNodes:
 
     @classmethod
     def teardown_class(cls):
-        pluginManager.unregisterPlugin(cls.plugin)
+        for node in cls.plugin.nodes.values():
+            pluginManager.unregisterNode(node)
         cls.plugin = None
     
     def test_loadedPlugin(self):

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1,0 +1,200 @@
+# coding:utf-8
+
+from meshroom.core import desc, pluginManager, loadClassesNodes
+from meshroom.core.plugins import NodePluginStatus, Plugin
+
+from itertools import islice
+import os
+
+class TestPluginWithValidNodesOnly:
+    plugin = None
+
+    @classmethod
+    def setup_class(cls):
+        folder = os.path.join(os.path.dirname(__file__), "plugins", "meshroom")
+        package = "pluginA"
+        cls.plugin = Plugin(package, folder)
+        nodes = loadClassesNodes(folder, package)
+        for node in nodes:
+            cls.plugin.addNodePlugin(node)
+        pluginManager.addPlugin(cls.plugin)
+
+    @classmethod
+    def teardown_class(cls):
+        pluginManager.unregisterPlugin(cls.plugin)
+        cls.plugin = None
+
+    def test_loadedPlugin(self):
+        # Assert that there are loaded plugins, and that "pluginA" is one of them
+        assert len(pluginManager.getPlugins()) >= 1
+        plugin = pluginManager.getPlugin("pluginA")
+        assert plugin == self.plugin
+        assert str(plugin.path) == os.path.join(os.path.dirname(__file__), "plugins", "meshroom")
+
+        # Assert that the nodes of pluginA have been successfully registered
+        assert len(pluginManager.getRegisteredNodePlugins()) >= 2
+        for nodeName, nodePlugin in plugin.nodes.items():
+            assert nodePlugin.status == NodePluginStatus.LOADED
+            assert pluginManager.isRegistered(nodeName)
+        
+        # Assert the template has been loaded
+        assert len(plugin.templates) == 1
+        name = list(plugin.templates.keys())[0]
+        assert name == "sharedTemplate"
+        assert plugin.templates[name] == os.path.join(str(plugin.path), "sharedTemplate.mg")
+    
+    def test_unloadPlugin(self):
+        plugin = pluginManager.getPlugin("pluginA")
+        assert plugin == self.plugin
+
+        # Unload the plugin without unregistering the nodes
+        pluginManager.removePlugin(plugin, unregisterNodePlugins=False)
+
+        # Assert the plugin is not loaded anymore
+        assert pluginManager.getPlugin(plugin.name) is None
+
+        # Assert the nodes are still registered and belong to an unloaded plugin
+        for nodeName, nodePlugin in plugin.nodes.items():
+            assert nodePlugin.status == NodePluginStatus.LOADED
+            assert pluginManager.isRegistered(nodeName)
+            assert pluginManager.belongsToPlugin(nodeName) is None
+
+        # Re-add the plugin
+        pluginManager.addPlugin(plugin, registerNodePlugins=False)
+        assert pluginManager.getPlugin(plugin.name)
+
+        # Unload the plugin with a full unregistration of the nodes
+        pluginManager.removePlugin(plugin)
+
+        # Assert the plugin is not loaded anymore
+        assert pluginManager.getPlugin(plugin.name) is None
+
+        # Assert the nodes have been successfully unregistered
+        for nodeName, nodePlugin in plugin.nodes.items():
+            assert nodePlugin.status == NodePluginStatus.NOT_LOADED
+            assert not pluginManager.isRegistered(nodeName)
+        
+        # Re-add the plugin and re-register the nodes
+        pluginManager.addPlugin(plugin)
+        assert pluginManager.getPlugin(plugin.name)
+        for nodeName, nodePlugin in plugin.nodes.items():
+            assert nodePlugin.status == NodePluginStatus.LOADED
+            assert pluginManager.isRegistered(nodeName)
+
+    def test_updateRegisteredNodes(self):
+        nbRegisteredNodes = len(pluginManager.getRegisteredNodePlugins())
+        plugin = pluginManager.getPlugin("pluginA")
+        assert plugin == self.plugin
+        nodeA = pluginManager.getRegisteredNodePlugin("PluginANodeA")
+        nodeAName = nodeA.nodeDescriptor.__name__
+
+        # Unregister a node
+        assert nodeA
+        pluginManager.unregisterNode(nodeA)
+        
+        # Check that the node has been fully unregistered:
+        #   - its status is "NOT_LOADED"
+        #   - it is still part of pluginA
+        #   - it is not in the list of registered plugins anymore (and returns None when requested)
+        assert nodeA.status == NodePluginStatus.NOT_LOADED
+        assert plugin.containsNodePlugin(nodeAName)
+        assert nodeA.plugin == plugin
+        
+        assert pluginManager.getRegisteredNodePlugin(nodeAName) is None
+        assert nodeAName not in pluginManager.getRegisteredNodePlugins()
+        assert len(pluginManager.getRegisteredNodePlugins()) == nbRegisteredNodes - 1
+
+        # Re-register the node
+        pluginManager.registerNode(nodeA)
+
+        assert nodeA.status == NodePluginStatus.LOADED
+        assert pluginManager.getRegisteredNodePlugin(nodeAName)
+        assert len(pluginManager.getRegisteredNodePlugins()) == nbRegisteredNodes
+
+
+class TestPluginWithInvalidNodes:
+    plugin = None
+
+    @classmethod
+    def setup_class(cls):
+        folder = os.path.join(os.path.dirname(__file__), "plugins", "meshroom")
+        package = "pluginB"
+        cls.plugin = Plugin(package, folder)
+        nodes = loadClassesNodes(folder, package)
+        for node in nodes:
+            cls.plugin.addNodePlugin(node)
+        pluginManager.addPlugin(cls.plugin)
+
+    @classmethod
+    def teardown_class(cls):
+        pluginManager.unregisterPlugin(cls.plugin)
+        cls.plugin = None
+    
+    def test_loadedPlugin(self):
+        # Assert that there are loaded plugins, and that "pluginB" is one of them
+        assert len(pluginManager.getPlugins()) >= 1
+        plugin = pluginManager.getPlugin("pluginB")
+        assert plugin == self.plugin
+        assert str(plugin.path) == os.path.join(os.path.dirname(__file__), "plugins", "meshroom")
+
+        # Assert that PluginBNodeA is successfully registered
+        assert pluginManager.isRegistered("PluginBNodeA")
+        assert plugin.nodes["PluginBNodeA"].status == NodePluginStatus.LOADED
+        assert plugin.nodes["PluginBNodeA"].plugin == plugin
+
+        # Assert that PluginBNodeB has not been registered (description error)
+        assert not pluginManager.isRegistered("PluginBNodeB")
+        assert plugin.nodes["PluginBNodeB"].status == NodePluginStatus.DESC_ERROR
+        assert plugin.nodes["PluginBNodeB"].plugin == plugin
+
+        # Assert the template has been loaded
+        assert len(plugin.templates) == 1
+        name = list(plugin.templates.keys())[0]
+        assert name == "sharedTemplate"
+        assert plugin.templates[name] == os.path.join(str(plugin.path), "sharedTemplate.mg")
+
+    def test_reloadNodePlugin(self):
+        plugin = pluginManager.getPlugin("pluginB")
+        assert plugin == self.plugin
+        node = plugin.nodes["PluginBNodeB"]
+        nodeName = node.nodeDescriptor.__name__
+
+        # Check that the node has not been registered
+        assert node.status == NodePluginStatus.DESC_ERROR
+        assert not pluginManager.isRegistered(nodeName)
+
+        # Check that the node cannot be registered
+        pluginManager.registerNode(node)
+        assert not pluginManager.isRegistered(nodeName)
+
+        # Replace directly in the node file the line that fails the validation
+        # on the description with a line that will pass
+        originalFileContent = None
+        with open(node.path, "r") as f:
+            originalFileContent = f.read()
+        
+        replaceFileContent = originalFileContent.replace('"not an integer"', '1')
+        with open(node.path, "w") as f:
+            f.write(replaceFileContent)
+        
+        # Reload the node and assert it is valid
+        node.reload()
+        assert node.status == NodePluginStatus.NOT_LOADED
+
+        # Attempt to register node plugin
+        pluginManager.registerNode(node)
+        assert pluginManager.isRegistered(nodeName)
+        
+        # Restore the node file to its original state (with a description error)
+        with open(node.path, "w") as f:
+            f.write(originalFileContent)
+        
+        # Reload the node and assert it is invalid while still registered
+        node.reload()
+        assert node.status == NodePluginStatus.DESC_ERROR
+        assert pluginManager.isRegistered(nodeName)
+
+        # Unregister it
+        pluginManager.unregisterNode(node)
+        assert node.status == NodePluginStatus.DESC_ERROR  # Not NOT_LOADED
+        assert not pluginManager.isRegistered(nodeName)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -18,7 +18,7 @@ def registeredNodeTypes(nodeTypes: list[Type[desc.Node]]):
 
 @contextmanager
 def overrideNodeTypeVersion(nodeType: Type[desc.Node], version: str):
-    """Helper context manager to override the version of a given node type."""
+    """ Helper context manager to override the version of a given node type. """
     unpatchedFunc = meshroom.core.nodeVersion
     with patch.object(
         meshroom.core,

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,23 +1,25 @@
 from contextlib import contextmanager
 from unittest.mock import patch
-from typing import Type
 
 import meshroom
-from meshroom.core import registerNodeType, unregisterNodeType
-from meshroom.core import desc
+from meshroom.core import desc, pluginManager
+from meshroom.core.plugins import NodePlugin
 
 @contextmanager
-def registeredNodeTypes(nodeTypes: list[Type[desc.Node]]):
+def registeredNodeTypes(nodeTypes: list[desc.Node]):
+    nodePluginsList = {}
     for nodeType in nodeTypes:
-        registerNodeType(nodeType)
+        nodePlugin = NodePlugin(nodeType)
+        pluginManager.registerNode(nodePlugin)
+        nodePluginsList[nodeType] = nodePlugin
 
     yield
 
     for nodeType in nodeTypes:
-        unregisterNodeType(nodeType)
+        pluginManager.unregisterNode(nodePluginsList[nodeType])
 
 @contextmanager
-def overrideNodeTypeVersion(nodeType: Type[desc.Node], version: str):
+def overrideNodeTypeVersion(nodeType: desc.Node, version: str):
     """ Helper context manager to override the version of a given node type. """
     unpatchedFunc = meshroom.core.nodeVersion
     with patch.object(

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 
 import meshroom
 from meshroom.core import desc, pluginManager
-from meshroom.core.plugins import NodePlugin
+from meshroom.core.plugins import NodePlugin, NodePluginStatus
 
 @contextmanager
 def registeredNodeTypes(nodeTypes: list[desc.Node]):
@@ -28,3 +28,16 @@ def overrideNodeTypeVersion(nodeType: desc.Node, version: str):
         side_effect=lambda type: version if type is nodeType else unpatchedFunc(type),
     ):
         yield
+
+def registerNodeDesc(nodeDesc: desc.Node):
+    name = nodeDesc.__name__
+    if not pluginManager.isRegistered(name):
+        pluginManager._nodePlugins[name] = NodePlugin(nodeDesc)
+        pluginManager._nodePlugins[name].status = NodePluginStatus.LOADED
+
+def unregisterNodeDesc(nodeDesc: desc.Node):
+    name = nodeDesc.__name__
+    if pluginManager.isRegistered(name):
+        plugin = pluginManager.getRegisteredNodePlugin(name)
+        plugin.status = NodePluginStatus.NOT_LOADED
+        del pluginManager._nodePlugins[name]


### PR DESCRIPTION
## Description

This PR adds the support for plugins in Meshroom, building on top of https://github.com/alicevision/Meshroom/pull/2703.

A `Plugin` is a collection of at least one `NodePlugin`, which contains the description of a node, and can be associated to templates. `Plugins` can be loaded and unloaded with the `NodePluginManager`, which is in charge of the registration and unregistration of all `NodePlugins` (a node cannot be instantiated until its `NodePlugin` has been registered).

All collections of nodes are now considered as plugins, may they be provided through the `MESHROOM_NODES_PATH` or through the `MESHROOM_PLUGINS_PATH` environment variables. In the case of `MESHROOM_NODES_PATH`, a Python module containing node descriptions is expected. For `MESHROOM_PLUGINS_PATH`, it is expected that the nodes are contained within a Python module that is itself located in a `meshroom` folder. 

## Features list

- [x] Add a "plugins" `core` module containing new classes: `Plugin`, `NodePlugin`, `NodePluginManager`;
- [x] Fully manage the loading and registration of nodes through the `NodePluginManager`;
- [x] Add unit tests for the newly added classes.

## Implementations remarks

Currently, the whole process of going through folders in search of Python packages remains in the `__init__.py` of the `core` module. This is because the method that is used to find files containing nodes is the same as the one used to discover submitters. Submitters are, for now, not included in the "plugins" module and are handled as they were previously. 

