### PR TITLE
[core] Runtime-specific environments support

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,3 +1,7 @@
+# [core] Linting following CI's flake8 report
+9b4bd68d5aa9e5c3af5e4bfc4fe6aae06437ca88
+# [tests] Linting following CI's flake8 report
+9b6549cc1dd525658080303f7ad453bd4ec10f52
 # [GraphEditor] Indentation fix
 87c0cef605e4ef2b359d7e678155e79b65b2e762
 # [qt6][qml] Clean-up code and harmonize comments

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -26,7 +26,7 @@ jobs:
       matrix:
         python-version: [ 3.9.13 ]
     env:
-      MESHROOM_NODES_PATH: '${{ github.workspace }}/../meshroomNodes/meshroom/nodes'
+      MESHROOM_PLUGINS_PATH: "${{ github.workspace }}/../mrSegmentation/meshroom/"
 
     steps:
     - uses: actions/checkout@v3
@@ -34,10 +34,10 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Clone meshroomNodes
+    - name: Clone mrSegmentation
       run: |
         cd ..
-        git clone https://github.com/alicevision/meshroomNodes.git
+        git clone https://github.com/meshroomHub/mrSegmentation.git
         cd ${{ github.workspace }}
     - name: Install dependencies
       run: |
@@ -70,7 +70,7 @@ jobs:
       matrix:
         python-version: [ 3.9.13 ]
     env:
-      MESHROOM_NODES_PATH: '${{ github.workspace }}/../meshroomNodes/meshroom/nodes'
+      MESHROOM_NODES_PATH: "${{ github.workspace }}/../mrSegmentation/meshroom"
 
     steps:
       - uses: actions/checkout@v3
@@ -78,10 +78,10 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Clone meshroomNodes
+      - name: Clone mrSegmentation
         run: |
           cd ..
-          git clone https://github.com/alicevision/meshroomNodes.git
+          git clone https://github.com/meshroomHub/mrSegmentation.git
           cd ${{ github.workspace }}
       - name: Install dependencies
         run: |

--- a/meshroom/core/__init__.py
+++ b/meshroom/core/__init__.py
@@ -19,7 +19,7 @@ try:
 except Exception:
     pass
 
-from meshroom.core.plugins import NodePlugin, NodePluginManager, Plugin, ProcessEnv
+from meshroom.core.plugins import NodePlugin, NodePluginManager, Plugin, ProcessEnv, processEnvFactory
 from meshroom.core.submitter import BaseSubmitter
 from meshroom.env import EnvVar, meshroomFolder
 from . import desc
@@ -351,11 +351,12 @@ def loadPluginFolder(folder):
         logging.info(f"Plugin folder '{folder}' does not contain a 'meshroom' folder.")
         return
 
-    processEnv = ProcessEnv(folder)
+    processEnv = processEnvFactory(folder)
 
     plugins = loadAllNodes(folder=mrFolder)
     if plugins:
         for plugin in plugins:
+            plugin.processEnv = processEnv
             pluginManager.addPlugin(plugin)
             pipelineTemplates.update(plugin.templates)
 

--- a/meshroom/core/__init__.py
+++ b/meshroom/core/__init__.py
@@ -7,7 +7,6 @@ import os
 from pathlib import Path
 import pkgutil
 import sys
-import tempfile
 import traceback
 import uuid
 
@@ -19,7 +18,7 @@ try:
 except Exception:
     pass
 
-from meshroom.core.plugins import NodePlugin, NodePluginManager, Plugin, ProcessEnv, processEnvFactory
+from meshroom.core.plugins import NodePlugin, NodePluginManager, Plugin, processEnvFactory
 from meshroom.core.submitter import BaseSubmitter
 from meshroom.env import EnvVar, meshroomFolder
 from . import desc
@@ -42,6 +41,7 @@ def hashValue(value) -> str:
     hashObject = hashlib.sha1(str(value).encode('utf-8'))
     return hashObject.hexdigest()
 
+
 @contextmanager
 def add_to_path(p):
     import sys
@@ -52,6 +52,7 @@ def add_to_path(p):
         yield
     finally:
         sys.path = old_path
+
 
 def loadClasses(folder: str, packageName: str, classType: type) -> list[type]:
     """
@@ -137,6 +138,7 @@ def loadClasses(folder: str, packageName: str, classType: type) -> list[type]:
 
     return classes
 
+
 def loadClassesNodes(folder: str, packageName: str) -> list[NodePlugin]:
     """
     Return the list of all the NodePlugins that were created following the search of the
@@ -153,6 +155,7 @@ def loadClassesNodes(folder: str, packageName: str) -> list[NodePlugin]:
                           module's search. If none has been created, an empty list is returned.
     """
     return loadClasses(folder, packageName, desc.BaseNode)
+
 
 def loadClassesSubmitters(folder: str, packageName: str) -> list[BaseSubmitter]:
     """
@@ -384,6 +387,7 @@ def loadSubmitters(folder, packageName):
 
     return loadClassesSubmitters(folder, packageName)
 
+
 def loadPipelineTemplates(folder: str):
     if not os.path.isdir(folder):
         logging.error(f"Pipeline templates folder '{folder}' does not exist.")
@@ -391,6 +395,7 @@ def loadPipelineTemplates(folder: str):
     for file in os.listdir(folder):
         if file.endswith(".mg") and file not in pipelineTemplates:
             pipelineTemplates[os.path.splitext(file)[0]] = os.path.join(folder, file)
+
 
 def initNodes():
     additionalNodesPath = EnvVar.getList(EnvVar.MESHROOM_NODES_PATH)

--- a/meshroom/core/__init__.py
+++ b/meshroom/core/__init__.py
@@ -429,7 +429,6 @@ def initPlugins():
     for f in pluginsFolders:
         plugins = loadPluginFolder(folder=f)
         # Set the ProcessEnv for each plugin
-        # TODO: make the distinction between default, conda, and venv plugins from the get-go
         if plugins:
             for plugin in plugins:
                 plugin.processEnv = processEnvFactory(f)

--- a/meshroom/core/attribute.py
+++ b/meshroom/core/attribute.py
@@ -50,7 +50,7 @@ class Attribute(BaseObject):
     """
     """
     stringIsLinkRe = re.compile(r'^\{[A-Za-z]+[A-Za-z0-9_.\[\]]*\}$')
-    
+
     VALID_IMAGE_SEMANTICS = ["image", "imageList", "sequence"]
     VALID_3D_EXTENSIONS = [".obj", ".stl", ".fbx", ".gltf", ".abc", ".ply"]
 
@@ -82,7 +82,6 @@ class Attribute(BaseObject):
 
         self._value = None
         self.initValue()
-
 
     @property
     def node(self):
@@ -339,30 +338,26 @@ class Attribute(BaseObject):
 
     def getInputConnections(self) -> list["Edge"]:
         """ Retrieve the upstreams connected edges """
-
         if not self.node.graph or not self.node.graph.edges:
             return []
-        
+
         return [edge for edge in self.node.graph.edges.values() if edge.dst == self]
 
     def getOutputConnections(self) -> list["Edge"]:
         """ Retrieve all the edges connected to this attribute """
-
         if not self.node.graph or not self.node.graph.edges:
             return []
-        
+
         return [edge for edge in self.node.graph.edges.values() if edge.src == self]
-    
+
     def getLinkedInAttributes(self) -> list["Attribute"]:
         """ Return the upstreams connected attributes  """
-
         return [edge.src for edge in self.getInputConnections()]
-    
+
     def getLinkedOutAttributes(self) -> list["Attribute"]:
         """ Return the downstreams connected attributes """
