### PR TITLE
[core] Setup logger to be able to use logging in plugins

### DIFF
--- a/bin/meshroom_batch
+++ b/bin/meshroom_batch
@@ -8,7 +8,7 @@ import re
 import sys
 
 import meshroom.core.graph
-from meshroom import setupEnvironment
+from meshroom import setupEnvironment, logStringToPython
 
 setupEnvironment()
 
@@ -135,14 +135,6 @@ advanced_group.add_argument(
 
 args = parser.parse_args()
 
-logStringToPython = {
-    'fatal': logging.FATAL,
-    'error': logging.ERROR,
-    'warning': logging.WARNING,
-    'info': logging.INFO,
-    'debug': logging.DEBUG,
-    'trace': logging.DEBUG,
-}
 logging.getLogger().setLevel(logStringToPython[args.verbose])
 
 if not args.input and not args.inputRecursive:

--- a/bin/meshroom_compute
+++ b/bin/meshroom_compute
@@ -95,6 +95,7 @@ if args.node:
         # Restore the log level
         logging.getLogger().setLevel(meshroom.logStringToPython[args.verbose])
 
+    node.prepareLogger(args.iteration)
     node.preprocess()
     if args.iteration != -1:
         chunk = node.chunks[args.iteration]
@@ -102,6 +103,7 @@ if args.node:
     else:
         node.process(args.forceCompute, args.inCurrentEnv)
     node.postprocess()
+    node.restoreLogger()
 else:
     if args.iteration != -1:
         print('Error: "--iteration" only make sense when used with "--node".')

--- a/meshroom/__init__.py
+++ b/meshroom/__init__.py
@@ -48,13 +48,32 @@ isFrozen = getattr(sys, "frozen", False)
 
 useMultiChunks = util.strtobool(os.environ.get("MESHROOM_USE_MULTI_CHUNKS", "True"))
 
+# Logging
+
+def addTraceLevel():
+    """ From https://stackoverflow.com/a/35804945 """
+    levelName, methodName, levelNum = 'TRACE', 'trace', logging.DEBUG - 5
+    if hasattr(logging, levelName) or hasattr(logging, methodName)or hasattr(logging.getLoggerClass(), methodName):
+       return
+    def logForLevel(self, message, *args, **kwargs):
+        if self.isEnabledFor(levelNum):
+            self._log(levelNum, message, args, **kwargs)
+    def logToRoot(message, *args, **kwargs):
+        logging.log(levelNum, message, *args, **kwargs)
+
+    logging.addLevelName(levelNum, levelName)
+    setattr(logging, levelName, levelNum)
+    setattr(logging.getLoggerClass(), methodName, logForLevel)
+    setattr(logging, methodName, logToRoot)
+
+addTraceLevel()
 logStringToPython = {
-    'fatal': logging.FATAL,
+    'fatal': logging.CRITICAL,
     'error': logging.ERROR,
     'warning': logging.WARNING,
     'info': logging.INFO,
     'debug': logging.DEBUG,
-    'trace': logging.DEBUG,
+    'trace': logging.TRACE,
 }
 logging.getLogger().setLevel(logStringToPython[os.environ.get('MESHROOM_VERBOSE', 'warning')])
 

--- a/meshroom/core/desc/node.py
+++ b/meshroom/core/desc/node.py
@@ -13,6 +13,7 @@ from .attribute import StringParam, ColorParam, ChoiceParam
 
 import meshroom
 from meshroom.core import cgroup
+from meshroom.core.utils import VERBOSE_LEVEL
 
 _MESHROOM_ROOT = Path(meshroom.__file__).parent.parent.as_posix()
 _MESHROOM_COMPUTE = (Path(_MESHROOM_ROOT) / "bin" / "meshroom_compute").as_posix()
@@ -68,11 +69,11 @@ class BaseNode(object):
             invalidate=False,
         ),
         ChoiceParam(
-            name='nodeDefaultLogLevel',
-            label='Default logging level',
-            description='''Default logging level for the node (critical, error, warning, info, debug).''',
-            value='info',
-            values=['critical', 'error', 'warning', 'info', 'debug', 'trace'],
+            name="nodeDefaultLogLevel",
+            label="Default Logging Level",
+            description="Default logging level for the node (critical, error, warning, info, debug).",
+            value="info",
+            values=VERBOSE_LEVEL,
             invalidate=False,
         ),
         ColorParam(

--- a/meshroom/core/desc/node.py
+++ b/meshroom/core/desc/node.py
@@ -9,7 +9,7 @@ import shutil
 import sys
 
 from .computation import Level, StaticNodeSize
-from .attribute import StringParam, ColorParam
+from .attribute import StringParam, ColorParam, ChoiceParam
 
 import meshroom
 from meshroom.core import cgroup
@@ -65,6 +65,14 @@ class BaseNode(object):
             description="Customize the default label (to replace the technical name of the node "
                         "instance).",
             value="",
+            invalidate=False,
+        ),
+        ChoiceParam(
+            name='nodeDefaultLogLevel',
+            label='Default logging level',
+            description='''Default logging level for the node (critical, error, warning, info, debug).''',
+            value='info',
+            values=['critical', 'error', 'warning', 'info', 'debug', 'trace'],
             invalidate=False,
         ),
         ColorParam(

--- a/meshroom/core/node.py
+++ b/meshroom/core/node.py
@@ -14,14 +14,14 @@ import types
 import uuid
 from collections import namedtuple, OrderedDict
 from enum import Enum, auto
-from typing import Callable, Optional
-
+from typing import Callable, Optional, List
 
 import meshroom
 from meshroom.common import Signal, Variant, Property, BaseObject, Slot, ListModel, DictModel
 from meshroom.core import desc, plugins, stats, hashValue, nodeVersion, Version, MrNodeType
 from meshroom.core.attribute import attributeFactory, ListAttribute, GroupAttribute, Attribute
 from meshroom.core.exception import NodeUpgradeError, UnknownNodeTypeError
+from meshroom.core.mtyping import PathLike
 
 
 def getWritingFilepath(filepath: str) -> str:
@@ -222,17 +222,17 @@ class LogManager:
     dateTimeFormatting = '%H:%M:%S'
 
     def __init__(self, logger, logFile):
-        self.logger = logger
-        self.logFile = logFile
-        self._previousHandlers = []
-        self._previousLevel = 0
-    
+        self.logger: logging.Logger = logger
+        self.logFile: PathLike = logFile
+        self._previousHandlers: List[logging.Handler] = []
+        self._previousLevel: int = 0
+
     class Formatter(logging.Formatter):
         def format(self, record):
             # Make level name lower case
             record.levelname = record.levelname.lower()
             return logging.Formatter.format(self, record)
-    
+
     def configureLogger(self):
         self._previousLevel = self.logger.level
         self._previousHandlers = []
@@ -244,7 +244,7 @@ class LogManager:
                                    self.dateTimeFormatting)
         handler.setFormatter(formatter)
         self.logger.addHandler(handler)
