### PR TITLE
[core] plugins: Add rez plugin's package to the list of resolved packages

### DIFF
--- a/meshroom/core/plugins.py
+++ b/meshroom/core/plugins.py
@@ -166,6 +166,11 @@ class RezProcessEnv(ProcessEnv):
                     continue
                 version = package.split("-")
                 resolvedVersions[version[0]] = version[1]
+
+                # Add the plugin's package
+                if version[0] == self.uri:
+                    packages.append(f"{version[0]}-{version[1]}")
+
             currentEnvPackages = [package + "-" + resolvedVersions[package] for package in resolvedVersions.keys()]
         logging.debug("Packages in the current environment: " + ", ".join(currentEnvPackages))
 


### PR DESCRIPTION
## Description

This PR updates `resolveRezSubrequires` to append the current plugin's package (with its version) to the `packages` list when it matches the plugin's URI, ensuring it is included in the resolved dependencies.

It ensures that the plugin's nodes will be correctly recognized when processing the `meshroom_compute` operations.