### PR TITLE
[ui] Import images: Fix that trying to import images twic, the dialog…

### DIFF
--- a/meshroom/ui/qml/main.qml
+++ b/meshroom/ui/qml/main.qml
@@ -111,8 +111,10 @@ ApplicationWindow {
             // If the dialog that's being opened is the "import images" dialog, use the "imagesFolder" property
             // which contains the last folder used to import images rather than the folder in which
             // projects have been saved
-            if (importImages && currentItem.imagesFolder.toString() !== "" && Filepath.exists(imagesFolder)) {
-                folder = currentItem.imagesFolder
+
+            const imageFolderPath = currentItem.imagesFolder.toString()
+            if (importImages && imageFolderPath !== "" && Filepath.exists(imageFolderPath)) {
+                folder = Filepath.stringToUrl(imageFolderPath)
             }
         }
 


### PR DESCRIPTION
## Description
When using the import images twice, the dialog wasn't opening anymore.



## Features list

- [X] Fix the opening of the import image folder
- [X] Fix the last path



## How to check
- Use the dialog `File/Import images`, and import one image.
- Use it again, and the dialog should open and pointing to the folder you just use before. 
