### PR TITLE
[core] desc.node: Support the use of custom Python executables for `meshroom_compute`

### DIFF
--- a/meshroom/core/desc/node.py
+++ b/meshroom/core/desc/node.py
@@ -263,6 +263,7 @@ class InputNode(BaseNode):
 
 
 class Node(BaseNode):
+    pythonExecutable = "python"
 
     def __init__(self):
         super(Node, self).__init__()

--- a/meshroom/core/desc/node.py
+++ b/meshroom/core/desc/node.py
@@ -17,7 +17,6 @@ from meshroom.core.utils import VERBOSE_LEVEL
 
 _MESHROOM_ROOT = Path(meshroom.__file__).parent.parent.as_posix()
 _MESHROOM_COMPUTE = (Path(_MESHROOM_ROOT) / "bin" / "meshroom_compute").as_posix()
-_MESHROOM_COMPUTE_EXE = f"python {_MESHROOM_COMPUTE}"
 
 
 class MrNodeType(enum.Enum):
@@ -272,7 +271,9 @@ class Node(BaseNode):
         return MrNodeType.NODE
 
     def processChunkInEnvironment(self, chunk):
-        meshroomComputeCmd = f"{_MESHROOM_COMPUTE_EXE} \"{chunk.node.graph.filepath}\" --node {chunk.node.name} --extern --inCurrentEnv"
+        meshroomComputeCmd = f"{chunk.node.nodeDesc.pythonExecutable} {_MESHROOM_COMPUTE}" + \
+                             f" \"{chunk.node.graph.filepath}\" --node {chunk.node.name}" + \
+                              " --extern --inCurrentEnv"
 
         if len(chunk.node.getChunks()) > 1:
             meshroomComputeCmd += f" --iteration {chunk.range.iteration}"
@@ -280,7 +281,8 @@ class Node(BaseNode):
         runtimeEnv = chunk.node.nodeDesc.plugin.runtimeEnv
         cmdPrefix = chunk.node.nodeDesc.plugin.commandPrefix
         cmdSuffix = chunk.node.nodeDesc.plugin.commandSuffix
-        self.executeChunkCommandLine(chunk, cmdPrefix + meshroomComputeCmd + cmdSuffix, env=runtimeEnv)
+        self.executeChunkCommandLine(chunk, cmdPrefix + meshroomComputeCmd + cmdSuffix,
+                                     env=runtimeEnv)
 
 
 class CommandLineNode(BaseNode):


### PR DESCRIPTION
## Description

This PR updates how the `meshroom_compute` executable is determined and invoked for each node, allowing for node-specific Python executables instead of using a global default. This provides greater flexibility for nodes that may require different Python environments: for example, in an environment that contains Houdini (which provides its own version of Python), one may want to call "hython" instead "python".

A `pythonExecutable` member, set by default to "python", is added to the `Node` class.

This is based on #2853, which adds the content of the `bin` folder to the packaged version of folder, thus removing the need to distinguish "release mode" from "regular mode".