-    
+
     def restorePreviousLogger(self):
         for h in self.logger.handlers[:]:
             self.logger.removeHandler(h)
@@ -683,7 +683,7 @@ class BaseNode(BaseObject):
         self._uid: str = uid
         self._cmdVars: dict = {}
         self._size: int = 0
-        self._logManager: LogManager = None
+        self._logManager: Optional[LogManager] = None
         self._position: Position = position or Position()
         self._attributes = DictModel(keyAttrName='name', parent=self)
         self._internalAttributes = DictModel(keyAttrName='name', parent=self)

--- a/meshroom/core/node.py
+++ b/meshroom/core/node.py
@@ -221,30 +221,42 @@ class StatusData(BaseObject):
 class LogManager:
     dateTimeFormatting = '%H:%M:%S'
 
-    def __init__(self, chunk):
-        self.chunk = chunk
-        self.logger = logging.getLogger(chunk.node.getName())
-
+    def __init__(self, logger, logFile):
+        self.logger = logger
+        self.logFile = logFile
+        self._previousHandlers = []
+        self._previousLevel = 0
+    
     class Formatter(logging.Formatter):
         def format(self, record):
             # Make level name lower case
             record.levelname = record.levelname.lower()
             return logging.Formatter.format(self, record)
-
+    
     def configureLogger(self):
+        self._previousLevel = self.logger.level
+        self._previousHandlers = []
         for handler in self.logger.handlers[:]:
+            self._previousHandlers.append(handler)
             self.logger.removeHandler(handler)
