### PR TITLE
[ui] Add additional node information in the documentation tab

### DIFF
--- a/meshroom/core/node.py
+++ b/meshroom/core/node.py
@@ -756,7 +756,7 @@ class BaseNode(BaseObject):
             ("module", self.nodeDesc.__module__),
             ("modulePath", self.nodeDesc.plugin.path),
         ])
-        # Infos from the plugin module
+        # > Infos from the plugin module
         plugin_module = sys.modules.get(self.nodeDesc.__module__)
         if getattr(plugin_module, "__author__", None):
             infos["author"] = plugin_module.__author__
@@ -764,9 +764,12 @@ class BaseNode(BaseObject):
             infos["license"] = plugin_module.__license__
         if getattr(plugin_module, "__version__", None):
             infos["version"] = plugin_module.__version__
-        # Additional node infos 
-        # They can be stored in a __nodeInfo__ parameter
-        # We can also use it to override variables here (like author or version)
+        # > Overrides at the node-level
+        if getattr(self.nodeDesc, "author", None):
+            infos["author"] = self.nodeDesc.author
+        if getattr(self.nodeDesc, "version", None):
+            infos["version"] = self.nodeDesc.version
+        # > Additional node infos stored in a __nodeInfo__ parameter
         additionalNodeInfos = getattr(self.nodeDesc, "__nodeInfo__", None)
         if additionalNodeInfos:
             for key, value in additionalNodeInfos:

--- a/meshroom/core/node.py
+++ b/meshroom/core/node.py
@@ -757,14 +757,11 @@ class BaseNode(BaseObject):
             ("modulePath", self.nodeDesc.plugin.path),
         ])
         # Infos from the plugin module
-        try:
-            plugin_module = sys.modules[self.nodeDesc.__module__]
-            if getattr(plugin_module, "__author__", None):
-                infos["author"] = plugin_module.__author__
-            if getattr(plugin_module, "__version__", None):
-                infos["version"] = plugin_module.__version__
-        except:
-            pass
+        plugin_module = sys.modules.get(self.nodeDesc.__module__)
+        if getattr(plugin_module, "__author__", None):
+            infos["author"] = plugin_module.__author__
+        if getattr(plugin_module, "__version__", None):
+            infos["version"] = plugin_module.__version__
         # Additional node infos 
         # They can be stored in a __nodeInfo__ parameter
         # We can also use it to override variables here (like author or version)

--- a/meshroom/core/node.py
+++ b/meshroom/core/node.py
@@ -760,6 +760,8 @@ class BaseNode(BaseObject):
         plugin_module = sys.modules.get(self.nodeDesc.__module__)
         if getattr(plugin_module, "__author__", None):
             infos["author"] = plugin_module.__author__
+        if getattr(plugin_module, "__license__", None):
+            infos["license"] = plugin_module.__license__
         if getattr(plugin_module, "__version__", None):
             infos["version"] = plugin_module.__version__
         # Additional node infos 

--- a/meshroom/core/node.py
+++ b/meshroom/core/node.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+import sys
 import atexit
 import copy
 import datetime
@@ -11,7 +12,7 @@ import shutil
 import time
 import types
 import uuid
-from collections import namedtuple
+from collections import namedtuple, OrderedDict
 from enum import Enum, auto
 from typing import Callable, Optional
 
@@ -743,8 +744,36 @@ class BaseNode(BaseObject):
     def getDocumentation(self):
         if not self.nodeDesc:
             return ""