-        
         return [edge.dst for edge in self.getOutputConnections()]
-    
+
     def _applyExpr(self):
         """
         For string parameters with an expression (when loaded from file),
@@ -431,8 +426,8 @@ class Attribute(BaseObject):
             return v
         # String, File, single value Choice are based on strings and should includes quotes
         # to deal with spaces
-        if withQuotes and \
-            isinstance(self.attributeDesc, (desc.StringParam, desc.File, desc.ChoiceParam)):
+        if withQuotes and isinstance(self.attributeDesc,
+                                     (desc.StringParam, desc.File, desc.ChoiceParam)):
             return f'"{self.getEvalValue()}"'
         return str(self.getEvalValue())
 
@@ -462,24 +457,23 @@ class Attribute(BaseObject):
 
     def _is3D(self) -> bool:
         """ Return True if the current attribute is considered as a 3d file """
-
         if self.desc.semantic == "3d":
             return True
-        
+
         # If the attribute is a File attribute, it is an instance of str and can be iterated over
         hasSupportedExt = isinstance(self.value, str) and any(ext in self.value for ext in Attribute.VALID_3D_EXTENSIONS)
         if hasSupportedExt:
             return True
-        
+
         return False
-    
+
     def _is2D(self) -> bool:
         """ Return True if the current attribute is considered as a 2d file """
-        
         if not self.desc.semantic:
             return False
-        
-        return next((imageSemantic for imageSemantic in Attribute.VALID_IMAGE_SEMANTICS if self.desc.semantic == imageSemantic), None) is not None
+
+        return next((imageSemantic for imageSemantic in Attribute.VALID_IMAGE_SEMANTICS
+                     if self.desc.semantic == imageSemantic), None) is not None
 
     name = Property(str, getName, constant=True)
     fullName = Property(str, getFullName, constant=True)
@@ -666,7 +660,7 @@ class ListAttribute(Attribute):
     def upgradeValue(self, exportedValues):
         if not isinstance(exportedValues, list):
             if isinstance(exportedValues, ListAttribute) or \
-                Attribute.isLinkExpression(exportedValues):
+               Attribute.isLinkExpression(exportedValues):
                 self._set_value(exportedValues)
                 return
             raise RuntimeError("ListAttribute.upgradeValue: the given value is of type " +
@@ -762,7 +756,7 @@ class ListAttribute(Attribute):
             return self.attributeDesc.joinChar.join([v.getValueStr(withQuotes=withQuotes)
                                                      for v in self.value])
         v = self.attributeDesc.joinChar.join([v.getValueStr(withQuotes=False)
-                                                for v in self.value])
+                                              for v in self.value])
         if withQuotes and v:
             return f'"{v}"'
         return v
@@ -780,7 +774,7 @@ class ListAttribute(Attribute):
         return self.isLink \
             or self.node.graph and self.isInput and self.node.graph._edges \
             and any(v in self.node.graph._edges.keys() for v in self._value)
-    
+
     # override
     @property
     def hasOutputConnections(self):
@@ -789,33 +783,30 @@ class ListAttribute(Attribute):
         # safety check to avoid evaluation errors
         if not self.node.graph or not self.node.graph.edges:
             return False
-        
+
         return next((edge for edge in self.node.graph.edges.values() if edge.src == self), None) is not None or \
             any(attr.hasOutputConnections for attr in self._value if hasattr(attr, 'hasOutputConnections'))
-    
+
     # override
     def getInputConnections(self) -> list["Edge"]:
-
         if not self.node.graph or not self.node.graph.edges:
             return []
-        
+
         return [edge for edge in self.node.graph.edges.values() if edge.dst == self or edge.dst in self._value]
-    
+
     # override
     def getOutputConnections(self) -> list["Edge"]:
-
         if not self.node.graph or not self.node.graph.edges:
             return []
-        
+
         return [edge for edge in self.node.graph.edges.values() if edge.src == self or edge.src in self._value]
-        
+
     # Override value property setter
     value = Property(Variant, Attribute._get_value, _set_value, notify=Attribute.valueChanged)
     isDefault = Property(bool, _isDefault, notify=Attribute.valueChanged)
     baseType = Property(str, getBaseType, constant=True)
     isLinkNested = Property(bool, isLinkNested.fget)
     hasOutputConnections = Property(bool, hasOutputConnections.fget, notify=Attribute.hasOutputConnectionsChanged)
-
 
 
 class GroupAttribute(Attribute):

--- a/meshroom/core/desc/node.py
+++ b/meshroom/core/desc/node.py
@@ -260,8 +260,8 @@ class Node(BaseNode):
             meshroomComputeCmd += f" --iteration {chunk.range.iteration}"
 
         runtimeEnv = chunk.node.nodeDesc.plugin.runtimeEnv
-        cmdPrefix = chunk.node.nodeDesc.plugin.processEnv.getCommandPrefix()
-        cmdSuffix = chunk.node.nodeDesc.plugin.processEnv.getCommandSuffix()
+        cmdPrefix = chunk.node.nodeDesc.plugin.commandPrefix
+        cmdSuffix = chunk.node.nodeDesc.plugin.commandSuffix
         self.executeChunkCommandLine(chunk, cmdPrefix + meshroomComputeCmd + cmdSuffix, env=runtimeEnv)
 
 
@@ -279,8 +279,8 @@ class CommandLineNode(BaseNode):
         return MrNodeType.COMMANDLINE
 
     def buildCommandLine(self, chunk) -> str:
-        cmdPrefix = chunk.node.nodeDesc.plugin.processEnv.getCommandPrefix()
-        cmdSuffix = chunk.node.nodeDesc.plugin.processEnv.getCommandSuffix()
+        cmdPrefix = chunk.node.nodeDesc.plugin.commandPrefix
+        cmdSuffix = chunk.node.nodeDesc.plugin.commandSuffix
         if chunk.node.isParallelized and chunk.node.size > 1:
             cmdSuffix = cmdSuffix + " " + self.commandLineRange.format(**chunk.range.toDict())
 

--- a/meshroom/core/desc/node.py
+++ b/meshroom/core/desc/node.py
@@ -78,8 +78,9 @@ class BaseNode(object):
     outputs = []
     size = StaticNodeSize(1)
     parallelization = None
-    documentation = ''
-    category = 'Other'
+    documentation = ""
+    category = "Other"
+    plugin = None
 
     def __init__(self):
         super(BaseNode, self).__init__()

--- a/meshroom/core/desc/node.py
+++ b/meshroom/core/desc/node.py
@@ -260,7 +260,9 @@ class Node(BaseNode):
             meshroomComputeCmd += f" --iteration {chunk.range.iteration}"
 
         runtimeEnv = chunk.node.nodeDesc.plugin.runtimeEnv
-        self.executeChunkCommandLine(chunk, meshroomComputeCmd, env=runtimeEnv)
+        cmdPrefix = chunk.node.nodeDesc.plugin.processEnv.getCommandPrefix()
+        cmdSuffix = chunk.node.nodeDesc.plugin.processEnv.getCommandSuffix()
+        self.executeChunkCommandLine(chunk, cmdPrefix + meshroomComputeCmd + cmdSuffix, env=runtimeEnv)
 
 
 class CommandLineNode(BaseNode):
@@ -276,7 +278,7 @@ class CommandLineNode(BaseNode):
     def getMrNodeType(self):
         return MrNodeType.COMMANDLINE
 
-    def buildCommandLine(self, chunk):
+    def buildCommandLine(self, chunk) -> str:
         cmdPrefix = chunk.node.nodeDesc.plugin.processEnv.getCommandPrefix()
         cmdSuffix = chunk.node.nodeDesc.plugin.processEnv.getCommandSuffix()
         if chunk.node.isParallelized and chunk.node.size > 1:
@@ -286,9 +288,7 @@ class CommandLineNode(BaseNode):
 
     def processChunk(self, chunk):
         cmd = self.buildCommandLine(chunk)
-        # TODO: Setup runtime env
         runtimeEnv = chunk.node.nodeDesc.plugin.runtimeEnv
-        print(runtimeEnv["PATH"])
         self.executeChunkCommandLine(chunk, cmd, env=runtimeEnv)
 
 
@@ -316,7 +316,7 @@ class AVCommandLineNode(CommandLineNode):
 
             AVCommandLineNode.cgroupParsed = True
 
-    def buildCommandLine(self, chunk):
+    def buildCommandLine(self, chunk) -> str:
         commandLineString = super(AVCommandLineNode, self).buildCommandLine(chunk)
 
         return commandLineString + AVCommandLineNode.cmdMem + AVCommandLineNode.cmdCore

--- a/meshroom/core/desc/node.py
+++ b/meshroom/core/desc/node.py
@@ -32,8 +32,8 @@ class BaseNode(object):
     cpu = Level.NORMAL
     gpu = Level.NONE
     ram = Level.NORMAL
-    packageName = ''
-    packageVersion = ''
+    packageName = ""
+    packageVersion = ""
     internalInputs = [
         StringParam(
             name="invalidation",
@@ -151,11 +151,11 @@ class BaseNode(object):
                 prog = shutil.which(cmdList[0], path=env.get('PATH') if env else None)
 
                 print(f"Starting Process for '{chunk.node.name}'")
-                print(f' - commandLine: {cmd}')
-                print(f' - logFile: {chunk.logFile}')
+                print(f" - commandLine: {cmd}")
+                print(f" - logFile: {chunk.logFile}")
                 if prog:
                     cmdList[0] = prog
-                    print(f' - command full path: {prog}')
+                    print(f" - command full path: {prog}")
 
                 # Change the process group to avoid Meshroom main process being killed if the
                 # subprocess gets terminated by the user or an Out Of Memory (OOM kill).
@@ -197,8 +197,8 @@ class BaseNode(object):
                         pass
 
             if chunk.subprocess.returncode != 0:
-                with open(chunk.logFile, 'r') as logF:
-                    logContent = ''.join(logF.readlines())
+                with open(chunk.logFile, "r") as logF:
+                    logContent = "".join(logF.readlines())
                 raise RuntimeError(f'Error on node "{chunk.name}":\nLog:\n{logContent}')
         finally:
             chunk.subprocess = None
@@ -266,9 +266,9 @@ class Node(BaseNode):
 class CommandLineNode(BaseNode):
     """
     """
-    commandLine = ''  # need to be defined on the node
+    commandLine = ""  # need to be defined on the node
     parallelization = None
-    commandLineRange = ''
+    commandLineRange = ""
 
     def __init__(self):
         super(CommandLineNode, self).__init__()
@@ -277,10 +277,10 @@ class CommandLineNode(BaseNode):
         return MrNodeType.COMMANDLINE
 
     def buildCommandLine(self, chunk):
-        cmdPrefix = ''
-        cmdSuffix = ''
+        cmdPrefix = ""
+        cmdSuffix = ""
         if chunk.node.isParallelized and chunk.node.size > 1:
-            cmdSuffix = ' ' + self.commandLineRange.format(**chunk.range.toDict())
+            cmdSuffix = " " + self.commandLineRange.format(**chunk.range.toDict())
 
         return cmdPrefix + chunk.node.nodeDesc.commandLine.format(**chunk.node._cmdVars) + cmdSuffix
 
@@ -294,23 +294,23 @@ class CommandLineNode(BaseNode):
 class AVCommandLineNode(CommandLineNode):
 
     cgroupParsed = False
-    cmdMem = ''
-    cmdCore = ''
+    cmdMem = ""
+    cmdCore = ""
 
     def __init__(self):
         super(AVCommandLineNode, self).__init__()
 
         if AVCommandLineNode.cgroupParsed is False:
 
-            AVCommandLineNode.cmdMem = ''
+            AVCommandLineNode.cmdMem = ""
             memSize = cgroup.getCgroupMemorySize()
             if memSize > 0:
-                AVCommandLineNode.cmdMem = f' --maxMemory={memSize}'
+                AVCommandLineNode.cmdMem = f" --maxMemory={memSize}"
 
-            AVCommandLineNode.cmdCore = ''
+            AVCommandLineNode.cmdCore = ""
             coresCount = cgroup.getCgroupCpuCount()
             if coresCount > 0:
-                AVCommandLineNode.cmdCore = f' --maxCores={coresCount}'
+                AVCommandLineNode.cmdCore = f" --maxCores={coresCount}"
 
             AVCommandLineNode.cgroupParsed = True
 

--- a/meshroom/core/desc/node.py
+++ b/meshroom/core/desc/node.py
@@ -259,7 +259,7 @@ class Node(BaseNode):
         if len(chunk.node.getChunks()) > 1:
             meshroomComputeCmd += f" --iteration {chunk.range.iteration}"
 
-        runtimeEnv = None
+        runtimeEnv = chunk.node.nodeDesc.plugin.runtimeEnv
         self.executeChunkCommandLine(chunk, meshroomComputeCmd, env=runtimeEnv)
 
 
@@ -287,7 +287,7 @@ class CommandLineNode(BaseNode):
     def processChunk(self, chunk):
         cmd = self.buildCommandLine(chunk)
         # TODO: Setup runtime env
-        runtimeEnv = chunk.node.nodeDesc.plugin.processEnv.getEnvDict()
+        runtimeEnv = chunk.node.nodeDesc.plugin.runtimeEnv
         print(runtimeEnv["PATH"])
         self.executeChunkCommandLine(chunk, cmd, env=runtimeEnv)
 

--- a/meshroom/core/desc/node.py
+++ b/meshroom/core/desc/node.py
@@ -277,17 +277,19 @@ class CommandLineNode(BaseNode):
         return MrNodeType.COMMANDLINE
 
     def buildCommandLine(self, chunk):
-        cmdPrefix = ""
-        cmdSuffix = ""
+        cmdPrefix = chunk.node.nodeDesc.plugin.processEnv.getCommandPrefix()
+        cmdSuffix = chunk.node.nodeDesc.plugin.processEnv.getCommandSuffix()
         if chunk.node.isParallelized and chunk.node.size > 1:
-            cmdSuffix = " " + self.commandLineRange.format(**chunk.range.toDict())
+            cmdSuffix = cmdSuffix + " " + self.commandLineRange.format(**chunk.range.toDict())
 
         return cmdPrefix + chunk.node.nodeDesc.commandLine.format(**chunk.node._cmdVars) + cmdSuffix
 
     def processChunk(self, chunk):
         cmd = self.buildCommandLine(chunk)
         # TODO: Setup runtime env
-        self.executeChunkCommandLine(chunk, cmd)
+        runtimeEnv = chunk.node.nodeDesc.plugin.processEnv.getEnvDict()
+        print(runtimeEnv["PATH"])
+        self.executeChunkCommandLine(chunk, cmd, env=runtimeEnv)
 
 
 # Specific command line node for AliceVision apps

--- a/meshroom/core/graph.py
+++ b/meshroom/core/graph.py
@@ -1311,14 +1311,15 @@ class Graph(BaseObject):
         return str(self.toDict())
 
     def copy(self) -> "Graph":
-        """Create a copy of this Graph instance."""
+        """ Create a copy of this Graph instance. """
         graph = Graph("")
         graph._deserialize(self.serialize())
         return graph
 
     def serialize(self, asTemplate: bool = False) -> dict:
-        """Serialize this Graph instance.
-        
+        """
+        Serialize this Graph instance.
+
         Args:
             asTemplate: Whether to use the template serialization.
 
@@ -1329,7 +1330,8 @@ class Graph(BaseObject):
         return SerializerClass(self).serialize()
 
     def serializePartial(self, nodes: list[Node]) -> dict:
-        """Partially serialize this graph considering only the given list of `nodes`.
+        """
+        Partially serialize this graph considering only the given list of `nodes`.
 
         Args:
             nodes: The list of nodes to serialize.

--- a/meshroom/core/graphIO.py
+++ b/meshroom/core/graphIO.py
@@ -126,7 +126,7 @@ class TemplateGraphSerializer(GraphSerializer):
 
     def serializeNode(self, node: Node) -> dict:
         """Adapt node serialization to template graphs.
