### PR TITLE
[core/submitters] Freeze rez plugins dependencies versions in subprocess and farm submitter

### DIFF
--- a/meshroom/core/plugins.py
+++ b/meshroom/core/plugins.py
@@ -151,6 +151,9 @@ class DirTreeProcessEnv(ProcessEnv):
 class RezProcessEnv(ProcessEnv):
     """
     """
+    
+    REZ_DELIMITER_PATTERN = re.compile(r"(-|==|>=|>|<=|<)")
+    
     def __init__(self, folder: str, configEnv: dict[str: str], uri: str = ""):
         if not uri:
             raise RuntimeError("Missing name of the Rez environment needs to be provided.")
@@ -168,30 +171,31 @@ class RezProcessEnv(ProcessEnv):
 
         # Packages that are resolved in the current environment
         currentEnvPackages = []
+        resolvedVersions = {}
         if "REZ_REQUEST" in os.environ:
             resolvedPackages = os.getenv("REZ_RESOLVE", "").split()
-            resolvedVersions = {}
             for package in resolvedPackages:
                 if package.startswith("~"):
                     continue
+                currentEnvPackages.append(package)
                 version = package.split("-")
-                resolvedVersions[version[0]] = version[1]
-            currentEnvPackages = [package + "-" + resolvedVersions[package] for package in resolvedVersions.keys()]
+                if len(version) == 2:
+                    resolvedVersions[version[0]] = version[1]
+                elif len(version) > 2:  # Handle case with multiple hyphen-minus
+                    resolvedVersions[version[0]] = "-".join(version[1:])
         logging.debug("Packages in the current environment: " + ", ".join(currentEnvPackages))
 
         # Take packages with the set versions for those which have one, and try to take packages in the current
         # environment (if they are resolved in it)
         for package in subrequires:
-            if "-" in package:
+            if self.REZ_DELIMITER_PATTERN.findall(package):  # The subrequires ask for a specific version
                 packages.append(package)
             else:
-                definedInParentEnv = False
-                for p in currentEnvPackages:
-                    if p.startswith(package + "-"):
-                        packages.append(p)
-                        definedInParentEnv = True
-                        break
-                if not definedInParentEnv:
+                packageName = self.REZ_DELIMITER_PATTERN.split(package)[0]
+                resolvedVersion = resolvedVersions.get(packageName)
+                if (resolvedVersion!=None) and (resolvedVersion!=""):
+                    packages.append(packageName + "==" + resolvedVersion)
+                else:
                     packages.append(package)
 
         logging.debug("Packages for the execution environment: " + ", ".join(packages))

--- a/meshroom/core/plugins.py
+++ b/meshroom/core/plugins.py
@@ -152,7 +152,7 @@ class RezProcessEnv(ProcessEnv):
     """
     """
     
-    REZ_DELIMITER_PATTERN = re.compile(r"(-|==|>=|>|<=|<)")
+    REZ_DELIMITER_PATTERN = re.compile(r"-|==|>=|>|<=|<")
     
     def __init__(self, folder: str, configEnv: dict[str: str], uri: str = ""):
         if not uri:
