### PR TITLE
[core] Support graph names with spaces

### DIFF
--- a/meshroom/core/desc/node.py
+++ b/meshroom/core/desc/node.py
@@ -260,7 +260,7 @@ class Node(BaseNode):
         return MrNodeType.NODE
 
     def processChunkInEnvironment(self, chunk):
-        meshroomComputeCmd = f"{_MESHROOM_COMPUTE_EXE} {chunk.node.graph.filepath} --node {chunk.node.name} --extern --inCurrentEnv"
+        meshroomComputeCmd = f"{_MESHROOM_COMPUTE_EXE} \"{chunk.node.graph.filepath}\" --node {chunk.node.name} --extern --inCurrentEnv"
 
         if len(chunk.node.getChunks()) > 1:
             meshroomComputeCmd += f" --iteration {chunk.range.iteration}"


### PR DESCRIPTION
<!-- Checklist before submission:

 - I have read the [contribution guidelines](../CONTRIBUTING.md).
 - I have updated the documentation, if applicable.
 - I have ensured that the change is tested somewhere.
 - I have followed the prevailing code style (for history readability and limit conflicts for maintainance).

-->
## Description
This PR is a bugfix to support graph names with spaces when computing a meshroom graph containing some plugins. Plugin computation is launched using meshroom_compute and double quote are needed around the graph name parameter.

cf issue: https://github.com/alicevision/Meshroom/issues/2808


## Features list

<!--
- [ ] Feature one. Fix #XXX
- [ ] Improve something else
- [ ] Connect to #3 (to declare link to issues without closing it when the PR is merged).
- [X] Add "X" when it is done.
-->


## Implementation remarks


<!--
Explain main implementation choices.
It is also the right place to ask for feedback and help when you hesitate on the implementation.
-->
