### PR TITLE
[core] plugins: Downgrade the log level when loading the config file

### DIFF
--- a/meshroom/core/plugins.py
+++ b/meshroom/core/plugins.py
@@ -363,8 +363,8 @@ class Plugin(BaseObject):
                         if resolvedPath.exists():
                             val = resolvedPath.as_posix()
                         else:
-                            logging.warning(f"{k}: {resolvedPath.as_posix()} does not exist "
-                                            f"(path before resolution: {val}).")
+                            logging.debug(f"{k}: {resolvedPath.as_posix()} does not exist "
+                                          f"(path before resolution: {val}).")
 
                     self._configEnv[k] = str(val)
 


### PR DESCRIPTION
## Description

This pull request makes a minor adjustment to the logging behavior in the `loadConfig` method of `meshroom/core/plugins.py`. The change lowers the logging level from warning to debug for messages about missing resolved paths, reducing noise in the logs for non-critical issues.