-        
+
         Instead of getting all the inputs and internal attribute keys, only get the keys of
         the attributes whose value is not the default one.
         The output attributes, UIDs, parallelization parameters and internal folder are
@@ -227,5 +227,3 @@ class PartialGraphSerializer(GraphSerializer):
             return {name: self._serializeAttribute(child) for name, child in attribute.value.items()}
 
         return attribute.getExportValue()
-
-

--- a/meshroom/core/plugins.py
+++ b/meshroom/core/plugins.py
@@ -395,6 +395,16 @@ class NodePlugin(BaseObject):
         """ Return the environment dictionary for the runtime. """
         return self.processEnv.getEnvDict()
 
+    @property
+    def commandPrefix(self) -> str:
+        """ Return the command prefix for the NodePlugin's execution. """
+        return self.processEnv.getCommandPrefix()
+
+    @property
+    def commandSuffix(self) -> str:
+        """ Return the command suffix for the NodePlugin's execution. """
+        return self.processEnv.getCommandSuffix()
+
 
 class NodePluginManager(BaseObject):
     """

--- a/meshroom/core/plugins.py
+++ b/meshroom/core/plugins.py
@@ -193,6 +193,7 @@ class NodePlugin(BaseObject):
         self.plugin: Plugin = plugin
         self.path: str = Path(getfile(nodeDesc)).resolve().as_posix()
         self.nodeDescriptor: desc.Node = nodeDesc
+        self.nodeDescriptor.plugin = self
 
         self.status: NodePluginStatus = NodePluginStatus.NOT_LOADED
         self.errors: list[str] = validateNodeDesc(nodeDesc)

--- a/meshroom/core/plugins.py
+++ b/meshroom/core/plugins.py
@@ -139,6 +139,16 @@ class RezProcessEnv(ProcessEnv):
         return "'"
 
 
+def processEnvFactory(folder: str, envType: str = "default", uri: str = "") -> ProcessEnv:
+    if envType == "default":
+        return DirTreeProcessEnv(folder)
+    if envType == "conda":
+        return DirTreeProcessEnv(folder, ProcessEnvType.CONDA, uri)
+    if envType == "virtualenv":
+        return DirTreeProcessEnv(folder, ProcessEnvType.VIRTUALENV, uri)
+    return RezProcessEnv(folder, ProcessEnvType.REZ, uri)
+
+
 class NodePluginStatus(Enum):
     """
     Loading status for NodePlugin objects.
