### PR TITLE
Fix the value validation for `Int`/`Float` attributes with expressions

### DIFF
--- a/meshroom/core/desc/attribute.py
+++ b/meshroom/core/desc/attribute.py
@@ -7,12 +7,6 @@ from collections.abc import Iterable
 from meshroom.common import BaseObject, JSValue, Property, Variant, VariantList
 
 
-
-def isanumber(s):
-    """ Returns True if string is a number. """
-    return s.replace('.','',1).isdigit()
-
-
 class Attribute(BaseObject):
     """
     """
@@ -347,9 +341,7 @@ class IntParam(Param):
         self._valueType = int
 
     def validateValue(self, value):
-        if isinstance(value, str) and isanumber(value):
-            return int(float(value))
-        if value is None or isinstance(value, str):
+        if value is None:
             return value
         # Handle unsigned int values that are translated to int by shiboken and may overflow
         try:
@@ -379,9 +371,7 @@ class FloatParam(Param):
         self._valueType = float
 
     def validateValue(self, value):
-        if isinstance(value, str) and isanumber(value):
-            return float(value)
-        if value is None or isinstance(value, str):
+        if value is None:
             return value
         try:
             return float(value)

--- a/meshroom/core/desc/attribute.py
+++ b/meshroom/core/desc/attribute.py
@@ -7,6 +7,12 @@ from collections.abc import Iterable
 from meshroom.common import BaseObject, JSValue, Property, Variant, VariantList
 
 
+
+def isanumber(s):
+    """ Returns True if string is a number. """
+    return s.replace('.','',1).isdigit()
+
+
 class Attribute(BaseObject):
     """
     """
@@ -341,6 +347,8 @@ class IntParam(Param):
         self._valueType = int
 
     def validateValue(self, value):
+        if isinstance(value, str) and isanumber(value):
+            return int(float(value))
         if value is None or isinstance(value, str):
             return value
         # Handle unsigned int values that are translated to int by shiboken and may overflow
@@ -371,6 +379,8 @@ class FloatParam(Param):
         self._valueType = float
 
     def validateValue(self, value):
+        if isinstance(value, str) and isanumber(value):
+            return float(value)
         if value is None or isinstance(value, str):
             return value
         try:

--- a/meshroom/ui/qml/GraphEditor/AttributeItemDelegate.qml
+++ b/meshroom/ui/qml/GraphEditor/AttributeItemDelegate.qml
@@ -261,7 +261,6 @@ RowLayout {
             case "FloatParam":
                 // We don't set a number because we want to keep the invalid expression
                 _reconstruction.setAttribute(root.attribute, Number(value))
-                // _reconstruction.setAttribute(root.attribute, value)
                 updateAttributeLabel()
                 break
             case "File":

--- a/meshroom/ui/qml/GraphEditor/AttributeItemDelegate.qml
+++ b/meshroom/ui/qml/GraphEditor/AttributeItemDelegate.qml
@@ -260,8 +260,8 @@ RowLayout {
             case "IntParam":
             case "FloatParam":
                 // We don't set a number because we want to keep the invalid expression
-                // _reconstruction.setAttribute(root.attribute, Number(value))
-                _reconstruction.setAttribute(root.attribute, value)
+                _reconstruction.setAttribute(root.attribute, Number(value))
+                // _reconstruction.setAttribute(root.attribute, value)
                 updateAttributeLabel()
                 break
             case "File":
@@ -623,15 +623,11 @@ RowLayout {
                     isInt: attribute.type === "FloatParam" ? false : true
                     
                     onEditingFinished: {
-                        if (hasExprError)
-                            setTextFieldAttribute(expressionTextField.text)  // On the undo stack we keep the expression
-                        else
+                        if (!hasExprError)
                             setTextFieldAttribute(expressionTextField.evaluatedValue)
                     }
                     onAccepted: {
-                        if (hasExprError)
-                            setTextFieldAttribute(expressionTextField.text)  // On the undo stack we keep the expression
-                        else
+                        if (!hasExprError)
                             setTextFieldAttribute(expressionTextField.evaluatedValue)
                         // When the text is too long, display the left part
                         // (with the most important values and cut the floating point details)
@@ -640,9 +636,7 @@ RowLayout {
                     
                     Component.onDestruction: {
                         if (activeFocus) {
-                            if (hasExprError)
-                                setTextFieldAttribute(expressionTextField.text)
-                            else
+                            if (!hasExprError)
                                 setTextFieldAttribute(expressionTextField.evaluatedValue)
                         }
                     }


### PR DESCRIPTION
## Description

Fix issue with IntParam/FloatParam value validation
In #2836 we introduced a system to evaluate expressions in int/float fields, however the way it was implemented broke the value validation on attributes on the python side.
With this PR the issue is solved however we loose undostack on wrong expressions
