### PR TITLE
Fix elapsed time when there is only one chunk

### DIFF
--- a/meshroom/core/node.py
+++ b/meshroom/core/node.py
@@ -1387,8 +1387,6 @@ class BaseNode(BaseObject):
     def getFusedStatus(self):
         if not self._chunks:
             return StatusData()
-        if len(self._chunks) == 1:
-            return self._chunks[0].status
         fusedStatus = StatusData()
         fusedStatus.fromDict(self._chunks[0].status.toDict())
         for chunk in self._chunks[1:]:


### PR DESCRIPTION
If a node has only one chunk, then getFusedStatus returned a reference (not a copy) which is then modified by getRecursiveFusedStatus() which considered it was a copy.