@@ -204,6 +214,9 @@ class Plugin(BaseObject):
         """ Return the environment required to successfully execute processes. """
         return self._processEnv
 
+    @processEnv.setter
+    def processEnv(self, processEnv: ProcessEnv):
+        self._processEnv = processEnv
     def addNodePlugin(self, nodePlugin: NodePlugin):
         """
         Add a node plugin to the current plugin object and assign it as its containing plugin.

--- a/meshroom/core/plugins.py
+++ b/meshroom/core/plugins.py
@@ -368,6 +368,11 @@ class NodePlugin(BaseObject):
             return self.plugin.processEnv
         return None
 
+    @property
+    def runtimeEnv(self) -> dict:
+        """ Return the environment dictionary for the runtime. """
+        return self.processEnv.getEnvDict()
+
 
 class NodePluginManager(BaseObject):
     """

--- a/meshroom/core/plugins.py
+++ b/meshroom/core/plugins.py
@@ -57,13 +57,30 @@ class ProcessEnvType(Enum):
 class ProcessEnv(BaseObject):
     """
     Describes the environment required by a node's process.
+
+    Args:
+        folder: the source folder for the process.
+        envType: (optional) the type of process environment.
+        uri: (optional) the Unique Resource Identifier to activate the environment.
     """
 
-    def __init__(self, folder: str):
+    def __init__(self, folder: str, envType: ProcessEnvType = ProcessEnvType.DEFAULT):
         super().__init__()
-        self.binPaths: list = [Path(folder, "bin")]
-        self.libPaths: list = [Path(folder, "lib"), Path(folder, "lib64")]
-        self.pythonPathFolders: list = [Path(folder)] + self.binPaths
+        self._folder = folder
+        self._processEnvType: ProcessEnvType = envType
+
+    def getEnvDict(self) -> dict:
+        """ Return the environment dictionary if it has been modified, None otherwise. """
+        return None
+
+    def getCommandPrefix(self) -> str:
+        """ Return the prefix to the command line that will be executed by the process. """
+        return ""
+
+    def getCommandSuffix(self) -> str:
+        """ Return the suffix to the command line that will be executed by the process. """
+        return ""
+
 
 
 class NodePluginStatus(Enum):

--- a/meshroom/core/plugins.py
+++ b/meshroom/core/plugins.py
@@ -362,6 +362,7 @@ class NodePlugin(BaseObject):
             return False
 
         self.nodeDescriptor = descriptor
+        self.nodeDescriptor.plugin = self
         self._timestamp = timestamp
         self.status = NodePluginStatus.NOT_LOADED
         logging.info(f"[Reload] {self.nodeDescriptor.__name__}: Successful reloading.")

--- a/meshroom/core/plugins.py
+++ b/meshroom/core/plugins.py
@@ -114,6 +114,31 @@ class DirTreeProcessEnv(ProcessEnv):
         return super().getCommandPrefix()
 
 
+class RezProcessEnv(ProcessEnv):
+    """
+    """
+    def __init__(self, folder: str, envType: ProcessEnvType = ProcessEnvType.REZ, uri: str = ""):
+        super().__init__(folder, envType)
+
+        if envType != ProcessEnvType.REZ:
+            raise RuntimeError("Wrong process environment type.")
+        if not uri:
+            raise RuntimeError("Wrong URI for Rez environment process.")
+
+    def getEnvDict(self):
+        env = os.environ.copy()
+
+        return env
+
+    def getCommandPrefix(self):
+        if Path(self.uri).exists() and Path(self.uri).suffix == ".rxt":
+            return f"rez env -i {self.uri} -c '"
+        return f"rez env {self.uri} -c '"
+
+    def getCommandSuffix(self):
+        return "'"
+
+
 class NodePluginStatus(Enum):
     """
     Loading status for NodePlugin objects.

--- a/meshroom/core/plugins.py
+++ b/meshroom/core/plugins.py
@@ -8,6 +8,7 @@ import sys
 from enum import Enum
 from inspect import getfile
 from pathlib import Path
+import glob
 
 from meshroom.common import BaseObject
 from meshroom.core import desc
@@ -91,7 +92,7 @@ class DirTreeProcessEnv(ProcessEnv):
 
         self.binPaths: list = [str(Path(folder, "bin"))]
         self.libPaths: list = [str(Path(folder, "lib")), str(Path(folder, "lib64"))]
-        self.pythonPaths: list = [str(Path(folder))] + self.binPaths
+        self.pythonPaths: list = [str(Path(folder))] + self.binPaths + glob.glob(f'{folder}/lib*/python[0-9].[0-9]*/site-packages', recursive=False)
 
     def getEnvDict(self) -> dict:
         env = os.environ.copy()

--- a/meshroom/core/plugins.py
+++ b/meshroom/core/plugins.py
@@ -13,6 +13,7 @@ from meshroom.common import BaseObject
 from meshroom.core import desc
 from meshroom.core.desc.node import _MESHROOM_ROOT
 
+
 def validateNodeDesc(nodeDesc: desc.Node) -> list:
     """
     Check that the node has a valid description before being loaded. For the description
