### PR TITLE
[desc] Add node process function to use on single-chunk nodes

### DIFF
--- a/meshroom/core/desc/node.py
+++ b/meshroom/core/desc/node.py
@@ -148,8 +148,14 @@ class BaseNode(object):
         """
         pass
 
+    def process(self, node):
+        raise NotImplementedError(f'No process implementation on node: "{node.name}"')
+    
     def processChunk(self, chunk):
-        raise NotImplementedError(f'No processChunk implementation on node: "{chunk.node.name}"')
+        if self.parallelization is None:
+            self.process(chunk.node)
+        else:
+            raise NotImplementedError(f'No process implementation on node: "{chunk.node.name}"')
 
     def executeChunkCommandLine(self, chunk, cmd, env=None):
         try:

--- a/tests/test_compute.py
+++ b/tests/test_compute.py
@@ -42,76 +42,114 @@ def executeChunks(node, tmpPath, size):
     return logFiles
 
 
+_INPUTS = [
+    desc.IntParam(
+        name="input",
+        label="Input",
+        description="input",
+        value=0,
+    ),
+]
+_OUTPUTS = [
+    desc.IntParam(
+        name="output",
+        label="Output",
+        description="Output",
+        value=None,
+    ),
+]
+
 class TestNodeA(desc.BaseNode):
+    """
+    Test process with chunks
+    """
     __test__ = False
-    
+    _size = 2
     size = desc.StaticNodeSize(2)
     parallelization = desc.Parallelization(blockSize=1)
-
-    inputs = [
-        desc.IntParam(
-            name="input",
-            label="Input",
-            description="input",
-            value=0,
-        ),
-    ]
-    outputs = [
-        desc.IntParam(
-            name="output",
-            label="Output",
-            description="Output",
-            value=None,
-        ),
-    ]
+    inputs = _INPUTS
+    outputs = _OUTPUTS
 
     def processChunk(self, chunk):
         chunk.logManager.start("info")
-        chunk.logger.info("> Message A")
-        LOGGER.info(f"> Message B")
+        iteration = chunk.range.iteration
+        nbBlocks = chunk.range.nbBlocks
+        chunk.logger.info(f"> (chunk.logger) {chunk.node.name}")
+        LOGGER.info(f"> (root logger) {iteration}/{nbBlocks}")
         chunk.logManager.end()
 
 
 class TestNodeB(TestNodeA):
+    """
+    Test process with 1 chunk but still implementing processChunk
+    """
+    __test__ = False
+    _size = 1
     size = desc.StaticNodeSize(1)
     parallelization = None
 
 
+class TestNodeC(desc.BaseNode):
+    """
+    Test process without chunks and without processChunk
+    """
+    __test__ = False
+    size = desc.StaticNodeSize(1)
+    parallelization = None
+    inputs = _INPUTS
+    outputs = _OUTPUTS
+
+    def process(self, node):
+        LOGGER.info(f"> {node.name}")
+
+
 class TestNodeLogger:
     
-    reA = re.compile(r"\[\d{2}:\d{2}:\d{2}\.\d{3}\]\[info\] > Message A")
-    reB = re.compile(r"\[\d{2}:\d{2}:\d{2}\.\d{3}\]\[info\] > Message B")
-
+    logPrefix = r"\[\d{2}:\d{2}:\d{2}\.\d{3}\]\[info\] > "
+    
     @classmethod
     def setup_class(cls):
         registerNodeDesc(TestNodeA)
         registerNodeDesc(TestNodeB)
+        registerNodeDesc(TestNodeC)
 
     @classmethod
     def teardown_class(cls):
         unregisterNodeDesc(TestNodeA)
         unregisterNodeDesc(TestNodeB)
-
-    def test_nodeWithChunks(self, tmp_path):
+        unregisterNodeDesc(TestNodeC)
+    
+    def test_processChunks(self, tmp_path):
         graph = Graph("")
         graph._cacheDir = tmp_path
-        node = graph.addNewNode(TestNodeA.__name__)
-        # Compute
-        logFiles = executeChunks(node, tmp_path, 2)
-        for chunkId, logFile in logFiles.items():
+        # TestNodeA : multiple chunks
+        nodeA = graph.addNewNode(TestNodeA.__name__)
+        logFiles = executeChunks(nodeA, tmp_path, 2)
+        for chunkIndex, logFile in logFiles.items():
             with open(logFile, "r") as f:
                 content = f.read()
-                assert len(self.reA.findall(content)) == 1
-                assert len(self.reB.findall(content)) == 1
+                reg = re.compile(self.logPrefix + r"\(chunk.logger\) TestNodeA_1")
+                assert len(reg.findall(content)) == 1
+                reg = re.compile(self.logPrefix + r"\(root logger\) " + f"{chunkIndex}/2")
+                assert len(reg.findall(content)) == 1
+        # TestNodeA : single chunk
+        nodeB = graph.addNewNode(TestNodeB.__name__)
+        logFiles = executeChunks(nodeB, tmp_path, 1)
+        for chunkIndex, logFile in logFiles.items():
+            with open(logFile, "r") as f:
+                content = f.read()
+                reg = re.compile(self.logPrefix + r"\(chunk.logger\) TestNodeB_1")
+                assert len(reg.findall(content)) == 1
+                reg = re.compile(self.logPrefix + r"\(root logger\) 0/0")
+                assert len(reg.findall(content)) == 1
     
-    def test_nodeWithoutChunks(self, tmp_path):
+    def test_process(self, tmp_path):
         graph = Graph("")
         graph._cacheDir = tmp_path
-        node = graph.addNewNode(TestNodeB.__name__)
-        # Compute
+        node = graph.addNewNode(TestNodeC.__name__)
         logFiles = executeChunks(node, tmp_path, 1)
         for _, logFile in logFiles.items():
             with open(logFile, "r") as f:
                 content = f.read()
-                assert len(self.reA.findall(content)) == 1
-                assert len(self.reB.findall(content)) == 1
+                reg = re.compile(self.logPrefix + "TestNodeC_1")
+                assert len(reg.findall(content)) == 1


### PR DESCRIPTION
> [!WARNING]
> It would be better to merge this PR after #2845 because the logger is not available in `process` for now (as it's provided by `chunk`). This PR mentioned fixes this by setuping `logging` so that we can use it directly

## Description

- Add a `process` function
- If there is no parallelization, then if `processChunk` has not been overrided, then `process` will be called

## Examples
Because we don't have access to the chunk we can't use `chunk.logger`
```py
import logging
logger = logging.getLogger("TestNode2")

def print_info():
    logger.info(f"Message with info    level ({logger})")
    logger.warning(f"Message with warning level ({logger})")
    logger.error(f"Message with error   level ({logger})")

class TestNode3(desc.Node):    
    inputs = [
        desc.ChoiceParam(
            name='verboseLevel',
            label='Verbose Level',
            description='''verbosity level (fatal, error, warning, info, debug, trace).''',
            value='info',
            values=['fatal', 'error', 'warning', 'info', 'debug', 'trace'],
            exclusive=True,
        ),
    ]

    outputs = [
        desc.File(
            name='outputFolder',
            label='outputFolder',
            description='outputFolder',
            value="{nodeCacheFolder}",
        ),
    ]

    def process(self, node):
        logger.setLevel(node.verboseLevel.value.upper())
        logger.info(f"> verboseLevel : {node.verboseLevel.value}")
        logger.info(f"> outputFolder : {node.outputFolder.value}")
        print_info()

```
<img width="949" height="126" alt="image" src="https://github.com/user-attachments/assets/4fa59ec0-48a0-41d5-85b3-a2a64de39572" />

However, after #2845 this won't be an issue because we could use logging normally :
<img width="949" height="126" alt="image" src="https://github.com/user-attachments/assets/6c456f90-e4b1-45ac-a043-aa93c9a013cc" />