@@ -167,35 +167,39 @@ class RezProcessEnv(ProcessEnv):
         environment (if this package is defined).
         """
         subrequires = os.environ.get(f"{self.uri.upper()}_SUBREQUIRES", "").split(os.pathsep)
-        packages = []
+        if not subrequires:
+            return []
 
+        packages = []
         # Packages that are resolved in the current environment
         currentEnvPackages = []
         resolvedVersions = {}
-        if "REZ_REQUEST" in os.environ:
-            resolvedPackages = os.getenv("REZ_RESOLVE", "").split()
+        if "REZ_USED_RESOLVE" in os.environ:
+            resolvedPackages = os.getenv("REZ_USED_RESOLVE", "").split()
             for package in resolvedPackages:
                 if package.startswith("~"):
                     continue
                 currentEnvPackages.append(package)
-                version = package.split("-")
-                if len(version) == 2:
-                    resolvedVersions[version[0]] = version[1]
-                elif len(version) > 2:  # Handle case with multiple hyphen-minus
-                    resolvedVersions[version[0]] = "-".join(version[1:])
+                name, version = self.REZ_DELIMITER_PATTERN.split(package, maxsplit=1)
+                resolvedVersions[name] = version
         logging.debug("Packages in the current environment: " + ", ".join(currentEnvPackages))
 
         # Take packages with the set versions for those which have one, and try to take packages in the current
         # environment (if they are resolved in it)
         for package in subrequires:
-            if self.REZ_DELIMITER_PATTERN.findall(package):  # The subrequires ask for a specific version
-                packages.append(package)
-            else:
-                packageName = self.REZ_DELIMITER_PATTERN.split(package)[0]
-                resolvedVersion = resolvedVersions.get(packageName)
-                if (resolvedVersion!=None) and (resolvedVersion!=""):
-                    packages.append(packageName + "==" + resolvedVersion)
-                else:
+            packageTuple = self.REZ_DELIMITER_PATTERN.split(package, maxsplit=1)
+            match len(packageTuple):
+                case 1:
+                    # Only the package name in the subrequires.
+                    # Search for a corresponding version in the parent environment.
+                    packageName = packageTuple[0]
+                    parentResolvedVersion = resolvedVersions.get(packageName)
+                    if parentResolvedVersion:
+                        packages.append(f"{packageName}=={parentResolvedVersion}")
+                    else:
+                        packages.append(package)
+                case 2:
+                    # The subrequires ask for a specific version
                     packages.append(package)
 
         logging.debug("Packages for the execution environment: " + ", ".join(packages))

--- a/meshroom/submitters/simpleFarmSubmitter.py
+++ b/meshroom/submitters/simpleFarmSubmitter.py
@@ -43,8 +43,9 @@ class SimpleFarmSubmitter(BaseSubmitter):
             for p in packages:
                 if p.startswith('~'):
                     continue
-                v = p.split('-')
-                self.reqPackages.append('-'.join([v[0], resolvedVersions[v[0]]]))
+                delimiter = "==" if "==" in p else "-"
+                v = p.split(delimiter)
+                self.reqPackages.append(delimiter.join([v[0], resolvedVersions[v[0]]]))
             logging.debug(f'REZ Packages: {str(self.reqPackages)}')
         elif 'REZ_MESHROOM_VERSION' in os.environ:
             self.reqPackages = [f"meshroom-{os.environ.get('REZ_MESHROOM_VERSION', '')}"]

--- a/meshroom/submitters/simpleFarmSubmitter.py
+++ b/meshroom/submitters/simpleFarmSubmitter.py
@@ -4,6 +4,7 @@ import os
 import json
 import logging
 import getpass
+import re
 
 import simpleFarm
 from meshroom.core.desc import Level
@@ -21,6 +22,7 @@ class SimpleFarmSubmitter(BaseSubmitter):
     environment = {}
     ENGINE = ''
     DEFAULT_TAGS = {'prod': ''}
+    REZ_DELIMITER_PATTERN = re.compile(r"(-|==|>=|>|<=|<)")
 
     def __init__(self, parent=None):
         super().__init__(name='SimpleFarm', parent=parent)
@@ -28,7 +30,7 @@ class SimpleFarmSubmitter(BaseSubmitter):
         self.share = os.environ.get('MESHROOM_SIMPLEFARM_SHARE', 'vfx')
         self.prod = os.environ.get('PROD', 'mvg')
         if 'REZ_REQUEST' in os.environ:
-            packages = os.environ.get('REZ_REQUEST', '').split()
+            packages = os.environ.get('REZ_USED_REQUEST', '').split()
             resolvedPackages = os.environ.get('REZ_RESOLVE', '').split()
             resolvedVersions = {}
             for r in resolvedPackages:
@@ -38,14 +40,20 @@ class SimpleFarmSubmitter(BaseSubmitter):
                 # logging.info('REZ: {}'.format(str(r)))
                 v = r.split('-')
                 # logging.info('    v: {}'.format(str(v)))
-                if len(v) >= 2:
+                if len(v) == 2:
                     resolvedVersions[v[0]] = v[1]
+                elif len(v) > 2:  # Handle case with multiple hyphen-minus
+                    resolvedVersions[v[0]] = "-".join(v[1:])
+            usedPackages = set()  # Use set to remove duplicates
             for p in packages:
-                if p.startswith('~'):
+                if p.startswith('~') or p.startswith("!"):
                     continue
-                delimiter = "==" if "==" in p else "-"
-                v = p.split(delimiter)
-                self.reqPackages.append(delimiter.join([v[0], resolvedVersions[v[0]]]))
+                v = self.REZ_DELIMITER_PATTERN.split(p)
+                usedPackages.add(v[0])
+            for p in usedPackages:
+                # Use "==" to make sure we have the same version in the job that the one we have in the env
+                # where meshroom is launched
+                self.reqPackages.append("==".join([p, resolvedVersions[p]]))
             logging.debug(f'REZ Packages: {str(self.reqPackages)}')
         elif 'REZ_MESHROOM_VERSION' in os.environ:
             self.reqPackages = [f"meshroom-{os.environ.get('REZ_MESHROOM_VERSION', '')}"]

--- a/meshroom/submitters/simpleFarmSubmitter.py
+++ b/meshroom/submitters/simpleFarmSubmitter.py
@@ -38,7 +38,7 @@ class SimpleFarmSubmitter(BaseSubmitter):
                 if r.startswith('~'):
                     continue
                 # logging.info('REZ: {}'.format(str(r)))
-                name, version = r.split('-', maxsplit=1)
+                name, version = self.REZ_DELIMITER_PATTERN.split(r, maxsplit=1)
                 # logging.info('    v: {}'.format(str(v)))
                 resolvedVersions[name] = version
             requestPackageNames = set()  # Use set to remove duplicates

--- a/meshroom/submitters/simpleFarmSubmitter.py
+++ b/meshroom/submitters/simpleFarmSubmitter.py
@@ -22,15 +22,15 @@ class SimpleFarmSubmitter(BaseSubmitter):
     environment = {}
     ENGINE = ''
     DEFAULT_TAGS = {'prod': ''}
-    REZ_DELIMITER_PATTERN = re.compile(r"(-|==|>=|>|<=|<)")
+    REZ_DELIMITER_PATTERN = re.compile(r"-|==|>=|>|<=|<")
 
     def __init__(self, parent=None):
         super().__init__(name='SimpleFarm', parent=parent)
         self.engine = os.environ.get('MESHROOM_SIMPLEFARM_ENGINE', 'tractor')
         self.share = os.environ.get('MESHROOM_SIMPLEFARM_SHARE', 'vfx')
         self.prod = os.environ.get('PROD', 'mvg')
-        if 'REZ_REQUEST' in os.environ:
-            packages = os.environ.get('REZ_USED_REQUEST', '').split()
+        if 'REZ_USED_REQUEST' in os.environ:
+            requestPackages = os.environ.get('REZ_USED_REQUEST', '').split()
             resolvedPackages = os.environ.get('REZ_RESOLVE', '').split()
             resolvedVersions = {}
             for r in resolvedPackages:
@@ -38,22 +38,19 @@ class SimpleFarmSubmitter(BaseSubmitter):
                 if r.startswith('~'):
                     continue
                 # logging.info('REZ: {}'.format(str(r)))
-                v = r.split('-')
+                name, version = r.split('-', maxsplit=1)
                 # logging.info('    v: {}'.format(str(v)))
-                if len(v) == 2:
-                    resolvedVersions[v[0]] = v[1]
-                elif len(v) > 2:  # Handle case with multiple hyphen-minus
-                    resolvedVersions[v[0]] = "-".join(v[1:])
-            usedPackages = set()  # Use set to remove duplicates
-            for p in packages:
-                if p.startswith('~') or p.startswith("!"):
+                resolvedVersions[name] = version
+            requestPackageNames = set()  # Use set to remove duplicates
+            for p in requestPackages:
+                if p.startswith('~'):
                     continue
-                v = self.REZ_DELIMITER_PATTERN.split(p)
-                usedPackages.add(v[0])
-            for p in usedPackages:
-                # Use "==" to make sure we have the same version in the job that the one we have in the env
-                # where meshroom is launched
-                self.reqPackages.append("==".join([p, resolvedVersions[p]]))
+                v = self.REZ_DELIMITER_PATTERN.split(p, maxsplit=1)
+                requestPackageNames.add(v[0])
+            for p in requestPackageNames:
+                # Use "==" to guarantee that the job uses the exact same version
+                # as the environment where Meshroom was launched.
+                self.reqPackages.append(f"{p}=={resolvedVersions[p]}")
             logging.debug(f'REZ Packages: {str(self.reqPackages)}')
         elif 'REZ_MESHROOM_VERSION' in os.environ:
             self.reqPackages = [f"meshroom-{os.environ.get('REZ_MESHROOM_VERSION', '')}"]


### PR DESCRIPTION
Force using specific versions on subprocess and simpleFarm jobs.

> [!NOTE]  
> Now, when we submit/compute a node, it uses the current env to select versions that are going to be used.
> However there are several case where we can have a mismatch.
> For example, if `pkg-v` and `pkg-v.1` are deployed and we have `pkg==v` in the current env, then `REZ_RESOLVE` will have resolved `pkg-v` (which is correct) however if we resolve `pkg-v` we won't have the version we want.

Therefore in this PR we propose to fix the packages whose version is taken from the current env and to fix it in the subprocess by using the `==` delimiter.
Also we address some other issues :
- package versions that are explicitely excluded (prefixed by `!`)
- packages with version delimiters different than `-`
- packages with `-` in the version string (because of the split on this symbol some issues could happen if a version is `pkg-version-0.1` for example, while it's a valid way to name packages)