### PR TITLE
[core] Stop checking for templates in "pipelines" folder

### DIFF
--- a/meshroom/core/__init__.py
+++ b/meshroom/core/__init__.py
@@ -419,8 +419,7 @@ def initSubmitters():
 def initPipelines():
     # Load pipeline templates: check in the default folder and any folder the user might have
     # added to the environment variable
-    additionalPipelinesPath = EnvVar.getList(EnvVar.MESHROOM_PIPELINE_TEMPLATES_PATH)
-    pipelineTemplatesFolders = [os.path.join(meshroomFolder, "pipelines")] + additionalPipelinesPath
+    pipelineTemplatesFolders = EnvVar.getList(EnvVar.MESHROOM_PIPELINE_TEMPLATES_PATH)
     for f in pipelineTemplatesFolders:
         loadPipelineTemplates(f)
     for plugin in pluginManager.getPlugins().values():


### PR DESCRIPTION
## Description

This PR removes the check in the "meshroom/pipelines" folder when looking for templates. The folder has been removed when ndoes have been moved out from Meshroom, therefore there's no need to look in it anymore. By doing so, we remove the error message that was generated precisely because the "meshroom/pipelines" folder did not exist.