### PR TITLE
[ui] Reconstruction: Fix setup of temporary `CameraInit` nodes

### DIFF
--- a/meshroom/ui/reconstruction.py
+++ b/meshroom/ui/reconstruction.py
@@ -699,7 +699,7 @@ class Reconstruction(UIGraph):
         if not sfmFile or not os.path.isfile(sfmFile):
             self.tempCameraInit = None
             return
-        nodeDesc = meshroom.core.pluginManager.getRegisteredNodePlugin("CameraInit")
+        nodeDesc = meshroom.core.pluginManager.getRegisteredNodePlugin("CameraInit").nodeDescriptor()
         views, intrinsics = nodeDesc.readSfMData(sfmFile)
         tmpCameraInit = Node("CameraInit", viewpoints=views, intrinsics=intrinsics)
         tmpCameraInit.locked = True


### PR DESCRIPTION
## Description

This PR fixes a bug introduced by https://github.com/alicevision/Meshroom/pull/2733 which caused the setup of temporary `CameraInit` nodes to fail, as we were attempting to call a method from an object that had not been instantiated yet. 

Temporary `CameraInit` nodes are used, among other things, to display the results of the `LdrToHdrMerge` node in the "Hdr Fusion" pipeline. 