### PR TITLE
[ui] WorkspaceView: Remove `Load Model` button from Viewer3D

### DIFF
--- a/meshroom/ui/qml/WorkspaceView.qml
+++ b/meshroom/ui/qml/WorkspaceView.qml
@@ -233,20 +233,6 @@ Item {
                                 Viewer3DSettings.syncWithPickedViewId = viewer2D.sync3DSelected
                             }
                         }
-                        
-                        // Load reconstructed model
-                        Button {
-                            readonly property var outputAttribute: _reconstruction && _reconstruction.texturing ? _reconstruction.texturing.attribute("outputMesh") : null
-                            readonly property bool outputReady: outputAttribute && _reconstruction.texturing.globalStatus === "SUCCESS"
-                            readonly property int outputMediaIndex: c_viewer3D.library.find(outputAttribute)
-
-                            text: "Load Model"
-                            anchors.bottom: parent.bottom
-                            anchors.bottomMargin: 10
-                            anchors.horizontalCenter: parent.horizontalCenter
-                            visible: outputReady && outputMediaIndex == -1
-                            onClicked: viewer3D.view(_reconstruction.texturing.attribute("outputMesh"))
-                        }
                     }
                     
                     // Inspector Panel


### PR DESCRIPTION
## Description

This PR removes the "Load Model" button that exists in the code for the 3D Viewer. It isn't used anymore, and has moreover faulty visibility conditions. It should thus be removed entirely.

Fixes https://github.com/alicevision/Meshroom/issues/1126.
