### PR TITLE
[Controls] Horizontally center the Color Selector with respect to the tool button

### DIFF
--- a/meshroom/ui/qml/Controls/ColorSelector.qml
+++ b/meshroom/ui/qml/Controls/ColorSelector.qml
@@ -33,7 +33,7 @@ MaterialToolButton {
                             "#C16162",
                         ]
 
-    // When a color gets selected/choosen
+    // When a color gets selected/chosen
     signal colorSelected(var color)
 
     // Toggles the visibility of the popup
@@ -64,9 +64,9 @@ MaterialToolButton {
         padding: 4
         width: (root.height * 4) + (padding * 4)
 
-        // center the current color
+        // Center the current color on the tool button
         y: -height
-        x: -width + root.width + padding
+        x: -width / 2 + (root.width + padding) / 2
 
         // Layout of the Colors
         Grid {


### PR DESCRIPTION
## Description

This pull request makes minor improvements to the `ColorSelector.qml` file, ensuring that the Color Selector pop-up is now horizontally centered with respect to the tool button that makes it appear/disappear. It previously was placed on its left, potentially causing it to be clipped out.

<div align="center">
<img width="192" height="188" alt="image" src="https://github.com/user-attachments/assets/54bccd61-5b54-43b0-ad0b-2e6366784cee" />

Previous position of the Color Selector
</div>
<div align="center">
<img width="192" height="216" alt="image" src="https://github.com/user-attachments/assets/38aaceaa-1adc-4186-a8f5-764b75119ca5" />

New position of the Color Selector
</div>

This fixes #2814.