### PR TITLE
[ui] [fix]: The focus on text components is now released on outside click

### DIFF
--- a/meshroom/ui/__main__.py
+++ b/meshroom/ui/__main__.py
@@ -10,4 +10,6 @@ import meshroom.ui
 import meshroom.ui.app
 
 meshroom.ui.uiInstance = meshroom.ui.app.MeshroomApp(sys.argv)
+clearFocusEventFilter = meshroom.ui.app.ClearFocusEventFilter()
+meshroom.ui.uiInstance.installEventFilter(clearFocusEventFilter)
 meshroom.ui.uiInstance.exec()

--- a/meshroom/ui/app.py
+++ b/meshroom/ui/app.py
@@ -6,7 +6,7 @@ import json
 
 from PySide6 import __version__ as PySideVersion
 from PySide6 import QtCore
-from PySide6.QtCore import QUrl, QJsonValue, qInstallMessageHandler, QtMsgType, QSettings
+from PySide6.QtCore import QUrl, QJsonValue, qInstallMessageHandler, QtMsgType, QSettings, QObject, QEvent
 from PySide6.QtGui import QIcon
 from PySide6.QtQml import QQmlDebuggingEnabler
 from PySide6.QtQuickControls2 import QQuickStyle
@@ -195,6 +195,21 @@ Additional Resources:
 
     return parser.parse_args(args[1:])
 
+
+class ClearFocusEventFilter(QObject):
+    """ Clear focus each time a mouse button is pressed
+    """
+
+    def eventFilter(self, watched: QObject, event: QtCore.QEvent) -> bool:
+        
+        if event.type() != QEvent.MouseButtonPress:
+            return False        
+    
+        focusObject = QApplication.focusObject()
+        if hasattr(focusObject, "setFocus"):
+            focusObject.setFocus(False)
+
+        return False
 
 class MeshroomApp(QApplication):
     """ Meshroom UI Application. """

--- a/meshroom/ui/qml/main.qml
+++ b/meshroom/ui/qml/main.qml
@@ -184,9 +184,4 @@ ApplicationWindow {
         replaceExit: Transition {}
     }
 
-    background: MouseArea {
-        onPressed: {
-            forceActiveFocus();
-        }
-    }
 }


### PR DESCRIPTION
<!-- Checklist before submission:

 - I have read the [contribution guidelines](../CONTRIBUTING.md).
 - I have updated the documentation, if applicable.
 - I have ensured that the change is tested somewhere.
 - I have followed the prevailing code style (for history readability and limit conflicts for maintenance).

-->
## Description
### Bug: 
Clicking outside of a text component (a search filter in the example below), didn't release the focus.
![Screenshot_2025-06-05_14-21-39](https://github.com/user-attachments/assets/b7742bc4-2760-4946-80d0-acf91e7c40a6)

Now the focus is stolen by the main.MouseArea component

## Related PR
This is an other approach of the PR provided by @waaake: https://github.com/alicevision/Meshroom/pull/2666
It avoid creating `MouseArea` on existing and future components.

## Implementation Details

It uses the eventFilter to only catch the mousePress events and clear focus each time an item have a focus at this step.

/!\ Having a python condition on each event can be time consuming.
It uses the `EventFilter` and can have some performance cost, but because it directly filtered event by type() _(not isinstance)_ , it should be imperceptible.
