### PR TITLE
[ui] Add NodeActions to launch computation

### DIFF
--- a/meshroom/ui/graph.py
+++ b/meshroom/ui/graph.py
@@ -1169,8 +1169,29 @@ class UIGraph(QObject):
             logging.warning("Content is not a valid graph data.")
             return []
         return result
-
-
+    
+    @Slot(Node, result=bool)
+    def canComputeNode(self, node: Node) -> bool:
+        """ Check if the node can be computed """
+        if node.isCompatibilityNode or not node.isComputableType:
+            return False
+        if node.isComputed:
+            return True
+        if self._graph.canComputeTopologically(node) and self._graph.canSubmitOrCompute(node) % 2 == 1:
+            return True
+        return False
+    
+    @Slot(Node, result=bool)
+    def canSubmitNode(self, node: Node) -> bool:
+        """ Check if the node can be submitted """
+        if node.isCompatibilityNode or not node.isComputableType:
+            return False
+        if node.isComputed:
+            return True
+        if self._graph.canComputeTopologically(node) and self._graph.canSubmitOrCompute(node)> 1:
+            return True
+        return False
+    
     undoStack = Property(QObject, lambda self: self._undoStack, constant=True)
     graphChanged = Signal()
     graph = Property(Graph, lambda self: self._graph, notify=graphChanged)

--- a/meshroom/ui/graph.py
+++ b/meshroom/ui/graph.py
@@ -1173,7 +1173,7 @@ class UIGraph(QObject):
     @Slot(Node, result=bool)
     def canComputeNode(self, node: Node) -> bool:
         """ Check if the node can be computed """
-        if node.isCompatibilityNode or not node.isComputableType:
+        if node.isCompatibilityNode or not node.isComputableType or node.getLocked():
             return False
         if node.isComputed:
             return True
@@ -1184,7 +1184,7 @@ class UIGraph(QObject):
     @Slot(Node, result=bool)
     def canSubmitNode(self, node: Node) -> bool:
         """ Check if the node can be submitted """
-        if node.isCompatibilityNode or not node.isComputableType:
+        if node.isCompatibilityNode or not node.isComputableType or node.getLocked():
             return False
         if node.isComputed:
             return True

