### PR TITLE
[qml] Use native FileDialogs

### DIFF
--- a/meshroom/ui/qml/Application.qml
+++ b/meshroom/ui/qml/Application.qml
@@ -132,7 +132,6 @@ Page {
     // File dialogs
     Platform.FileDialog {
         id: saveFileDialog
-        options: Platform.FileDialog.DontUseNativeDialog
 
         property var _callback: undefined
 
@@ -178,7 +177,6 @@ Page {
 
     Platform.FileDialog {
         id: saveTemplateDialog
-        options: Platform.FileDialog.DontUseNativeDialog
 
         signal closed(var result)
 
@@ -202,7 +200,6 @@ Page {
 
     Platform.FileDialog {
         id: loadTemplateDialog
-        options: Platform.FileDialog.DontUseNativeDialog
         title: "Load Template"
         nameFilters: ["Meshroom Graphs (*.mg)"]
         onAccepted: {
@@ -215,7 +212,6 @@ Page {
 
     Platform.FileDialog {
         id: importImagesDialog
-        options: Platform.FileDialog.DontUseNativeDialog
         title: "Import Images"
         fileMode: Platform.FileDialog.OpenFiles
         nameFilters: []
@@ -228,7 +224,6 @@ Page {
 
     Platform.FileDialog {
         id: importProjectDialog
-        options: Platform.FileDialog.DontUseNativeDialog
         title: "Import Project"
         fileMode: Platform.FileDialog.OpenFile
         nameFilters: ["Meshroom Graphs (*.mg)"]

--- a/meshroom/ui/qml/GraphEditor/ScriptEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/ScriptEditor.qml
@@ -105,7 +105,6 @@ Item {
 
     Platform.FileDialog {
         id: loadScriptDialog
-        options: Platform.FileDialog.DontUseNativeDialog
         title: "Load Script"
         nameFilters: ["Python Script (*.py)"]
         onAccepted: {
@@ -116,7 +115,6 @@ Item {
 
     Platform.FileDialog {
         id: saveScriptDialog
-        options: Platform.FileDialog.DontUseNativeDialog
         title: "Save script"
         nameFilters: ["Python Script (*.py)"]
         fileMode: Platform.FileDialog.SaveFile

--- a/meshroom/ui/qml/main.qml
+++ b/meshroom/ui/qml/main.qml
@@ -123,7 +123,6 @@ ApplicationWindow {
 
     Platform.FileDialog {
         id: openFileDialog
-        options: Platform.FileDialog.DontUseNativeDialog
         title: "Open File"
         nameFilters: ["Meshroom Graphs (*.mg)"]
         onAccepted: {


### PR DESCRIPTION
## Description

This PR reverts to using native FileDialogs. On Windows and Linux systems running GTK+, this allows to use features such as the favorite folders and so.
