### PR TITLE
[core] plugins: Add support for virtual environments on Windows

### DIFF
--- a/meshroom/core/plugins.py
+++ b/meshroom/core/plugins.py
@@ -94,6 +94,13 @@ class DirTreeProcessEnv(ProcessEnv):
         self.libPaths: list = [str(Path(folder, "lib")), str(Path(folder, "lib64"))]
         self.pythonPaths: list = [str(Path(folder))] + self.binPaths + glob.glob(f'{folder}/lib*/python[0-9].[0-9]*/site-packages', recursive=False)
 
+        if sys.platform == "win32":
+            # For Windows platforms, try and include the content of the virtual env if it exists
+            # The virtual env is expected to be named as its containing folder
+            venvPath = f"{folder}/{Path(folder).name}/Lib/site-packages"
+            if os.path.exists(venvPath):
+                self.pythonPaths.append(str(Path(venvPath)))
+
     def getEnvDict(self) -> dict:
         env = os.environ.copy()
         env["PYTHONPATH"] = os.pathsep.join([f"{_MESHROOM_ROOT}"] + self.pythonPaths + [f"{os.getenv('PYTHONPATH', '')}"])


### PR DESCRIPTION
## Description

If a virtual environment exists on Windows for the process, it is now added to the list of Python paths. The virtual environment is expected to have the same name as its containing folder.

The structure of virtual environments differs depending on the platform. Virtual environments on Linux were already supported.