### PR TITLE
[release] Start Development 2026.1.0

### DIFF
--- a/meshroom/__init__.py
+++ b/meshroom/__init__.py
@@ -10,9 +10,9 @@ class VersionStatus(Enum):
     develop = 2
 
 
-__version__ = "2025.1.0"
+__version__ = "2026.1.0"
 # Always increase the minor version when switching from release to develop.
-__version_status__ = VersionStatus.release
+__version_status__ = VersionStatus.develop
 
 if __version_status__ is VersionStatus.develop:
     __version__ += "-" + __version_status__.name


### PR DESCRIPTION
Following the release of Meshroom 2025.1.0, this PR sets the current version to 2026.1.0 with the "develop" status.