### PR TITLE
Dev/connect group attributes and avoid cyclic dependency

### DIFF
--- a/meshroom/core/attribute.py
+++ b/meshroom/core/attribute.py
@@ -881,10 +881,21 @@ class GroupAttribute(Attribute):
         if not linkedParam:
             return self._value
         
+        def linkAttributesValues(srcAttr, dstAttr):
+            
+            for i, attrDesc in enumerate(dstAttr.desc._groupDesc):
+                linkedAttrDesc = srcAttr.desc._groupDesc[i]
+
+                subSrcAttr = srcAttr._value.get(linkedAttrDesc.name)
+                subDstAttr = dstAttr._value.get(attrDesc.name)
+
+                if isinstance(linkedAttrDesc, desc.GroupAttribute) and isinstance(attrDesc, desc.GroupAttribute):
+                    linkAttributesValues(subSrcAttr, subDstAttr)
+                else:
+                    subDstAttr.value = subSrcAttr.value
+
         # If linked, the driver attributes values are copied to the current attribute
-        for i, attrDesc in enumerate(self.desc._groupDesc):
-            linkedAttrDesc = linkedParam.desc._groupDesc[i]
-            self._value.get(attrDesc.name).value = linkedParam._value.get(linkedAttrDesc.name).value
+        linkAttributesValues(linkedParam, self)
 
         return self._value
 
@@ -1036,7 +1047,9 @@ class GroupAttribute(Attribute):
             return False
         
         for i, attr in enumerate(self._value):
-            if attr.baseType != otherAttribute._value[i].baseType:
+            if isinstance(attr, GroupAttribute):
+                return attr._haveSameStructure(otherAttribute._value[i])
+            elif attr.baseType != otherAttribute._value[i].baseType:
                 return False
         
         return True

--- a/meshroom/core/exception.py
+++ b/meshroom/core/exception.py
@@ -11,6 +11,13 @@ class GraphException(MeshroomException):
     pass
 
 
+class InvalidEdgeError(GraphException):
+    """Raised when an edge between two attributes cannot be created."""
+
+    def __init__(self, srcAttrName: str, dstAttrName: str, msg: str) -> None:
+        super().__init__(f"Failed to connect {srcAttrName}->{dstAttrName}: {msg}")
+
+
 class GraphCompatibilityError(GraphException):
     """
     Raised when node compatibility issues occur when loading a graph.

--- a/meshroom/core/exception.py
+++ b/meshroom/core/exception.py
@@ -64,3 +64,8 @@ class StopGraphVisit(GraphVisitMessage):
 class StopBranchVisit(GraphVisitMessage):
     """ Immediately stop branch visit. """
     pass
+
+
+class CyclicDependencyError(Exception):
+    """ Raised if a cyclic dependency is find in a DAG graph """
+    pass

--- a/meshroom/core/graph.py
+++ b/meshroom/core/graph.py
@@ -15,7 +15,7 @@ import meshroom.core
 from meshroom.common import BaseObject, DictModel, Slot, Signal, Property
 from meshroom.core import Version
 from meshroom.core.attribute import Attribute, ListAttribute, GroupAttribute
-from meshroom.core.exception import GraphCompatibilityError, StopGraphVisit, StopBranchVisit
+from meshroom.core.exception import GraphCompatibilityError, InvalidEdgeError, StopGraphVisit, StopBranchVisit
 from meshroom.core.graphIO import GraphIO, GraphSerializer, TemplateGraphSerializer, PartialGraphSerializer
 from meshroom.core.node import BaseNode, Status, Node, CompatibilityNode
 from meshroom.core.nodeFactory import nodeFactory
@@ -498,41 +498,38 @@ class Graph(BaseObject):
             node._applyExpr()
         return node
 
-    def copyNode(self, srcNode, withEdges=False):
+    def copyNode(self, srcNode: Node, withEdges: bool=False):
         """
         Get a copy instance of a node outside the graph.
 
         Args:
-            srcNode (Node): the node to copy
-            withEdges (bool): whether to copy edges
+            srcNode: the node to copy
+            withEdges: whether to copy edges
 
         Returns:
