### PR TITLE
[core] Add support for keyable attributes

### DIFF
--- a/meshroom/core/attribute.py
+++ b/meshroom/core/attribute.py
@@ -9,7 +9,7 @@ from collections.abc import Iterable, Sequence
 from string import Template
 from meshroom.common import BaseObject, Property, Variant, Signal, ListModel, DictModel, Slot
 from meshroom.core import desc, hashValue
-
+from meshroom.core.keyValues import KeyValues
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -77,6 +77,7 @@ class Attribute(BaseObject):
         self._invalidate = False if self._isOutput else attributeDesc.invalidate
         self._invalidationValue = "" # invalidation value for output attributes
         self._value = None
+        self._keyValues = None # list of pairs (key, value) for keyable attribute
         self._initValue()
 
     def _getFullName(self) -> str:
@@ -119,7 +120,12 @@ class Attribute(BaseObject):
         Initialize the attribute value.
         Called in the attribute factory for each attributes.
         """
-        if self._desc._valueType is not None:
+        if self._desc.keyable:
+            # Keyable attribute, initialize keyValues from attribute description
+            self._keyValues = KeyValues(self._desc)
+            # Send signal and updates if keyValues changed
+            self._keyValues.pairsChanged.connect(self._onKeyValuesChanged)
+        elif self._desc._valueType is not None:
             self._value = self._desc._valueType()
 
     def _getEvalValue(self):
@@ -144,6 +150,8 @@ class Attribute(BaseObject):
         """
         Return the value of the attribute or the linked attribute value.
         """
+        if self.keyable:
+            raise RuntimeError(f"Cannot get value of {self._getFullName()}, the attribute is keyable.")
         if self.isLink:
             return self._getInputLink().value
         return self._value
@@ -157,6 +165,14 @@ class Attribute(BaseObject):
         if isinstance(value, Attribute) or Attribute.isLinkExpression(value):
             # if we set a link to another attribute
             self._value = value
+            if self.keyable:
+                self._keyValues.reset()
+        elif self.keyable and isinstance(value, dict):
+            # keyable attribute initialize from a dict
+            self.keyValues.resetFromDict(value)
+        elif self.keyable:
+            # keyable attribute but value is not a dict
+            raise RuntimeError(f"Cannot set value of {self._getFullName()}, the attribute is keyable.")
         elif callable(value):
             # evaluate the function
             self._value = value(self)
@@ -177,6 +193,16 @@ class Attribute(BaseObject):
             # Internal attributes are set as inputs
             self.requestNodeUpdate()
         self.valueChanged.emit()
+
+    def _getKeyValues(self):
+        """
+        Return the per-key values object of the attribute or of the linked attribute.
+        """
+        if not self.keyable:
+            raise RuntimeError(f"Cannot get keyValues of {self._getFullName()}, the attribute is not keyable.")
+        if self.isLink:
+            return self._getInputLink().keyValues
+        return self._keyValues
 
     def _applyExpr(self):
         """
@@ -209,7 +235,11 @@ class Attribute(BaseObject):
         """
         Reset the attribute to its default value.
         """
-        self._setValue(copy.copy(self.getDefaultValue()))
+        if self.keyable:
+            self._value = None
+            self._keyValues.reset()
+        else:
+            self._setValue(copy.copy(self.getDefaultValue()))
 
     def getDefaultValue(self):
         """
@@ -232,6 +262,8 @@ class Attribute(BaseObject):
         """
         if self.isLink:
             return self._getInputLink().asLinkExpr()
+        if self.keyable:
+            return self._keyValues.getSerializedValues()
         if self.isOutput and self._desc.isExpression:
             return self.getDefaultValue()
         return self.value
@@ -247,6 +279,9 @@ class Attribute(BaseObject):
         If it is an empty list, it will returns a really empty string.
         If it is a list with one empty string element, it will returns 2 quotes.
         """
+        # Keyable attribute, for now return the list of pairs as a JSON sting
+        if self.keyable:
+            return self._keyValues.getJson()
         # ChoiceParam with multiple values should be combined
         if isinstance(self._desc, desc.ChoiceParam) and not self._desc.exclusive:
             # Ensure value is a list as expected
@@ -273,6 +308,12 @@ class Attribute(BaseObject):
         """
         self._setValue(exportedValue)
 
