### PR TITLE
[ui] Implement status bar to display messages

### DIFF
--- a/meshroom/core/node.py
+++ b/meshroom/core/node.py
@@ -522,6 +522,10 @@ class NodeChunk(BaseObject):
         executionStatus = None
         self.statThread = stats.StatisticsThread(self)
         self.statThread.start()
+        
+        # Display message
+        
+        
         try:
             self.node.nodeDesc.processChunk(self)
             # NOTE: this assumes saving the output attributes for each chunk

--- a/meshroom/core/node.py
+++ b/meshroom/core/node.py
@@ -523,9 +523,6 @@ class NodeChunk(BaseObject):
         self.statThread = stats.StatisticsThread(self)
         self.statThread.start()
         
-        # Display message
-        
-        
         try:
             self.node.nodeDesc.processChunk(self)
             # NOTE: this assumes saving the output attributes for each chunk

--- a/meshroom/ui/app.py
+++ b/meshroom/ui/app.py
@@ -362,9 +362,11 @@ class MeshroomApp(QApplication):
         self.processEvents()
     
     def showMessage(self, message, status=None, duration=5000):
-        root = self.engine.rootObjects()[0]
-        statusBar = root.findChild(QObject, "statusBar")
-        statusBar.showMessage(message, status, duration)
+        root = self.engine.rootObjects()
+        if root:
+            statusBar = root[0].findChild(QObject, "statusBar")
+            if statusBar is not None:
+                statusBar.showMessage(message, status, duration)
 
     def _retrieveThumbnailPath(self, filepath: str) -> str:
         """

--- a/meshroom/ui/app.py
+++ b/meshroom/ui/app.py
@@ -6,7 +6,7 @@ import json
 
 from PySide6 import __version__ as PySideVersion
 from PySide6 import QtCore
-from PySide6.QtCore import QUrl, QJsonValue, qInstallMessageHandler, QtMsgType, QSettings
+from PySide6.QtCore import QObject, QUrl, QJsonValue, qInstallMessageHandler, QtMsgType, QSettings
 from PySide6.QtGui import QIcon
 from PySide6.QtQml import QQmlDebuggingEnabler
 from PySide6.QtQuickControls2 import QQuickStyle
@@ -353,6 +353,18 @@ class MeshroomApp(QApplication):
     def reloadTemplateList(self):
         meshroom.core.initPipelines()
         self.pipelineTemplateFilesChanged.emit()
+    
+    @Slot()
+    def forceUIUpdate(self):
+        """ Force UI to process pending events
+        Necessary when we want to update the UI while a trigger is still running (e.g. reloadPlugins)
+        """
+        self.processEvents()
+    
+    def showMessage(self, message, status=None, duration=5000):
+        root = self.engine.rootObjects()[0]
+        statusBar = root.findChild(QObject, "statusBar")
+        statusBar.showMessage(message, status, duration)
 
     def _retrieveThumbnailPath(self, filepath: str) -> str:
         """

--- a/meshroom/ui/app.py
+++ b/meshroom/ui/app.py
@@ -25,6 +25,7 @@ from meshroom.ui.components.filepath import FilepathHelper
 from meshroom.ui.components.scene3D import Scene3DHelper, Transformations3DHelper
 from meshroom.ui.components.scriptEditor import ScriptEditorManager
 from meshroom.ui.components.thumbnail import ThumbnailCache
+from meshroom.ui.components.statusBar import MessageController
 from meshroom.ui.palette import PaletteManager
 from meshroom.ui.reconstruction import Reconstruction
 from meshroom.ui.utils import QmlInstantEngine
@@ -281,6 +282,8 @@ class MeshroomApp(QApplication):
         self.engine.rootContext().setContextProperty("ThumbnailCache", ThumbnailCache(parent=self))
 
         # additional context properties
