### PR TITLE
[ui] [fix] MediaLibrary: Check if the model.source is actually an Attribute…

### DIFF
--- a/meshroom/ui/qml/Viewer3D/MediaLibrary.qml
+++ b/meshroom/ui/qml/Viewer3D/MediaLibrary.qml
@@ -386,14 +386,26 @@ Entity {
         onObjectAdded: function(index, object) {
             // Notify object that it is now fully instantiated
             object.fullyInstantiated = true
-            _reconstruction.displayedAttrs3D.append(object.modelSource)
+
+            // We only update the actually displayed attributes if the media.source is an attribute. 
+            // A string mean that a file has been dropped on the viewer3D
+            if (object.modelSource &&object.modelSource.hasOwnProperty("desc")) {
+                _reconstruction.displayedAttrs3D.append(object.modelSource)
+            }
+
         }
 
         onObjectRemoved: function(index, object) {
             if (m.sourceToEntity[object.modelSource])
                 
                 delete m.sourceToEntity[object.modelSource]
-                _reconstruction.displayedAttrs3D.remove(object.modelSource)                           
+
+                // We only update the actually displayed attributes if the media.source is an attribute. 
+                // A string mean that a file has been dropped on the viewer3D
+                if(object.modelSource && object.modelSource.hasOwnProperty("desc")) {
+                    _reconstruction.displayedAttrs3D.remove(object.modelSource)
+                }
+                                      
         }
 
     }


### PR DESCRIPTION
<!-- Checklist before submission:

 - I have read the [contribution guidelines](../CONTRIBUTING.md).
 - I have updated the documentation, if applicable.
 - I have ensured that the change is tested somewhere.
 - I have followed the prevailing code style (for history readability and limit conflicts for maintenance).

-->
## Description
Drop a 3d file in `Viewer3D` raised warnings.

Fix:
`model.source` can be an attribute or a string (when dropped in the Viewer3D), so a check has been added to only add display3DAttribute when model.source is an attribute.

<!--
- [ ] Feature one. Fix #XXX
- [ ] Improve something else
- [ ] Connect to #3 (to declare link to issues without closing it when the PR is merged).
- [X] Add "X" when it is done.
-->


<!--
Explain main implementation choices.
It is also the right place to ask for feedback and help when you hesitate on the implementation.
-->