+    def _isDefault(self):
+        if self.keyable:
+            return len(self._keyValues.pairs) == 0
+        else:
+            return self._getValue() == self.getDefaultValue()
+        
     def _isValid(self):
         """
         Check attribute description validValue:
@@ -328,6 +369,8 @@ class Attribute(BaseObject):
         if self.isLink:
             linkRootAttribute = self._getInputLink(recursive=True)
             return linkRootAttribute.uid()
+        if self.keyable:
+            return self._keyValues.uid()
         if isinstance(self._value, (list, tuple, set,)):
             # non-exclusive choice param
             # hash of sorted values hashed
@@ -421,6 +464,17 @@ class Attribute(BaseObject):
     # Slots
 
     @Slot()
+    def _onKeyValuesChanged(self):
+        """
+        For keyable attribute, when the list or pairs (key, value) is modified this method should be called.
+        Emit Attribute.valueChanged and update node / graph like _setValue().
+        """
+        if self.isInput:
+            self.requestGraphUpdate()
+            self.requestNodeUpdate()
+        self.valueChanged.emit()
+
+    @Slot()
     def _onValueChanged(self):
         self.node._onAttributeChanged(self)
 
@@ -464,9 +518,13 @@ class Attribute(BaseObject):
     valueChanged = Signal()
     value = Property(Variant, _getValue, _setValue, notify=valueChanged)
     evalValue = Property(Variant, _getEvalValue, notify=valueChanged)
+    # Whether the attribute can have a distinct value per key.
+    keyable = Property(bool, lambda self: self._desc.keyable, constant=True)
+    # The list of pairs (key, value) of the attribute.
+    keyValues = Property(Variant, _getKeyValues, notify=valueChanged)
 
     # Whether the attribute value is the default value.
-    isDefault = Property(bool, lambda self: self.value == self.getDefaultValue(), notify=valueChanged)
+    isDefault = Property(bool, _isDefault, notify=valueChanged)
     # Whether the attribute value is valid.
     isValid = Property(bool, _isValid, notify=valueChanged)
     # Whether the attribute value is displayable in 2d.

--- a/meshroom/core/attribute.py
+++ b/meshroom/core/attribute.py
@@ -252,6 +252,9 @@ class Attribute(BaseObject):
                 if not self.node.isCompatibilityNode:
                     logging.warning(f"Failed to evaluate 'defaultValue' (node lambda) for attribute '{self.fullName}': {e}")
                 return None
+        # keyable attribute default value
+        if self.keyable:
+            return {}
         # Need to force a copy, for the case where the value is a list
         # (avoid reference to the desc value)
         return copy.copy(self._desc.value)

--- a/meshroom/core/desc/attribute.py
+++ b/meshroom/core/desc/attribute.py
@@ -10,13 +10,16 @@ class Attribute(BaseObject):
     """
     """
 
-    def __init__(self, name, label, description, value, advanced, semantic, group, enabled, invalidate=True,
-                 uidIgnoreValue=None, validValue=True, errorMessage="", visible=True, exposed=False):
+    def __init__(self, name, label, description, value, advanced, semantic, group, enabled, 
+                 keyable=False, keyType=None, invalidate=True, uidIgnoreValue=None, 
+                 validValue=True, errorMessage="", visible=True, exposed=False):
         super(Attribute, self).__init__()
         self._name = name
         self._label = label
         self._description = description
         self._value = value
+        self._keyable = keyable
+        self._keyType = keyType
         self._group = group
         self._advanced = advanced
         self._enabled = enabled
@@ -82,6 +85,14 @@ class Attribute(BaseObject):
     #   The default value of the attribute's descriptor is None, so it is not an input value,
     #   but an output value that is computed during the Node's process execution.
     isDynamicValue = Property(bool, lambda self: self._isDynamicValue, constant=True)
+    # keyable:
+    #   Whether the attribute can have a distinct value per key.
+    #   By default, atribute value is not keyable.
+    keyable = Property(bool, lambda self: self._keyable, constant=True)
+    # keyType:
+    #   The type of key corresponding to the attribute value.
+    #   This property only makes sense for keyable attributes.
+    keyType = Property(str, lambda self: self._keyType, constant=True)
     group = Property(str, lambda self: self._group, constant=True)
     advanced = Property(bool, lambda self: self._advanced, constant=True)
     enabled = Property(Variant, lambda self: self._enabled, constant=True)
@@ -265,11 +276,13 @@ class GroupAttribute(Attribute):
 class Param(Attribute):
     """
     """
-    def __init__(self, name, label, description, value, group, advanced, semantic, enabled, invalidate=True,
-                 uidIgnoreValue=None, validValue=True, errorMessage="", visible=True, exposed=False):
+    def __init__(self, name, label, description, value, group, advanced, semantic, enabled, 
+                 keyable=False, keyType=None, invalidate=True, uidIgnoreValue=None, 
+                 validValue=True, errorMessage="", visible=True, exposed=False):
         super(Param, self).__init__(name=name, label=label, description=description, value=value,
-                                    group=group, advanced=advanced, enabled=enabled, invalidate=invalidate,
-                                    semantic=semantic, uidIgnoreValue=uidIgnoreValue, validValue=validValue,
+                                    keyable=keyable, keyType=keyType, group=group, advanced=advanced, 
+                                    enabled=enabled, invalidate=invalidate, semantic=semantic, 
+                                    uidIgnoreValue=uidIgnoreValue, validValue=validValue,
                                     errorMessage=errorMessage, visible=visible, exposed=exposed)
 
 
@@ -302,11 +315,13 @@ class File(Attribute):
 class BoolParam(Param):
     """
     """
-    def __init__(self, name, label, description, value, group="allParams", advanced=False, enabled=True,
-                 invalidate=True, semantic="", visible=True, exposed=False):
+    def __init__(self, name, label, description, value, keyable=False, keyType=None, 
+                 group="allParams", advanced=False, enabled=True, invalidate=True, 
+                 semantic="", visible=True, exposed=False):
         super(BoolParam, self).__init__(name=name, label=label, description=description, value=value,
-                                        group=group, advanced=advanced, enabled=enabled, invalidate=invalidate,
-                                        semantic=semantic, visible=visible, exposed=exposed)
+                                        keyable=keyable, keyType=keyType, group=group, advanced=advanced, 
+                                        enabled=enabled, invalidate=invalidate, semantic=semantic, 
+                                        visible=visible, exposed=exposed)
         self._valueType = bool
 
     def validateValue(self, value):
@@ -330,12 +345,14 @@ class BoolParam(Param):
 class IntParam(Param):
     """
     """
-    def __init__(self, name, label, description, value, range=None, group="allParams", advanced=False, enabled=True,
-                 invalidate=True, semantic="", validValue=True, errorMessage="", visible=True, exposed=False):
+    def __init__(self, name, label, description, value, range=None, keyable=False, keyType=None, 
+                 group="allParams", advanced=False, enabled=True, invalidate=True, semantic="", 
+                 validValue=True, errorMessage="", visible=True, exposed=False):
         self._range = range
         super(IntParam, self).__init__(name=name, label=label, description=description, value=value,
-                                       group=group, advanced=advanced, enabled=enabled, invalidate=invalidate,
-                                       semantic=semantic, validValue=validValue, errorMessage=errorMessage,
+                                       keyable=keyable, keyType=keyType, group=group, advanced=advanced, 
+                                       enabled=enabled, invalidate=invalidate, semantic=semantic, 
+                                       validValue=validValue, errorMessage=errorMessage,
                                        visible=visible, exposed=exposed)
         self._valueType = int
 
@@ -360,12 +377,14 @@ class IntParam(Param):
 class FloatParam(Param):
     """
     """
-    def __init__(self, name, label, description, value, range=None, group="allParams", advanced=False, enabled=True,
-                 invalidate=True, semantic="", validValue=True, errorMessage="", visible=True, exposed=False):
+    def __init__(self, name, label, description, value, range=None, keyable=False, keyType=None, 
+                 group="allParams", advanced=False, enabled=True, invalidate=True, semantic="", 
+                 validValue=True, errorMessage="", visible=True, exposed=False):
         self._range = range
         super(FloatParam, self).__init__(name=name, label=label, description=description, value=value,
-                                         group=group, advanced=advanced, enabled=enabled, invalidate=invalidate,
-                                         semantic=semantic, validValue=validValue, errorMessage=errorMessage,
+                                         keyable=keyable, keyType=keyType, group=group, advanced=advanced, 
+                                         enabled=enabled, invalidate=invalidate, semantic=semantic, 
+                                         validValue=validValue, errorMessage=errorMessage,
                                          visible=visible, exposed=exposed)
         self._valueType = float
 

--- a/meshroom/core/desc/attribute.py
+++ b/meshroom/core/desc/attribute.py
@@ -49,6 +49,15 @@ class Attribute(BaseObject):
         """
         raise NotImplementedError("Attribute.validateValue is an abstract function that should be "
                                   "implemented in the derived class.")
+    
+    def validateKeyValues(self, keyValues):
+        """ Return validated/conformed 'keyValues'.
+
+        Raises:
+            ValueError: if a value does not have the proper type
+        """
+        return isinstance(keyValues, dict) and \
+               all(isinstance(k, str) and self.validateValue(v) for k,v in keyValues.items())
 
     def checkValueTypes(self):
         """ Returns the attribute's name if the default value's type is invalid or if the range's type (when available)
@@ -68,7 +77,10 @@ class Attribute(BaseObject):
             strict: strict test for the match (for instance, regarding a group with some parameter changes)
         """
         try:
