### PR TITLE
[core] Templates test: Access node descriptor from `NodePlugin` object

### DIFF
--- a/meshroom/core/test.py
+++ b/meshroom/core/test.py
@@ -31,7 +31,7 @@ def checkTemplateVersions(path: str, nodesAlreadyLoaded: bool = False) -> bool:
             if not meshroom.core.pluginManager.isRegistered(nodeType):
                 return False
 
-            nodeDesc = meshroom.core.pluginManager.getRegisteredNodePlugin(nodeType)
+            nodeDesc = meshroom.core.pluginManager.getRegisteredNodePlugin(nodeType).nodeDescriptor
             currentNodeVersion = meshroom.core.nodeVersion(nodeDesc)
 
             inputs = nodeData.get("inputs", {})


### PR DESCRIPTION
## Description

In addition to #2750, this PR updates the templates test in order for it to correctly access the node descriptor of a `NodePlugin` object.