### PR TITLE
[build] Package the scripts in `bin` alongside the executables

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,3 +1,5 @@
+# [build] `setup.py`: Use double quotes everywhere
+571de38ef1a9e72e6c1d2a997b60de5bd3caa5bf
 # [bin] `meshroom_batch`: Minor clean-up in the file
 15d9ecd888faa7216cfc5d97d473f5717a3118a3
 # [core] Linting following CI's flake8 report

--- a/meshroom/core/desc/node.py
+++ b/meshroom/core/desc/node.py
@@ -15,12 +15,8 @@ import meshroom
 from meshroom.core import cgroup
 
 _MESHROOM_ROOT = Path(meshroom.__file__).parent.parent.as_posix()
-if getattr(sys, "frozen", False):  # When in release package mode, the path to meshroom_compute differs
-    _MESHROOM_COMPUTE = (Path(_MESHROOM_ROOT).parent / "meshroom_compute").as_posix()
-    _MESHROOM_COMPUTE_EXE = _MESHROOM_COMPUTE
-else:
-    _MESHROOM_COMPUTE = (Path(_MESHROOM_ROOT) / "bin" / "meshroom_compute").as_posix()
-    _MESHROOM_COMPUTE_EXE = f"python {_MESHROOM_COMPUTE}"
+_MESHROOM_COMPUTE = (Path(_MESHROOM_ROOT) / "bin" / "meshroom_compute").as_posix()
+_MESHROOM_COMPUTE_EXE = f"python {_MESHROOM_COMPUTE}"
 
 
 class MrNodeType(enum.Enum):

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ build_exe_options = {
         "cmath",
         "numpy"
     ],
-    "include_files": ["CHANGES.md", "COPYING.md", "LICENSE-MPL2.md", "README.md"]
+    "include_files": ["CHANGES.md", "COPYING.md", "LICENSE-MPL2.md", "README.md", "bin"]
 }
 if os.path.isdir(os.path.join(currentDir, "tractor")):
     build_exe_options["packages"].append("tractor")

--- a/setup.py
+++ b/setup.py
@@ -143,9 +143,9 @@ executables = [
 setup(
     name="Meshroom",
     description="Meshroom",
-    install_requires=['psutil', 'PySide6', 'markdown'],
+    install_requires=["psutil", "PySide6", "markdown"],
     setup_requires=[
-        'cx_Freeze'
+        "cx_Freeze"
     ],
     version=meshroom.__version__,
     options={"build_exe": build_exe_options},

--- a/setup.py
+++ b/setup.py
@@ -143,7 +143,7 @@ executables = [
 setup(
     name="Meshroom",
     description="Meshroom",
-    install_requires=['psutil', 'pytest', 'PySide6', 'markdown'],
+    install_requires=['psutil', 'PySide6', 'markdown'],
     setup_requires=[
         'cx_Freeze'
     ],


### PR DESCRIPTION
## Description

This PR updates the build options in `setup.py` to include the `bin` directory in the packaged version of Meshroom: the executables for these scripts will still be generated, but they will also be added as is to a `bin` directory, meaning one can do both `meshroom_compute [options]` and `python bin/meshroom_compute [options]`.

This allows to simplify the calls to `meshroom_compute` in the `Node` class, as the need to distinguish the "release mode" from the "regular mode" disappears.

Additionally, "pytest" is removed from the list of `install_requires` as no test is ever packaged. 

Finally, all the remaining single quotes in `setup.py` are replaced with double ones.


## Features list

- [x] Package the content of the `bin` folder
- [x] Remove "pytest" from the packaging dependencies
- [x] Unify calls to `meshroom_compute` in and out of "release mode"