### PR TITLE
[gitignore] Ignore virtual environments and QtCreator configuration files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,13 @@ __pycache__
 *.qmlc
 *.jsc
 
+# QtCreator project files
+*.cflags
+*.cxxflags
+*.creator*
+*.files
+*.includes
+
 *.dll
 
 *.lib

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,9 @@ __pycache__
 /dist
 /dl
 
+# virtual environment
+/venv
+
 # tests
 /.tests
 /.pytest_cache


### PR DESCRIPTION
## Description

This PR updates the `.gitignore` file to ignore configuration files generated by QtCreator projects (except for .config files as the extension can be used outside of that context) and standard virtual environments (if they are named "venv").