### PR TITLE
[release] Update version to "2025.2.0" and status to "develop"

### DIFF
--- a/meshroom/__init__.py
+++ b/meshroom/__init__.py
@@ -10,7 +10,7 @@ class VersionStatus(Enum):
     develop = 2
 
 
-__version__ = "2025.1.0"
+__version__ = "2025.2.0"
 # Always increase the minor version when switching from release to develop.
 __version_status__ = VersionStatus.develop
 


### PR DESCRIPTION
Following the release of Meshroom 2025.1.0, this PR sets the current version to 2025.2.0 with the "develop" status.