@@ -122,7 +123,6 @@ class RezProcessEnv(ProcessEnv):
         # Packages that are resolved in the current environment
         currentEnvPackages = []
         if "REZ_REQUEST" in os.environ:
-            nonDefPackages = [n.split("-")[0] for n in os.getenv("REZ_REQUEST", "").split()]
             resolvedPackages = os.getenv("REZ_RESOLVE", "").split()
             resolvedVersions = {}
             for package in resolvedPackages:
@@ -335,7 +335,7 @@ class NodePlugin(BaseObject):
         except FileNotFoundError:
             self.status = NodePluginStatus.ERROR
             logging.error(f"[Reload] {self.nodeDescriptor.__name__}: The path at {self.path} was not "
-                           "not found.")
+                          f"not found.")
             return False
 
         if self._timestamp == timestamp:
@@ -349,14 +349,14 @@ class NodePlugin(BaseObject):
         if not descriptor:
             self.status = NodePluginStatus.ERROR
             logging.error(f"[Reload] {self.nodeDescriptor.__name__}: The node description at {self.path} "
-                           "was not found.")
+                          f"was not found.")
             return False
 
         self.errors = validateNodeDesc(descriptor)
         if self.errors:
             self.status = NodePluginStatus.DESC_ERROR
             logging.error(f"[Reload] {self.nodeDescriptor.__name__}: The node description at {self.path} "
-                           "has description errors.")
+                          f"has description errors.")
             return False
 
         self.nodeDescriptor = descriptor

--- a/meshroom/core/plugins.py
+++ b/meshroom/core/plugins.py
@@ -189,10 +189,10 @@ class Plugin(BaseObject):
     Members:
         name: the name of the plugin (e.g. name of the Python module containing the node plugins)
         path: the absolute path of the plugin
-        _nodePlugins: dictionary mapping the name of a node plugin contained in the plugin
-                      to its corresponding NodePlugin object
-        _templates: dictionary mapping the name of templates (.mg files) associated to the plugin
-                    with their absolute paths
+        nodePlugins: dictionary mapping the name of a node plugin contained in the plugin
+                     to its corresponding NodePlugin object
+        templates: dictionary mapping the name of templates (.mg files) associated to the plugin
+                   with their absolute paths
         processEnv: the environment required for the nodes' processes to be correctly executed
     """
 
@@ -238,7 +238,9 @@ class Plugin(BaseObject):
 
     @processEnv.setter
     def processEnv(self, processEnv: ProcessEnv):
+        """ Set the environment required to successfully execute processes. """
         self._processEnv = processEnv
+
     def addNodePlugin(self, nodePlugin: NodePlugin):
         """
         Add a node plugin to the current plugin object and assign it as its containing plugin.
@@ -376,6 +378,7 @@ class NodePlugin(BaseObject):
 
     @plugin.setter
     def plugin(self, plugin: Plugin):
+        """ Assign this node plugin to a containing Plugin object. """
         self._plugin = plugin
 
     @property
@@ -411,8 +414,8 @@ class NodePluginManager(BaseObject):
     Manager for all the loaded Plugin objects as well as the registered NodePlugin objects.
 
     Members:
-        _plugins: dictionary containing all the loaded Plugins, with their name as the key
-        _nodePlugins: dictionary containing all the NodePlugins that have been registered
+        plugins: dictionary containing all the loaded Plugins, with their name as the key
+        nodePlugins: dictionary containing all the NodePlugins that have been registered
                       (a NodePlugin may exist without having been registered) with their name as
                       the key
     """

--- a/meshroom/core/plugins.py
+++ b/meshroom/core/plugins.py
@@ -46,6 +46,14 @@ def validateNodeDesc(nodeDesc: desc.Node) -> list:
     return errors
 
 
+class ProcessEnvType(Enum):
+    """ Supported process environments. """
+    DEFAULT = "default",
+    CONDA = "conda",
+    VIRTUALENV = "virtualenv",
+    REZ = "rez"
+
+
 class ProcessEnv(BaseObject):
     """
     Describes the environment required by a node's process.

--- a/meshroom/core/plugins.py
+++ b/meshroom/core/plugins.py
@@ -69,6 +69,7 @@ class ProcessEnv(BaseObject):
         super().__init__()
         self._folder = folder
         self._processEnvType: ProcessEnvType = envType
+        self.uri = ""
 
     def getEnvDict(self) -> dict:
         """ Return the environment dictionary if it has been modified, None otherwise. """
@@ -87,11 +88,12 @@ class DirTreeProcessEnv(ProcessEnv):
     """
     """
     def __init__(self, folder: str, envType: ProcessEnvType = ProcessEnvType.DEFAULT, uri: str = ""):
-        super().__init__(folder, envType)
         if envType == ProcessEnvType.REZ:
             raise RuntimeError("Wrong process environment type.")
         if not uri and envType != ProcessEnvType.DEFAULT:
             raise RuntimeError("URI should be provided for the process environment.")
+
+        super().__init__(folder, envType)
 
         self.uri = uri
         self.binPaths: list = [str(Path(folder, "bin"))]
@@ -103,6 +105,9 @@ class DirTreeProcessEnv(ProcessEnv):
         env["PYTHONPATH"] = f"{_MESHROOM_ROOT}{os.pathsep}{os.pathsep.join(self.pythonPaths)}{os.pathsep}{os.getenv('PYTHONPATH', '')}"
         env["LD_LIBRARY_PATH"] = f"{os.pathsep.join(self.libPaths)}{os.pathsep}{os.getenv('LD_LIBRARY_PATH', '')}"
         env["PATH"] = f"{os.pathsep.join(self.binPaths)}{os.pathsep}{os.getenv('PATH', '')}"
+        # env["PYTHONPATH"] = f"{_MESHROOM_ROOT}{os.pathsep}{os.pathsep.join(self.pythonPaths)}"
+        # env["LD_LIBRARY_PATH"] = f"{os.pathsep.join(self.libPaths)}"
+        # env["PATH"] = f"{os.pathsep.join(self.binPaths)}"
 
         return env
 
@@ -118,13 +123,13 @@ class RezProcessEnv(ProcessEnv):
     """
     """
     def __init__(self, folder: str, envType: ProcessEnvType = ProcessEnvType.REZ, uri: str = ""):
-        super().__init__(folder, envType)
-
         if envType != ProcessEnvType.REZ:
             raise RuntimeError("Wrong process environment type.")
         if not uri:
             raise RuntimeError("Wrong URI for Rez environment process.")
 
+        super().__init__(folder, envType)
+        self.uri = uri
     def getEnvDict(self):
         env = os.environ.copy()
 

