### PR TITLE
bugfix ExecMode status

### DIFF
--- a/meshroom/core/node.py
+++ b/meshroom/core/node.py
@@ -80,6 +80,8 @@ class StatusData(BaseObject):
         self.sessionUid: Optional[str] = None
         self.submitterSessionUid: Optional[str] = None
 
+        self.execMode: ExecMode = ExecMode.NONE
+
         self.resetDynamicValues()
 
     def setNode(self, node):
@@ -108,11 +110,11 @@ class StatusData(BaseObject):
         self.packageName: str = ""
         self.packageVersion: str = ""
         self.mrNodeType: MrNodeType = MrNodeType.NONE
+        self.execMode: ExecMode = ExecMode.NONE
         self.resetDynamicValues()
 
     def resetDynamicValues(self):
         self.status: Status = Status.NONE
-        self.execMode: ExecMode = ExecMode.NONE
         self.graph = ""
         self.commandLine: str = ""
         self.env: str = ""


### PR DESCRIPTION
<!-- Checklist before submission:

 - I have read the [contribution guidelines](../CONTRIBUTING.md).
 - I have updated the documentation, if applicable.
 - I have ensured that the change is tested somewhere.
 - I have followed the prevailing code style (for history readability and limit conflicts for maintainance).

-->
## Description
This PR allows to stop the computation of a pure python node when processing locally. Before, the ExecMode status was reset to NONE when starting the computation in the subprocess. ExecMode is not a dynamic value, it has been removed from the resetDynamicValues method and set only at initialization.


