### PR TITLE
[ui] [fix] Viewer2D: using the keyboard shortcuts (r,g,b,a) break the channelBox combobox

### DIFF
--- a/meshroom/ui/qml/Viewer/HdrImageToolbar.qml
+++ b/meshroom/ui/qml/Viewer/HdrImageToolbar.qml
@@ -39,6 +39,34 @@ FloatingPane {
         if(userDefinedYPixel !== null) { userDefinedYPixel = null }        
     }
 
+    function toggleChannel(channelName, defaultChannel) {
+        /* 
+            toggle channelBox to the given channelName.
+            If the channel is already set, the defaultChannel is set
+
+         */
+        if (!setChannel(channelName)) {
+            setChannel(defaultChannel)
+        }
+    }
+
+    function setChannel(channelName) {
+        /* 
+            set the given channel in the combobox
+         */
+        if (channelName === channelsCtrl.value) {
+            return false
+        }
+
+        const channelIndex = channelsCtrl.channels.indexOf(channelName)
+        if (channelIndex === -1 ) { 
+            return false 
+        }
+
+        channelsCtrl.currentIndex = channelIndex
+        return true
+    }
+
     onMousePositionChanged: {
         resetPixelCoordinates()
     }

--- a/meshroom/ui/qml/Viewer/Viewer2D.qml
+++ b/meshroom/ui/qml/Viewer/Viewer2D.qml
@@ -1797,11 +1797,7 @@ FocusScope {
 
         shortcut: "R"
         onTriggered: {
-            if (hdrImageToolbar.channelModeValue !== "r") {
-                hdrImageToolbar.channelModeValue = "r"
-            } else {
-                hdrImageToolbar.channelModeValue = "rgba"
-            }
+            hdrImageToolbar.toggleChannel("r", "rgba")
         }
     }
 
@@ -1810,11 +1806,7 @@ FocusScope {
 
         shortcut: "G"
         onTriggered: {
-            if (hdrImageToolbar.channelModeValue !== "g") {
-                hdrImageToolbar.channelModeValue = "g"
-            } else {
-                hdrImageToolbar.channelModeValue = "rgba"
-            }
+            hdrImageToolbar.toggleChannel("g", "rgba")
         }
     }
 
@@ -1823,11 +1815,7 @@ FocusScope {
 
         shortcut: "B"
         onTriggered: {
-            if (hdrImageToolbar.channelModeValue !== "b") {
-                hdrImageToolbar.channelModeValue = "b"
-            } else {
-                hdrImageToolbar.channelModeValue = "rgba"
-            }
+            hdrImageToolbar.toggleChannel("b", "rgba")
         }
     }
 
@@ -1836,11 +1824,7 @@ FocusScope {
 
         shortcut: "A"
         onTriggered: {
-            if (hdrImageToolbar.channelModeValue !== "a") {
-                hdrImageToolbar.channelModeValue = "a"
-            } else {
-                hdrImageToolbar.channelModeValue = "rgba"
-            }
+            hdrImageToolbar.toggleChannel("a", "rgba")
         }
     }
 


### PR DESCRIPTION
## Description
In viewer2D, using keyboard shortcuts break the channelBox combobox

## Features list
- [X] The keyboard shortcuts can be used without any break

## Implementation remarks
Add functions to let the component internally manage the way it set the channel