-        handler = logging.FileHandler(self.chunk.logFile)
+        handler = logging.FileHandler(self.logFile)
         formatter = self.Formatter('[%(asctime)s.%(msecs)03d][%(levelname)s] %(message)s',
                                    self.dateTimeFormatting)
         handler.setFormatter(formatter)
         self.logger.addHandler(handler)
+    
+    def restorePreviousLogger(self):
+        for h in self.logger.handlers[:]:
+            self.logger.removeHandler(h)
+        for h in self._previousHandlers:
+            self.logger.addHandler(h)
+        self.logger.setLevel(self._previousLevel)
 
     def start(self, level):
         # Clear log file
-        open(self.chunk.logFile, 'w').close()
-
+        open(self.logFile, 'w').close()
         self.configureLogger()
+        self.logger.propagate = False
         self.logger.setLevel(self.textToLevel(level))
         self.progressBar = False
 
@@ -261,7 +273,7 @@ class LogManager:
         self.currentProgressTics = 0
         self.progressBar = True
 
-        with open(self.chunk.logFile, 'a') as f:
+        with open(self.logFile, 'a') as f:
             if message:
                 f.write(message+'\n')
             f.write('0%   10   20   30   40   50   60   70   80   90   100%\n')
@@ -269,7 +281,7 @@ class LogManager:
 
             f.close()
 
-        with open(self.chunk.logFile) as f:
+        with open(self.logFile) as f:
             content = f.read()
             self.progressBarPosition = content.rfind('\n')
 
@@ -281,7 +293,7 @@ class LogManager:
 
         tics = round((value/self.progressEnd)*51)
 
-        with open(self.chunk.logFile, 'r+') as f:
+        with open(self.logFile, 'r+') as f:
             text = f.read()
             for i in range(tics-self.currentProgressTics):
                 text = text[:self.progressBarPosition]+'*'+text[self.progressBarPosition:]
@@ -296,7 +308,8 @@ class LogManager:
 
         self.progressBar = False
 
-    def textToLevel(self, text):
+    @staticmethod
+    def textToLevel(text):
         if text == "critical":
             return logging.CRITICAL
         elif text == "error":
@@ -325,7 +338,7 @@ class NodeChunk(BaseObject):
         super().__init__(parent)
         self.node = node
         self.range = range
-        self.logManager: LogManager = LogManager(self)
+        self._logManager = None
         self._status: StatusData = StatusData(node.name, node.nodeType, node.packageName,
                                               node.packageVersion, node.getMrNodeType())
         self.statistics: stats.Statistics = stats.Statistics()
@@ -344,6 +357,13 @@ class NodeChunk(BaseObject):
             return f"{self.node.name}({self.index})"
         else:
             return self.node.name
+    
+    @property
+    def logManager(self):
+        if self._logManager is None:
+            logger = logging.getLogger(self.node.getName())
+            self._logManager = LogManager(logger, self.logFile)
+        return self._logManager
 
     @property
     def statusName(self):
@@ -660,6 +680,7 @@ class BaseNode(BaseObject):
         self._uid: str = uid
         self._cmdVars: dict = {}
         self._size: int = 0
+        self._logManager: LogManager = None
         self._position: Position = position or Position()
         self._attributes = DictModel(keyAttrName='name', parent=self)
         self._internalAttributes = DictModel(keyAttrName='name', parent=self)
@@ -1311,6 +1332,25 @@ class BaseNode(BaseObject):
         # Invoke the post process on Client Node to execute after the processing on the
         # node is completed
         self.nodeDesc.postprocess(self)
+
+    def getLogHandlers(self):
+        return self._handlers
+
+    def prepareLogger(self, iteration=-1):
+        # Get file handler path
+        logFileName = "log"
+        if iteration != -1:
+            chunk = self.chunks[iteration]
+            logFileName = str(chunk.index) + ".log"
+        logFile = os.path.join(self.graph.cacheDir, self.internalFolder, logFileName)
+        # Setup logger
+        rootLogger = logging.getLogger()
+        self._logManager = LogManager(rootLogger, logFile)
+        self._logManager.configureLogger()
+        rootLogger.setLevel(logging.INFO)  # Set info by default
+
+    def restoreLogger(self):
+        self._logManager.restorePreviousLogger()
 
     def updateOutputAttr(self):
         if not self.nodeDesc:

