### PR TITLE
[ui] Application: Use CamelCase and disable tooltips when menus are disabled

### DIFF
--- a/meshroom/ui/qml/Application.qml
+++ b/meshroom/ui/qml/Application.qml
@@ -909,18 +909,18 @@ Page {
             Menu {
                 title: "Process"
                 Action {
-                    text: "Compute all nodes"
+                    text: "Compute All Nodes"
                     onTriggered: computeManager.compute(null)
                     enabled: _reconstruction ? !_reconstruction.computingLocally : false
                 }
                 Action {
-                    text: "Submit all nodes"
+                    text: "Submit All Nodes"
                     onTriggered: computeManager.submit(null)
                     enabled: _reconstruction ? _reconstruction.canSubmit : false
                 }
                 MenuSeparator {}
                 Action {
-                    text: "Stop computation"
+                    text: "Stop Computation"
                     onTriggered: _reconstruction.stopExecution()
                     enabled: _reconstruction ? _reconstruction.computingLocally : false
                 }


### PR DESCRIPTION
## Description

This PR does the following:
- Disable the tooltips for all the menu actions in the "Edit" menu if these actions are disabled themselves. This prevents having floating tooltips when hovering over menus that cannot be clicked.
- Use CamelCase for the title of all the menu actions in the "Process" menu.