+        self._messageController = MessageController(parent=self)
+        self.engine.rootContext().setContextProperty("_messageController", self._messageController)
         self.engine.rootContext().setContextProperty("_PaletteManager", PaletteManager(self.engine, parent=self))
         self.engine.rootContext().setContextProperty("ScriptEditorManager", ScriptEditorManager(parent=self))
         self.engine.rootContext().setContextProperty("MeshroomApp", self)
@@ -362,11 +365,7 @@ class MeshroomApp(QApplication):
         self.processEvents()
     
     def showMessage(self, message, status=None, duration=5000):
-        root = self.engine.rootObjects()
-        if root:
-            statusBar = root[0].findChild(QObject, "statusBar")
-            if statusBar is not None:
-                statusBar.showMessage(message, status, duration)
+        self._messageController.sendMessage(message, status, duration)
 
     def _retrieveThumbnailPath(self, filepath: str) -> str:
         """

--- a/meshroom/ui/components/statusBar.py
+++ b/meshroom/ui/components/statusBar.py
@@ -1,0 +1,16 @@
+from PySide6.QtCore import QObject, Signal
+
+
+class MessageController(QObject):
+    """
+    Handles messages sent from the Python side to the StatusBar component
+    """
+    
+    message = Signal(str, str, int)
+    
+    def __init__(self, parent):
+        super().__init__(parent)
+    
+    def sendMessage(self, msg, status, duration):
+        """ Sends a message that will be displayed on the status bar """
+        self.message.emit(msg, status, duration)

--- a/meshroom/ui/qml/Application.qml
+++ b/meshroom/ui/qml/Application.qml
@@ -552,7 +552,9 @@ Page {
         text: "Reload Plugins Source Code"
         shortcut: "Ctrl+Shift+R"
         onTriggered: {
+            statusBar.showMessage("Reloading plugins...")
             _reconstruction.reloadPlugins()
+            statusBar.showMessage("Plugins reloaded !", "ok")
         }
     }
 
@@ -1023,9 +1025,10 @@ Page {
         rightPadding: 4
         palette.window: Qt.darker(activePalette.window, 1.15)
 
-        // Cache Folder
         RowLayout {
+            anchors.fill: parent
             spacing: 0
+
             MaterialToolButton {
                 font.pointSize: 8
                 text: MaterialIcons.folder_open
@@ -1039,6 +1042,17 @@ Page {
                 text: _reconstruction ? _reconstruction.graph.cacheDir : "Unknown"
                 color: Qt.darker(palette.text, 1.2)
                 background: Item {}
+            }
+
+            // Spacer to push status bar to the right
+            Item { Layout.fillWidth: true }
+
+            StatusBar {
+                id: statusBar
+                objectName: "statusBar"  // Expose to python
+                height: parent.height
+                defaultColor: Qt.darker(palette.text, 1.2)
+                defaultIcon : MaterialIcons.comment
             }
         }
     }

--- a/meshroom/ui/qml/Application.qml
+++ b/meshroom/ui/qml/Application.qml
@@ -553,8 +553,7 @@ Page {
         shortcut: "Ctrl+Shift+R"
         onTriggered: {
             statusBar.showMessage("Reloading plugins...")
-            _reconstruction.reloadPlugins()
-            statusBar.showMessage("Plugins reloaded !", "ok")
+            _reconstruction.reloadPlugins()  // This will handle the message to show that it finished properly
         }
     }
 

--- a/meshroom/ui/qml/Application.qml
+++ b/meshroom/ui/qml/Application.qml
@@ -1050,7 +1050,6 @@ Page {
                 id: statusBar
                 objectName: "statusBar"  // Expose to python
                 height: parent.height
-                defaultColor: Qt.darker(palette.text, 1.2)
                 defaultIcon : MaterialIcons.comment
             }
         }

--- a/meshroom/ui/qml/Controls/StatusBar.qml
+++ b/meshroom/ui/qml/Controls/StatusBar.qml
@@ -1,0 +1,101 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import MaterialIcons 2.2
+
+RowLayout {
+    id: root
+
+    property color  defaultColor: "white"
+    property string defaultIcon : MaterialIcons.circle
+    property int    interval    : 5000
+    property bool   logMessage  : false
+
+    TextField {
+        id: statusBarField
+        Layout.fillHeight: true
+        readOnly: true
+        selectByMouse: true
+        text: statusBar.message
+        color: defaultColor
+        background: Item {}
+        visible: statusBar.message !== ""
+    }
+
+    // TODO : Idea for later : implement a ProgressBar here
+
+    MaterialToolButton {
+        id: statusBarButton
+        Layout.fillHeight: true
+        Layout.preferredWidth: 17
+        visible: true
+        font.pointSize: 8
+        text: defaultIcon
+        ToolTip.text: "Open Messages UI"
+        // TODO : Open messages UI
+        // onClicked: statusBar.showMessage("NotImplementedError : Cannot open interface", "error", 2000)
+        Component.onCompleted: {
+            statusBarButton.contentItem.color = defaultColor
+        }
+    }
+
+    Timer {
+        id: statusBarTimer
+        interval: root.interval
+        running: false
+        repeat: false
+        onTriggered: {
+            // Erase message and reset button icon
+            statusBar.message = ""
+            statusBarField.color = defaultColor
+            statusBarButton.contentItem.color = defaultColor
+            statusBarButton.text = defaultIcon
+        }
+    }
+
+    QtObject {
+        id: statusBar
+        property string message: ""
+
+        function showMessage(msg, status=undefined, duration=undefined) {
+            var textColor = defaultColor
+            var logMsg = "[Message][INFO]"
+            switch (status) {
+                case "ok": {
+                    logMsg = "[Message][ERR]"
+                    textColor = Qt.lighter("green", 1.6)
+                    statusBarButton.text = MaterialIcons.check_circle
+                    break
+                }
+                case "warning": {
+                    logMsg = "[Message][WARN]"
+                    textColor = Qt.lighter("yellow", 1.4)
+                    statusBarButton.text = MaterialIcons.warning
+                    break
+                }
+                case "error": {
+                    logMsg = "[Message][ERR ]"
+                    textColor = Qt.lighter("red", 1.4)
+                    statusBarButton.text = MaterialIcons.error
+                    break
+                }
+                default: {
+                    statusBarButton.text = defaultIcon
+                }
+            }
+            if (logMessage === true) {
+                console.log(logMsg + " " + msg)
+            }
+            statusBarField.color = textColor
+            statusBarButton.contentItem.color = textColor
+            statusBar.message = msg
+            statusBarTimer.interval = duration !== undefined ? duration : root.interval
+            statusBarTimer.restart()
+        }
+    }
+
+    function showMessage(msg, status=undefined, duration=undefined) {
+        statusBar.showMessage(msg, status, duration)
+        MeshroomApp.forceUIUpdate()
+    }
+}

--- a/meshroom/ui/qml/Controls/StatusBar.qml
+++ b/meshroom/ui/qml/Controls/StatusBar.qml
@@ -59,22 +59,22 @@ RowLayout {
 
         function showMessage(msg, status=undefined, duration=undefined) {
             var textColor = defaultColor
-            var logMsg = "[Message][INFO]"
+            var logLevel = "info"
             switch (status) {
                 case "ok": {
-                    logMsg = "[Message][ERR]"
+                    logLevel = "info"
                     textColor = Qt.lighter("green", 1.6)
                     statusBarButton.text = MaterialIcons.check_circle
                     break
                 }
                 case "warning": {
-                    logMsg = "[Message][WARN]"
+                    logLevel = "warn"
                     textColor = Qt.lighter("yellow", 1.4)
                     statusBarButton.text = MaterialIcons.warning
                     break
                 }
                 case "error": {
-                    logMsg = "[Message][ERR ]"
+                    logLevel = "error"
                     textColor = Qt.lighter("red", 1.4)
                     statusBarButton.text = MaterialIcons.error
                     break
@@ -84,7 +84,7 @@ RowLayout {
                 }
             }
             if (logMessage === true) {
-                console.log(logMsg + " " + msg)
+                console.log("[Message][" + logLevel.toUpperCase().padEnd(5) + "] " + msg)
             }
             statusBarField.color = textColor
             statusBarButton.contentItem.color = textColor

--- a/meshroom/ui/qml/Controls/StatusBar.qml
+++ b/meshroom/ui/qml/Controls/StatusBar.qml
@@ -91,11 +91,11 @@ RowLayout {
             statusBar.message = msg
             statusBarTimer.interval = duration !== undefined ? duration : root.interval
             statusBarTimer.restart()
+            MeshroomApp.forceUIUpdate()
         }
     }
 
     function showMessage(msg, status=undefined, duration=undefined) {
         statusBar.showMessage(msg, status, duration)
-        MeshroomApp.forceUIUpdate()
     }
 }

--- a/meshroom/ui/qml/Controls/StatusBar.qml
+++ b/meshroom/ui/qml/Controls/StatusBar.qml
@@ -6,7 +6,7 @@ import MaterialIcons 2.2
 RowLayout {
     id: root
 
-    property color  defaultColor: "white"
+    property color  defaultColor: Qt.darker(palette.text, 1.2)
     property string defaultIcon : MaterialIcons.circle
     property int    interval    : 5000
     property bool   logMessage  : false
@@ -34,6 +34,8 @@ RowLayout {
         ToolTip.text: "Open Messages UI"
         // TODO : Open messages UI
         // onClicked: statusBar.showMessage("NotImplementedError : Cannot open interface", "error", 2000)
+        enabled: false  // TODO: to remove when implemented  
+        ToolTip.visible: false  // TODO: to remove when implemented  
         Component.onCompleted: {
             statusBarButton.contentItem.color = defaultColor
         }
@@ -57,25 +59,24 @@ RowLayout {
         id: statusBar
         property string message: ""
 
-        function showMessage(msg, status=undefined, duration=undefined) {
+        function showMessage(msg, status=undefined, duration=root.interval) {
             var textColor = defaultColor
             var logLevel = "info"
             switch (status) {
                 case "ok": {
-                    logLevel = "info"
-                    textColor = Qt.lighter("green", 1.6)
+                    statusBarField.color = Colors.green
                     statusBarButton.text = MaterialIcons.check_circle
                     break
                 }
                 case "warning": {
                     logLevel = "warn"
-                    textColor = Qt.lighter("yellow", 1.4)
+                    statusBarField.color = Colors.orange
                     statusBarButton.text = MaterialIcons.warning
                     break
                 }
                 case "error": {
                     logLevel = "error"
-                    textColor = Qt.lighter("red", 1.4)
+                    statusBarField.color = Colors.red
                     statusBarButton.text = MaterialIcons.error
                     break
                 }
@@ -86,16 +87,22 @@ RowLayout {
             if (logMessage === true) {
                 console.log("[Message][" + logLevel.toUpperCase().padEnd(5) + "] " + msg)
             }
-            statusBarField.color = textColor
-            statusBarButton.contentItem.color = textColor
+            statusBarButton.contentItem.color = statusBarField.color
             statusBar.message = msg
-            statusBarTimer.interval = duration !== undefined ? duration : root.interval
+            statusBarTimer.interval = duration
             statusBarTimer.restart()
             MeshroomApp.forceUIUpdate()
         }
     }
 
-    function showMessage(msg, status=undefined, duration=undefined) {
+    function showMessage(msg, status=undefined, duration=root.interval) {
         statusBar.showMessage(msg, status, duration)
+    }
+
+    Connections {
+        target: _messageController
+        function onMessage(message, color, duration) {
+            showMessage(message, color, duration)
+        }
     }
 }

--- a/meshroom/ui/qml/Controls/StatusBar.qml
+++ b/meshroom/ui/qml/Controls/StatusBar.qml
@@ -3,6 +3,8 @@ import QtQuick.Controls
 import QtQuick.Layouts
 import MaterialIcons 2.2
 
+import Utils 1.0
+
 RowLayout {
     id: root
 

--- a/meshroom/ui/qml/Controls/qmldir
+++ b/meshroom/ui/qml/Controls/qmldir
@@ -21,3 +21,4 @@ SelectionBox 1.0 SelectionBox.qml
 SelectionLine 1.0 SelectionLine.qml
 DelegateSelectionBox 1.0 DelegateSelectionBox.qml
 DelegateSelectionLine 1.0 DelegateSelectionLine.qml
+StatusBar 1.0 StatusBar.qml

--- a/meshroom/ui/reconstruction.py
+++ b/meshroom/ui/reconstruction.py
@@ -7,8 +7,9 @@ from multiprocessing.pool import ThreadPool
 from threading import Thread
 from typing import Callable
 
-from PySide6.QtCore import QObject, Slot, Property, Signal, QUrl, QSizeF, QPoint
+from PySide6.QtCore import QObject, Slot, Property, Signal, QUrl, QSizeF, QPoint, QRegularExpression
 from PySide6.QtGui import QMatrix4x4, QMatrix3x3, QQuaternion, QVector3D, QVector2D
+from PySide6.QtQml import QQmlContext
 
 import meshroom.core
 import meshroom.common
@@ -930,7 +931,7 @@ class Reconstruction(UIGraph):
     displayedAttr2D = makeProperty(QObject, "_displayedAttr2D", displayedAttr2DChanged)   
 
     displayedAttrs3DChanged = Signal()    
-    displayedAttrs3D = Property(QObject, lambda self: self._displayedAttrs3D, notify=displayedAttrs3DChanged)  
+    displayedAttrs3D = Property(QObject, lambda self: self._displayedAttrs3D, notify=displayedAttrs3DChanged)
 
     @Slot(QObject)
     def setActiveNode(self, node, categories=True, inputs=True):

--- a/meshroom/ui/reconstruction.py
+++ b/meshroom/ui/reconstruction.py
@@ -454,7 +454,7 @@ class Reconstruction(UIGraph):
     @Slot(list)
     def _onPluginsReloaded(self, nodeTypes: list):
         self._graph.reloadNodePlugins(nodeTypes)
-        self.parent().showMessage("Plugins reloaded !", "ok")
+        self.parent().showMessage("Plugins reloaded!", "ok")
 
     @Slot()
     @Slot(str)


### PR DESCRIPTION
## Description
- Add a `StatusBar` QML element to display messages
  - Consists of a text message and an icon
  - a `showMessage(message, status, duration)` funciton is used to change the icon/text for a specific duration (5 seconds by default)
  - 4 status : default, ok, warning, error
    <img width="145" height="35" alt="image" src="https://github.com/user-attachments/assets/f2708f75-4ed5-4422-a5ff-e9ed95c9a9b1" /> <img width="145" height="35" alt="image" src="https://github.com/user-attachments/assets/438185b8-1678-47ed-8480-8b3b8e8e437e" /> <img width="145" height="35" alt="image" src="https://github.com/user-attachments/assets/f1b77665-f576-485b-bc43-7a436844d6f9" /> <img width="145" height="35" alt="image" src="https://github.com/user-attachments/assets/496933db-8a99-4e44-9c7e-c53a311c0e44" />
- integrate this `StatusBar` on Meshroom footer ToolBar
- Add slots to be able to send the messages for the python side
- Add slots and signals on `reconstruciton` to make sure the UI is not blocked when plugins are reloaded

## Example
![reload](https://github.com/user-attachments/assets/7c54ac11-55cb-4813-817f-7f042f2a9118)
