### PR TITLE
[ui] app: Correctly evaluate env vars that enable/disable components

### DIFF
--- a/meshroom/ui/app.py
+++ b/meshroom/ui/app.py
@@ -203,7 +203,7 @@ class MeshroomApp(QApplication):
 
         args = createMeshroomParser(inputArgs)
         qtArgs = []
-    
+
         if EnvVar.get(EnvVar.MESHROOM_QML_DEBUG):
             debuggerParams = EnvVar.get(EnvVar.MESHROOM_QML_DEBUG_PARAMS)
             self.debugger = QQmlDebuggingEnabler(printWarning=True)
@@ -673,10 +673,26 @@ class MeshroomApp(QApplication):
         ]
 
     def _default8bitViewerEnabled(self):
-        return bool(os.environ.get("MESHROOM_USE_8BIT_VIEWER", False))
-    
+        return self._getEnvironmentVariableValue("MESHROOM_USE_8BIT_VIEWER", False)
+
     def _defaultSequencePlayerEnabled(self):
-        return bool(os.environ.get("MESHROOM_USE_SEQUENCE_PLAYER", True))
+        return self._getEnvironmentVariableValue("MESHROOM_USE_SEQUENCE_PLAYER", True)
+
+    def _getEnvironmentVariableValue(self, key: str, defaultValue: bool) -> bool:
+        """
+        Fetch the value of a provided environment variable if it exists, and ensure it is correctly
+        evaluated.
+
+        Args:
+            key: the key for the environment variable
+            defaultValue: the value to use if the key does not exist
+        """
+        val = os.environ.get(key, defaultValue)
+        # os.environ.get returns a string if the key exists, no matter its value, and converting a
+        # string to a bool always evaluates to "True"
+        if val != True and str(val).lower() in ("0", "false", "off"):
+            return False
+        return True
 
     activeProjectChanged = Signal()
     activeProject = Property(Variant, lambda self: self._activeProject, notify=activeProjectChanged)


### PR DESCRIPTION
## Description

This PR fixes a minor issue with the retrieval and evaluation of environment variables that is made when starting Meshroom. In particular, some environment variables were always evaluating to `True` as long as they were set, as their retrieval was made with `os.environ.get`, which always returns a string if the key exists, and strings always evaluate to `True` when converting them to booleans. 

This for example prevented disabling the sequence player using the `MESHROOM_USE_SEQUENCE_PLAYER` variable, since it could not be evaluated to anything but `True` as soon as it existed in the environment.
