### PR TITLE
[core] Adding rangeBlocksCount to `Parallelization`

### DIFF
--- a/meshroom/core/desc/computation.py
+++ b/meshroom/core/desc/computation.py
@@ -11,10 +11,11 @@ class Level(Enum):
 
 
 class Range:
-    def __init__(self, iteration=0, blockSize=0, fullSize=0):
+    def __init__(self, iteration=0, blockSize=0, fullSize=0, nbBlocks=0):
         self.iteration = iteration
         self.blockSize = blockSize
         self.fullSize = fullSize
+        self.nbBlocks = nbBlocks
 
     @property
     def start(self):
@@ -42,6 +43,7 @@ class Range:
             "rangeBlockSize": self.blockSize,
             "rangeEffectiveBlockSize": self.effectiveBlockSize,
             "rangeFullSize": self.fullSize,
+            "rangeBlocksCount": self.nbBlocks
             }
 
 
@@ -66,13 +68,13 @@ class Parallelization:
 
     def getRange(self, node, iteration):
         blockSize, fullSize, nbBlocks = self.getSizes(node)
-        return Range(iteration=iteration, blockSize=blockSize, fullSize=fullSize)
+        return Range(iteration=iteration, blockSize=blockSize, fullSize=fullSize, nbBlocks=nbBlocks)
 
     def getRanges(self, node):
         blockSize, fullSize, nbBlocks = self.getSizes(node)
         ranges = []
         for i in range(nbBlocks):
-            ranges.append(Range(iteration=i, blockSize=blockSize, fullSize=fullSize))
+            ranges.append(Range(iteration=i, blockSize=blockSize, fullSize=fullSize, nbBlocks=nbBlocks))
         return ranges
 
 


### PR DESCRIPTION
By adding `rangeBlocksCount` to `parallelization`, called nodes have knowledge of the number of parallelized chunks. This enable easier estimation of optimal work partition.