### PR TITLE
[core] plugins: Virtual environments should be named "venv" instead of having the plugin's name

### DIFF
--- a/INSTALL_PLUGINS.md
+++ b/INSTALL_PLUGINS.md
@@ -6,7 +6,7 @@ Plugins are collections of nodes and templates with their own dependencies. Plug
 
 - **Meshroom folder**: All plugin nodes and templates must be placed within a `./meshroom/` directory
 - **Configuration file (optional)**: `./meshroom/config.json` file allows to define custom environment variables for the plugin  
-- **Virtual environment (optional)**: If you have specific dependencies, you can create a virtual environment in a folder with the plugin name and this python will be used when computing the node.
+- **Virtual environment (optional)**: If you have specific dependencies, you can create a virtual environment named "venv" in a folder and this Python will be used when computing the node.
 
 ## Example Structure
 
@@ -25,7 +25,7 @@ For a plugin named "customPlugin", Meshroom expects this layout:
 │   │   ├── customTemplate1.mg   # Ready-to-use pipeline templates
 │   │   ├── customTemplate2.mg
 │   │   ├── config.json          # Optional plugin configuration file
-│   ├── customPlugin/            # Optional virtual environment with installed dependencies
+│   ├── venv/                    # Optional virtual environment with installed dependencies
 │   └── ...                      # Custom code (any structure)
 ```
 

--- a/meshroom/core/plugins.py
+++ b/meshroom/core/plugins.py
@@ -99,10 +99,10 @@ class DirTreeProcessEnv(ProcessEnv):
 
         if sys.platform == "win32":
             # For Windows platforms, try and include the content of the virtual env if it exists
-            # The virtual env is expected to be named as its containing folder
-            venvPath = f"{folder}/{Path(folder).name}/Lib/site-packages"
-            if os.path.exists(venvPath):
-                self.pythonPaths.append(str(Path(venvPath)))
+            # The virtual env is expected to be named "venv"
+            venvPath = Path(folder, "venv", "Lib", "site-packages")
+            if venvPath.exists():
+                self.pythonPaths.append(venvPath.as_posix())
         else:
             # For Linux platforms, lib paths may need to be discovered recursively to be properly
             # added to LD_LIBRARY_PATH


### PR DESCRIPTION
## Description

This PR updates the handling and documentation of virtual environments for plugins in the Meshroom project. The changes standardize the naming convention for virtual environments to "venv" (in opposition of giving them the plugin's name) and update the relevant code and documentation accordingly.
