### PR TITLE
Fix local versioning to match PyPA standards and modern `setuptools` requirements

### DIFF
--- a/meshroom/__init__.py
+++ b/meshroom/__init__.py
@@ -3,7 +3,7 @@ from enum import Enum
 import logging
 import os
 import sys
-
+import re
 
 class VersionStatus(Enum):
     release = 1
@@ -15,7 +15,7 @@ __version__ = "2025.1.0"
 __version_status__ = VersionStatus.develop
 
 if __version_status__ is VersionStatus.develop:
-    __version__ += "-" + __version_status__.name
+    __version__ += "+" + __version_status__.name
 
 __version_label__ = __version__
 # Modify version label if we are in a development phase.
@@ -28,10 +28,10 @@ if __version_status__ is VersionStatus.develop:
         with open(headFilepath, "r") as headFile:
             data = headFile.readlines()
             branchName = data[0].split('/')[-1].strip()
-            __version_label__ += " branch=" + branchName
+            __version_label__ += ".branch." + re.sub('[^0-9a-zA-Z]+', '.', branchName)
     else:
         # Add a generic default label "develop"
-        __version_label__ += "-" + __version_status__.name
+        __version_label__ += "+" + __version_status__.name
 
     # Allow override from env variable
     if "REZ_MESHROOM_VERSION" in os.environ:

--- a/meshroom/__init__.py
+++ b/meshroom/__init__.py
@@ -29,9 +29,6 @@ if __version_status__ is VersionStatus.develop:
             data = headFile.readlines()
             branchName = data[0].split('/')[-1].strip()
             __version_label__ += ".branch." + re.sub('[^0-9a-zA-Z]+', '.', branchName)
-    else:
-        # Add a generic default label "develop"
-        __version_label__ += "+" + __version_status__.name
 
     # Allow override from env variable
     if "REZ_MESHROOM_VERSION" in os.environ:


### PR DESCRIPTION
## Description
The same as described in #2773 

Basically, modern `setuptools` demands the specific [PyPA versioning semantics ](https://packaging.python.org/en/latest/specifications/version-specifiers/). The main issue is with local versioning (i.e., `develop` versions). 

As the documentation notes:

> Local version identifiers MUST comply with the following scheme:

> `<public version identifier>[+<local version label>]`

> They consist of a normal public version identifier (as defined in the previous section), along with an arbitrary “local version label”, separated from the public version identifier by a plus. Local version labels have no specific semantics assigned, but some syntactic restrictions are imposed.

Those restrictions are: 

>  ASCII letters ([a-zA-Z])
ASCII digits ([0-9])
periods (.)


## Features 
- [X] Fix #2773 
- [X] Remove redundant `-develop` tag

## Implementation remarks
I tried to address the `branch =` logic by switching it to `.branch.`, which is legal in this new semantic system. 
The branch name swaps out any non alphanumeric characters with periods. So something like `2025.1.0 branch=cool-testing` becomes `2025.1.0.branch.cool.testing`. It might be worth considering using a different marker (perhaps `.BRANCH.` will stand out more).

I also removed a few lines that seem to redundantly add a `-develop` marker if the git repo is missing. 
I thought I was misunderstanding the code, but after running some experiments (purposely hiding away my `.git` repo), I found the final version came out to something like `2025.1.0-develop-develop`, which seems like a mistake to me.

## Motivation
I'm sure that some developers here aren't running with the newest version of `setuptools`, but as the developers note [here](https://github.com/pypa/setuptools/issues/3772#issuecomment-1384342813), these changes have been discouraged since 2014 and deprecated since 2021. Modern versions of `setuptools` outright refuse to allow the versioning schemes provided by default, meaning something must be done. I ran into issues just trying to build the software in docker, and I'm sure there will be plenty more like me as the years go on. 