### PR TITLE
[ui] [fix] Attribute: Fix the qml warnings on intrisincs

### DIFF
--- a/meshroom/core/attribute.py
+++ b/meshroom/core/attribute.py
@@ -502,8 +502,12 @@ class Attribute(BaseObject):
     isLinkNested = isLink
     hasOutputConnectionsChanged = Signal()
     hasOutputConnections = Property(bool, hasOutputConnections.fget, notify=hasOutputConnectionsChanged)
-    linkedInAttributes = Property(Variant, getLinkedInAttributes)
-    linkedOutAttributes = Property(Variant, getLinkedOutAttributes)
+
+    linkedInAttributesChanged = Signal()
+    linkedInAttributes = Property(Variant, getLinkedInAttributes, notify=linkedInAttributesChanged)
+    linkedOutAttributesChanged = Signal()
+    linkedOutAttributes = Property(Variant, getLinkedOutAttributes, notify=linkedOutAttributesChanged)
+
     isDefault = Property(bool, _isDefault, notify=valueChanged)
     linkParam = Property(BaseObject, getLinkParam, notify=isLinkChanged)
     rootLinkParam = Property(BaseObject, lambda self: self.getLinkParam(recursive=True), notify=isLinkChanged)


### PR DESCRIPTION
…n/outAttributes notifyable

<!-- Checklist before submission:

 - I have read the [contribution guidelines](../CONTRIBUTING.md).
 - I have updated the documentation, if applicable.
 - I have ensured that the change is tested somewhere.
 - I have followed the prevailing code style (for history readability and limit conflicts for maintainance).

-->
## Description
When filtering by intrinsics in the ImageGallery, an warning message appear concerning the linkedIn/OutAttributes not notifyable
![image](https://github.com/user-attachments/assets/a60fb28c-6546-4aae-803b-b9c5ebd8f18a)

This fix add a signal to these properties

<!--
Explain main implementation choices.
It is also the right place to ask for feedback and help when you hesitate on the implementation.
-->
