### PR TITLE
Improve behaviour when dropping folders

### DIFF
--- a/meshroom/multiview.py
+++ b/meshroom/multiview.py
@@ -136,13 +136,29 @@ def findFilesByTypeInFolder(folder, recursive=False):
             continue
         elif os.path.isdir(currentFolder):
             if recursive:
+                # Get through all of the depth levels
                 for root, directories, files in os.walk(currentFolder):
                     for filename in files:
                         output.addFile(os.path.join(root, filename))
             else:
-                output.addFiles([os.path.join(currentFolder, filename) for filename in os.listdir(currentFolder)])
+                # Only get the first level of depth, so top-level folders'
+                # files will be added, if they exist.
+                # This may prevent from importing nothing at all when files
+                # are nested a level down
+                try:
+                    root, directories, files = next(os.walk(currentFolder))
+                    output.addFiles([os.path.join(root, file) for file in files])
+                    for directory in directories:
+                        for file in os.listdir(os.path.join(root, directory)):
+                            filepath = os.path.join(root, directory, file)
+                            if os.path.isfile(filepath):
+                                output.addFile(filepath)
+                except (StopIteration, OSError):
+                    # Directory empty or inaccessible, skip processing
+                    pass
+
         else:
-            # if not a directory or a file, it may be an expression
+            # If not a directory or a file, it may be an expression
             import glob
             paths = glob.glob(currentFolder)
             filesByType = findFilesByTypeInFolder(paths, recursive=recursive)

--- a/meshroom/multiview.py
+++ b/meshroom/multiview.py
@@ -72,6 +72,8 @@ meshroomSceneExtensions = ('.mg')
 
 def hasExtension(filepath, extensions):
     """ Return whether filepath is one of the following extensions. """
+    if os.path.isdir(filepath):
+        return False
     return os.path.splitext(filepath)[1].lower() in extensions
 
 

--- a/meshroom/multiview.py
+++ b/meshroom/multiview.py
@@ -1,7 +1,7 @@
 import os
 
 # Supported image extensions
-imageExtensions = (
+imageExtensions = [
     # bmp:
     '.bmp',
     # cineon:
@@ -57,17 +57,17 @@ imageExtensions = (
     '.zfile',
     # osl:
     '.osl', '.oso', '.oslgroup', '.oslbody',
-    )
-videoExtensions = (
+    ]
+videoExtensions = [
     '.avi', '.mov', '.qt',
     '.mkv', '.webm',
     '.mp4', '.mpg', '.mpeg', '.m2v', '.m4v',
     '.wmv',
     '.ogv', '.ogg',
     '.mxf',
-    )
-panoramaInfoExtensions = ('.xml')
-meshroomSceneExtensions = ('.mg')
+    ]
+panoramaInfoExtensions = ['.xml']
+meshroomSceneExtensions = ['.mg']
 
 
 def hasExtension(filepath, extensions):

--- a/meshroom/ui/graph.py
+++ b/meshroom/ui/graph.py
@@ -952,6 +952,8 @@ class UIGraph(QObject):
 
     @Slot(Attribute)
     def removeImage(self, image):
+        if image is None:
+            return
         with self.groupedGraphModification("Remove Image"):
             # look if the viewpoint's intrinsic is used by another viewpoint
             # if not, remove it

--- a/meshroom/ui/reconstruction.py
+++ b/meshroom/ui/reconstruction.py
@@ -763,12 +763,15 @@ class Reconstruction(UIGraph):
     @Slot("QList<QUrl>", result="QVariantMap")
     def getFilesByTypeFromDrop(self, urls):
         """
+        Given a list of filepaths, sort them into distinct categories and return a map for all
+        these categories.
 
         Args:
             urls: list of filepaths
 
         Returns:
-            {images, videos, panoramaInfo, meshroomScenes, otherFiles}: Map containing the lists of paths for recognized images, videos, Meshroom scenes and other files.
+            {images, videos, panoramaInfo, meshroomScenes, otherFiles}: Map containing the lists of paths for
+            recognized images, videos, Meshroom scenes and other files.
         """
         # Build the list of images paths
         filesByType = multiview.FilesByType()


### PR DESCRIPTION
## Description

This pull request makes improvements to how files and directories are handled and categorized in `meshroom/multiview.py` and `meshroom/ui/reconstruction.py`. The main changes focus on more accurately detecting file types, improving directory traversal (especially for non-recursive cases), and clarifying documentation.

This addresses the frequent error dialog that was raised when dropping a folder that contained other folders: since `hasExtension` attempted to retrieve an extension from folders, it ended up with an empty string that satisfied the `in` requirement when compared to extensions for the panorama pipelines.

**File and directory handling improvements:**

* Updated `hasExtension` to return `False` for directories, ensuring only files are checked for extensions.
* Improved non-recursive directory traversal in `findFilesByTypeInFolder` to include files from both the top-level and immediate subdirectories, preventing missed files that are nested one level down.

**Documentation and code clarity:**

* Enhanced the docstring for `getFilesByTypeFromDrop` to clarify its purpose and return value, making it easier to understand how files are categorized.