### PR TITLE
[qml] Minor UI fixes

### DIFF
--- a/meshroom/ui/palette.py
+++ b/meshroom/ui/palette.py
@@ -42,6 +42,8 @@ class PaletteManager(QObject):
 
         self.darkPalette = darkPalette
         self.defaultPalette = QApplication.instance().palette()
+        self.defaultPalette.setColor(QPalette.Text, QColor(50, 50, 50))
+        self.defaultPalette.setColor(QPalette.HighlightedText, Qt.black)
         self.togglePalette()
 
     @Slot()

--- a/meshroom/ui/qml/Application.qml
+++ b/meshroom/ui/qml/Application.qml
@@ -5,7 +5,7 @@ import QtQuick.Controls
 import QtQuick.Layouts
 import QtQml.Models
 
-import Qt.labs.platform 1.0 as Platform
+import Qt.labs.platform as Platform
 import QtQuick.Dialogs
 
 import GraphEditor 1.0

--- a/meshroom/ui/qml/Controls/MessageDialog.qml
+++ b/meshroom/ui/qml/Controls/MessageDialog.qml
@@ -86,6 +86,7 @@ Dialog {
             visible: text != ""
             onLinkActivated: function(link) { Qt.openUrlExternally(link) }
 
+            Layout.minimumWidth: 500
             Layout.preferredWidth: titleLabel.width
             wrapMode: Text.WordWrap
         }
@@ -96,6 +97,7 @@ Dialog {
             visible: text != ""
             onLinkActivated: function(link) { Qt.openUrlExternally(link) }
 
+            Layout.minimumWidth: 500
             Layout.preferredWidth: titleLabel.width
             wrapMode: Text.WordWrap
         }
@@ -105,6 +107,7 @@ Dialog {
             visible: text != ""
             onLinkActivated: function(link) { Qt.openUrlExternally(link) }
 
+            Layout.minimumWidth: 500
             Layout.preferredWidth: titleLabel.width
             wrapMode: Text.WordWrap
         }

--- a/meshroom/ui/qml/GraphEditor/Node.qml
+++ b/meshroom/ui/qml/GraphEditor/Node.qml
@@ -346,7 +346,7 @@ Item {
                             Layout.fillWidth: true
                             text: node ? node.label : ""
                             padding: 4
-                            color: root.mainSelected ? "white" : activePalette.text
+                            color: root.mainSelected ? activePalette.highlightedText : activePalette.text
                             elide: Text.ElideMiddle
                             font.pointSize: 8
                         }

