### PR TITLE
[tests] Improve unit test coverage for plugins

### DIFF
--- a/tests/plugins/meshroom/config.json
+++ b/tests/plugins/meshroom/config.json
@@ -1,0 +1,17 @@
+[
+    {
+        "key": "CONFIG_PATH",
+        "type": "path",
+        "value": "sharedTemplate.mg"
+    },
+    {
+        "key": "ERRONEOUS_CONFIG_PATH",
+        "type": "path",
+        "value": "erroneous_path"
+    },
+    {
+        "key": "CONFIG_STRING",
+        "type": "string",
+        "value": "configFile"
+    }
+]

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -2,7 +2,7 @@
 
 from meshroom.core import pluginManager, loadClassesNodes
 from meshroom.core.plugins import NodePluginStatus, Plugin
-from .utils import registeredPlugins
+from .utils import overrideOsEnvironmentVariables, registeredPlugins
 
 from pathlib import Path
 import os
@@ -260,13 +260,14 @@ class TestPluginsConfiguration:
 
     def test_loadedConfigWithOnlyExistingKeys(self):
         # Set the keys from the config file in the current environment
-        env = os.environ.copy()
-        os.environ[self.CONFIG_PATH[0]] = self.CONFIG_PATH[2]
-        os.environ[self.ERRONEOUS_CONFIG_PATH[0]] = self.ERRONEOUS_CONFIG_PATH[2]
-        os.environ[self.CONFIG_STRING[0]] = self.CONFIG_STRING[2]
+        environment = {
+            self.CONFIG_PATH[0]: self.CONFIG_PATH[2],
+            self.ERRONEOUS_CONFIG_PATH[0]: self.ERRONEOUS_CONFIG_PATH[2],
+            self.CONFIG_STRING[0]: self.CONFIG_STRING[2]
+        }
 
         folder = os.path.join(os.path.dirname(__file__), "plugins")
-        with registeredPlugins(folder):
+        with (overrideOsEnvironmentVariables(environment), registeredPlugins(folder)):
             plugin = pluginManager.getPlugin("pluginA")
             assert plugin
 
@@ -295,17 +296,15 @@ class TestPluginsConfiguration:
             assert config[self.CONFIG_STRING[0]] != self.CONFIG_STRING[2]
             assert configFullEnv[self.CONFIG_STRING[0]] == self.CONFIG_STRING[2]
 
-        # Restore os.environ to its original state
-        os.environ = env
-
     def test_loadedConfigWithSomeExistingKeys(self):
         # Set some keys from the config file in the current environment
-        env = os.environ.copy()
-        os.environ[self.ERRONEOUS_CONFIG_PATH[0]] = self.ERRONEOUS_CONFIG_PATH[2]
-        os.environ[self.CONFIG_STRING[0]] = self.CONFIG_STRING[2]
+        environment = {
+            self.ERRONEOUS_CONFIG_PATH[0]: self.ERRONEOUS_CONFIG_PATH[2],
+            self.CONFIG_STRING[0]: self.CONFIG_STRING[2]
+        }
 
         folder = os.path.join(os.path.dirname(__file__), "plugins")
-        with registeredPlugins(folder):
+        with (overrideOsEnvironmentVariables(environment), registeredPlugins(folder)):
             plugin = pluginManager.getPlugin("pluginA")
             assert plugin
 
@@ -335,6 +334,3 @@ class TestPluginsConfiguration:
 
             assert config[self.CONFIG_STRING[0]] != self.CONFIG_STRING[2]
             assert configFullEnv[self.CONFIG_STRING[0]] == self.CONFIG_STRING[2]
-
-        # Restore os.environ to its original state
-        os.environ = env

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -2,9 +2,10 @@ from contextlib import contextmanager
 from unittest.mock import patch
 
 import meshroom
-from meshroom.core import desc, pluginManager
+from meshroom.core import desc, pluginManager, loadPluginFolder
 from meshroom.core.plugins import NodePlugin, NodePluginStatus
 
+import os
 
 @contextmanager
 def registeredNodeTypes(nodeTypes: list[desc.Node]):
@@ -45,3 +46,12 @@ def unregisterNodeDesc(nodeDesc: desc.Node):
         plugin = pluginManager.getRegisteredNodePlugin(name)
         plugin.status = NodePluginStatus.NOT_LOADED
         del pluginManager._nodePlugins[name]
+
+@contextmanager
+def registeredPlugins(folder: str):
+    plugins = loadPluginFolder(folder)
+
+    yield
+
+    for plugin in plugins:
+        pluginManager.removePlugin(plugin)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -55,3 +55,8 @@ def registeredPlugins(folder: str):
 
     for plugin in plugins:
         pluginManager.removePlugin(plugin)
+
+@contextmanager
+def overrideOsEnvironmentVariables(envVariables: dict):
+    with patch.dict(os.environ, envVariables, clear=False):
+        yield


### PR DESCRIPTION
## Description

This pull request adds comprehensive tests for plugin configuration loading and environment variable handling in the plugin system. It introduces a new test class for verifying how plugin configuration files and environment variables interact, and adds a utility context manager to simplify plugin registration and cleanup during tests.

**New plugin configuration tests:**

* Added `TestPluginsConfiguration` class in `tests/test_plugins.py` with tests to verify that plugin configuration files are loaded correctly, and that environment variables override or coexist with config file values as expected. The tests cover scenarios with all, some, or none of the relevant environment variables set.

**Test utilities:**

* Introduced `registeredPlugins` context manager in `tests/utils.py` to handle loading and cleanup of plugins from a test folder, streamlining the setup and teardown of plugin-related tests.
* Updated imports in `tests/test_plugins.py` and `tests/utils.py` to use the new `registeredPlugins` utility and ensure necessary modules are available. [[1]](diffhunk://#diff-a0773d3b66660065199dac35469bf44f14799b6cd3bfd7feea4eec60082fed31R5-R7) [[2]](diffhunk://#diff-9e08e8c7769db7b58089fd7659d75ca96df40bb7b5d50299d3a30abd54da9ad6L5-R8)