### PR TITLE
[qml] Fix some minor QML warnings

### DIFF
--- a/meshroom/ui/qml/Controls/TextFileViewer.qml
+++ b/meshroom/ui/qml/Controls/TextFileViewer.qml
@@ -120,7 +120,7 @@ Item {
                 keyNavigationEnabled: false
                 highlightFollowsCurrentItem: true
                 highlightMoveDuration: 0
-                Keys.onPressed: {
+                Keys.onPressed: function(event) {
                     switch (event.key) {
                         case Qt.Key_Home:
                             textView.positionViewAtBeginning()

--- a/meshroom/ui/qml/GraphEditor/GraphEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/GraphEditor.qml
@@ -484,7 +484,12 @@ Item {
                     property bool isValidEdge: src !== undefined && dst !== undefined
                     visible: isValidEdge && src.visible && dst.visible
 
-                    property bool forLoop: src.attribute.type === "ListAttribute" && dst.attribute.type != "ListAttribute"
+                    property bool forLoop: {
+                        if (src !== undefined && dst !== undefined) {
+                            return src.attribute.type === "ListAttribute" && dst.attribute.type != "ListAttribute"
+                        }
+                        return false
+                    }
 
                     property bool inFocus: containsMouse || (edgeMenu.opened && edgeMenu.currentEdge === edge)
 

--- a/meshroom/ui/qml/ImageGallery/ImageGallery.qml
+++ b/meshroom/ui/qml/ImageGallery/ImageGallery.qml
@@ -674,7 +674,9 @@ Panel {
                 text: MaterialIcons.navigate_next
                 property string nextGroupName: {
                     if (root.cameraInits && root.cameraInitIndex + 1 < root.cameraInits.count) {
-                        return root.cameraInits.at(root.cameraInitIndex + 1).label
+                        var group = root.cameraInits.at(root.cameraInitIndex + 1)
+                        if (group)
+                            return root.cameraInits.at(root.cameraInitIndex + 1).label
                     }
                     return ""
                 }


### PR DESCRIPTION
## Description

This PR fixes a couple of QML warnings:
- some which are triggered because of the use of the old JS syntax for slots
- some which may be triggered when Meshroom is in some specific states as objects are being deleted (e.g. wrapping everything up to exit the application)