--- a/meshroom/env.py
+++ b/meshroom/env.py
@@ -42,12 +42,13 @@ class EnvVar(Enum):
     )
 
     # Core
-    MESHROOM_PLUGINS_PATH = VarDefinition(str, "", "Paths to plugins folders containing nodes, submitters and pipeline templates")
-    MESHROOM_NODES_PATH = VarDefinition(str, "", "Paths to set of nodes folders")
-    MESHROOM_SUBMITTERS_PATH = VarDefinition(str, "", "Paths to set of submitters folders")
-    MESHROOM_PIPELINE_TEMPLATES_PATH = VarDefinition(str, "", "Paths to et of pipeline templates folders")
-    MESHROOM_REZ_PLUGINS = VarDefinition(str, "", "Paths to plugins folders containing nodes, submitters and pipeline templates that will be executed in a Rez environment")
-    MESHROOM_TEMP_PATH = VarDefinition(str, tempfile.gettempdir(), "Path to the temporary folder")
+    MESHROOM_PLUGINS_PATH = VarDefinition(str, "", "Paths to plugins folders containing nodes, submitters and pipeline templates.")
+    MESHROOM_NODES_PATH = VarDefinition(str, "", "Paths to set of nodes folders.")
+    MESHROOM_SUBMITTERS_PATH = VarDefinition(str, "", "Paths to set of submitters folders.")
+    MESHROOM_PIPELINE_TEMPLATES_PATH = VarDefinition(str, "", "Paths to et of pipeline templates folders.")
+    MESHROOM_REZ_PLUGINS = VarDefinition(str, "", "List of Rez plugins, defined by the package name associated with the plugin's root path. "
+                                                  "For example, 'packageA=/path/to/packageA/version/root'.")
+    MESHROOM_TEMP_PATH = VarDefinition(str, tempfile.gettempdir(), "Path to the temporary folder.")
 
 
     @staticmethod

--- a/meshroom/env.py
+++ b/meshroom/env.py
@@ -46,6 +46,7 @@ class EnvVar(Enum):
     MESHROOM_NODES_PATH = VarDefinition(str, "", "Paths to set of nodes folders")
     MESHROOM_SUBMITTERS_PATH = VarDefinition(str, "", "Paths to set of submitters folders")
     MESHROOM_PIPELINE_TEMPLATES_PATH = VarDefinition(str, "", "Paths to et of pipeline templates folders")
+    MESHROOM_REZ_PLUGINS = VarDefinition(str, "", "Paths to plugins folders containing nodes, submitters and pipeline templates that will be executed in a Rez environment")
     MESHROOM_TEMP_PATH = VarDefinition(str, tempfile.gettempdir(), "Path to the temporary folder")
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,3 @@
-from pathlib import Path
 import tempfile
 
 import pytest

--- a/tests/plugins/meshroom/pluginA/PluginANodeA.py
+++ b/tests/plugins/meshroom/pluginA/PluginANodeA.py
@@ -2,6 +2,7 @@ __version__ = "1.0"
 
 from meshroom.core import desc
 