-        return self.nodeDesc.documentation
-
+        if self.nodeDesc.documentation:
+            return self.nodeDesc.documentation
+        else:
+            return self.nodeDesc.__doc__
+    
+    def getNodeInfos(self):
+        if not self.nodeDesc:
+            return []
+        infos = OrderedDict([
+            ("module", self.nodeDesc.__module__),
+            ("modulePath", self.nodeDesc.plugin.path),
+        ])
+        # Infos from the plugin module
+        try:
+            plugin_module = sys.modules[self.nodeDesc.__module__]
+            if getattr(plugin_module, "__author__", None):
+                infos["author"] = plugin_module.__author__
+            if getattr(plugin_module, "__version__", None):
+                infos["version"] = plugin_module.__version__
+        except:
+            pass
+        # Additional node infos 
+        # They can be stored in a __nodeInfo__ parameter
+        # We can also use it to override variables here (like author or version)
+        additionalNodeInfos = getattr(self.nodeDesc, "__nodeInfo__", None)
+        if additionalNodeInfos:
+            for key, value in additionalNodeInfos:
+                infos[key] = value
+        return [{"key": k, "value": v} for k, v in infos.items()]
+    
     @property
     def packageFullName(self):
         return '-'.join([self.packageName, self.packageVersion])
@@ -1626,6 +1655,7 @@ class BaseNode(BaseObject):
     defaultLabel = Property(str, getDefaultLabel, constant=True)
     nodeType = Property(str, nodeType.fget, constant=True)
     documentation = Property(str, getDocumentation, constant=True)
+    nodeInfos = Property(Variant, getNodeInfos, constant=True)
     positionChanged = Signal()
     position = Property(Variant, position.fget, position.fset, notify=positionChanged)
     x = Property(float, lambda self: self._position.x, notify=positionChanged)