--- a/meshroom/ui/qml/GraphEditor/Node.qml
+++ b/meshroom/ui/qml/GraphEditor/Node.qml
@@ -27,7 +27,6 @@ Item {
     /// Combined x and y
     property point position: Qt.point(x, y)
     /// Styling
-    property color shadowColor: "#cc000000"
     readonly property color defaultColor: isCompatibilityNode ? "#444" : !node.isComputableType ? "#BA3D69" : activePalette.base
     property color baseColor: defaultColor
 
@@ -297,7 +296,7 @@ Item {
             color: node.color === "" ? Qt.lighter(activePalette.base, 1.4) : node.color
             layer.enabled: true
             layer.effect: MultiEffect {
-                shadowColor: shadowColor
+                shadowColor: activePalette.shadow
                 // Performance tip: Reduce blurMax (not shadowBlur) to minimize shadow blur.
                 shadowBlur: 1.0  // So we keep shadowBlur at 1.0.
                 shadowEnabled: true

--- a/meshroom/ui/qml/GraphEditor/Node.qml
+++ b/meshroom/ui/qml/GraphEditor/Node.qml
@@ -27,7 +27,7 @@ Item {
     /// Combined x and y
     property point position: Qt.point(x, y)
     /// Styling
-    readonly property color defaultColor: isCompatibilityNode ? "#444" : !node.isComputableType ? "#BA3D69" : activePalette.base
+    readonly property color defaultColor: isCompatibilityNode ? activePalette.mid : !node.isComputableType ? "#BA3D69" : activePalette.base
     property color baseColor: defaultColor
 
     /// Shake Relevance

--- a/meshroom/ui/qml/GraphEditor/Node.qml
+++ b/meshroom/ui/qml/GraphEditor/Node.qml
@@ -304,7 +304,7 @@ Item {
                 blurMax: 4  // large values could impact performances
             }
             radius: 3
-            opacity: 0.7
+            opacity: 0.85
         }
 
         Rectangle {

--- a/meshroom/ui/qml/GraphEditor/ScriptEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/ScriptEditor.qml
@@ -7,7 +7,7 @@ import Controls 1.0
 import MaterialIcons 2.2
 import Utils 1.0
 
-import Qt.labs.platform 1.0 as Platform
+import Qt.labs.platform as Platform
 
 import ScriptEditor 1.0
 

--- a/meshroom/ui/qml/LiveSfmView.qml
+++ b/meshroom/ui/qml/LiveSfmView.qml
@@ -3,7 +3,7 @@ import QtQuick.Controls
 import QtQuick.Layouts
 
 import MaterialIcons 2.2
-import Qt.labs.platform 1.0 as Platform
+import Qt.labs.platform as Platform
 
 import Controls 1.0
 

--- a/meshroom/ui/qml/main.qml
+++ b/meshroom/ui/qml/main.qml
@@ -4,7 +4,7 @@ import QtQuick
 import QtQuick.Controls
 import QtQuick.Dialogs
 
-import Qt.labs.platform 1.0 as Platform
+import Qt.labs.platform as Platform
 
 ApplicationWindow {
     id: _window


### PR DESCRIPTION
## Description

This pull request introduces several updates to improve UI consistency, enhance styling, and standardize imports across the `meshroom` project. The most significant changes include adjustments to palette colors, layout properties, and shadow effects, as well as the removal of version-specific imports for `Qt.labs.platform`.

### UI Styling and Palette Updates:
* Updated the default text and highlighted text colors in the `defaultPalette` initialization in `meshroom/ui/palette.py` to improve readability. (`[meshroom/ui/palette.pyR45-R46](diffhunk://#diff-f7fe8399c1c9910e333103be4045293618a446507cdf54fe025f3f088e08992eR45-R46)`)
* Modified `GraphEditor/Node.qml` to use `activePalette` for `defaultColor`, `shadowColor`, and `highlightedText` properties, ensuring consistent theming across nodes. (`[[1]](diffhunk://#diff-e932096a868b75dfc38e5f6ad260277cbe72a0da4b8d7ff14b07e0cb6e1ae133L30-R30)`, `[[2]](diffhunk://#diff-e932096a868b75dfc38e5f6ad260277cbe72a0da4b8d7ff14b07e0cb6e1ae133L300-R306)`, `[[3]](diffhunk://#diff-e932096a868b75dfc38e5f6ad260277cbe72a0da4b8d7ff14b07e0cb6e1ae133L350-R349)`)

### Layout Enhancements:
* Added a `Layout.minimumWidth` property with a value of 500 to `MessageDialog.qml` to ensure dialogs have a minimum width for better usability. (`[[1]](diffhunk://#diff-f5939bf96aefc9549c628ab1f04d6eabce7bde37a35c746a409021fdd2a055e8R89)`, `[[2]](diffhunk://#diff-f5939bf96aefc9549c628ab1f04d6eabce7bde37a35c746a409021fdd2a055e8R100)`, `[[3]](diffhunk://#diff-f5939bf96aefc9549c628ab1f04d6eabce7bde37a35c746a409021fdd2a055e8R110)`)

### Import Standardization:
* Replaced version-specific `Qt.labs.platform 1.0` imports with generic `Qt.labs.platform` across multiple files (`Application.qml`, `ScriptEditor.qml`, `LiveSfmView.qml`, `main.qml`) to simplify and standardize the import statements. (`[[1]](diffhunk://#diff-dabaaa1b7233f68be82e222aef3823182a96b7ecc4038a97aecb1fb57525edd3L8-R8)`, `[[2]](diffhunk://#diff-6ad1d48f46bbdc0e8d4afb76072e85f54a636c38d348dfd395d27eab9c7e4745L10-R10)`, `[[3]](diffhunk://#diff-181dd186abbd2576ddcb46aeb5fb77a8ce1d438e942a01a8a0e6d8815483606dL6-R6)`, `[[4]](diffhunk://#diff-aa5698a4abe93605fab4c01a002f3e909b6d23662947b399d1f42d7d0e112da4L7-R7)`)