--- a/meshroom/core/node.py
+++ b/meshroom/core/node.py
@@ -310,7 +310,8 @@ class LogManager:
 
     @staticmethod
     def textToLevel(text):
-        if text == "critical":
+        text = text.lower()
+        if text in ["critical", "fatal"]:
             return logging.CRITICAL
         elif text == "error":
             return logging.ERROR
@@ -320,6 +321,8 @@ class LogManager:
             return logging.INFO
         elif text == "debug":
             return logging.DEBUG
+        elif text == "trace":
+            return logging.TRACE
         else:
             return logging.NOTSET
 
@@ -726,6 +729,15 @@ class BaseNode(BaseObject):
                 return label
         return self.getDefaultLabel()
 
+    def getNodeLogLevel(self):
+        """
+        Returns:
+            str: the user-provided log level used for logging on process launched by this node
+        """
+        if self.hasInternalAttribute("nodeDefaultLogLevel"):
+            return self.internalAttribute("nodeDefaultLogLevel").value.strip()
+        return "info"
+    
     def getColor(self):
         """
         Returns:
@@ -1346,8 +1358,7 @@ class BaseNode(BaseObject):
         # Setup logger
         rootLogger = logging.getLogger()
         self._logManager = LogManager(rootLogger, logFile)
-        self._logManager.configureLogger()
-        rootLogger.setLevel(logging.INFO)  # Set info by default
+        self._logManager.start(self.getNodeLogLevel())
 
     def restoreLogger(self):
         self._logManager.restorePreviousLogger()

--- a/meshroom/core/nodeFactory.py
+++ b/meshroom/core/nodeFactory.py
@@ -174,13 +174,15 @@ class _NodeCreator:
 
     def _createNode(self) -> Node:
         logging.info(f"Creating node '{self.name}'")
-        # TODO: user inputs/outputs may conflicts with internal names (like position, uid)
+        # TODO: user inputs/outputs may conflicts with internal names (like logLevel, position, uid)
+        # The line below can cause UI issues but at least prevent crashes
+        internalInputs = {k: v for k, v in self.internalInputs.items() if k not in self.inputs.keys()}
         return Node(
             self.nodeType,
             position=self.position,
             uid=self.uid,
             **self.inputs,
-            **self.internalInputs,
+            **internalInputs,
             **self.outputs,
         )
 

--- a/tests/test_compute.py
+++ b/tests/test_compute.py
@@ -1,0 +1,120 @@
+# coding:utf-8
+
+"""
+In this test we test the code that is usually launched directly from the meshroom_compute script
+
+TODO : Directly test by launching the executable
+- We can get the path with `desc.node._MESHROOM_COMPUTE_EXE`
+- However this is not implemented yet because it requires to create a plugin that meshroom could discover
+  and I didn't want to create a plugin just for what I'm doing here right now (which is testing the logger)
+"""
+
+import os
+import re
+from pathlib import Path
+import logging
+
+from meshroom.core.graph import Graph
+from meshroom.core import desc
+from .utils import registerNodeDesc, unregisterNodeDesc
+
+LOGGER = logging.getLogger("TestCompute")
+
+
+def executeChunks(node, tmpPath, size):
+    nodeCache = os.path.join(tmpPath, node.internalFolder)
+    os.makedirs(nodeCache)
+    logFiles = {}
+    for chunkIndex in range(size):
+        iteration = chunkIndex if size > 1 else -1
+        logFileName = "log"
+        if size > 1:
+            logFileName = f"{chunkIndex}.log"
+        logFile = Path(nodeCache) / logFileName
+        logFiles[chunkIndex] = logFile
+        logFile.touch()
+        node.prepareLogger(iteration) 
+        node.preprocess()
+        if size > 1:
+            chunk = node.chunks[chunkIndex]
+            chunk.process(True, True)
+        else:
+            node.process(True, True)
+        node.postprocess()
+        node.restoreLogger()
+    return logFiles
+
+
+class TestNodeA(desc.BaseNode):
+    __test__ = False
+    
+    size = desc.StaticNodeSize(2)
+    parallelization = desc.Parallelization(blockSize=1)
+
+    inputs = [
+        desc.IntParam(
+            name="input",
+            label="Input",
+            description="input",
+            value=0,
+        ),
+    ]
+    outputs = [
+        desc.IntParam(
+            name="output",
+            label="Output",
+            description="Output",
+            value=None,
+        ),
+    ]
+
+    def processChunk(self, chunk):
+        chunk.logManager.start("info")
+        chunk.logger.info("> Message A")
+        LOGGER.info(f"> Message B")
+        chunk.logManager.end()
+
+
+class TestNodeB(TestNodeA):
+    size = desc.StaticNodeSize(1)
+    parallelization = None
+
+
+class TestNodeLogger:
+    
+    reA = re.compile(r"\[\d{2}:\d{2}:\d{2}\.\d{3}\]\[info\] > Message A")
+    reB = re.compile(r"\[\d{2}:\d{2}:\d{2}\.\d{3}\]\[info\] > Message B")
+
+    @classmethod
+    def setup_class(cls):
+        registerNodeDesc(TestNodeA)
+        registerNodeDesc(TestNodeB)
+
+    @classmethod
+    def teardown_class(cls):
+        unregisterNodeDesc(TestNodeA)
+        unregisterNodeDesc(TestNodeB)
+
+    def test_nodeWithChunks(self, tmp_path):
+        graph = Graph("")
+        graph._cacheDir = tmp_path
+        node = graph.addNewNode(TestNodeA.__name__)
+        # Compute
+        logFiles = executeChunks(node, tmp_path, 2)
+        for chunkId, logFile in logFiles.items():
+            with open(logFile, "r") as f:
+                content = f.read()
+                assert len(self.reA.findall(content)) == 1
+                assert len(self.reB.findall(content)) == 1
+    
+    def test_nodeWithoutChunks(self, tmp_path):
+        graph = Graph("")
+        graph._cacheDir = tmp_path
+        node = graph.addNewNode(TestNodeB.__name__)
+        # Compute
+        logFiles = executeChunks(node, tmp_path, 1)
+        for _, logFile in logFiles.items():
+            with open(logFile, "r") as f:
+                content = f.read()
+                assert len(self.reA.findall(content)) == 1
+                assert len(self.reB.findall(content)) == 1

--- a/tests/test_compute.py
+++ b/tests/test_compute.py
@@ -3,10 +3,7 @@
 """
 In this test we test the code that is usually launched directly from the meshroom_compute script
 