--- a/meshroom/ui/qml/GraphEditor/NodeDocumentation.qml
+++ b/meshroom/ui/qml/GraphEditor/NodeDocumentation.qml
@@ -104,9 +104,9 @@ FocusScope {
 
             TextEdit {
                 id: documentationText
-                anchors.top: nodeInfoListView.bottom
                 padding: 8
-                topPadding: 15
+                topPadding: 20
+                Layout.alignment: Qt.AlignTop | Qt.AlignLeft
                 Layout.preferredWidth: width
                 width: parent.parent.parent.width
                 textFormat: TextEdit.MarkdownText

--- a/meshroom/ui/qml/GraphEditor/NodeDocumentation.qml
+++ b/meshroom/ui/qml/GraphEditor/NodeDocumentation.qml
@@ -38,7 +38,6 @@ FocusScope {
                             id: nodeInfoKey
                             anchors.margins: 2
                             color: Qt.darker(activePalette.window, 1.1)
-                            //Layout.preferredWidth: sizeHandle.x
                             Layout.preferredWidth: nodeDocColumnLayout.keyColumnWidth
                             Layout.minimumWidth: 0.2 * parent.width
                             Layout.maximumWidth: 0.8 * parent.width
@@ -98,7 +97,6 @@ FocusScope {
                 width: parent.width
                 height: childrenRect.height
                 Layout.preferredWidth: width
-                // anchors.fill: parent
                 spacing: 3
                 model: node.nodeInfos
                 delegate: nodeInfoItem
@@ -107,10 +105,10 @@ FocusScope {
             TextEdit {
                 id: documentationText
                 anchors.top: nodeInfoListView.bottom
+                padding: 8
                 topPadding: 15
                 Layout.preferredWidth: width
                 width: parent.parent.parent.width
-                padding: 8
                 textFormat: TextEdit.MarkdownText
                 selectByMouse: true
                 selectionColor: activePalette.highlight

--- a/meshroom/ui/qml/GraphEditor/NodeDocumentation.qml
+++ b/meshroom/ui/qml/GraphEditor/NodeDocumentation.qml
@@ -22,17 +22,102 @@ FocusScope {
         ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
         clip: true
 
-        TextEdit {
-            width: parent.parent.width
-            height: parent.height
+        ColumnLayout {
+            id: nodeDocColumnLayout
+            property real keyColumnWidth: 10.0 * Qt.application.font.pixelSize
 
-            padding: 8
-            textFormat: TextEdit.MarkdownText
-            selectByMouse: true
-            selectionColor: activePalette.highlight
-            color: activePalette.text
-            text: node ? node.documentation : ""
-            wrapMode: TextEdit.Wrap
+            Component {
+                id: nodeInfoItem
+                Rectangle {
+                    color: activePalette.window
+                    width: parent.width
+                    height: childrenRect.height
+                    RowLayout {
+                        width: parent.width
+                        Rectangle {
+                            id: nodeInfoKey
+                            anchors.margins: 2
+                            color: Qt.darker(activePalette.window, 1.1)
+                            //Layout.preferredWidth: sizeHandle.x
+                            Layout.preferredWidth: nodeDocColumnLayout.keyColumnWidth
+                            Layout.minimumWidth: 0.2 * parent.width
+                            Layout.maximumWidth: 0.8 * parent.width
+                            Layout.fillWidth: false
+                            Layout.fillHeight: true
+                            Label {
+                                text: modelData.key
+                                anchors.fill: parent
+                                anchors.top: parent.top
+                                topPadding: 4
+                                leftPadding: 6
+                                verticalAlignment: TextEdit.AlignTop
+                                elide: Text.ElideRight
+                            }
+                        }
+                        // Drag handle for resizing
+                        Rectangle {
+                            width: 2
+                            Layout.fillHeight: true
+                            color: "transparent"
+                            MouseArea {
+                                anchors.fill: parent
+                                anchors.margins: -2
+                                cursorShape: Qt.SizeHorCursor
+                                drag {
+                                    target: parent
+                                    axis: Drag.XAxis
+                                    threshold: 0
+                                    // Not required
+                                    minimumX: 0.2 * nodeDocColumnLayout.width
+                                    maximumX: 0.8 * nodeDocColumnLayout.width
+                                }
+                                onPositionChanged: (mouse)=> {
+                                    nodeDocColumnLayout.keyColumnWidth = parent.x
+                                }
+                            }
+
+                        }
+                        TextArea {
+                            id: nodeInfoValue
+                            text: modelData.value
+                            anchors.margins: 2
+                            Layout.fillWidth: true
+                            Layout.fillHeight: true
+                            wrapMode: Label.WrapAtWordBoundaryOrAnywhere
+                            textFormat: TextEdit.PlainText
+                            readOnly: true
+                            selectByMouse: true
+                            background: Rectangle { anchors.fill: parent; color: Qt.darker(activePalette.window, 1.05) }
+                        }
+                    }
+                }
+            }
+
+            ListView {
+                id: nodeInfoListView
+                width: parent.width
+                height: childrenRect.height
+                Layout.preferredWidth: width
+                // anchors.fill: parent
+                spacing: 3
+                model: node.nodeInfos
+                delegate: nodeInfoItem
+            }
+
+            TextEdit {
+                id: documentationText
+                anchors.top: nodeInfoListView.bottom
+                topPadding: 15
+                Layout.preferredWidth: width
+                width: parent.parent.parent.width
+                padding: 8
+                textFormat: TextEdit.MarkdownText
+                selectByMouse: true
+                selectionColor: activePalette.highlight
+                color: activePalette.text
+                text: node ? node.documentation : ""
+                wrapMode: TextEdit.Wrap
+            }
         }
     }
 }

--- a/meshroom/ui/qml/GraphEditor/NodeDocumentation.qml
+++ b/meshroom/ui/qml/GraphEditor/NodeDocumentation.qml
@@ -45,6 +45,7 @@ FocusScope {
                             Layout.fillHeight: true
                             Label {
                                 text: modelData.key
+                                font.capitalization: Font.Capitalize
                                 anchors.fill: parent
                                 anchors.top: parent.top
                                 topPadding: 4

--- a/tests/plugins/meshroom/pluginC/PluginCNodeA.py
+++ b/tests/plugins/meshroom/pluginC/PluginCNodeA.py
@@ -1,0 +1,28 @@
+__version__ = "1.0"
+__license__ = "no-license"
+
+from meshroom.core import desc
+
+
+class PluginCNodeA(desc.Node):
+    """PluginCNodeA"""
+    
+    author = "testAuthor"
+    
+    inputs = [
+        desc.File(
+            name="input",
+            label="Input",
+            description="",
+            value="",
+        ),
+    ]
+
+    outputs = [
+        desc.File(
+            name="output",
+            label="Output",
+            description="",
+            value="",
+        ),
+    ]

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python
+# coding:utf-8
+
+import os
+from pathlib import Path
+
+from meshroom.core import pluginManager, loadClassesNodes
+from meshroom.core.plugins import Plugin
+from meshroom.core import pluginManager
+from meshroom.core import pluginManager
+from meshroom.core.graph import Graph
+
+from .utils import registerNodeDesc
+
+
+class TestNodeInfos:
+    plugin = None
+
+    @classmethod
+    def setup_class(cls):
+        cls.folder = os.path.join(os.path.dirname(__file__), "plugins", "meshroom")
+        package = "pluginC"
+        cls.plugin = Plugin(package, cls.folder)
+        nodes = loadClassesNodes(cls.folder, package)
+        for node in nodes:
+            cls.plugin.addNodePlugin(node)
+        pluginManager.addPlugin(cls.plugin)
+
+    @classmethod
+    def teardown_class(cls):
+        for node in cls.plugin.nodes.values():
+            pluginManager.unregisterNode(node)
+        cls.plugin = None
+
+    def test_loadedPlugin(self):
+        assert len(pluginManager.getPlugins()) >= 1
+        plugin = pluginManager.getPlugin("pluginC")
+        assert plugin == self.plugin
+        node = plugin.nodes["PluginCNodeA"]
+        nodeType = node.nodeDescriptor
+        
+        g = Graph("")
+        registerNodeDesc(nodeType)
+        node = g.addNewNode(nodeType.__name__)
+        
+        nodeDocumentation = node.getDocumentation()
+        assert nodeDocumentation == "PluginCNodeA"
+        nodeInfos = {item["key"]: item["value"] for item in node.getNodeInfos()}
+        assert nodeInfos["module"] == "pluginC.PluginCNodeA"
+        plugin_path = os.path.join(self.folder, "pluginC", "PluginCNodeA.py")
+        assert nodeInfos["modulePath"] == Path(plugin_path).as_posix()  # modulePath seems to follow linux convention
+        assert nodeInfos["author"] == "testAuthor"
+        assert nodeInfos["license"] == "no-license"
+        assert nodeInfos["version"] == "1.0"


### PR DESCRIPTION
## Description

This PR adds additional information on the Documentation tab of nodes. 
Here are examples :
```py
import os
from meshroom.core import desc

__version__ = "1.0"
__author__ = "moduleauthor"
__license__ = "MIT"

class TestCLNode(desc.CommandLineNode):
    category = 'TestPlugin'
    commandLine = 'command'
    
    documentation = """# TestCLNode
## Node info
here are info on the node

## How to use it
Here are more info
1. First step
2. Second step
"""
```
<img width="945" height="383" alt="image" src="https://github.com/user-attachments/assets/ff331b80-399b-4f89-b6d4-c92907409c37" />

Also we can override parameters at the node level :
- "author" and "version" can be directly overrided
- It is possible to put any additional information in a `__nodeInfo__` list
```py
class TestCLNode2(desc.CommandLineNode):
    """# TestCLNode

## Node info
here are info on the node

## How to use it
Here are more info
1. First step
2. Second step
"""

    category = 'TestPlugin'
    author = "Alice"
    version = "2.0.0"
    __nodeInfo__ = [
        ("model link", "https://huggingface.co/alicevision/great-model")
    ]
```
<img width="945" height="383" alt="image" src="https://github.com/user-attachments/assets/5e5cbb93-43b7-4b5a-960c-2226360ae2a7" />

Finally I also added the possibility to read the documentation from the class `__doc__` parameterr
