### PR TITLE
Perform path resolution function in Meshroom core

### DIFF
--- a/meshroom/core/fileUtils.py
+++ b/meshroom/core/fileUtils.py
@@ -1,25 +1,30 @@
 import os
 import re
 
+pattern = r"(?P<FILESTEM_PREFIX>.*?)(?P<FRAMEID_STR>[-._]\d+)?(?P<EXTENSION>\.\w{3,4})"
+compiled_pattern = re.compile(pattern)
+compiled_frameId = re.compile(r"(\D+)?(?P<FRAMEID>\d+$)")
+
 def getFileElements(inputFilePath: str):
 
     filename = os.path.basename(inputFilePath)
-    pattern = r"(?P<FILESTEM>.*?)(?P<FRAME_ID>[-._]\d+)?(?P<EXTENSION>\.\w{3,4})"
-    match = re.search(pattern, filename)
-    frameId = match.group("FRAME_ID")
+    match = compiled_pattern.search(filename)
+    frameId_str = match.group("FRAMEID_STR")
     
     fileElements = {}
     if match:
         fileElements = {
             "<PATH>": inputFilePath,
             "<FILENAME>": filename,
-            "<FILESTEM>": match.group("FILESTEM"),
-            "<FILESTEM_PREFIX>": match.group("FILESTEM"),
+            "<FILESTEM>": match.group("FILESTEM_PREFIX"),
+            "<FILESTEM_PREFIX>": match.group("FILESTEM_PREFIX"),
             "<EXTENSION>": match.group("EXTENSION"),
         }
-    if frameId is not None:
-        fileElements["<FRAMEID>"] = frameId
-        fileElements["<FILESTEM>"] += frameId
+    if frameId_str is not None:
+        fileElements["<FRAMEID_STR>"] = frameId_str
+        fileElements["<FILESTEM>"] += frameId_str
+        match_frameId = compiled_frameId.search(frameId_str)
+        fileElements["<FRAMEID>"] = match_frameId.group("FRAMEID")
 
     return fileElements
 
@@ -43,8 +48,10 @@ def replacePatterns(input, pattern, replacements):
     def replaceMatch(match):
         key = match.group()
         return replacements.get(key, "")
-    return re.sub(pattern, replaceMatch, input)
+    return pattern.sub(replaceMatch, input)
 
+
+compiled_element = re.compile(r"<\w*>")
 
 def resolvePath(input, outputTemplate: str) -> str:
 
@@ -53,7 +60,7 @@ def resolvePath(input, outputTemplate: str) -> str:
     else:
         replacements = getViewElements(input)
 
-    resolved = replacePatterns(outputTemplate, r"<\w*>", replacements)
+    resolved = replacePatterns(outputTemplate, compiled_element, replacements)
 
     return resolved
 

--- a/meshroom/core/fileUtils.py
+++ b/meshroom/core/fileUtils.py
@@ -1,0 +1,59 @@
+import os
+import re
+
+def getFileElements(inputFilePath: str):
+
+    filename = os.path.basename(inputFilePath)
+    pattern = r"(?P<FILESTEM>.*?)(?P<FRAME_ID>[-._]\d+)?(?P<EXTENSION>\.\w{3,4})"
+    match = re.search(pattern, filename)
+    frameId = match.group("FRAME_ID")
+    
+    fileElements = {}
+    if match:
+        fileElements = {
+            "<PATH>": inputFilePath,
+            "<FILENAME>": filename,
+            "<FILESTEM>": match.group("FILESTEM"),
+            "<FILESTEM_PREFIX>": match.group("FILESTEM"),
+            "<EXTENSION>": match.group("EXTENSION"),
+        }
+    if frameId is not None:
+        fileElements["<FRAMEID>"] = frameId
+        fileElements["<FILESTEM>"] += frameId
+
+    return fileElements
+
+
+def getViewElements(vp):
+
+    vpPath = vp.childAttribute("path").value
+
+    viewElements = getFileElements(vpPath)
+
+    viewElements["<VIEW_ID>"] = str(vp.childAttribute("viewId").value)
+    viewElements["<INTRINSIC_ID>"] = str(vp.childAttribute("intrinsicId").value)
+    viewElements["<POSE_ID>"] = str(vp.childAttribute("poseId").value)
+
+    return viewElements
+
+
+def replacePatterns(input, pattern, replacements):
+    # Use all substrings of "input" matching the regex "pattern" as a key to substitute themselves by their value in the dictionnary "replacements".
+    # If "replacements" does not contain the key, the key is removed from "input" to build the resolved string.
+    def replaceMatch(match):
+        key = match.group()
+        return replacements.get(key, "")
+    return re.sub(pattern, replaceMatch, input)
+
+
+def resolvePath(input, outputTemplate: str) -> str:
+
+    if isinstance(input, str):
+        replacements = getFileElements(input)
+    else:
+        replacements = getViewElements(input)
+
+    resolved = replacePatterns(outputTemplate, r"<\w*>", replacements)
+
+    return resolved
+