+
 class PluginANodeA(desc.Node):
     inputs = [
         desc.File(

--- a/tests/plugins/meshroom/pluginA/PluginANodeB.py
+++ b/tests/plugins/meshroom/pluginA/PluginANodeB.py
@@ -2,6 +2,7 @@ __version__ = "1.0"
 
 from meshroom.core import desc
 
+
 class PluginANodeB(desc.Node):
     inputs = [
         desc.File(

--- a/tests/plugins/meshroom/pluginB/PluginBNodeA.py
+++ b/tests/plugins/meshroom/pluginB/PluginBNodeA.py
@@ -2,6 +2,7 @@ __version__ = "1.0"
 
 from meshroom.core import desc
 
+
 class PluginBNodeA(desc.Node):
     inputs = [
         desc.File(

--- a/tests/plugins/meshroom/pluginB/PluginBNodeB.py
+++ b/tests/plugins/meshroom/pluginB/PluginBNodeB.py
@@ -2,6 +2,7 @@ __version__ = "1.0"
 
 from meshroom.core import desc
 
+
 class PluginBNodeB(desc.Node):
     inputs = [
         desc.File(

--- a/tests/test_attributeChoiceParam.py
+++ b/tests/test_attributeChoiceParam.py
@@ -1,7 +1,8 @@
-from meshroom.core import desc, pluginManager
+from meshroom.core import desc
 from meshroom.core.graph import Graph, loadGraph
 
 from .utils import registerNodeDesc, unregisterNodeDesc
+
 
 class NodeWithChoiceParams(desc.Node):
     inputs = [
@@ -26,6 +27,7 @@ class NodeWithChoiceParams(desc.Node):
             exposed=True,
         ),
     ]
+
 
 class NodeWithChoiceParamsSavingValuesOverride(desc.Node):
     inputs = [
@@ -140,7 +142,6 @@ class TestChoiceParamSavingCustomValues:
         assert loadedGraph.node(node.name).choice.value == "CustomValue"
         assert loadedGraph.node(node.name).choiceMulti.value == ["custom", "value"]
 
-
     def test_overridenValuesAreSerialized(self, graphSavedOnDisk):
         graph: Graph = graphSavedOnDisk
         node = graph.addNewNode(NodeWithChoiceParamsSavingValuesOverride.__name__)
@@ -154,7 +155,6 @@ class TestChoiceParamSavingCustomValues:
 
         assert loadedNode.choice.values == ["D", "E", "F"]
         assert loadedNode.choiceMulti.values == ["D", "E", "F"]
-
 
     def test_connectionsAreSerialized(self, graphSavedOnDisk):
         graph: Graph = graphSavedOnDisk

--- a/tests/test_attributes.py
+++ b/tests/test_attributes.py
@@ -34,9 +34,9 @@ def test_attribute_retrieve_linked_input_and_output_attributes():
     assert len(n0.input.getLinkedInAttributes()) == 0
     assert len(n1.input.getLinkedInAttributes()) == 1
     assert n1.input.getLinkedInAttributes()[0] == n0.output
-    
+
     assert len(n1.output.getLinkedOutAttributes()) == 2
-    
+
     assert n1.output.getLinkedOutAttributes()[0] == n2.input
     assert n1.output.getLinkedOutAttributes()[1] == n3.input
 
@@ -46,6 +46,7 @@ def test_attribute_retrieve_linked_input_and_output_attributes():
     assert not n0.output.hasOutputConnections
     assert len(n0.input.getLinkedInAttributes()) == 0
     assert len(n0.output.getLinkedOutAttributes()) == 0
+
 
 @pytest.mark.parametrize("givenFile,expected", valid3DExtensionFiles + invalid3DExtensionFiles)
 def test_attribute_is3D_file_extensions(givenFile, expected):
@@ -71,7 +72,7 @@ def test_attribute_i3D_by_description_semantic():
 
     # Given
     g = Graph('')
-    n0 = g.addNewNode('Ls', input='')  
+    n0 = g.addNewNode('Ls', input='')
 
     assert not n0.output.is3D
 
@@ -80,6 +81,7 @@ def test_attribute_i3D_by_description_semantic():
 
     # Then
     assert n0.output.is3D
+
 
 @pytest.mark.parametrize("givenSemantic,expected", valid2DSemantics + invalid2DSemantics)
 def test_attribute_is2D_file_semantic(givenSemantic, expected):

--- a/tests/test_compatibility.py
+++ b/tests/test_compatibility.py
@@ -167,7 +167,6 @@ class SampleInputNodeV2(desc.InputNode):
     ]
 
 
-
 def replaceNodeTypeDesc(nodeType: str, nodeDesc: Type[desc.Node]):
     """Change the `nodeDesc` associated to `nodeType`."""
     pluginManager.getRegisteredNodePlugins()[nodeType] = NodePlugin(nodeDesc)
@@ -185,7 +184,6 @@ def test_unknown_node_type():
     internalFolder = n.internalFolder
     nodeName = n.name
     unregisterNodeDesc(SampleNodeV1)
-
 
     # Reload file
     g = loadGraph(graphFile)
@@ -433,7 +431,6 @@ class TestGraphLoadingWithStrictCompatibility:
         with pytest.raises(GraphCompatibilityError):
             loadGraph(graph.filepath, strictCompatibility=True)
 
-
     def test_failsOnNodeDescriptionCompatibilityIssue(self, graphSavedOnDisk):
         with registeredNodeTypes([SampleNodeV1, SampleNodeV2]):
             graph: Graph = graphSavedOnDisk
@@ -488,6 +485,7 @@ class TestGraphTemplateLoading:
 
             loadGraph(graph.filepath, strictCompatibility=True)
 
+
 class TestVersionConflict:
 
     def test_loadingConflictingNodeVersionCreatesCompatibilityNodes(self, graphSavedOnDisk):
@@ -528,7 +526,7 @@ class UidTestingNodeV1(desc.Node):
 
 
 class UidTestingNodeV2(desc.Node):
-    """ 
+    """
     Changes from SampleNodeBV1:
         * 'param' has been added
     """
@@ -642,7 +640,6 @@ class TestUidConflict:
             assert checkNodeAConnectionsToNodeB()
             assert len(loadedGraph.compatibilityNodes) == 0
 
-
     def test_uidConflictDoesNotPropagateToValidDownstreamNodeThroughConnection(
             self, graphSavedOnDisk):
         with registeredNodeTypes([UidTestingNodeV1, UidTestingNodeV2]):
@@ -659,7 +656,7 @@ class TestUidConflict:
             assert len(loadedGraph.compatibilityNodes) == 1
 
     def test_uidConflictDoesNotPropagateToValidDownstreamNodeThroughListConnection(
-            self,graphSavedOnDisk):
+            self, graphSavedOnDisk):
         with registeredNodeTypes([UidTestingNodeV2, UidTestingNodeV3]):
             graph: Graph = graphSavedOnDisk
             nodeA = graph.addNewNode(UidTestingNodeV2.__name__)

--- a/tests/test_graphIO.py
+++ b/tests/test_graphIO.py
@@ -213,6 +213,7 @@ class TestImportGraphContent:
         assert len(otherGraph.compatibilityNodes) == 1
         assert otherGraph.node(node.name).issue is CompatibilityIssue.VersionConflict
 
+
 class TestGraphPartialSerialization:
     def test_emptyGraph(self):
         graph = Graph("")
@@ -357,8 +358,8 @@ class TestImportGraphContentFromMinimalGraphData:
         with registeredNodeTypes([SimpleNode]):
             sampleGraphContent = dedent("""
             {
-                "SimpleNode_1": { 
-                    "nodeType": "SimpleNode", "inputs": { "input": "{NotSerializedNode.output}" } 
+                "SimpleNode_1": {
+                    "nodeType": "SimpleNode", "inputs": { "input": "{NotSerializedNode.output}" }
                 }
             }
             """)

--- a/tests/test_invalidation.py
+++ b/tests/test_invalidation.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # coding:utf-8
 from meshroom.core.graph import Graph
-from meshroom.core import desc, pluginManager
+from meshroom.core import desc
 
 from .utils import registerNodeDesc
 
@@ -18,7 +18,9 @@ class SampleNode(desc.Node):
         desc.File(name='output', label='Output', description='', value="{nodeCacheFolder}")
     ]
 
+
 registerNodeDesc(SampleNode)  # register standalone NodePlugin
+
 
 def test_output_invalidation():
     graph = Graph("")

--- a/tests/test_listAttribute.py
+++ b/tests/test_listAttribute.py
@@ -3,6 +3,7 @@ from meshroom.core.graph import Graph
 
 from .utils import registerNodeDesc, unregisterNodeDesc
 
+
 class NodeWithListAttribute(desc.Node):
     inputs = [
         desc.ListAttribute(
@@ -30,7 +31,7 @@ class TestListAttribute:
         nodeA = graph.addNewNode(NodeWithListAttribute.__name__)
         nodeB = graph.addNewNode(NodeWithListAttribute.__name__)
 
-        graph.addEdge(nodeA.listInput, nodeB.listInput) 
+        graph.addEdge(nodeA.listInput, nodeB.listInput)
 
         nodeA.listInput.append("test")
 
@@ -42,7 +43,7 @@ class TestListAttribute:
         nodeA = graph.addNewNode(NodeWithListAttribute.__name__)
         nodeB = graph.addNewNode(NodeWithListAttribute.__name__)
 
-        graph.addEdge(nodeA.listInput, nodeB.listInput) 
+        graph.addEdge(nodeA.listInput, nodeB.listInput)
 
         nodeA.listInput.extend(["A", "B", "C"])
 
@@ -55,7 +56,7 @@ class TestListAttribute:
         nodeA = graph.addNewNode(NodeWithListAttribute.__name__)
         nodeB = graph.addNewNode(NodeWithListAttribute.__name__)
 
-        graph.addEdge(nodeA.listInput, nodeB.listInput) 
+        graph.addEdge(nodeA.listInput, nodeB.listInput)
 
         nodeA.listInput.extend(["A", "B", "C"])
 

--- a/tests/test_nodeAttributeChangedCallback.py
+++ b/tests/test_nodeAttributeChangedCallback.py
@@ -1,7 +1,7 @@
 # coding:utf-8
 
 from meshroom.core.graph import Graph, loadGraph, executeGraph
-from meshroom.core import desc, pluginManager
+from meshroom.core import desc
 from meshroom.core.node import Node
 
 from .utils import registerNodeDesc, unregisterNodeDesc
@@ -35,7 +35,6 @@ class NodeWithAttributeChangedCallback(desc.BaseNode):
 
     def processChunk(self, chunk):
         pass  # No-op.
-
 
 
 class TestNodeWithAttributeChangedCallback:

--- a/tests/test_nodeCallbacks.py
+++ b/tests/test_nodeCallbacks.py
@@ -1,4 +1,4 @@
-from meshroom.core import desc, pluginManager
+from meshroom.core import desc
 from meshroom.core.node import Node
 from meshroom.core.graph import Graph, loadGraph
 

--- a/tests/test_nodeCommandLineFormatting.py
+++ b/tests/test_nodeCommandLineFormatting.py
@@ -1,9 +1,8 @@
 #!/usr/bin/env python
 # coding:utf-8
 
-from meshroom.core.graph import Graph, loadGraph, executeGraph
-from meshroom.core import desc, pluginManager
-from meshroom.core.node import Node
+from meshroom.core.graph import Graph
+from meshroom.core import desc
 
 from .utils import registerNodeDesc, unregisterNodeDesc
 
@@ -100,6 +99,7 @@ class NodeWithAttributesNeedingFormatting(desc.Node):
             value="{nodeCacheFolder}",
         ),
     ]
+
 
 class TestCommandLineFormatting:
 

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1,10 +1,11 @@
 # coding:utf-8
 
-from meshroom.core import desc, pluginManager, loadClassesNodes
+from meshroom.core import pluginManager, loadClassesNodes
 from meshroom.core.plugins import NodePluginStatus, Plugin
 
 import os
 import time
+
 
 class TestPluginWithValidNodesOnly:
     plugin = None
@@ -37,13 +38,13 @@ class TestPluginWithValidNodesOnly:
         for nodeName, nodePlugin in plugin.nodes.items():
             assert nodePlugin.status == NodePluginStatus.LOADED
             assert pluginManager.isRegistered(nodeName)
-        
+
         # Assert the template has been loaded
         assert len(plugin.templates) == 1
         name = list(plugin.templates.keys())[0]
         assert name == "sharedTemplate"
         assert plugin.templates[name] == os.path.join(str(plugin.path), "sharedTemplate.mg")
-    
+
     def test_unloadPlugin(self):
         plugin = pluginManager.getPlugin("pluginA")
         assert plugin == self.plugin
@@ -74,7 +75,7 @@ class TestPluginWithValidNodesOnly:
         for nodeName, nodePlugin in plugin.nodes.items():
             assert nodePlugin.status == NodePluginStatus.NOT_LOADED
             assert not pluginManager.isRegistered(nodeName)
-        
+
         # Re-add the plugin and re-register the nodes
         pluginManager.addPlugin(plugin)
         assert pluginManager.getPlugin(plugin.name)
@@ -92,7 +93,7 @@ class TestPluginWithValidNodesOnly:
         # Unregister a node
         assert nodeA
         pluginManager.unregisterNode(nodeA)
-        
+
         # Check that the node has been fully unregistered:
         #   - its status is "NOT_LOADED"
         #   - it is still part of pluginA
@@ -100,7 +101,7 @@ class TestPluginWithValidNodesOnly:
         assert nodeA.status == NodePluginStatus.NOT_LOADED
         assert plugin.containsNodePlugin(nodeAName)
         assert nodeA.plugin == plugin
-        
+
         assert pluginManager.getRegisteredNodePlugin(nodeAName) is None
         assert nodeAName not in pluginManager.getRegisteredNodePlugins()
         assert len(pluginManager.getRegisteredNodePlugins()) == nbRegisteredNodes - 1
@@ -131,7 +132,7 @@ class TestPluginWithInvalidNodes:
         for node in cls.plugin.nodes.values():
             pluginManager.unregisterNode(node)
         cls.plugin = None
-    
+
     def test_loadedPlugin(self):
         # Assert that there are loaded plugins, and that "pluginB" is one of them
         assert len(pluginManager.getPlugins()) >= 1
@@ -174,11 +175,11 @@ class TestPluginWithInvalidNodes:
         originalFileContent = None
         with open(node.path, "r") as f:
             originalFileContent = f.read()
-        
+
         replaceFileContent = originalFileContent.replace('"not an integer"', '1')
         with open(node.path, "w") as f:
             f.write(replaceFileContent)
-        
+
         # Reload the node and assert it is valid
         node.reload()
         assert node.status == NodePluginStatus.NOT_LOADED
@@ -190,7 +191,7 @@ class TestPluginWithInvalidNodes:
         # Reload the node again without any change
         node.reload()
         assert pluginManager.isRegistered(nodeName)
-        
+
         # Hack to ensure that the timestamp of the file will be different after being rewritten
         # Without it, on some systems, the operation is too fast and the timestamp does not change,
         # cause the test to fail
@@ -203,7 +204,7 @@ class TestPluginWithInvalidNodes:
         timestampOr2 = os.path.getmtime(node.path)
         print(f"New timestamp: {timestampOr2}")
         print(os.stat(node.path))
-        
+
         # Reload the node and assert it is invalid while still registered
         node.reload()
         assert node.status == NodePluginStatus.DESC_ERROR

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -5,6 +5,7 @@ import meshroom
 from meshroom.core import desc, pluginManager
 from meshroom.core.plugins import NodePlugin, NodePluginStatus
 
+
 @contextmanager
 def registeredNodeTypes(nodeTypes: list[desc.Node]):
     nodePluginsList = {}
@@ -18,6 +19,7 @@ def registeredNodeTypes(nodeTypes: list[desc.Node]):
     for nodeType in nodeTypes:
         pluginManager.unregisterNode(nodePluginsList[nodeType])
 
+
 @contextmanager
 def overrideNodeTypeVersion(nodeType: desc.Node, version: str):
     """ Helper context manager to override the version of a given node type. """
@@ -29,11 +31,13 @@ def overrideNodeTypeVersion(nodeType: desc.Node, version: str):
     ):
         yield
 
+
 def registerNodeDesc(nodeDesc: desc.Node):
     name = nodeDesc.__name__
     if not pluginManager.isRegistered(name):
         pluginManager._nodePlugins[name] = NodePlugin(nodeDesc)
         pluginManager._nodePlugins[name].status = NodePluginStatus.LOADED
+
 
 def unregisterNodeDesc(nodeDesc: desc.Node):
     name = nodeDesc.__name__


### PR DESCRIPTION
## Description

This PR builds on top of #2703 and #2733, which respectively added the notion of local isolated computations for nodes, and the concept of plugins. This pull request adds the notion of runtime-specific environment, allowing nodes to be executed in a dedicated environment that contains their required dependencies independently from Meshroom's. 

Two types of execution environments are added in this PR:

1. **DirTreeProcessEnv**

Based on the root folder of the plugin, it sets up the environment (`PYTHONPATH`, `PATH` and `LD_LIBRARY_PATH` environment variables). It assumes the plugin has a standard hierarchy:
```
mrPlugin/
|-- bin
|-- lib
|   `-- pythonX.X
|       `-- site-packages
|           |-- anotherModule
|           `-- myCustomModule
`-- meshroom
    |-- myNodes
    |   |-- NodeA.py
    |   |-- NodeB.py
    |   |-- NodeC.py
    |   `-- __init__.py
    |-- myPipelineA.mg
    `-- myPipelineB.mg
```
To declare a plugin using the DirTree, set the env variable `MESHROOM_PLUGINS_PATH`.

2. **RezProcessEnv**

Based on a [Rez](https://rez.readthedocs.io) package that's provided through a dedicated environment variable, it gathers all the requirements to execute the process within that Rez environment.

To declare plugins using Rez for their execution, use the `MESHROOM_REZ_PLUGINS` environment variable.

Rez plugins need to be provided to `MESHROOM_REZ_PLUGINS` with the following syntax: `packageName=/path/to/root`. Their `package.py` also need to follow a certain structure. An example is given below for a package named "mrExample":
```
name="mrExample"
version="1.0"

plugin_for=["meshroom"]
requires = []

def commands():
    subRequires = [
        'python-3',
        'dependency1-1.0',
        'dependency2-1.0',
        'dependency3'
    ]
    env.MESHROOM_REZ_PLUGINS.append(this.name + "={root}/folder")
    env.MREXAMPLE_SUBREQUIRES = ":".join(subRequires)
``` 


## Features list

- [x] Add a new `MESHROOM_REZ_PLUGINS` environment variable to load Rez plugins;
- [x] Use an isolated and node-specific runtime environment for all the nodes. 

## Implementation remarks

For Rez plugins, a few things are to be noted:
1. Meshroom's ability to detect and set up the runtime environment for Rez plugins relies on the "name=path" pair being correctly provided to `MESHROOM_REZ_PLUGINS`.
2. Setting `env.MRNAME_SUBREQUIRES` in the Rez package's `package.py` is necessary, as it is used by Meshroom to list the dependencies.
5. Providing versions of packages for the subrequires is not mandatory: if a version is provided, it will strictly be respected; otherwise, Meshroom will attempt to match the package's version with its own, if it exists in its environment.
6. When the node is executed in its dedicated Rez environment, both Meshroom's path and the Rez package's are injected into the `PYTHONPATH` environment variable, strictly within the Rez environment.