### PR TITLE
Add support for `ALICEVISION_LIBPATH` environment variable

### DIFF
--- a/meshroom/__init__.py
+++ b/meshroom/__init__.py
@@ -150,10 +150,12 @@ def setupEnvironment(backend=Backend.STANDALONE):
             if key not in os.environ and os.path.exists(value):
                 logging.debug(f"Set {key}: {value}")
                 os.environ[key] = value
-    else:
-        addToEnvPath("PATH", os.environ.get("ALICEVISION_BIN_PATH", ""))
 
-    addToEnvPath("PATH", os.environ.get("ALICEVISION_LIBPATH", ""))
+    addToEnvPath("PATH", os.environ.get("ALICEVISION_BIN_PATH", ""))
+    if sys.platform == "win32":
+        addToEnvPath("PATH", os.environ.get("ALICEVISION_LIBPATH", ""))
+    else:
+        addToEnvPath("LD_LIBRARY_PATH", os.environ.get("ALICEVISION_LIBPATH", ""))
 
 
 os.environ["QML_XHR_ALLOW_FILE_READ"] = '1'

--- a/start.bat
+++ b/start.bat
@@ -9,8 +9,9 @@ REM set MESHROOM_OUTPUT_QML_WARNINGS=1
 REM set MESHROOM_INSTANT_CODING=1
 REM set QT_PLUGIN_PATH=C:\dev\meshroom\install
 REM set QML2_IMPORT_PATH=C:\dev\meshroom\install\qml
-REM set PATH=C:\dev\AliceVision\install\bin;C:\dev\vcpkg\installed\x64-windows\bin;%PATH%
 REM set ALICEVISION_ROOT=C:\dev\AliceVision\install
+REM set ALICEVISION_LIBPATH=%ALICEVISION_ROOT%\bin;C:\dev\vcpkg\installed\x64-windows\bin
+
+REM PYTHONPATH=%ALICEVISION_ROOT%\lib\python;%PYTHONPATH%
 
 python meshroom\ui
-


### PR DESCRIPTION
## Description

Following alicevision/AliceVision#1894 which adds the `ALICEVISION_LIBPATH` environment variable to ensure that DLLs on Windows can be loaded for the Python binding without raising any issue related to the way the `PATH` variable is edited and iterated over, the content of this variable is added temporarily to the `PATH` variable during Meshroom's runtime.

This prevents the user from editing and altering the `PATH` variable while still allowing the paths to DLLs and executables to be added.

The `start.bat` script is edited to include an example on how to set `ALICEVISION_LIBPATH`.