### PR TITLE
[core] Templates test: Remove outdated `unregisterNodeType` import

### DIFF
--- a/meshroom/core/test.py
+++ b/meshroom/core/test.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from meshroom.core import unregisterNodeType, pipelineTemplates, Version
+from meshroom.core import pipelineTemplates, Version
 from meshroom.core.node import CompatibilityIssue, CompatibilityNode
 from meshroom.core.graphIO import GraphIO
 


### PR DESCRIPTION
## Description

This PR removes the import of `unregisterNodeType` from the test on templates, as the method has been removed from `meshroom.core` and is now part of the PluginManager. 