### PR TITLE
Fix manual frame selection in viewer 2D

### DIFF
--- a/meshroom/ui/qml/Viewer/SequencePlayer.qml
+++ b/meshroom/ui/qml/Viewer/SequencePlayer.qml
@@ -149,11 +149,17 @@ FloatingPane {
 
             tooltipText: "Frame"
 
-            value: m.frame
             range: frameRange
 
             onValueChanged: {
                 m.frame = value
+            }
+
+            Binding {
+                target: frameInput
+                property: "value"
+                value: m.frame
+                when: !frameInput.activeFocus
             }
         }
 
@@ -184,6 +190,8 @@ FloatingPane {
 
             Layout.fillWidth: true
 
+            value: m.frame
+
             stepSize: 1
             snapMode: Slider.SnapAlways
             live: true
@@ -207,12 +215,6 @@ FloatingPane {
                 text: m.frame
             }
 
-            Connections {
-                target: m
-                function onFrameChanged() {
-                    frameSlider.value = m.frame
-                }
-            }
 
             background: Rectangle {
                 x: frameSlider.leftPadding


### PR DESCRIPTION
When using the manual frame IntSelector (the manual widget to select the frame), the widget did not receive anymore update on its backend value. Therefore if you did change the frame with the slider then clicked on next, the value did not take into account the slider modification.