### PR TITLE
Fix for QFontDatabase crash on exit

### DIFF
--- a/meshroom/ui/__main__.py
+++ b/meshroom/ui/__main__.py
@@ -10,4 +10,5 @@ import meshroom.ui
 import meshroom.ui.app
 
 meshroom.ui.uiInstance = meshroom.ui.app.MeshroomApp(sys.argv)
+meshroom.ui.uiInstance.aboutToQuit.connect(meshroom.ui.uiInstance.terminateManual)
 meshroom.ui.uiInstance.exec()

--- a/meshroom/ui/app.py
+++ b/meshroom/ui/app.py
@@ -331,6 +331,11 @@ class MeshroomApp(QApplication):
 
         self.engine.load(os.path.normpath(url))
 
+    def terminateManual(self):
+        self.engine.clearComponentCache()
+        self.engine.collectGarbage()
+        self.engine.deleteLater()
+
     def _pipelineTemplateFiles(self):
         templates = []
         for key in sorted(meshroom.core.pipelineTemplates.keys()):


### PR DESCRIPTION
This pull request introduces a new method to handle application termination more cleanly in the `Meshroom` UI. The changes ensure proper cleanup of resources when the application is about to quit.

### Enhancements to application termination:

* [`meshroom/ui/__main__.py`](diffhunk://#diff-4f66a16d1765dbede9b6146f7d925aaaf14677a7cd311e0006cd12e4f7c34ec6R13): Added a connection to the `aboutToQuit` signal to invoke the new `terminateManual` method for resource cleanup.
* [`meshroom/ui/app.py`](diffhunk://#diff-20c58f7c9b99cbd4c2d9ca1de580aa0c691adea40dead5a4fde7de26eb59bb4fR334-R338): Introduced the `terminateManual` method, which performs cleanup tasks such as clearing the component cache, collecting garbage, and deleting the engine instance.