-            Node, dict: the created node instance,
-                        a dictionary of linked attributes with their original value (empty if withEdges is True)
+            The created node instance and the mapping of skipped edge per attribute (always empty if `withEdges` is True).
         """
+        def _removeLinkExpressions(attribute: Attribute, removed: dict[Attribute, str]):
+            """Recursively remove link expressions from the given root `attribute`."""
+            # Link expressions are only stored on input attributes.
+            if attribute.isOutput:
+                return
+
+            if attribute._linkExpression:
+                removed[attribute] = attribute._linkExpression
+                attribute._linkExpression = None
+            elif isinstance(attribute, (ListAttribute, GroupAttribute)):
+                for child in attribute.value:
+                    _removeLinkExpressions(child, removed)
+
         with GraphModification(self):
-            # create a new node of the same type and with the same attributes values
-            # keep links as-is so that CompatibilityNodes attributes can be created with correct automatic description
-            # (File params for link expressions)
-            node = nodeFactory(srcNode.toDict(), srcNode.nodeType)  # use nodeType as name
-            # skip edges: filter out attributes which are links by resetting default values
+            node = nodeFactory(srcNode.toDict(), name=srcNode.nodeType)
+
             skippedEdges = {}
             if not withEdges:
-                for n, attr in node.attributes.items():
-                    if attr.isOutput:
-                        # edges are declared in input with an expression linking
-                        # to another param (which could be an output)
-                        continue
-                    # find top-level links
-                    if Attribute.isLinkExpression(attr.value):
-                        skippedEdges[attr] = attr.value
-                        attr.resetToDefaultValue()
-                    # find links in ListAttribute children
-                    elif isinstance(attr, (ListAttribute, GroupAttribute)):
-                        for child in attr.value:
-                            if Attribute.isLinkExpression(child.value):
-                                skippedEdges[child] = child.value
-                                child.resetToDefaultValue()
+                for _, attr in node.attributes.items():
+                    _removeLinkExpressions(attr, skippedEdges)
+
         return node, skippedEdges
 
     def duplicateNodes(self, srcNodes):
@@ -892,11 +889,11 @@ class Graph(BaseObject):
         return set(self._nodes) - nodesWithInputLink
 
     @changeTopology
-    def addEdge(self, srcAttr, dstAttr):
-        assert isinstance(srcAttr, Attribute)
-        assert isinstance(dstAttr, Attribute)
-        if srcAttr.node.graph != self or dstAttr.node.graph != self:
-            raise RuntimeError('The attributes of the edge should be part of a common graph.')
+    def addEdge(self, srcAttr: Attribute, dstAttr: Attribute):
+        if not (srcAttr.node.graph == dstAttr.node.graph == self):
+            raise InvalidEdgeError(
+                srcAttr.fullNameToGraph, dstAttr.fullNameToGraph, "Attributes do not belong to this Graph"
+            )
         if dstAttr in self.edges.keys():
             raise RuntimeError(f'Destination attribute "{dstAttr.getFullNameToNode()}" is already connected.')
         edge = Edge(srcAttr, dstAttr)

--- a/meshroom/ui/commands.py
+++ b/meshroom/ui/commands.py
@@ -6,7 +6,7 @@ from PySide6.QtGui import QUndoCommand, QUndoStack
 from PySide6.QtCore import Property, Signal
 
 from meshroom.core.attribute import ListAttribute, Attribute
-from meshroom.core.graph import Graph, GraphModification
+from meshroom.core.graph import Graph, GraphModification, CyclicDependencyError
 from meshroom.core.node import Position, CompatibilityIssue
 from meshroom.core.nodeFactory import nodeFactory
 from meshroom.core.mtyping import PathLike
@@ -318,7 +318,13 @@ class AddEdgeCommand(GraphCommand):
             raise ValueError(f"Attribute are not compatible and cannot be connected: '{self.srcAttr}'({src.baseType})->'{self.dstAttr}'({dst.baseType})")
 
     def redoImpl(self):
-        self.graph.addEdge(self.graph.attribute(self.srcAttr), self.graph.attribute(self.dstAttr))
+
+        try:
+            self.graph.addEdge(self.graph.attribute(self.srcAttr), self.graph.attribute(self.dstAttr))
+        except CyclicDependencyError:
+            self.graph.removeEdge(self.graph.attribute(self.dstAttr))
+            return False
+        
         return True
 
     def undoImpl(self):

--- a/meshroom/ui/commands.py
+++ b/meshroom/ui/commands.py
@@ -314,8 +314,8 @@ class AddEdgeCommand(GraphCommand):
         self.dstAttr = dst.getFullNameToNode()
         self.setText(f"Connect '{self.srcAttr}'->'{self.dstAttr}'")
 
-        if src.baseType != dst.baseType:
-            raise ValueError(f"Attribute types are not compatible and cannot be connected: '{self.srcAttr}'({src.baseType})->'{self.dstAttr}'({dst.baseType})")
+        if not dst.validateConnectionFrom(src):
+            raise ValueError(f"Attribute are not compatible and cannot be connected: '{self.srcAttr}'({src.baseType})->'{self.dstAttr}'({dst.baseType})")
 
     def redoImpl(self):
         self.graph.addEdge(self.graph.attribute(self.srcAttr), self.graph.attribute(self.dstAttr))

--- a/meshroom/ui/qml/GraphEditor/AttributeItemDelegate.qml
+++ b/meshroom/ui/qml/GraphEditor/AttributeItemDelegate.qml
@@ -769,7 +769,7 @@ RowLayout {
                     var obj = cpt.createObject(groupItem,
                                                {
                                                    'model': Qt.binding(function() { return attribute.value }),
-                                                   'readOnly': Qt.binding(function() { return root.readOnly }),
+                                                   'readOnly': Qt.binding(function() { return !root.editable }),
                                                    'labelWidth': 100,  // Reduce label width for children (space gain)
                                                    'objectsHideable': Qt.binding(function() { return root.objectsHideable }),
                                                    'filterText': Qt.binding(function() { return root.filterText }),

--- a/meshroom/ui/qml/GraphEditor/AttributePin.qml
+++ b/meshroom/ui/qml/GraphEditor/AttributePin.qml
@@ -106,7 +106,7 @@ RowLayout {
                 // Check if attributes are compatible to create a valid connection
                 if (root.readOnly                                            // Cannot connect on a read-only attribute
                     || drag.source.objectName != inputDragTarget.objectName  // Not an edge connector
-                    || drag.source.baseType !== inputDragTarget.baseType     // Not the same base type
+                    || !inputDragTarget.attribute.validateConnectionFrom(drag.source.attribute)  //  
                     || drag.source.nodeItem === inputDragTarget.nodeItem     // Connection between attributes of the same node
                     || (drag.source.isList && childrenRepeater.count)        // Source/target are lists but target already has children
                     || drag.source.connectorType === "input"                 // Refuse to connect an "input pin" on another one (input attr can be connected to input attr, but not the graphical pin)
@@ -256,7 +256,7 @@ RowLayout {
             onEntered: function(drag) {
                 // Check if attributes are compatible to create a valid connection
                 if (drag.source.objectName != outputDragTarget.objectName   // Not an edge connector
-                    || drag.source.baseType !== outputDragTarget.baseType   // Not the same base type
+                    || !outputDragTarget.attribute.validateConnectionFrom(drag.source.attribute)  // 
                     || drag.source.nodeItem === outputDragTarget.nodeItem   // Connection between attributes of the same node
                     || (!drag.source.isList && outputDragTarget.isList)     // Connection between a list and a simple attribute
                     || (drag.source.isList && childrenRepeater.count)       // Source/target are lists but target already has children


### PR DESCRIPTION
## Description
This PR is a rebase of this PR from @yann-lty : https://github.com/alicevision/Meshroom/pull/2684 with some adjustment.

## Features list

- [X] Support connection between GroupAttributes (API, serialization, UI).
- [X] [ui] Make connected GroupAttribute readonly.

- [X] GroupAttributeConnection do not replace the attributes, but copy value only
- [X] Only GroupAttribute with same structure can be connected. (Ordered sub attributes with same types)
- [X] Nested GroupAttributes are handled recursively

- [X] Cyclic dependency is now forbidden


## Implementation remarks

- A new DAGVisitor has been added and used as default visitor to avoid the cyclic dependency
- Attributes are now responsible of the connection validation

