### PR TITLE
[core] desc.node: Ensure all paths are sent to the command line as POSIX strings

### DIFF
--- a/meshroom/core/desc/node.py
+++ b/meshroom/core/desc/node.py
@@ -14,8 +14,8 @@ from .attribute import StringParam, ColorParam
 import meshroom
 from meshroom.core import cgroup
 
-_MESHROOM_ROOT = Path(meshroom.__file__).parent.parent
-_MESHROOM_COMPUTE = _MESHROOM_ROOT / "bin" / "meshroom_compute"
+_MESHROOM_ROOT = Path(meshroom.__file__).parent.parent.as_posix()
+_MESHROOM_COMPUTE = (Path(_MESHROOM_ROOT) / "bin" / "meshroom_compute").as_posix()
 
 
 class MrNodeType(enum.Enum):
@@ -148,14 +148,14 @@ class BaseNode(object):
                 chunk.saveStatusFile()
                 cmdList = shlex.split(cmd)
                 # Resolve executable to full path
-                prog = shutil.which(cmdList[0], path=env.get('PATH') if env else None)
+                prog = shutil.which(cmdList[0], path=env.get("PATH") if env else None)
 
                 print(f"Starting Process for '{chunk.node.name}'")
                 print(f" - commandLine: {cmd}")
                 print(f" - logFile: {chunk.logFile}")
                 if prog:
-                    cmdList[0] = prog
-                    print(f" - command full path: {prog}")
+                    cmdList[0] = Path(prog).as_posix()
+                    print(f" - command full path: {cmdList[0]}")
 
                 # Change the process group to avoid Meshroom main process being killed if the
                 # subprocess gets terminated by the user or an Out Of Memory (OOM kill).

--- a/meshroom/core/graph.py
+++ b/meshroom/core/graph.py
@@ -7,6 +7,7 @@ from collections.abc import Iterable
 import weakref
 from collections import defaultdict, OrderedDict
 from contextlib import contextmanager
+from pathlib import Path
 
 from enum import Enum
 
@@ -1400,9 +1401,12 @@ class Graph(BaseObject):
             self._unsetFilepath()
             return
 
-        if self._filepath == filepath:
+        # Make sure the path is stored using the POSIX convention
+        # so that it can be used when creating sub-processes for node execution.
+        newFilepath = Path(filepath).as_posix()
+        if self._filepath == newFilepath:
             return
-        self._filepath = filepath
+        self._filepath = newFilepath
         # For now:
         #  * cache folder is located next to the graph file
         #  * graph name if the basename of the graph file


### PR DESCRIPTION
## Description

All the paths that are used for the command lines are converted as POSIX strings to ensure they are correctly parsed by `shlex.split()`. Otherwise, on Windows, "\\" may be removed from paths, leading to errors.