--- a/meshroom/core/fileUtils.py
+++ b/meshroom/core/fileUtils.py
@@ -38,7 +38,7 @@ def getViewElements(vp):
 
 
 def replacePatterns(input, pattern, replacements):
-    # Use all substrings of "input" matching the regex "pattern" as a key to substitute themselves by their value in the dictionnary "replacements".
+    # Use all substrings of "input" matching the regex "pattern" as a key to substitute themselves by their value in the dictionary "replacements".
     # If "replacements" does not contain the key, the key is removed from "input" to build the resolved string.
     def replaceMatch(match):
         key = match.group()

--- a/meshroom/ui/components/filepath.py
+++ b/meshroom/ui/components/filepath.py
@@ -111,8 +111,8 @@ class FilepathHelper(QObject):
     @Slot(str, QObject, result=str)
     def resolve(self, path, vp):
         # Resolve dynamic path that depends on viewpoint
+        from meshroom.core import fileUtils
 
-        replacements = {}
         if vp == None:
             replacements = FilepathHelper.getFilenamesFromFolder(FilepathHelper, FilepathHelper.dirname(FilepathHelper, path), FilepathHelper.extension(FilepathHelper, path))
             resolved = [path for i in range(len(replacements))]
@@ -120,25 +120,8 @@ class FilepathHelper(QObject):
                 for i in range(len(resolved)):
                     resolved[i] = resolved[i].replace("<FRAMEID>", replacements[i])
             return resolved
-        else:
 
-            vpPath = vp.childAttribute("path").value
-            filename = FilepathHelper.basename(FilepathHelper, vpPath)
-            replacements = {
-                "<VIEW_ID>": str(vp.childAttribute("viewId").value),
-                "<INTRINSIC_ID>": str(vp.childAttribute("intrinsicId").value),
-                "<POSE_ID>": str(vp.childAttribute("poseId").value),
-                "<PATH>": vpPath,
-                "<FILENAME>": filename,
-                "<FILESTEM>": FilepathHelper.removeExtension(FilepathHelper, filename),
-                "<EXTENSION>": FilepathHelper.extension(FilepathHelper, filename),
-            }
-
-        resolved = path
-        for key in replacements:
-            resolved = resolved.replace(key, replacements[key])
-
-        return resolved
+        return fileUtils.resolvePath(vp, path)
     
     @Slot(str, result="QVariantList")
     @Slot(str, str, result="QVariantList")


### PR DESCRIPTION
<!-- Checklist before submission:

 - I have read the [contribution guidelines](../CONTRIBUTING.md).
 - I have updated the documentation, if applicable.
 - I have ensured that the change is tested somewhere.
 - I have followed the prevailing code style (for history readability and limit conflicts for maintainance).

-->
## Description
This PR implements the path resolution function within meshroom core in the new file fileUtils.py. That resolution was formerly implemented in meshroom ui components. The original method still exists but has been cleaned up and calls the new ones.

The path resolution function replace all the fields <FIELD> in a template name by their corresponding value extracted whether from an input filepath or a viewpoint.

A dictionary is built from the input filepath or the viewpoint. The fields to be replaced in the template name are supposed to be found amongst the keys of that dictionary. In case a key does not exist the corresponding input field is discarded to build the resolved path. Such a case can occur for example if the field <FRAMEID> is used in the template whereas the input filepath does not contain any value corresponding to a frame number.

The way the replacement is done has also been optimized using regex sub function.

## Features list

<!--
- [ ] Feature one. Fix #XXX
- [ ] Improve something else
- [ ] Connect to #3 (to declare link to issues without closing it when the PR is merged).
- [X] Add "X" when it is done.
-->


## Implementation remarks


<!--
Explain main implementation choices.
It is also the right place to ask for feedback and help when you hesitate on the implementation.
-->