--- a/meshroom/ui/qml/Controls/NodeActions.qml
+++ b/meshroom/ui/qml/Controls/NodeActions.qml
@@ -74,11 +74,9 @@ Item {
         // Update position
         function updatePosition() {
             if (!selectedNodeDelegate || !draggable) return
-
             // Calculate node position in screen coordinates
             const nodeScreenX = selectedNodeDelegate.x * draggable.scale + draggable.x
             const nodeScreenY = selectedNodeDelegate.y * draggable.scale + draggable.y
-
             // Position header above the node (fixed offset in screen pixels)
             x = nodeScreenX + (selectedNodeDelegate.width * draggable.scale - width) / 2
             y = nodeScreenY - height - headerOffset
@@ -105,7 +103,11 @@ Item {
         // 
 
         property bool nodeIsLocked: false
-        property bool submittedExternally: false
+        property bool canComputeNode: false
+        property bool canStopNode: false
+        property bool canSubmitNode: false
+        property bool nodeSubmitted: false
+
         property int computeButtonState: NodeActions.ButtonState.LAUNCHABLE
         property string computeButtonIcon: {
             switch (computeButtonState) {
@@ -117,56 +119,39 @@ Item {
         property int submitButtonState: NodeActions.ButtonState.LAUNCHABLE
 
         function getComputeButtonState(node) {
-            if (!node.isComputableType || node.isCompatibilityNode)
-                return NodeActions.ButtonState.DISABLED
-            if (node.canBeStopped()) return NodeActions.ButtonState.STOPPABLE
-            if (node.canBeCanceled()) return NodeActions.ButtonState.STOPPABLE
-            if (actionHeader.nodeIsLocked) return NodeActions.ButtonState.DISABLED
-            switch (node.globalStatus) {
-                case "NONE":
-                case "ERROR":
-                case "STOPPED":
-                case "KILLED":
-                    return NodeActions.ButtonState.LAUNCHABLE
-                case "SUCCESS":
-                    return NodeActions.ButtonState.DELETABLE
-            }
+            if (actionHeader.canStopNode)
+                return NodeActions.ButtonState.STOPPABLE
+            if (!actionHeader.nodeIsLocked && node.globalStatus == "SUCCESS")
+                return NodeActions.ButtonState.DELETABLE
+            if (!actionHeader.nodeIsLocked && actionHeader.canComputeNode)
+                return NodeActions.ButtonState.LAUNCHABLE
             return NodeActions.ButtonState.DISABLED
         }
 
         function getSubmitButtonState(node) {
-            if (!node.isComputableType || node.isCompatibilityNode)
+            if (actionHeader.nodeIsLocked || actionHeader.canStopNode)
                 return NodeActions.ButtonState.DISABLED
-            if (actionHeader.nodeIsLocked || node.canBeStopped()) {
-                return NodeActions.ButtonState.DISABLED
-            }
-            switch (node.globalStatus) {
-                case "NONE":
-                case "ERROR":
-                case "STOPPED":
-                case "KILLED":
-                case "SUCCESS":
-                    return NodeActions.ButtonState.LAUNCHABLE
-                    return NodeActions.ButtonState.LAUNCHABLE
-                    break
-                // SUBMITTED / RUNNING / INPUT -> DISABLED
-            }
+            if (!actionHeader.nodeIsLocked && actionHeader.canSubmitNode)
+                return NodeActions.ButtonState.LAUNCHABLE
             return NodeActions.ButtonState.DISABLED
         }
         
         function isSubmittedExternally(node) {
-            if (node.globalExecMode == "EXTERN" && node.globalStatus == "SUBMITTED")
-                return true
-            return false
+            return node.globalExecMode == "EXTERN" && ["RUNNING", "SUBMITTED"].includes(node.globalStatus)
         }
 
         function updateProperties(node) {
+            if (!node) return
+            // Update properties values
+            actionHeader.canComputeNode = uigraph.canComputeNode(node)
+            actionHeader.canSubmitNode = uigraph.canSubmitNode(node)
+            actionHeader.canStopNode = node.canBeStopped()
             actionHeader.nodeIsLocked = node.locked
+            actionHeader.nodeSubmitted = isSubmittedExternally(node)
+            // Update button states
             actionHeader.computeButtonState = getComputeButtonState(node)
             actionHeader.submitButtonState = getSubmitButtonState(node)
-            actionHeader.submittedExternally = isSubmittedExternally(node)
         }
-
 
         // Set initial state & position
         onSelectedNodeDelegateChanged: {
@@ -208,7 +193,7 @@ Item {
                 font.pointSize: 16
                 text: actionHeader.computeButtonIcon
                 padding: 6
-                ToolTip.text: "Start/Stop Compute"
+                ToolTip.text: "Start/Stop/Restart Compute"
                 ToolTip.visible: hovered
                 ToolTip.delay: 1000
                 enabled: actionHeader.computeButtonState != NodeActions.ButtonState.DISABLED
@@ -233,6 +218,10 @@ Item {
                     radius: 3
                 }
                 onClicked: {
+                    // The remaining issue with this design is that if we computed half the chunks
+                    // then the only option we have is to resume the compute
+                    // We don't have a restart from zero (delete + start) in this case
+                    // But this would require an additional button
                     switch (actionHeader.computeButtonState) {
                         case NodeActions.ButtonState.STOPPABLE: 
                             root.stopComputeRequest(actionHeader.selectedNode)
@@ -243,7 +232,6 @@ Item {
                         case NodeActions.ButtonState.DELETABLE: 
                             root.deleteDataRequest(actionHeader.selectedNode)
                             break
-                        default: break
                     }
                 }
             }
@@ -259,10 +247,9 @@ Item {
                 ToolTip.delay: 1000
                 visible: root.uigraph ? root.uigraph.canSubmit : false
                 enabled: actionHeader.submitButtonState != NodeActions.ButtonState.DISABLED
-                // enabled: actionHeader.selectedNode ? !actionHeader.nodeLocked : false
                 background: Rectangle {
                     color: {
-                        if (actionHeader.submittedExternally) 
+                        if (actionHeader.nodeSubmitted) 
                             return Qt.darker(Colors.statusColors["SUBMITTED"], 1.2)
                         if (!submitButton.enabled) return activePalette.button
                         if (submitButton.hovered) return activePalette.highlight

--- a/meshroom/ui/qml/Controls/NodeActions.qml
+++ b/meshroom/ui/qml/Controls/NodeActions.qml
@@ -212,7 +212,11 @@ Item {
                 enabled: actionHeader.computeButtonState % 2 == 1  // Launchable & Stoppable
                 background: Rectangle {
                     color: {
-                        if (!computeButton.enabled) return activePalette.button
+                        if (!computeButton.enabled) {
+                            if (actionHeader.nodeSubmitted) 
+                                return Qt.darker(Colors.statusColors["SUBMITTED"], 1.2)
+                            return activePalette.button
+                        }
                         if (actionHeader.computeButtonState == NodeActions.ButtonState.STOPPABLE)
                             return computeButton.hovered ? Colors.orange : Qt.darker(Colors.orange, 1.3)
                         return computeButton.hovered ? activePalette.highlight : activePalette.button
@@ -270,9 +274,11 @@ Item {
                 enabled: actionHeader.submitButtonState != NodeActions.ButtonState.DISABLED
                 background: Rectangle {
                     color: {
-                        if (!submitButton.enabled) return activePalette.button
-                        if (actionHeader.nodeSubmitted) 
-                            return Qt.darker(Colors.statusColors["SUBMITTED"], 1.2)
+                        if (!submitButton.enabled) {
+                            if (actionHeader.nodeSubmitted) 
+                                return Qt.darker(Colors.statusColors["SUBMITTED"], 1.2)
+                            return activePalette.button
+                        }
                         return submitButton.hovered ? activePalette.highlight : activePalette.button
                     }
                     opacity: submitButton.hovered ? 1 : root._opacity

--- a/meshroom/ui/qml/Controls/NodeActions.qml
+++ b/meshroom/ui/qml/Controls/NodeActions.qml
@@ -5,7 +5,6 @@ import QtQuick.Layouts
 import MaterialIcons 2.2
 import Utils 1.0
 
-
 Item {
     id: root
     
@@ -34,7 +33,7 @@ Item {
         if (!nodeRepeater) 
             return null
         
-        for(var i = 0; i < nodeRepeater.count; ++i) {
+        for (var i = 0; i < nodeRepeater.count; ++i) {
             if (nodeRepeater.itemAt(i).node === node)
                 return nodeRepeater.itemAt(i)
         }
@@ -45,11 +44,8 @@ Item {
     Rectangle {
         id: actionHeader
 
-        function hasSelectedNode() {
-            return uigraph && uigraph.nodeSelection.selectedIndexes.length===1
-        }
-
-        readonly property var selectedNode: hasSelectedNode() ? uigraph.selectedNode : null
+        readonly property bool hasSelectedNode: uigraph && uigraph.nodeSelection.selectedIndexes.length === 1
+        readonly property var selectedNode: hasSelectedNode ? uigraph.selectedNode : null
         readonly property var selectedNodeDelegate: selectedNode ? root.nodeDelegate(selectedNode) : null
 
         visible: selectedNodeDelegate !== null
@@ -57,33 +53,27 @@ Item {
         width: actionItemsRow.width
         height: actionItemsRow.height
 
-        // Properties depending on selectedNode
-        readonly property string currentExecMode: selectedNode ? selectedNode.globalExecMode : "NONE"
-        readonly property string currentStatus: selectedNode ? selectedNode.globalStatus : "NONE"
-        readonly property bool nodeCanBeStopped: selectedNode ? selectedNode.canBeStopped() : false
-        readonly property bool nodeIsExternal: selectedNode ? selectedNode.isExternal : false
-        readonly property bool nodeLocked: selectedNode ? selectedNode.locked : false
+        // State properties 
+        property string currentExecMode: selectedNode ? selectedNode.globalExecMode : "NONE"
+        property string currentStatus: selectedNode ? selectedNode.globalStatus : "NONE"
+        property bool nodeCanBeStopped: selectedNode ? selectedNode.canBeStopped() : false
+        property bool nodeIsExternal: selectedNode ? selectedNode.isExternal : false
+        property bool nodeLocked: selectedNode ? selectedNode.locked : false
 
-        Connections {
-            target: actionHeader.selectedNode
-            function onGlobalStatusChanged() {
-                actionHeader.currentStatusChanged()
-            }
-            function onGlobalExecModeChanged() {
-                actionHeader.currentExecModeChanged()
-            }
-            ignoreUnknownSignals: true
-        }
+        // Derived values
+        readonly property bool runningExternally: currentExecMode === "EXTERN"
+                                                  && ["SUBMITTED", "RUNNING"].includes(currentStatus)
+        readonly property bool stoppable: selectedNode && currentStatus === "RUNNING" && nodeCanBeStopped
+        readonly property bool launchable: selectedNode &&
+                                           (nodeCanBeStopped || ["NONE","STOPPED","KILLED","ERROR"].includes(currentStatus))
 
         // Prevents losing focus on the node when we click on buttons of the actionItems
         MouseArea {
             anchors.fill: parent
-            // Consume all mouse events to prevent propagation to GraphEditor
             onPressed:       function(mouse) { mouse.accepted = true }
             onReleased:      function(mouse) { mouse.accepted = true }
             onClicked:       function(mouse) { mouse.accepted = true }
             onDoubleClicked: function(mouse) { mouse.accepted = true }
-            // Allow the buttons to receive hover events
             hoverEnabled: false
         }
 
@@ -116,29 +106,29 @@ Item {
             ignoreUnknownSignals: true
         }
         
-        // Initial position update
+        // Set initial position
         onSelectedNodeDelegateChanged: updatePosition()
 
-        function isRunningExternally() {
-            return actionHeader.currentExecMode === "EXTERN" && ["SUBMITTED", "RUNNING"].includes(actionHeader.currentStatus)
+        // Listen to updates to status
+        Connections {
+            target: actionHeader.selectedNode
+            function onGlobalStatusChanged()   { actionHeader.currentStatus = target.globalStatus }
+            function onGlobalExecModeChanged() { actionHeader.currentExecMode = target.globalExecMode }
+            function onIsComputedChanged()     { actionHeader.nodeCanBeStopped = target.canBeStopped() }
+            function onLockedChanged()         { actionHeader.nodeLocked = target.locked }
+            ignoreUnknownSignals: true
         }
 
-        function isRunningLocally() {
-            if (!actionHeader.selectedNode) return false
-            if (actionHeader.nodeIsExternal) return false
-            return actionHeader.currentStatus === "RUNNING"
-        }
-
-        function canBeStopped() {
-            if (!actionHeader.selectedNode) return false
-            if (actionHeader.currentStatus !== "RUNNING") return false
-            return actionHeader.nodeCanBeStopped
-        }
-
-        function canBeLaunched() {
-            if (!actionHeader.selectedNode) return false
-            if (actionHeader.nodeCanBeStopped) return true
-            return ["NONE", "STOPPED", "KILLED", "ERROR"].includes(actionHeader.currentStatus)
+        // Also listen to uigraph for status updates
+        Connections {
+            target: root.uigraph
+            function onComputationStatusChanged() { 
+                actionHeader.currentStatus = actionHeader.selectedNode ? actionHeader.selectedNode.globalStatus : "NONE"
+            }
+            function onNodeStatusUpdated() {
+                actionHeader.currentStatus = actionHeader.selectedNode ? actionHeader.selectedNode.globalStatus : "NONE"
+            }
+            ignoreUnknownSignals: true
         }
 
         Row {
@@ -150,12 +140,12 @@ Item {
             MaterialToolButton {
                 id: computeButton
                 font.pointSize: 16
-                text: actionHeader.canBeStopped() ? MaterialIcons.cancel_schedule_send : MaterialIcons.send
+                text: actionHeader.stoppable ? MaterialIcons.cancel_schedule_send : MaterialIcons.send
                 padding: 6
                 ToolTip.text: "Start/Stop Compute"
                 ToolTip.visible: hovered
                 ToolTip.delay: 1000
-                enabled: actionHeader.selectedNode && actionHeader.canBeLaunched()
+                enabled: actionHeader.selectedNode && actionHeader.launchable
                 background: Rectangle {
                     color: {
                         if (!computeButton.enabled) return activePalette.button
@@ -173,7 +163,7 @@ Item {
                     radius: 3
                 }
                 onClicked: {
-                    if (actionHeader.isRunningLocally()) {
+                    if (actionHeader.selectedNode && !actionHeader.nodeIsExternal && actionHeader.currentStatus === "RUNNING") {
                         root.stopComputeRequest(actionHeader.selectedNode)
                     } else {
                         root.computeRequest(actionHeader.selectedNode)
@@ -190,12 +180,12 @@ Item {
                 ToolTip.text: "Re-compute"
                 ToolTip.visible: hovered
                 ToolTip.delay: 1000
-                enabled: actionHeader.selectedNode && !actionHeader.isRunningExternally()
+                enabled: actionHeader.selectedNode && !actionHeader.runningExternally
                 background: Rectangle {
                     color: {
                         if (!reComputeButton.enabled) return activePalette.button
-                        if (reComputeButton.hovered) return activePalette.highlight;
-                        return activePalette.button;
+                        if (reComputeButton.hovered) return activePalette.highlight
+                        return activePalette.button
                     }
                     opacity: reComputeButton.hovered ? 1 : root._opacity
                     border.color: reComputeButton.hovered ? activePalette.highlight : Qt.darker(activePalette.window, 1.3)
@@ -219,14 +209,13 @@ Item {
                 ToolTip.visible: hovered
                 ToolTip.delay: 1000
                 visible: root.uigraph ? root.uigraph.canSubmit : false
-                enabled: actionHeader.selectedNode ? !actionHeader.selectedNode.locked : false
-                
+                enabled: actionHeader.selectedNode ? !actionHeader.nodeLocked : false
                 background: Rectangle {
                     color: {
                         if (!submitButton.enabled) return activePalette.button
-                        if (actionHeader.isRunningExternally()) return Colors.statusColors["SUBMITTED"];
-                        if (submitButton.hovered) return activePalette.highlight;
-                        return activePalette.button;
+                        if (actionHeader.runningExternally) return Colors.statusColors["SUBMITTED"]
+                        if (submitButton.hovered) return activePalette.highlight
+                        return activePalette.button
                     }
                     opacity: submitButton.hovered ? 1 : root._opacity
                     border.color: submitButton.hovered ? activePalette.highlight : Qt.darker(activePalette.window, 1.3)
@@ -255,8 +244,8 @@ Item {
                 background: Rectangle {
                     color: {
                         if (!actionHeader.selectedNode) return activePalette.button
-                        if (reSubmitButton.hovered) return activePalette.highlight;
-                        return activePalette.button;
+                        if (reSubmitButton.hovered) return activePalette.highlight
+                        return activePalette.button
                     }
                     opacity: reSubmitButton.hovered ? 1 : root._opacity
                     border.color: reSubmitButton.hovered ? activePalette.highlight : Qt.darker(activePalette.window, 1.3)

--- a/meshroom/ui/qml/Controls/NodeActions.qml
+++ b/meshroom/ui/qml/Controls/NodeActions.qml
@@ -125,19 +125,19 @@ Item {
         function getComputeButtonState(node) {
             if (actionHeader.canStopNode)
                 return NodeActions.ButtonState.STOPPABLE
-            if (!actionHeader.nodeIsLocked) {
-                if (node.globalStatus == "SUCCESS")
-                    return NodeActions.ButtonState.DELETABLE
-                if (actionHeader.canComputeNode)
-                    return NodeActions.ButtonState.LAUNCHABLE
-            } 
+            if (!actionHeader.nodeIsLocked && node.globalStatus == "SUCCESS")
+                return NodeActions.ButtonState.DELETABLE
+            if (actionHeader.canComputeNode)
+                return NodeActions.ButtonState.LAUNCHABLE
             return NodeActions.ButtonState.DISABLED
         }
 
         function getSubmitButtonState(node) {
             if (actionHeader.nodeIsLocked || actionHeader.canStopNode)
                 return NodeActions.ButtonState.DISABLED
-            if (!actionHeader.nodeIsLocked && actionHeader.canSubmitNode)
+            if (!actionHeader.nodeIsLocked && node.globalStatus == "SUCCESS")
+                return NodeActions.ButtonState.DISABLED
+            if (actionHeader.canSubmitNode)
                 return NodeActions.ButtonState.LAUNCHABLE
             return NodeActions.ButtonState.DISABLED
         }
@@ -240,7 +240,7 @@ Item {
 
             // Clear node
             MaterialToolButton {
-                id: restartButton
+                id: deleteDataButton
                 font.pointSize: 16
                 text: MaterialIcons.delete_
                 padding: 6

--- a/meshroom/ui/qml/Controls/NodeActions.qml
+++ b/meshroom/ui/qml/Controls/NodeActions.qml
@@ -39,10 +39,10 @@ Item {
     }
 
     enum ButtonState {
-        LAUNCHABLE,
-        STOPPABLE,
-        DELETABLE,
-        DISABLED
+        DISABLED   = 0,
+        LAUNCHABLE = 1,
+        DELETABLE  = 2,
+        STOPPABLE  = 3
     }
 
     Rectangle {
@@ -105,6 +105,7 @@ Item {
         property bool nodeIsLocked: false
         property bool canComputeNode: false
         property bool canStopNode: false
+        property bool canRestartNode: false
         property bool canSubmitNode: false
         property bool nodeSubmitted: false
 
@@ -112,7 +113,6 @@ Item {
         property string computeButtonIcon: {
             switch (computeButtonState) {
                 case NodeActions.ButtonState.STOPPABLE: return MaterialIcons.cancel_schedule_send
-                case NodeActions.ButtonState.DELETABLE: return MaterialIcons.delete_
                 default: return MaterialIcons.send
             }
         }
@@ -121,10 +121,12 @@ Item {
         function getComputeButtonState(node) {
             if (actionHeader.canStopNode)
                 return NodeActions.ButtonState.STOPPABLE
-            if (!actionHeader.nodeIsLocked && node.globalStatus == "SUCCESS")
-                return NodeActions.ButtonState.DELETABLE
-            if (!actionHeader.nodeIsLocked && actionHeader.canComputeNode)
-                return NodeActions.ButtonState.LAUNCHABLE
+            if (!actionHeader.nodeIsLocked) {
+                if (node.globalStatus == "SUCCESS")
+                    return NodeActions.ButtonState.DELETABLE
+                if (actionHeader.canComputeNode)
+                    return NodeActions.ButtonState.LAUNCHABLE
+            } 
             return NodeActions.ButtonState.DISABLED
         }
 
@@ -139,18 +141,24 @@ Item {
         function isSubmittedExternally(node) {
             return node.globalExecMode == "EXTERN" && ["RUNNING", "SUBMITTED"].includes(node.globalStatus)
         }
+        
+        function isNodeRestartable(node) {
+            return actionHeader.computeButtonState == NodeActions.ButtonState.LAUNCHABLE && 
+                ["ERROR", "STOPPED", "KILLED"].includes(node.globalStatus)
+        }
 
         function updateProperties(node) {
             if (!node) return
             // Update properties values
             actionHeader.canComputeNode = uigraph.canComputeNode(node)
             actionHeader.canSubmitNode = uigraph.canSubmitNode(node)
-            actionHeader.canStopNode = node.canBeStopped()
+            actionHeader.canStopNode = node.canBeStopped() || node.canBeCanceled()
             actionHeader.nodeIsLocked = node.locked
             actionHeader.nodeSubmitted = isSubmittedExternally(node)
             // Update button states
             actionHeader.computeButtonState = getComputeButtonState(node)
             actionHeader.submitButtonState = getSubmitButtonState(node)
+            actionHeader.canRestartNode = isNodeRestartable(node)
         }
 
         // Set initial state & position
@@ -196,21 +204,14 @@ Item {
                 ToolTip.text: "Start/Stop/Restart Compute"
                 ToolTip.visible: hovered
                 ToolTip.delay: 1000
-                enabled: actionHeader.computeButtonState != NodeActions.ButtonState.DISABLED
+                visible: actionHeader.computeButtonState != NodeActions.ButtonState.DELETABLE
+                enabled: actionHeader.computeButtonState % 2 == 1  // Launchable & Stoppable
                 background: Rectangle {
                     color: {
                         if (!computeButton.enabled) return activePalette.button
-                        switch (actionHeader.computeButtonState) {
-                            case NodeActions.ButtonState.STOPPABLE:
-                                if (computeButton.hovered) return Colors.orange
-                                return Qt.darker(Colors.orange, 1.3)
-                            case NodeActions.ButtonState.DELETABLE:
-                                if (computeButton.hovered) return Colors.red
-                                return Qt.darker(Colors.red, 1.3)
-                            default: break
-                        }
-                        if (computeButton.hovered) return activePalette.highlight
-                        return activePalette.button
+                        if (actionHeader.computeButtonState == NodeActions.ButtonState.STOPPABLE)
+                            return computeButton.hovered ? Colors.orange : Qt.darker(Colors.orange, 1.3)
+                        return computeButton.hovered ? activePalette.highlight : activePalette.button
                     }
                     opacity: computeButton.hovered ? 1 : root._opacity
                     border.color: computeButton.hovered ? activePalette.highlight : Qt.darker(activePalette.window, 1.3)
@@ -218,10 +219,6 @@ Item {
                     radius: 3
                 }
                 onClicked: {
-                    // The remaining issue with this design is that if we computed half the chunks
-                    // then the only option we have is to resume the compute
-                    // We don't have a restart from zero (delete + start) in this case
-                    // But this would require an additional button
                     switch (actionHeader.computeButtonState) {
                         case NodeActions.ButtonState.STOPPABLE: 
                             root.stopComputeRequest(actionHeader.selectedNode)
@@ -229,10 +226,30 @@ Item {
                         case NodeActions.ButtonState.LAUNCHABLE: 
                             root.computeRequest(actionHeader.selectedNode)
                             break
-                        case NodeActions.ButtonState.DELETABLE: 
-                            root.deleteDataRequest(actionHeader.selectedNode)
-                            break
                     }
+                }
+            }
+
+            // Clear node
+            MaterialToolButton {
+                id: restartButton
+                font.pointSize: 16
+                text: MaterialIcons.delete_
+                padding: 6
+                ToolTip.text: "Delete data"
+                ToolTip.visible: hovered
+                ToolTip.delay: 1000
+                visible: actionHeader.canRestartNode || actionHeader.computeButtonState == NodeActions.ButtonState.DELETABLE
+                enabled: visible
+                background: Rectangle {
+                    color: computeButton.hovered ? Colors.red : Qt.darker(Colors.red, 1.3)
+                    opacity: computeButton.hovered ? 1 : root._opacity
+                    border.color: computeButton.hovered ? activePalette.highlight : Qt.darker(activePalette.window, 1.3)
+                    border.width: 1
+                    radius: 3
+                }
+                onClicked: {
+                    root.deleteDataRequest(actionHeader.selectedNode)
                 }
             }
 
@@ -249,11 +266,10 @@ Item {
                 enabled: actionHeader.submitButtonState != NodeActions.ButtonState.DISABLED
                 background: Rectangle {
                     color: {
+                        if (!submitButton.enabled) return activePalette.button
                         if (actionHeader.nodeSubmitted) 
                             return Qt.darker(Colors.statusColors["SUBMITTED"], 1.2)
-                        if (!submitButton.enabled) return activePalette.button
-                        if (submitButton.hovered) return activePalette.highlight
-                        return activePalette.button
+                        return submitButton.hovered ? activePalette.highlight : activePalette.button
                     }
                     opacity: submitButton.hovered ? 1 : root._opacity
                     border.color: submitButton.hovered ? activePalette.highlight : Qt.darker(activePalette.window, 1.3)

--- a/meshroom/ui/qml/Controls/NodeActions.qml
+++ b/meshroom/ui/qml/Controls/NodeActions.qml
@@ -1,0 +1,274 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+import MaterialIcons 2.2
+import Utils 1.0
+
+
+Item {
+    id: root
+    
+    // Settings
+    property real headerOffset: 10   // Distance above the node in screen pixels
+    property real _opacity: 0.9
+
+    // Objects passed from the graph editor
+    property var uigraph: null
+    property var draggable: null     // The draggable container from GraphEditor
+    property var nodeRepeater: null  // Reference to nodeRepeater to find delegates
+
+    // Signals
+    signal computeRequest(var node)
+    signal stopComputeRequest(var node)
+    signal reComputeRequest(var node)
+    signal submitRequest(var node)
+    signal reSubmitRequest(var node)
+    
+    SystemPalette { id: activePalette }
+
+    /**
+      * Get the node delegate
+      */
+    function nodeDelegate(node) {
+        if (!nodeRepeater) 
+            return null
+        
+        for(var i = 0; i < nodeRepeater.count; ++i) {
+            if (nodeRepeater.itemAt(i).node === node)
+                return nodeRepeater.itemAt(i)
+        }
+        
+        return null
+    }
+    
+    Rectangle {
+        id: actionHeader
+
+        function hasSelectedNode() {
+            return uigraph && uigraph.nodeSelection.selectedIndexes.length===1
+        }
+
+        readonly property var selectedNode: hasSelectedNode() ? uigraph.selectedNode : null
+        readonly property var selectedNodeDelegate: selectedNode ? root.nodeDelegate(selectedNode) : null
+
+        visible: selectedNodeDelegate !== null
+        color: "transparent"
+        width: actionItemsRow.width
+        height: actionItemsRow.height
+
+        // Properties depending on selectedNode
+        readonly property string currentExecMode: selectedNode ? selectedNode.globalExecMode : "NONE"
+        readonly property string currentStatus: selectedNode ? selectedNode.globalStatus : "NONE"
+        readonly property bool nodeCanBeStopped: selectedNode ? selectedNode.canBeStopped() : false
+        readonly property bool nodeIsExternal: selectedNode ? selectedNode.isExternal : false
+        readonly property bool nodeLocked: selectedNode ? selectedNode.locked : false
+
+        Connections {
+            target: actionHeader.selectedNode
+            function onGlobalStatusChanged() {
+                actionHeader.currentStatusChanged()
+            }
+            function onGlobalExecModeChanged() {
+                actionHeader.currentExecModeChanged()
+            }
+            ignoreUnknownSignals: true
+        }
+
+        // Prevents losing focus on the node when we click on buttons of the actionItems
+        MouseArea {
+            anchors.fill: parent
+            // Consume all mouse events to prevent propagation to GraphEditor
+            onPressed:       function(mouse) { mouse.accepted = true }
+            onReleased:      function(mouse) { mouse.accepted = true }
+            onClicked:       function(mouse) { mouse.accepted = true }
+            onDoubleClicked: function(mouse) { mouse.accepted = true }
+            // Allow the buttons to receive hover events
+            hoverEnabled: false
+        }
+
+        // Update position
+        function updatePosition() {
+            if (!selectedNodeDelegate || !draggable) return
+            
+            // Calculate node position in screen coordinates
+            const nodeScreenX = selectedNodeDelegate.x * draggable.scale + draggable.x
+            const nodeScreenY = selectedNodeDelegate.y * draggable.scale + draggable.y
+            
+            // Position header above the node (fixed offset in screen pixels)
+            x = nodeScreenX + (selectedNodeDelegate.width * draggable.scale - width) / 2
+            y = nodeScreenY - height - headerOffset
+        }
+
+        // Update position when the user moves on the graph
+        Connections {
+            target: root.draggable
+            function onXChanged()     { actionHeader.updatePosition() }
+            function onYChanged()     { actionHeader.updatePosition() }
+            function onScaleChanged() { actionHeader.updatePosition() }
+        }
+        
+        // Update position when nodes are moved
+        Connections {
+            target: actionHeader.selectedNodeDelegate
+            function onXChanged() { actionHeader.updatePosition() }
+            function onYChanged() { actionHeader.updatePosition() }
+            ignoreUnknownSignals: true
+        }
+        
+        // Initial position update
+        onSelectedNodeDelegateChanged: updatePosition()
+
+        function isRunningExternally() {
+            return actionHeader.currentExecMode === "EXTERN" && ["SUBMITTED", "RUNNING"].includes(actionHeader.currentStatus)
+        }
+
+        function isRunningLocally() {
+            if (!actionHeader.selectedNode) return false
+            if (actionHeader.nodeIsExternal) return false
+            return actionHeader.currentStatus === "RUNNING"
+        }
+
+        function canBeStopped() {
+            if (!actionHeader.selectedNode) return false
+            if (actionHeader.currentStatus !== "RUNNING") return false
+            return actionHeader.nodeCanBeStopped
+        }
+
+        function canBeLaunched() {
+            if (!actionHeader.selectedNode) return false
+            if (actionHeader.nodeCanBeStopped) return true
+            return ["NONE", "STOPPED", "KILLED", "ERROR"].includes(actionHeader.currentStatus)
+        }
+
+        Row {
+            id: actionItemsRow
+            anchors.centerIn: parent
+            spacing: 2
+            
+            // Compute button
+            MaterialToolButton {
+                id: computeButton
+                font.pointSize: 16
+                text: actionHeader.canBeStopped() ? MaterialIcons.cancel_schedule_send : MaterialIcons.send
+                padding: 6
+                ToolTip.text: "Start/Stop Compute"
+                ToolTip.visible: hovered
+                ToolTip.delay: 1000
+                enabled: actionHeader.selectedNode && actionHeader.canBeLaunched()
+                background: Rectangle {
+                    color: {
+                        if (!computeButton.enabled) return activePalette.button
+                        if (actionHeader.currentStatus === "RUNNING") {
+                            if (computeButton.hovered) return Colors.statusColors["STOPPED"]
+                            return Qt.darker(Colors.statusColors["STOPPED"], 1.3)
+                        } else {
+                            if (computeButton.hovered) return activePalette.highlight
+                            return activePalette.button
+                        }
+                    }
+                    opacity: computeButton.hovered ? 1 : root._opacity
+                    border.color: computeButton.hovered ? activePalette.highlight : Qt.darker(activePalette.window, 1.3)
+                    border.width: 1
+                    radius: 3
+                }
+                onClicked: {
+                    if (actionHeader.isRunningLocally()) {
+                        root.stopComputeRequest(actionHeader.selectedNode)
+                    } else {
+                        root.computeRequest(actionHeader.selectedNode)
+                    }
+                }
+            }
+            
+            // Re-compute button : stop local process and relaunch locally 
+            MaterialToolButton {
+                id: reComputeButton
+                font.pointSize: 16
+                text: MaterialIcons.autorenew
+                padding: 6
+                ToolTip.text: "Re-compute"
+                ToolTip.visible: hovered
+                ToolTip.delay: 1000
+                enabled: actionHeader.selectedNode && !actionHeader.isRunningExternally()
+                background: Rectangle {
+                    color: {
+                        if (!reComputeButton.enabled) return activePalette.button
+                        if (reComputeButton.hovered) return activePalette.highlight;
+                        return activePalette.button;
+                    }
+                    opacity: reComputeButton.hovered ? 1 : root._opacity
+                    border.color: reComputeButton.hovered ? activePalette.highlight : Qt.darker(activePalette.window, 1.3)
+                    border.width: 1
+                    radius: 3
+                }
+                onClicked: {
+                    if (actionHeader.selectedNode) {
+                        root.reComputeRequest(actionHeader.selectedNode)
+                    }
+                }
+            }
+
+            // Submit button
+            MaterialToolButton {
+                id: submitButton
+                font.pointSize: 16
+                text: MaterialIcons.rocket_launch
+                padding: 6
+                ToolTip.text: "Submit on Render Farm"
+                ToolTip.visible: hovered
+                ToolTip.delay: 1000
+                visible: root.uigraph ? root.uigraph.canSubmit : false
+                enabled: actionHeader.selectedNode ? !actionHeader.selectedNode.locked : false
+                
+                background: Rectangle {
+                    color: {
+                        if (!submitButton.enabled) return activePalette.button
+                        if (actionHeader.isRunningExternally()) return Colors.statusColors["SUBMITTED"];
+                        if (submitButton.hovered) return activePalette.highlight;
+                        return activePalette.button;
+                    }
+                    opacity: submitButton.hovered ? 1 : root._opacity
+                    border.color: submitButton.hovered ? activePalette.highlight : Qt.darker(activePalette.window, 1.3)
+                    border.width: 1
+                    radius: 3
+                }
+                onClicked: {
+                    if (actionHeader.selectedNode) {
+                        root.submitRequest(actionHeader.selectedNode)
+                    }
+                }
+            }
+            
+            // Re-submit button : stop everything and relaunch on farm
+            // TODO : disabled for now because we can't stop jobs submitted on farm
+            MaterialToolButton {
+                id: reSubmitButton
+                font.pointSize: 16
+                text: MaterialIcons.double_arrow
+                padding: 6
+                ToolTip.text: "Re-submit on Render Farm"
+                ToolTip.visible: hovered
+                ToolTip.delay: 1000
+                visible: false  // root.uigraph ? root.uigraph.canSubmit : false
+                enabled: actionHeader.selectedNode !== null
+                background: Rectangle {
+                    color: {
+                        if (!actionHeader.selectedNode) return activePalette.button
+                        if (reSubmitButton.hovered) return activePalette.highlight;
+                        return activePalette.button;
+                    }
+                    opacity: reSubmitButton.hovered ? 1 : root._opacity
+                    border.color: reSubmitButton.hovered ? activePalette.highlight : Qt.darker(activePalette.window, 1.3)
+                    border.width: 1
+                    radius: 3
+                }
+                onClicked: {
+                    if (actionHeader.selectedNode) {
+                        root.reSubmitRequest(actionHeader.selectedNode)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/meshroom/ui/qml/Controls/NodeActions.qml
+++ b/meshroom/ui/qml/Controls/NodeActions.qml
@@ -117,6 +117,8 @@ Item {
         property int submitButtonState: NodeActions.ButtonState.LAUNCHABLE
 
         function getComputeButtonState(node) {
+            if (!node.isComputableType || node.isCompatibilityNode)
+                return NodeActions.ButtonState.DISABLED
             if (node.canBeStopped()) return NodeActions.ButtonState.STOPPABLE
             if (node.canBeCanceled()) return NodeActions.ButtonState.STOPPABLE
             if (actionHeader.nodeIsLocked) return NodeActions.ButtonState.DISABLED
@@ -133,6 +135,8 @@ Item {
         }
 
         function getSubmitButtonState(node) {
+            if (!node.isComputableType || node.isCompatibilityNode)
+                return NodeActions.ButtonState.DISABLED
             if (actionHeader.nodeIsLocked || node.canBeStopped()) {
                 return NodeActions.ButtonState.DISABLED
             }

--- a/meshroom/ui/qml/Controls/NodeActions.qml
+++ b/meshroom/ui/qml/Controls/NodeActions.qml
@@ -20,7 +20,7 @@ Item {
     // Signals
     signal computeRequest(var node)
     signal stopComputeRequest(var node)
-    signal reComputeRequest(var node)
+    signal deleteDataRequest(var node)
     signal submitRequest(var node)
     
     SystemPalette { id: activePalette }
@@ -41,7 +41,7 @@ Item {
     enum ButtonState {
         LAUNCHABLE,
         STOPPABLE,
-        RELAUNCHABLE,
+        DELETABLE,
         DISABLED
     }
 
@@ -110,7 +110,7 @@ Item {
         property string computeButtonIcon: {
             switch (computeButtonState) {
                 case NodeActions.ButtonState.STOPPABLE: return MaterialIcons.cancel_schedule_send
-                case NodeActions.ButtonState.RELAUNCHABLE: return MaterialIcons.autorenew
+                case NodeActions.ButtonState.DELETABLE: return MaterialIcons.delete_
                 default: return MaterialIcons.send
             }
         }
@@ -127,7 +127,7 @@ Item {
                 case "KILLED":
                     return NodeActions.ButtonState.LAUNCHABLE
                 case "SUCCESS":
-                    return NodeActions.ButtonState.RELAUNCHABLE
+                    return NodeActions.ButtonState.DELETABLE
             }
             return NodeActions.ButtonState.DISABLED
         }
@@ -213,8 +213,11 @@ Item {
                         if (!computeButton.enabled) return activePalette.button
                         switch (actionHeader.computeButtonState) {
                             case NodeActions.ButtonState.STOPPABLE:
-                                if (computeButton.hovered) return Colors.statusColors["STOPPED"]
-                                return Qt.darker(Colors.statusColors["STOPPED"], 1.3)
+                                if (computeButton.hovered) return Colors.orange
+                                return Qt.darker(Colors.orange, 1.3)
+                            case NodeActions.ButtonState.DELETABLE:
+                                if (computeButton.hovered) return Colors.red
+                                return Qt.darker(Colors.red, 1.3)
                             default: break
                         }
                         if (computeButton.hovered) return activePalette.highlight
@@ -233,8 +236,8 @@ Item {
                         case NodeActions.ButtonState.LAUNCHABLE: 
                             root.computeRequest(actionHeader.selectedNode)
                             break
-                        case NodeActions.ButtonState.RELAUNCHABLE: 
-                            root.reComputeRequest(actionHeader.selectedNode)
+                        case NodeActions.ButtonState.DELETABLE: 
+                            root.deleteDataRequest(actionHeader.selectedNode)
                             break
                         default: break
                     }

--- a/meshroom/ui/qml/Controls/NodeActions.qml
+++ b/meshroom/ui/qml/Controls/NodeActions.qml
@@ -82,6 +82,10 @@ Item {
             y = nodeScreenY - height - headerOffset
         }
 
+        onWidthChanged: {
+            updatePosition()
+        }
+
         // Update position when the user moves on the graph
         Connections {
             target: root.draggable
@@ -163,9 +167,9 @@ Item {
 
         // Set initial state & position
         onSelectedNodeDelegateChanged: {
-            updatePosition()
             if (actionHeader.selectedNode) {
                 actionHeader.updateProperties(actionHeader.selectedNode)
+                Qt.callLater(actionHeader.updatePosition)
             }
         }
 

--- a/meshroom/ui/qml/Controls/NodeActions.qml
+++ b/meshroom/ui/qml/Controls/NodeActions.qml
@@ -9,8 +9,8 @@ Item {
     id: root
     
     // Settings
-    property real headerOffset: 10   // Distance above the node in screen pixels
-    property real _opacity: 0.9
+    readonly property real headerOffset: 10   // Distance above the node in screen pixels
+    readonly property real _opacity: 0.9
 
     // Objects passed from the graph editor
     property var uigraph: null
@@ -22,7 +22,6 @@ Item {
     signal stopComputeRequest(var node)
     signal reComputeRequest(var node)
     signal submitRequest(var node)
-    signal reSubmitRequest(var node)
     
     SystemPalette { id: activePalette }
 
@@ -32,15 +31,20 @@ Item {
     function nodeDelegate(node) {
         if (!nodeRepeater) 
             return null
-        
         for (var i = 0; i < nodeRepeater.count; ++i) {
             if (nodeRepeater.itemAt(i).node === node)
                 return nodeRepeater.itemAt(i)
         }
-        
         return null
     }
-    
+
+    enum ButtonState {
+        LAUNCHABLE,
+        STOPPABLE,
+        RELAUNCHABLE,
+        DISABLED
+    }
+
     Rectangle {
         id: actionHeader
 
@@ -53,19 +57,9 @@ Item {
         width: actionItemsRow.width
         height: actionItemsRow.height
 
-        // State properties 
-        property string currentExecMode: selectedNode ? selectedNode.globalExecMode : "NONE"
-        property string currentStatus: selectedNode ? selectedNode.globalStatus : "NONE"
-        property bool nodeCanBeStopped: selectedNode ? selectedNode.canBeStopped() : false
-        property bool nodeIsExternal: selectedNode ? selectedNode.isExternal : false
-        property bool nodeLocked: selectedNode ? selectedNode.locked : false
-
-        // Derived values
-        readonly property bool runningExternally: currentExecMode === "EXTERN"
-                                                  && ["SUBMITTED", "RUNNING"].includes(currentStatus)
-        readonly property bool stoppable: selectedNode && currentStatus === "RUNNING" && nodeCanBeStopped
-        readonly property bool launchable: selectedNode &&
-                                           (nodeCanBeStopped || ["NONE","STOPPED","KILLED","ERROR"].includes(currentStatus))
+        // 
+        // ===== Manage NodeActions position =====
+        // 
 
         // Prevents losing focus on the node when we click on buttons of the actionItems
         MouseArea {
@@ -80,11 +74,11 @@ Item {
         // Update position
         function updatePosition() {
             if (!selectedNodeDelegate || !draggable) return
-            
+
             // Calculate node position in screen coordinates
             const nodeScreenX = selectedNodeDelegate.x * draggable.scale + draggable.x
             const nodeScreenY = selectedNodeDelegate.y * draggable.scale + draggable.y
-            
+
             // Position header above the node (fixed offset in screen pixels)
             x = nodeScreenX + (selectedNodeDelegate.width * draggable.scale - width) / 2
             y = nodeScreenY - height - headerOffset
@@ -97,7 +91,7 @@ Item {
             function onYChanged()     { actionHeader.updatePosition() }
             function onScaleChanged() { actionHeader.updatePosition() }
         }
-        
+
         // Update position when nodes are moved
         Connections {
             target: actionHeader.selectedNodeDelegate
@@ -105,28 +99,96 @@ Item {
             function onYChanged() { actionHeader.updatePosition() }
             ignoreUnknownSignals: true
         }
+
+        // 
+        // ===== Manage buttons =====
+        // 
+
+        property bool nodeIsLocked: false
+        property bool submittedExternally: false
+        property int computeButtonState: NodeActions.ButtonState.LAUNCHABLE
+        property string computeButtonIcon: {
+            switch (computeButtonState) {
+                case NodeActions.ButtonState.STOPPABLE: return MaterialIcons.cancel_schedule_send
+                case NodeActions.ButtonState.RELAUNCHABLE: return MaterialIcons.autorenew
+                default: return MaterialIcons.send
+            }
+        }
+        property int submitButtonState: NodeActions.ButtonState.LAUNCHABLE
+
+        function getComputeButtonState(node) {
+            if (node.canBeStopped()) return NodeActions.ButtonState.STOPPABLE
+            if (node.canBeCanceled()) return NodeActions.ButtonState.STOPPABLE
+            if (actionHeader.nodeIsLocked) return NodeActions.ButtonState.DISABLED
+            switch (node.globalStatus) {
+                case "NONE":
+                case "ERROR":
+                case "STOPPED":
+                case "KILLED":
+                    return NodeActions.ButtonState.LAUNCHABLE
+                case "SUCCESS":
+                    return NodeActions.ButtonState.RELAUNCHABLE
+            }
+            return NodeActions.ButtonState.DISABLED
+        }
+
+        function getSubmitButtonState(node) {
+            if (actionHeader.nodeIsLocked || node.canBeStopped()) {
+                return NodeActions.ButtonState.DISABLED
+            }
+            switch (node.globalStatus) {
+                case "NONE":
+                case "ERROR":
+                case "STOPPED":
+                case "KILLED":
+                case "SUCCESS":
+                    return NodeActions.ButtonState.LAUNCHABLE
+                    return NodeActions.ButtonState.LAUNCHABLE
+                    break
+                // SUBMITTED / RUNNING / INPUT -> DISABLED
+            }
+            return NodeActions.ButtonState.DISABLED
+        }
         
-        // Set initial position
-        onSelectedNodeDelegateChanged: updatePosition()
+        function isSubmittedExternally(node) {
+            if (node.globalExecMode == "EXTERN" && node.globalStatus == "SUBMITTED")
+                return true
+            return false
+        }
+
+        function updateProperties(node) {
+            actionHeader.nodeIsLocked = node.locked
+            actionHeader.computeButtonState = getComputeButtonState(node)
+            actionHeader.submitButtonState = getSubmitButtonState(node)
+            actionHeader.submittedExternally = isSubmittedExternally(node)
+        }
+
+
+        // Set initial state & position
+        onSelectedNodeDelegateChanged: {
+            updatePosition()
+            if (actionHeader.selectedNode) {
+                actionHeader.updateProperties(actionHeader.selectedNode)
+            }
+        }
 
         // Listen to updates to status
         Connections {
             target: actionHeader.selectedNode
-            function onGlobalStatusChanged()   { actionHeader.currentStatus = target.globalStatus }
-            function onGlobalExecModeChanged() { actionHeader.currentExecMode = target.globalExecMode }
-            function onIsComputedChanged()     { actionHeader.nodeCanBeStopped = target.canBeStopped() }
-            function onLockedChanged()         { actionHeader.nodeLocked = target.locked }
+            function onGlobalStatusChanged() {
+                actionHeader.updateProperties(target)
+            }
+            function onLockedChanged() { 
+                actionHeader.nodeIsLocked = target.locked
+            }
             ignoreUnknownSignals: true
         }
 
-        // Also listen to uigraph for status updates
+        // Listen to updates from nodes that are not selected
         Connections {
             target: root.uigraph
-            function onComputationStatusChanged() { 
-                actionHeader.currentStatus = actionHeader.selectedNode ? actionHeader.selectedNode.globalStatus : "NONE"
-            }
-            function onNodeStatusUpdated() {
-                actionHeader.currentStatus = actionHeader.selectedNode ? actionHeader.selectedNode.globalStatus : "NONE"
+            function onComputingChanged() { 
+                actionHeader.updateProperties(actionHeader.selectedNode)
             }
             ignoreUnknownSignals: true
         }
@@ -135,27 +197,28 @@ Item {
             id: actionItemsRow
             anchors.centerIn: parent
             spacing: 2
-            
+
             // Compute button
             MaterialToolButton {
                 id: computeButton
                 font.pointSize: 16
-                text: actionHeader.stoppable ? MaterialIcons.cancel_schedule_send : MaterialIcons.send
+                text: actionHeader.computeButtonIcon
                 padding: 6
                 ToolTip.text: "Start/Stop Compute"
                 ToolTip.visible: hovered
                 ToolTip.delay: 1000
-                enabled: actionHeader.selectedNode && actionHeader.launchable
+                enabled: actionHeader.computeButtonState != NodeActions.ButtonState.DISABLED
                 background: Rectangle {
                     color: {
                         if (!computeButton.enabled) return activePalette.button
-                        if (actionHeader.currentStatus === "RUNNING") {
-                            if (computeButton.hovered) return Colors.statusColors["STOPPED"]
-                            return Qt.darker(Colors.statusColors["STOPPED"], 1.3)
-                        } else {
-                            if (computeButton.hovered) return activePalette.highlight
-                            return activePalette.button
+                        switch (actionHeader.computeButtonState) {
+                            case NodeActions.ButtonState.STOPPABLE:
+                                if (computeButton.hovered) return Colors.statusColors["STOPPED"]
+                                return Qt.darker(Colors.statusColors["STOPPED"], 1.3)
+                            default: break
                         }
+                        if (computeButton.hovered) return activePalette.highlight
+                        return activePalette.button
                     }
                     opacity: computeButton.hovered ? 1 : root._opacity
                     border.color: computeButton.hovered ? activePalette.highlight : Qt.darker(activePalette.window, 1.3)
@@ -163,38 +226,17 @@ Item {
                     radius: 3
                 }
                 onClicked: {
-                    if (actionHeader.selectedNode && !actionHeader.nodeIsExternal && actionHeader.currentStatus === "RUNNING") {
-                        root.stopComputeRequest(actionHeader.selectedNode)
-                    } else {
-                        root.computeRequest(actionHeader.selectedNode)
-                    }
-                }
-            }
-            
-            // Re-compute button : stop local process and relaunch locally 
-            MaterialToolButton {
-                id: reComputeButton
-                font.pointSize: 16
-                text: MaterialIcons.autorenew
-                padding: 6
-                ToolTip.text: "Re-compute"
-                ToolTip.visible: hovered
-                ToolTip.delay: 1000
-                enabled: actionHeader.selectedNode && !actionHeader.runningExternally
-                background: Rectangle {
-                    color: {
-                        if (!reComputeButton.enabled) return activePalette.button
-                        if (reComputeButton.hovered) return activePalette.highlight
-                        return activePalette.button
-                    }
-                    opacity: reComputeButton.hovered ? 1 : root._opacity
-                    border.color: reComputeButton.hovered ? activePalette.highlight : Qt.darker(activePalette.window, 1.3)
-                    border.width: 1
-                    radius: 3
-                }
-                onClicked: {
-                    if (actionHeader.selectedNode) {
-                        root.reComputeRequest(actionHeader.selectedNode)
+                    switch (actionHeader.computeButtonState) {
+                        case NodeActions.ButtonState.STOPPABLE: 
+                            root.stopComputeRequest(actionHeader.selectedNode)
+                            break
+                        case NodeActions.ButtonState.LAUNCHABLE: 
+                            root.computeRequest(actionHeader.selectedNode)
+                            break
+                        case NodeActions.ButtonState.RELAUNCHABLE: 
+                            root.reComputeRequest(actionHeader.selectedNode)
+                            break
+                        default: break
                     }
                 }
             }
@@ -209,11 +251,13 @@ Item {
                 ToolTip.visible: hovered
                 ToolTip.delay: 1000
                 visible: root.uigraph ? root.uigraph.canSubmit : false
-                enabled: actionHeader.selectedNode ? !actionHeader.nodeLocked : false
+                enabled: actionHeader.submitButtonState != NodeActions.ButtonState.DISABLED
+                // enabled: actionHeader.selectedNode ? !actionHeader.nodeLocked : false
                 background: Rectangle {
                     color: {
+                        if (actionHeader.submittedExternally) 
+                            return Qt.darker(Colors.statusColors["SUBMITTED"], 1.2)
                         if (!submitButton.enabled) return activePalette.button
-                        if (actionHeader.runningExternally) return Colors.statusColors["SUBMITTED"]
                         if (submitButton.hovered) return activePalette.highlight
                         return activePalette.button
                     }
@@ -225,36 +269,6 @@ Item {
                 onClicked: {
                     if (actionHeader.selectedNode) {
                         root.submitRequest(actionHeader.selectedNode)
-                    }
-                }
-            }
-            
-            // Re-submit button : stop everything and relaunch on farm
-            // TODO : disabled for now because we can't stop jobs submitted on farm
-            MaterialToolButton {
-                id: reSubmitButton
-                font.pointSize: 16
-                text: MaterialIcons.double_arrow
-                padding: 6
-                ToolTip.text: "Re-submit on Render Farm"
-                ToolTip.visible: hovered
-                ToolTip.delay: 1000
-                visible: false  // root.uigraph ? root.uigraph.canSubmit : false
-                enabled: actionHeader.selectedNode !== null
-                background: Rectangle {
-                    color: {
-                        if (!actionHeader.selectedNode) return activePalette.button
-                        if (reSubmitButton.hovered) return activePalette.highlight
-                        return activePalette.button
-                    }
-                    opacity: reSubmitButton.hovered ? 1 : root._opacity
-                    border.color: reSubmitButton.hovered ? activePalette.highlight : Qt.darker(activePalette.window, 1.3)
-                    border.width: 1
-                    radius: 3
-                }
-                onClicked: {
-                    if (actionHeader.selectedNode) {
-                        root.reSubmitRequest(actionHeader.selectedNode)
                     }
                 }
             }

--- a/meshroom/ui/qml/Controls/qmldir
+++ b/meshroom/ui/qml/Controls/qmldir
@@ -22,3 +22,4 @@ SelectionLine 1.0 SelectionLine.qml
 DelegateSelectionBox 1.0 DelegateSelectionBox.qml
 DelegateSelectionLine 1.0 DelegateSelectionLine.qml
 StatusBar 1.0 StatusBar.qml
+NodeActions 1.0 NodeActions.qml

--- a/meshroom/ui/qml/GraphEditor/GraphEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/GraphEditor.qml
@@ -1087,7 +1087,11 @@ Item {
         }
         
         onStopComputeRequest: function(node) {
-            uigraph.stopNodeComputation(node)
+            if (node.canBeStopped()) {
+                uigraph.stopNodeComputation(node)
+            } else if (node.canBeCanceled()) {
+                uigraph.cancelNodeComputation(node)
+            }
         }
         
         onDeleteDataRequest: function(node) {

--- a/meshroom/ui/qml/GraphEditor/GraphEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/GraphEditor.qml
@@ -1099,7 +1099,6 @@ Item {
         }
         
         onSubmitRequest: function(node) {
-            if (node.isComputed) uigraph.clearSelectedNodesData();
             root.submitRequest([node])
         }
     }

--- a/meshroom/ui/qml/GraphEditor/GraphEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/GraphEditor.qml
@@ -1090,12 +1090,8 @@ Item {
             uigraph.stopNodeComputation(node)
         }
         
-        onReComputeRequest: function(node) {
-            // Only triggered if the node is already computed
-            // so we don't have to check if we should erase the data
-            if (node.canBeStopped) uigraph.stopNodeComputation(node)
+        onDeleteDataRequest: function(node) {
             uigraph.clearSelectedNodesData();
-            root.computeRequest([node])
         }
         
         onSubmitRequest: function(node) {

--- a/meshroom/ui/qml/GraphEditor/GraphEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/GraphEditor.qml
@@ -1075,6 +1075,41 @@ Item {
         }
     }
 
+    NodeActions {
+        id: nodeActions
+        uigraph: root.uigraph
+        draggable: draggable
+        nodeRepeater: nodeRepeater
+        anchors.fill: parent
+        
+        onComputeRequest: function(node) {
+            root.computeRequest([node])
+        }
+        
+        onStopComputeRequest: function(node) {
+            uigraph.stopNodeComputation(node)
+        }
+        
+        onReComputeRequest: function(node) {
+            // Only triggered if the node is already computed
+            // so we don't have to check if we should erase the data
+            if (node.canBeStopped) uigraph.stopNodeComputation(node)
+            uigraph.clearSelectedNodesData();
+            root.computeRequest([node])
+        }
+        
+        onSubmitRequest: function(node) {
+            if (node.isComputed) uigraph.clearSelectedNodesData();
+            root.submitRequest([node])
+        }
+        
+        // TODO : If we want this, we should add the possibility to stop job on farm first
+        // onReSubmitRequest: function(node) {
+        //     uigraph.clearSelectedNodesData();
+        //     root.submitRequest([node])
+        // }
+    }
+    
     MessageDialog {
         id: errorDialog
 

--- a/meshroom/ui/qml/GraphEditor/GraphEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/GraphEditor.qml
@@ -1102,12 +1102,6 @@ Item {
             if (node.isComputed) uigraph.clearSelectedNodesData();
             root.submitRequest([node])
         }
-        
-        // TODO : If we want this, we should add the possibility to stop job on farm first
-        // onReSubmitRequest: function(node) {
-        //     uigraph.clearSelectedNodesData();
-        //     root.submitRequest([node])
-        // }
     }
     
     MessageDialog {


### PR DESCRIPTION
# Description

Add `NodeActions`
- Creates a header on top of the nodes with buttons to launch / force relaunch / submit the node
- The NodeActions follows the node but keeps a uniform scale

_Demonstration on how the items process work_
![Peek 2025-09-30 15-37](https://github.com/user-attachments/assets/fbb26ea4-7b57-4111-86ca-2407558d6df3)


> [!NOTE]
> Small remark : `selectNodeByIndex` triggers `onSelectedNodeDelegateChanged` twice...