-TODO : Directly test by launching the executable
-- We can get the path with `desc.node._MESHROOM_COMPUTE_EXE`
-- However this is not implemented yet because it requires to create a plugin that meshroom could discover
-  and I didn't want to create a plugin just for what I'm doing here right now (which is testing the logger)
+TODO : We could directly test by launching the executable (`desc.node._MESHROOM_COMPUTE_EXE`)
 """
 
 import os


### PR DESCRIPTION

## Description

- Adding `prepareLogger` and `restoreLogger` on the node, that can be used to setup and restore the root logger
- Update the `LogManager` to handle more than only the chunks
- Add trace log level to logging with an inferior level than debug (debug is 10 by default so trace would be 5 with this PR)
- Add new internal input "logLevel" to setup default logging level for the node



## Now here's how we can use it

1. Using `chunk.logger` (previous way)
```py
class TestNode(desc.Node):
    def processChunk(self, chunk):
        chunk.logManager.start(chunk.node.verboseLevel.value)
        chunk.logger.info   (f"Message with info    level ({chunk.logger})")
        chunk.logger.warning(f"Message with warning level ({chunk.logger})")
        chunk.logger.error  (f"Message with error   level ({chunk.logger})")
        chunk.logManager.end()
```
<img width="609" height="78" alt="image" src="https://github.com/user-attachments/assets/46ada86b-8eff-41be-aa1e-06a859bad8a0" />

2. Using `logging`
```py
import logging
logger = logging.getLogger("TestNode2")

def print_info():
    logger.info   (f"Message with info    level ({logger})")
    logger.warning(f"Message with warning level ({logger})")
    logger.error  (f"Message with error   level ({logger})")

class TestNode2(desc.Node):
    def processChunk(self, chunk):
        logger.setLevel(chunk.node.verboseLevel.value.upper())
        print_info()
```
<img width="606" height="73" alt="image" src="https://github.com/user-attachments/assets/7a27b9c4-441e-4e86-887a-bf53b1d2ad55" />