-            self.validateValue(value)
+            if self._keyable:
+                self.validateKeyValues(value)
+            else:
+                self.validateValue(value)
         except ValueError:
             return False
         return True

--- a/meshroom/core/keyValues.py
+++ b/meshroom/core/keyValues.py
@@ -79,7 +79,7 @@ class KeyValues(BaseObject):
         """
         Return the list of pairs serialized.
         """
-        return { pair.key: pair.value for pair in self._pairs }
+        return { str(pair.key): pair.value for pair in self._pairs }
 
     def getJson(self) -> str:
         """

--- a/meshroom/core/keyValues.py
+++ b/meshroom/core/keyValues.py
@@ -29,7 +29,7 @@ class KeyValues(BaseObject):
         """
         super().__init__(parent)
         self._desc = desc
-        self._pairs = DictModel(keyAttrName="key")
+        self._pairs = DictModel(keyAttrName="key", parent=self)
         # TODO: Add interpolation. For now no interpolation.
 
     def reset(self):
@@ -45,7 +45,7 @@ class KeyValues(BaseObject):
         """
         self._pairs.clear()
         for k,v in pairs.items():
-            self._pairs.add(KeyValues.KeyValuePair(int(k), self._desc.validateValue(v)))
+            self._pairs.add(KeyValues.KeyValuePair(int(k), self._desc.validateValue(v), self))
         self.pairsChanged.emit()
 
     def add(self, key: str, value: Any):
@@ -61,7 +61,7 @@ class KeyValues(BaseObject):
         if pair is not None:
             self._pairs.remove(pair)
         # Add new pair
-        self._pairs.add(KeyValues.KeyValuePair(int(key), self._desc.validateValue(value)))
+        self._pairs.add(KeyValues.KeyValuePair(int(key), self._desc.validateValue(value), self))
         self.pairsChanged.emit()
 
     def remove(self, key: str):

--- a/meshroom/core/keyValues.py
+++ b/meshroom/core/keyValues.py
@@ -1,0 +1,124 @@
+from meshroom.common import BaseObject, Property, Variant, Signal, DictModel, Slot
+from meshroom.core import desc, hashValue
+from typing import Any
+import json
+
+class KeyValues(BaseObject):
+    """
+    Used to store a list of pairs (key, value) based on an attribute description.
+    """
+
+    class KeyValuePair(BaseObject):
+        """ 
+        Pair of (key, value), this object cannot be modified.
+        """
+        def __init__(self, key: int, value: Any, parent=None):
+            super().__init__(parent)
+            self._key = key
+            self._value = value
+
+        key = Property(int, lambda self: self._key, constant=True)
+        value = Property(Variant, lambda self: self._value, constant=True)
+
+    def __init__(self, desc: desc.Attribute, parent=None):
+        """
+        KeyValues constructor
+        Args:
+            description: The corresponding Attribute description.
+            parent: (optional) The parent BaseObject if any.
+        """
+        super().__init__(parent)
+        self._desc = desc
+        self._pairs = DictModel(keyAttrName="key")
+        # TODO: Add interpolation. For now no interpolation.
+
+    def reset(self):
+        """ 
+        Clear the list of pairs.
+        """
+        self._pairs.clear()
+        self.pairsChanged.emit()
+
+    def resetFromDict(self, pairs: dict):
+        """ 
+        Reset the list of pairs from a given dict.
+        """
+        self._pairs.clear()
+        for k,v in pairs.items():
+            self._pairs.add(KeyValues.KeyValuePair(int(k), self._desc.validateValue(v)))
+        self.pairsChanged.emit()
+
+    def add(self, key: str, value: Any):
+        """
+        Add a new pair (key, value) to the list of pairs from a given key and value.
+        """
+        # Avoid negative key
+        if int(key) < 0:
+            return
+        # Get existing pair with the given key (or None)
+        pair = self._pairs.get(int(key))
+        # Remove existing pair
+        if pair is not None:
+            self._pairs.remove(pair)
+        # Add new pair
+        self._pairs.add(KeyValues.KeyValuePair(int(key), self._desc.validateValue(value)))
+        self.pairsChanged.emit()
+
+    def remove(self, key: str):
+        """
+        Remove a pair (key, value) of the list of pairs from a given key.
+        """
+        # Get existing pair with the given key (or None)
+        pair = self._pairs.get(int(key))
+        # Remove existing pair
+        if pair is not None:
+            self._pairs.remove(pair)
+            self.pairsChanged.emit()
+
+    def getSerializedValues(self) -> Any:
+        """
+        Return the list of pairs serialized.
+        """
+        return { pair.key: pair.value for pair in self._pairs }
+
+    def getJson(self) -> str:
+        """
+        Return the list of pairs formatted as a JSON string.
+        """
+        return json.dumps(self.getSerializedValues())
+
+    def uid(self) -> str:
+        """
+        Compute the UID from the list of pairs. 
+        """
+        uids = []
+        for pair in sorted(self._pairs, key=lambda pair: pair.key):
+            uids.extend([pair.key, pair.value])
+        return hashValue(uids)
+
+    @Slot(str, result=bool)
+    def hasKey(self, key: str) -> bool:
+        """
+        Whether this given key exists in the list of pairs.
+        """
+        return self._pairs.get(int(key)) is not None
+
+    @Slot(str, result=Variant)
+    def getValueAtKeyOrDefault(self, key: str) -> Any:
+        """
+        Return the value or the default value from a given key.
+        """
+        # Get existing pair with the given key (or None)
+        pair = self._pairs.get(int(key))
+        # Return pair value
+        if pair is not None:
+            return pair.value
+        # Return default value
+        return self._desc.value
+
+    # Emitted when something changed in the list of pairs.
+    pairsChanged = Signal()
+    # The list of pairs (key, value).
+    pairs = Property(Variant, lambda self: self._pairs, notify=pairsChanged)
+    # The type of key used (viewId, poseId, ...).
+    keyType = Property(str, lambda self: self._desc.keyType, constant=True)

--- a/meshroom/core/node.py
+++ b/meshroom/core/node.py
@@ -944,7 +944,7 @@ class BaseNode(BaseObject):
             # In particular, when loading a project file, the UIDs are updated first,
             # and the node status and the dynamic output values are not yet loaded,
             # so we should not read the attribute value.
-            if not dynamicOutputAttr and attr.value == attr.desc.uidIgnoreValue:
+            if not dynamicOutputAttr and not attr.keyable and attr.value == attr.desc.uidIgnoreValue:
                 continue  # For non-dynamic attributes, check if the value should be ignored
             uidAttributes.append((attr.name, attr.uid()))
         uidAttributes.sort()
@@ -1225,7 +1225,7 @@ class BaseNode(BaseObject):
             # And we do not want notifications during the graph processing.
             return
 
-        if attr.value is None:
+        if not attr.keyable and attr.value is None:
             # Discard dynamic values depending on the graph processing.
             return
 

--- a/meshroom/ui/commands.py
+++ b/meshroom/ui/commands.py
@@ -313,7 +313,9 @@ class AddAttributeKeyValueCommand(GraphCommand):
         self.keyable = attribute.keyable
         self.key = key
         self.value = value
-        self.oldValue = None if not attribute.keyable else attribute.keyValues.pairs.get(int(key))
+        self.oldValue = None
+        if attribute.keyable and attribute.keyValues.hasKey(key):
+             self.oldValue = attribute.keyValues.pairs.get(int(key)).value
         self.setText(f"Add (key, value) for attribute '{attribute.fullName}' at key: '{key}'")
 
     def redoImpl(self):
@@ -346,7 +348,9 @@ class RemoveAttributeKeyCommand(GraphCommand):
         self.attrName = attribute.fullName
         self.keyable = attribute.keyable
         self.key = key
-        self.oldValue = None if not attribute.keyable else attribute.keyValues.pairs.get(int(key))
+        self.oldValue = None
+        if attribute.keyable and attribute.keyValues.hasKey(key):
+             self.oldValue = attribute.keyValues.pairs.get(int(key)).value
         self.setText(f"Remove (key, value) for attribute '{attribute.fullName}' at key: '{key}'")
 
     def redoImpl(self):

--- a/meshroom/ui/commands.py
+++ b/meshroom/ui/commands.py
@@ -305,32 +305,6 @@ class SetAttributeCommand(GraphCommand):
             self.graph.attribute(self.attrName).value = self.oldValue
         else:
             self.graph.internalAttribute(self.attrName).value = self.oldValue
-
-class ResetAttributeKeyValuesCommand(GraphCommand):
-    def __init__(self, graph, attribute, parent=None):
-        super().__init__(graph, parent)
-        self.attrName = attribute.fullName
-        self.keyable = attribute.keyable
-        self.oldKeyValues = None if not attribute.keyable else attribute.keyValues.getSerializedValues()
-        self.setText(f"Reset keyable attribute '{attribute.fullName}'")
-
-    def redoImpl(self):
-        if not self.keyable:
-            return False
-        if self.graph.attribute(self.attrName) is not None:
-            self.graph.attribute(self.attrName).keyValues.reset()
-        else:
-            self.graph.internalAttribute(self.attrName).keyValues.reset()
-        return True
-
-    def undoImpl(self):
-        if not self.keyable:
-            return False    
-        if self.graph.attribute(self.attrName) is not None:
-            self.graph.attribute(self.attrName).keyValues.resetFromDict(self.oldKeyValues)
-        else:
-            self.graph.internalAttribute(self.attrName).keyValues.resetFromDict(self.oldKeyValues)
-        return True
     
 class AddAttributeKeyValueCommand(GraphCommand):
     def __init__(self, graph, attribute, key, value, parent=None):

--- a/meshroom/ui/commands.py
+++ b/meshroom/ui/commands.py
@@ -332,6 +332,40 @@ class ResetAttributeKeyValuesCommand(GraphCommand):
             self.graph.internalAttribute(self.attrName).keyValues.resetFromDict(self.oldKeyValues)
         return True
     
+class AddAttributeKeyValueCommand(GraphCommand):
+    def __init__(self, graph, attribute, key, value, parent=None):
+        super().__init__(graph, parent)
+        self.attrName = attribute.fullName
+        self.keyable = attribute.keyable
+        self.key = key
+        self.value = value
+        self.oldValue = None if not attribute.keyable else attribute.keyValues.pairs.get(int(key))
+        self.setText(f"Add (key, value) for attribute '{attribute.fullName}' at key: '{key}'")
+
+    def redoImpl(self):
+        if not self.keyable or self.value == self.oldValue:
+            return False
+        if self.graph.attribute(self.attrName) is not None:
+            self.graph.attribute(self.attrName).keyValues.add(self.key, self.value)
+        else:
+            self.graph.internalAttribute(self.attrName).keyValues.add(self.key, self.value)
+        return True
+
+    def undoImpl(self):
+        if not self.keyable or self.value == self.oldValue:
+            return False    
+        if self.graph.attribute(self.attrName) is not None:
+            if self.oldValue is None:
+                self.graph.attribute(self.attrName).keyValues.remove(self.key)
+            else:
+                self.graph.attribute(self.attrName).keyValues.add(self.key, self.oldValue)
+        else:
+            if self.oldValue is None:
+                self.graph.internalAttribute(self.attrName).keyValues.remove(self.key)
+            else:
+                self.graph.internalAttribute(self.attrName).keyValues.add(self.key, self.oldValue)
+        return True
+
 class AddEdgeCommand(GraphCommand):
     def __init__(self, graph, src, dst, parent=None):
         super().__init__(graph, parent)

--- a/meshroom/ui/commands.py
+++ b/meshroom/ui/commands.py
@@ -366,6 +366,33 @@ class AddAttributeKeyValueCommand(GraphCommand):
                 self.graph.internalAttribute(self.attrName).keyValues.add(self.key, self.oldValue)
         return True
 
+class RemoveAttributeKeyCommand(GraphCommand):
+    def __init__(self, graph, attribute, key, parent=None):
+        super().__init__(graph, parent)
+        self.attrName = attribute.fullName
+        self.keyable = attribute.keyable
+        self.key = key
+        self.oldValue = None if not attribute.keyable else attribute.keyValues.pairs.get(int(key))
+        self.setText(f"Remove (key, value) for attribute '{attribute.fullName}' at key: '{key}'")
+
+    def redoImpl(self):
+        if not self.keyable or self.oldValue == None:
+            return False
+        if self.graph.attribute(self.attrName) is not None:
+            self.graph.attribute(self.attrName).keyValues.remove(self.key)
+        else:
+            self.graph.internalAttribute(self.attrName).keyValues.remove(self.key)
+        return True
+
+    def undoImpl(self):
+        if not self.keyable or self.oldValue == None:
+            return False    
+        if self.graph.attribute(self.attrName) is not None:
+            self.graph.attribute(self.attrName).keyValues.add(self.key, self.oldValue)
+        else:
+            self.graph.internalAttribute(self.attrName).keyValues.add(self.key, self.oldValue)
+        return True
+    
 class AddEdgeCommand(GraphCommand):
     def __init__(self, graph, src, dst, parent=None):
         super().__init__(graph, parent)

--- a/meshroom/ui/commands.py
+++ b/meshroom/ui/commands.py
@@ -306,7 +306,32 @@ class SetAttributeCommand(GraphCommand):
         else:
             self.graph.internalAttribute(self.attrName).value = self.oldValue
 
+class ResetAttributeKeyValuesCommand(GraphCommand):
+    def __init__(self, graph, attribute, parent=None):
+        super().__init__(graph, parent)
+        self.attrName = attribute.fullName
+        self.keyable = attribute.keyable
+        self.oldKeyValues = None if not attribute.keyable else attribute.keyValues.getSerializedValues()
+        self.setText(f"Reset keyable attribute '{attribute.fullName}'")
 
+    def redoImpl(self):
+        if not self.keyable:
+            return False
+        if self.graph.attribute(self.attrName) is not None:
+            self.graph.attribute(self.attrName).keyValues.reset()
+        else:
+            self.graph.internalAttribute(self.attrName).keyValues.reset()
+        return True
+
+    def undoImpl(self):
+        if not self.keyable:
+            return False    
+        if self.graph.attribute(self.attrName) is not None:
+            self.graph.attribute(self.attrName).keyValues.resetFromDict(self.oldKeyValues)
+        else:
+            self.graph.internalAttribute(self.attrName).keyValues.resetFromDict(self.oldKeyValues)
+        return True
+    
 class AddEdgeCommand(GraphCommand):
     def __init__(self, graph, src, dst, parent=None):
         super().__init__(graph, parent)

--- a/meshroom/ui/graph.py
+++ b/meshroom/ui/graph.py
@@ -970,6 +970,11 @@ class UIGraph(QObject):
         """ Add the given (key, value) pair to the given keyable attribute. """
         self.push(commands.AddAttributeKeyValueCommand(self._graph, attribute, key, value))
 
+    @Slot(Attribute, str)
+    def addAttributeKeyDefaultValue(self, attribute, key):
+        """ Add the given key with the default value to the given keyable attribute. """
+        self.push(commands.AddAttributeKeyValueCommand(self._graph, attribute, key, attribute.getDefaultValue()))
+
     @Slot(CompatibilityNode, result=Node)
     def upgradeNode(self, node):
         """ Upgrade a CompatibilityNode. """

--- a/meshroom/ui/graph.py
+++ b/meshroom/ui/graph.py
@@ -953,10 +953,6 @@ class UIGraph(QObject):
     def resetAttribute(self, attribute):
         """ Reset 'attribute' to its default value """
         with self.groupedGraphModification(f"Reset Attribute '{attribute.name}'"):
-            # if the attribute is keyable reset keyValues
-            if attribute.keyable:
-                self.push(commands.ResetAttributeKeyValuesCommand(self._graph, attribute))
-                return
             # if the attribute is a ListAttribute, remove all edges
             if isinstance(attribute, ListAttribute):
                 for edge in self._graph.edges:

--- a/meshroom/ui/graph.py
+++ b/meshroom/ui/graph.py
@@ -975,6 +975,11 @@ class UIGraph(QObject):
         """ Add the given key with the default value to the given keyable attribute. """
         self.push(commands.AddAttributeKeyValueCommand(self._graph, attribute, key, attribute.getDefaultValue()))
 
+    @Slot(Attribute, str)
+    def removeAttributeKey(self, attribute, key):
+        """ Remove the given key from the given keyable attribute. """
+        self.push(commands.RemoveAttributeKeyCommand(self._graph, attribute, key))
+
     @Slot(CompatibilityNode, result=Node)
     def upgradeNode(self, node):
         """ Upgrade a CompatibilityNode. """

--- a/meshroom/ui/graph.py
+++ b/meshroom/ui/graph.py
@@ -953,6 +953,10 @@ class UIGraph(QObject):
     def resetAttribute(self, attribute):
         """ Reset 'attribute' to its default value """
         with self.groupedGraphModification(f"Reset Attribute '{attribute.name}'"):
+            # if the attribute is keyable reset keyValues
+            if attribute.keyable:
+                self.push(commands.ResetAttributeKeyValuesCommand(self._graph, attribute))
+                return
             # if the attribute is a ListAttribute, remove all edges
             if isinstance(attribute, ListAttribute):
                 for edge in self._graph.edges:

--- a/meshroom/ui/graph.py
+++ b/meshroom/ui/graph.py
@@ -965,6 +965,11 @@ class UIGraph(QObject):
                         self.removeEdge(edge)
             self.push(commands.SetAttributeCommand(self._graph, attribute, attribute.getDefaultValue()))
 
+    @Slot(Attribute, str, "QVariant")
+    def addAttributeKeyValue(self, attribute, key, value):
+        """ Add the given (key, value) pair to the given keyable attribute. """
+        self.push(commands.AddAttributeKeyValueCommand(self._graph, attribute, key, value))
+
     @Slot(CompatibilityNode, result=Node)
     def upgradeNode(self, node):
         """ Upgrade a CompatibilityNode. """

--- a/meshroom/ui/qml/GraphEditor/AttributeItemDelegate.qml
+++ b/meshroom/ui/qml/GraphEditor/AttributeItemDelegate.qml
@@ -149,7 +149,7 @@ RowLayout {
                         }
                         MenuItem {
                             text: "Copy"
-                            enabled: attribute.value != ""
+                            enabled: !attribute.keyable && attribute.value != ""
                             onTriggered: {
                                 Clipboard.clear()
                                 Clipboard.setText(attribute.value)
@@ -157,7 +157,7 @@ RowLayout {
                         }
                         MenuItem {
                             text: "Paste"
-                            enabled: Clipboard.getText() != "" && root.editable
+                            enabled: Clipboard.getText() != "" && !attribute.keyable && root.editable
                             onTriggered: {
                                 _reconstruction.setAttribute(attribute, Clipboard.getText())
                             }
@@ -260,7 +260,10 @@ RowLayout {
             case "IntParam":
             case "FloatParam":
                 // We don't set a number because we want to keep the invalid expression
-                _reconstruction.setAttribute(root.attribute, Number(value))
+                if(attribute.keyable)
+                    _reconstruction.addAttributeKeyValue(root.attribute, _reconstruction.selectedViewId, Number(value))
+                else
+                    _reconstruction.setAttribute(root.attribute, Number(value))
                 updateAttributeLabel()
                 break
             case "File":
@@ -274,11 +277,12 @@ RowLayout {
     }
 
     Loader {
+        id: attributeLoader
         Layout.fillWidth: true
 
         sourceComponent: {
             // PushButtonParam always has value == undefined, so it needs to be excluded from this check
-            if (attribute.type != "PushButtonParam" && attribute.value === undefined) {
+            if (attribute.type != "PushButtonParam" && !attribute.keyable && attribute.value === undefined) {
                 return notComputedComponent
             }
             switch (attribute.type) {
@@ -612,7 +616,9 @@ RowLayout {
                     Layout.fillWidth: !slider.active
                     enabled: root.editable
                     // Cast value to string to avoid intrusive scientific notations on numbers
-                    property string displayValue: String(slider.active && slider.item.pressed ? slider.item.formattedValue : attribute.value)
+                    property string displayValue: String(slider.active && slider.item.pressed ? slider.item.formattedValue : 
+                                                        attribute.keyable ? attribute.keyValues.getValueAtKeyOrDefault(_reconstruction.selectedViewId) : 
+                                                        attribute.value)
                     text: displayValue
                     selectByMouse: true
                     // Note: Use autoScroll as a workaround for alignment
@@ -654,7 +660,7 @@ RowLayout {
                         readonly property int stepDecimalCount: stepSize <  1 ? String(stepSize).split(".").pop().length : 0
                         readonly property real formattedValue: value.toFixed(stepDecimalCount)
                         enabled: root.editable
-                        value: attribute.value
+                        value: attribute.keyable ? attribute.keyValues.getValueAtKeyOrDefault(_reconstruction.selectedViewId) : attribute.value
                         from: attribute.desc.range[0]
                         to: attribute.desc.range[1]
                         stepSize: attribute.desc.range[2]
@@ -662,7 +668,10 @@ RowLayout {
 
                         onPressedChanged: {
                             if (!pressed) {
-                                _reconstruction.setAttribute(attribute, formattedValue)
+                                if(attribute.keyable)
+                                    _reconstruction.addAttributeKeyValue(attribute, _reconstruction.selectedViewId, formattedValue)
+                                else
+                                    _reconstruction.setAttribute(attribute, formattedValue)
                                 updateAttributeLabel()
                             }
                         }
@@ -676,8 +685,18 @@ RowLayout {
             Row {
                 CheckBox {
                     enabled: root.editable
-                    checked: attribute.value
-                    onToggled: _reconstruction.setAttribute(attribute, !attribute.value)
+                    checked: attribute.keyable ? attribute.keyValues.getValueAtKeyOrDefault(_reconstruction.selectedViewId) : attribute.value
+                    onToggled: {
+                        if(attribute.keyable) 
+                        {
+                            const value = attribute.keyValues.getValueAtKeyOrDefault(_reconstruction.selectedViewId)
+                            _reconstruction.addAttributeKeyValue(attribute, _reconstruction.selectedViewId, !value)
+                        }
+                        else 
+                        {
+                            _reconstruction.setAttribute(attribute, !attribute.value)
+                        }
+                    }
                 }
             }
         }
@@ -830,6 +849,25 @@ RowLayout {
                         fragmentShader: "qrc:/shaders/AttributeItemDelegate.frag.qsb"
                     }
                 }
+            }
+        }
+    }
+
+    // Add or remove key button for keyable attribute
+    Loader {
+        active: attribute.keyable
+        sourceComponent: MaterialToolButton {
+            font.pointSize: 5
+            padding: 6
+            text: MaterialIcons.circle
+            checkable: true
+            checked: attribute.keyable && attribute.keyValues.hasKey(_reconstruction.selectedViewId)
+            enabled: root.editable
+            onClicked: {
+                if (attribute.keyValues.hasKey(_reconstruction.selectedViewId))
+                    _reconstruction.removeAttributeKey(attribute, _reconstruction.selectedViewId)
+                else
+                    _reconstruction.addAttributeKeyDefaultValue(attribute, _reconstruction.selectedViewId)
             }
         }
     }

--- a/meshroom/ui/qml/GraphEditor/AttributeItemDelegate.qml
+++ b/meshroom/ui/qml/GraphEditor/AttributeItemDelegate.qml
@@ -23,7 +23,8 @@ RowLayout {
     property alias label: parameterLabel  // Accessor to the internal Label (attribute's name)
     property int labelWidth               // Shortcut to set the fixed size of the Label
 
-    readonly property bool editable: !attribute.isOutput && !attribute.isLink && !readOnly
+    readonly property bool editable: !attribute.isOutput && !attribute.isLink &&   
+                                     !readOnly && !(attribute.keyable && _reconstruction.selectedViewId === "-1")
 
     signal doubleClicked(var mouse, var attr)
     signal inAttributeClicked(var srcItem, var mouse, var inAttributes)

--- a/tests/test_attributeKeyValues.py
+++ b/tests/test_attributeKeyValues.py
@@ -64,10 +64,15 @@ class TestKeyableAttribute:
         assert nodeA.keyableInt.isDefault 
         assert nodeA.keyableFloat.isDefault
 
+        # Check attribute description value
+        assert nodeA.keyableBool.desc.value == True
+        assert nodeA.keyableInt.desc.value  == 5
+        assert nodeA.keyableFloat.desc.value  == 5.5
+
         # Check attribute default value
-        assert nodeA.keyableBool.getDefaultValue() == True
-        assert nodeA.keyableInt.getDefaultValue() == 5
-        assert nodeA.keyableFloat.getDefaultValue() == 5.5
+        assert nodeA.keyableBool.getDefaultValue() == {}
+        assert nodeA.keyableInt.getDefaultValue() == {}
+        assert nodeA.keyableFloat.getDefaultValue() == {}
 
         # Check attribute serialized value
         assert nodeA.keyableBool.getSerializedValue() == {}

--- a/tests/test_attributeKeyValues.py
+++ b/tests/test_attributeKeyValues.py
@@ -1,0 +1,267 @@
+from meshroom.core import desc
+from meshroom.core.graph import Graph
+
+from .utils import registerNodeDesc, unregisterNodeDesc
+
+
+class NodeWithKeyableAttributes(desc.Node):
+    inputs = [
+        desc.BoolParam(
+            name="keyableBool",
+            label="Keyable Bool",
+            description="A keyable bool parameter.",
+            value=True,
+            keyable=True,
+            keyType="viewId"
+        ),
+        desc.IntParam(
+            name="keyableInt",
+            label="Keyable Integer",
+            description="A keyable integer parameter.",
+            value=5,
+            range=(0, 100, 2),
+            keyable=True,
+            keyType="viewId"
+        ),
+        desc.FloatParam(
+            name="keyableFloat",
+            label="Keyable Float",
+            description="A keyable float parameter.",
+            value=5.5,
+            range=(0.0, 100.0, 2.2),
+            keyable=True,
+            keyType="viewId"
+        ),
+    ]
+
+class TestKeyableAttribute:
+
+    @classmethod
+    def setup_class(cls):
+        registerNodeDesc(NodeWithKeyableAttributes)
+
+    @classmethod
+    def teardown_class(cls):
+        unregisterNodeDesc(NodeWithKeyableAttributes)
+
+    def test_initialization(self):
+        graph = Graph("")
+
+        nodeA = graph.addNewNode(NodeWithKeyableAttributes.__name__)
+
+        # Check attribute is keyable
+        assert nodeA.keyableBool.keyable
+        assert nodeA.keyableInt.keyable
+        assert nodeA.keyableFloat.keyable
+
+        # Check attribute key type
+        assert nodeA.keyableBool.keyValues.keyType == "viewId"
+        assert nodeA.keyableInt.keyValues.keyType == "viewId"
+        assert nodeA.keyableFloat.keyValues.keyType == "viewId"
+
+        # Check attribute pairs empty
+        assert nodeA.keyableBool.isDefault
+        assert nodeA.keyableInt.isDefault 
+        assert nodeA.keyableFloat.isDefault
+
+        # Check attribute default value
+        assert nodeA.keyableBool.getDefaultValue() == True
+        assert nodeA.keyableInt.getDefaultValue() == 5
+        assert nodeA.keyableFloat.getDefaultValue() == 5.5
+
+        # Check attribute serialized value
+        assert nodeA.keyableBool.getSerializedValue() == {}
+        assert nodeA.keyableInt.getSerializedValue() == {}
+        assert nodeA.keyableFloat.getSerializedValue() == {}
+
+        # Check attribute string value
+        assert nodeA.keyableBool.getValueStr() == "{}"
+        assert nodeA.keyableInt.getValueStr() == "{}"
+        assert nodeA.keyableFloat.getValueStr() == "{}"
+
+
+    def test_createReadUpdateDelete(self):
+        graph = Graph("")
+
+        nodeA = graph.addNewNode(NodeWithKeyableAttributes.__name__)
+
+        # Check attribute value at key "0", should be default value
+        assert nodeA.keyableBool.keyValues.getValueAtKeyOrDefault("0") == True
+        assert nodeA.keyableInt.keyValues.getValueAtKeyOrDefault("0") == 5
+        assert nodeA.keyableFloat.keyValues.getValueAtKeyOrDefault("0") == 5.5
+
+        # Check attribute has key "0", should be False (no key)
+        assert nodeA.keyableBool.keyValues.hasKey("0") == False
+        assert nodeA.keyableInt.keyValues.hasKey("0") == False
+        assert nodeA.keyableFloat.keyValues.hasKey("0") == False
+
+        # Add attribute (key, value) at key "0"
+        nodeA.keyableBool.keyValues.add("0", False)
+        nodeA.keyableInt.keyValues.add("0", 10)
+        nodeA.keyableFloat.keyValues.add("0", 10.1)
+
+        # Check attribute value at key "0", should be the new value
+        assert nodeA.keyableBool.keyValues.getValueAtKeyOrDefault("0") == False
+        assert nodeA.keyableInt.keyValues.getValueAtKeyOrDefault("0") == 10
+        assert nodeA.keyableFloat.keyValues.getValueAtKeyOrDefault("0") == 10.1
+
+        # Check attribute has key "0", should be True (key exists)
+        assert nodeA.keyableBool.keyValues.hasKey("0") == True
+        assert nodeA.keyableInt.keyValues.hasKey("0") == True
+        assert nodeA.keyableFloat.keyValues.hasKey("0") == True
+
+        # Update attribute (key, value) at key "0"
+        nodeA.keyableBool.keyValues.add("0", True)
+        nodeA.keyableInt.keyValues.add("0", 20)
+        nodeA.keyableFloat.keyValues.add("0", 20.2)
+
+        # Check attribute value at key "0", should be the new updated value
+        assert nodeA.keyableBool.keyValues.getValueAtKeyOrDefault("0") == True
+        assert nodeA.keyableInt.keyValues.getValueAtKeyOrDefault("0") == 20
+        assert nodeA.keyableFloat.keyValues.getValueAtKeyOrDefault("0") == 20.2
+
+        # Check attribute has key "0", should be True (key exists)
+        assert nodeA.keyableBool.keyValues.hasKey("0") == True
+        assert nodeA.keyableInt.keyValues.hasKey("0") == True
+        assert nodeA.keyableFloat.keyValues.hasKey("0") == True
+
+        # Remove (key, value) at key "0"
+        nodeA.keyableBool.keyValues.remove("0")
+        nodeA.keyableInt.keyValues.remove("0")
+        nodeA.keyableFloat.keyValues.remove("0")
+
+        # Check attributes values at key "0", should be default value
+        assert nodeA.keyableBool.keyValues.getValueAtKeyOrDefault("0") == True
+        assert nodeA.keyableInt.keyValues.getValueAtKeyOrDefault("0") == 5
+        assert nodeA.keyableFloat.keyValues.getValueAtKeyOrDefault("0") == 5.5
+
+        # Check attribute has key "0", should be False (no key)
+        assert nodeA.keyableBool.keyValues.hasKey("0") == False
+        assert nodeA.keyableInt.keyValues.hasKey("0") == False
+        assert nodeA.keyableFloat.keyValues.hasKey("0") == False
+
+
+    def test_multipleKeys(self):
+        graph = Graph("")
+
+        nodeA = graph.addNewNode(NodeWithKeyableAttributes.__name__)
+
+        # Add attribute (key, value) at key "0"
+        nodeA.keyableBool.keyValues.add("0", False)
+        nodeA.keyableInt.keyValues.add("0", 1)
+        nodeA.keyableFloat.keyValues.add("0", 1.1)
+
+        # Add attribute (key, value) at key "1"
+        nodeA.keyableBool.keyValues.add("1", False)
+        nodeA.keyableInt.keyValues.add("1", 2)
+        nodeA.keyableFloat.keyValues.add("1", 2.2)
+
+        # Add attribute (key, value) at key "2"
+        nodeA.keyableBool.keyValues.add("2", True)
+        nodeA.keyableInt.keyValues.add("2", 3)
+        nodeA.keyableFloat.keyValues.add("2", 3.3)
+
+        # Check attribute has key "0", should be True (key exists)
+        assert nodeA.keyableBool.keyValues.hasKey("0") == True
+        assert nodeA.keyableInt.keyValues.hasKey("0") == True
+        assert nodeA.keyableFloat.keyValues.hasKey("0") == True
+
+        # Check attribute has key "1", should be True (key exists)
+        assert nodeA.keyableBool.keyValues.hasKey("1") == True
+        assert nodeA.keyableInt.keyValues.hasKey("1") == True
+        assert nodeA.keyableFloat.keyValues.hasKey("1") == True
+
+        # Check attribute has key "2", should be True (key exists)
+        assert nodeA.keyableBool.keyValues.hasKey("2") == True
+        assert nodeA.keyableInt.keyValues.hasKey("2") == True
+        assert nodeA.keyableFloat.keyValues.hasKey("2") == True
+
+        # Check attributes values at key "0", should be default value
+        assert nodeA.keyableBool.keyValues.getValueAtKeyOrDefault("0") == False 
+        assert nodeA.keyableInt.keyValues.getValueAtKeyOrDefault("0") == 1
+        assert nodeA.keyableFloat.keyValues.getValueAtKeyOrDefault("0") == 1.1
+
+        # Check attributes values at key "1", should be default value
+        assert nodeA.keyableBool.keyValues.getValueAtKeyOrDefault("1") == False
+        assert nodeA.keyableInt.keyValues.getValueAtKeyOrDefault("1") == 2
+        assert nodeA.keyableFloat.keyValues.getValueAtKeyOrDefault("1") == 2.2
+
+        # Check attributes values at key "2", should be default value
+        assert nodeA.keyableBool.keyValues.getValueAtKeyOrDefault("2") == True
+        assert nodeA.keyableInt.keyValues.getValueAtKeyOrDefault("2") == 3
+        assert nodeA.keyableFloat.keyValues.getValueAtKeyOrDefault("2") == 3.3
+
+        # Remove (key, value) at key "1"
+        nodeA.keyableBool.keyValues.remove("1")
+        nodeA.keyableInt.keyValues.remove("1")
+        nodeA.keyableFloat.keyValues.remove("1")
+
+        # Check attribute has key "1", should be False (no key)
+        assert nodeA.keyableBool.keyValues.hasKey("1") == False
+        assert nodeA.keyableInt.keyValues.hasKey("1") == False
+        assert nodeA.keyableFloat.keyValues.hasKey("1") == False
+
+
+    def test_linkAttribute(self):
+        graph = Graph("")
+
+        nodeA = graph.addNewNode(NodeWithKeyableAttributes.__name__)
+        nodeB = graph.addNewNode(NodeWithKeyableAttributes.__name__)
+
+        # Add some keys for nodeA.keyableInt
+        nodeA.keyableInt.keyValues.add("0", 0)
+        nodeA.keyableInt.keyValues.add("1", 1)
+        nodeA.keyableInt.keyValues.add("2", 2)
+
+        # Add link:
+        # nodeB.keyableInt is a link for nodeA.keyableInt
+        graph.addEdge(nodeA.keyableInt, nodeB.keyableInt)
+
+        # Check link
+        assert nodeB.keyableInt.isLink == True
+        assert nodeB.keyableInt.keyValues == nodeA.keyableInt.keyValues
+
+        # Check existing (key, value) in nodeA.keyableInt and nodeB.keyableInt
+        assert nodeA.keyableInt.keyValues.hasKey("1") == True
+        assert nodeB.keyableInt.keyValues.hasKey("1") == True
+        assert nodeA.keyableInt.keyValues.getValueAtKeyOrDefault("1") == 1
+        assert nodeB.keyableInt.keyValues.getValueAtKeyOrDefault("1") == 1
+
+        # Add a key to nodeB.keyableInt
+        nodeB.keyableInt.keyValues.add("3", 3)
+
+        # Check new (key, value) in nodeA.keyableInt and nodeB.keyableInt
+        assert nodeA.keyableInt.keyValues.hasKey("3") == True
+        assert nodeB.keyableInt.keyValues.hasKey("3") == True
+        assert nodeA.keyableInt.keyValues.getValueAtKeyOrDefault("3") == 3
+        assert nodeB.keyableInt.keyValues.getValueAtKeyOrDefault("3") == 3
+
+        # Check nodeB.keyableInt serialized values
+        assert nodeB.keyableInt.getSerializedValue() == nodeA.keyableInt.asLinkExpr()
+
+
+    def test_uid(self):
+        graph = Graph("")
+
+        nodeA = graph.addNewNode(NodeWithKeyableAttributes.__name__)
+        nodeB = graph.addNewNode(NodeWithKeyableAttributes.__name__)
+
+        # Add some keys for nodeA.keyableInt
+        nodeA.keyableInt.keyValues.add("0", 0)
+        nodeA.keyableInt.keyValues.add("1", 1)
+        nodeA.keyableInt.keyValues.add("2", 2)
+
+        # Add the same keys for nodeB.keyableInt
+        # But not in the same order
+        nodeB.keyableInt.keyValues.add("2", 2)
+        nodeB.keyableInt.keyValues.add("0", 0)
+        nodeB.keyableInt.keyValues.add("1", 1)
+
+        # Check UID, should be the same
+        assert nodeA.keyableInt.uid() == nodeB.keyableInt.uid()
+
+        # Remove (key, value) at key "1" from nodeA.keyableInt
+        nodeA.keyableInt.keyValues.remove("1")
+
+        # Check UID, should not be the same
+        assert nodeA.keyableInt.uid() != nodeB.keyableInt.uid()

--- a/tests/test_attributeKeyValues.py
+++ b/tests/test_attributeKeyValues.py
@@ -66,8 +66,8 @@ class TestKeyableAttribute:
 
         # Check attribute description value
         assert nodeA.keyableBool.desc.value == True
-        assert nodeA.keyableInt.desc.value  == 5
-        assert nodeA.keyableFloat.desc.value  == 5.5
+        assert nodeA.keyableInt.desc.value == 5
+        assert nodeA.keyableFloat.desc.value == 5.5
 
         # Check attribute default value
         assert nodeA.keyableBool.getDefaultValue() == {}


### PR DESCRIPTION
## Description

Previously, all attributes were implicitly treated as non-keyable.
This PR introduces support for keyable attributes, allowing them to be loaded, stored, animated or manipulated.
Backward compatibility is preserved.

<p align="center">
<img width="466" height="149" alt="testKeyable" src="https://github.com/user-attachments/assets/5c4fddb3-0c98-444d-bd8f-db24e2559648" /><br/>
<i>A test node with keyable attributes.</i>
</p>

**Current limitations and scope:**

- Keyable support is implemented for: `BoolParam`, `IntParam`, and `FloatParam`.
- Only `viewId` is currently supported as the `keyType`.
- Interpolation mechanisms are not yet implemented.

**Unit tests cover:**

- Creation and initialization of keyable attributes.
- Modification and deletion of keyable attributes.
- Linked keyable attribute.
- Keyable attribute UID.

**Sample Node:**

A sample node for testing: [TestNode.zip](https://github.com/user-attachments/files/22564165/TestNode.zip)

## Features list
- [x] New `KeyValues` class to manage the keyable attribute list of `(key, value)` pairs.
- [x] Add keyable support in attribute description.
- [x] Add keyable support for: `BoolParam`, `IntParam`, and `FloatParam`.
- [x] Graph commands for keyable attribute.
- [x] UI integration in `AttributeItemDelegate.qml`
- [x] Unit tests

## Implementation remarks
This PR is designed in the context of developing the new shape editor.
It can serve as a foundation for full support of keyable attributes in the future.