### PR TITLE
[ui] fix: Overlay image doesn't work on pipeline "Photogrametry experimental" 

### DIFF
--- a/meshroom/ui/reconstruction.py
+++ b/meshroom/ui/reconstruction.py
@@ -203,6 +203,7 @@ class ViewpointWrapper(QObject):
         self._undistortedImagePath = ''
         self._activeNode_PrepareDenseScene = self._reconstruction.activeNodes.get("PrepareDenseScene")
         self._activeNode_ExportAnimatedCamera = self._reconstruction.activeNodes.get("ExportAnimatedCamera")
+        self._activeNode_ExportImages = self._reconstruction.activeNodes.get("ExportImages")
         self._principalPointCorrected = False
         self.principalPointCorrectedChanged.connect(self.uvCenterOffsetChanged)
         self.sfmParamsChanged.connect(self.uvCenterOffsetChanged)
@@ -219,6 +220,8 @@ class ViewpointWrapper(QObject):
             self._activeNode_PrepareDenseScene.nodeChanged.connect(self._updateUndistortedImageParams)
         if self._activeNode_ExportAnimatedCamera:
             self._activeNode_ExportAnimatedCamera.nodeChanged.connect(self._updateUndistortedImageParams)
+        if self._activeNode_ExportImages:
+            self._activeNode_ExportImages.nodeChanged.connect(self._updateUndistortedImageParams)
 
     def _updateInitialParams(self):
         """ Update internal members depending on CameraInit. """
@@ -259,6 +262,9 @@ class ViewpointWrapper(QObject):
                 self._principalPointCorrected = self._activeNode_ExportAnimatedCamera.node.correctPrincipalPoint.value
             elif self._activeNode_PrepareDenseScene.node:
                 self._undistortedImagePath = FilepathHelper.resolve(FilepathHelper, self._activeNode_PrepareDenseScene.node.undistorted.value, self._viewpoint)
+                self._principalPointCorrected = False
+            elif self._activeNode_ExportImages:
+                self._undistortedImagePath = FilepathHelper.resolve(FilepathHelper, self._activeNode_ExportImages.node.undistorted.value, self._viewpoint)
                 self._principalPointCorrected = False
             else:
                 self._undistortedImagePath = ''

--- a/meshroom/ui/reconstruction.py
+++ b/meshroom/ui/reconstruction.py
@@ -257,13 +257,13 @@ class ViewpointWrapper(QObject):
         """ Update internal members depending on PrepareDenseScene or ExportAnimatedCamera. """
         # undistorted image path
         try:
-            if self._activeNode_ExportAnimatedCamera.node:
+            if self._activeNode_ExportAnimatedCamera and self._activeNode_ExportAnimatedCamera.node:
                 self._undistortedImagePath = FilepathHelper.resolve(FilepathHelper, self._activeNode_ExportAnimatedCamera.node.outputImages.value, self._viewpoint)
-                self._principalPointCorrected = self._activeNode_ExportAnimatedCamera.node.correctPrincipalPoint.value
-            elif self._activeNode_PrepareDenseScene.node:
+                self._principalPointCorrected = self._activeNode_ExportAnimatedCamera.node.correctPrincipalPoint.value            
+            elif self._activeNode_PrepareDenseScene and self._activeNode_PrepareDenseScene.node:
                 self._undistortedImagePath = FilepathHelper.resolve(FilepathHelper, self._activeNode_PrepareDenseScene.node.undistorted.value, self._viewpoint)
                 self._principalPointCorrected = False
-            elif self._activeNode_ExportImages:
+            elif self._activeNode_ExportImages and self._activeNode_ExportImages.node:
                 self._undistortedImagePath = FilepathHelper.resolve(FilepathHelper, self._activeNode_ExportImages.node.undistorted.value, self._viewpoint)
                 self._principalPointCorrected = False
             else:


### PR DESCRIPTION
## Description
The image overlay (see through camera) should work for exportImage node.


# Implementation
**This is a quick and dirty fix,  a refacto is necessary on this area.**

We should use ioc (inversion of control) for this kind of behavior, the system should be able to retrieve nodes that implements some features, and call the the node implementation on runtime. 
The node that implements a feature (ex: provideOverlayImage) is responsible of the implmentaiton (here how to return the image overlay to the system)

## Features list
- [ X ]  Add the exportImages node to the activeNodes able to provide image to overlay sysgtem.
