### PR TITLE
[core] Rez plugins: Ensure dependencies for `meshroom_compute` are present

### DIFF
--- a/meshroom/core/desc/node.py
+++ b/meshroom/core/desc/node.py
@@ -17,6 +17,7 @@ from meshroom.core.utils import VERBOSE_LEVEL
 
 _MESHROOM_ROOT = Path(meshroom.__file__).parent.parent.as_posix()
 _MESHROOM_COMPUTE = (Path(_MESHROOM_ROOT) / "bin" / "meshroom_compute").as_posix()
+_MESHROOM_COMPUTE_DEPS = ["psutil"]
 
 
 class MrNodeType(enum.Enum):

--- a/meshroom/core/plugins.py
+++ b/meshroom/core/plugins.py
@@ -14,7 +14,7 @@ from pathlib import Path
 
 from meshroom.common import BaseObject
 from meshroom.core import desc
-from meshroom.core.desc.node import _MESHROOM_ROOT
+from meshroom.core.desc.node import _MESHROOM_ROOT, _MESHROOM_COMPUTE_DEPS
 
 
 def validateNodeDesc(nodeDesc: desc.Node) -> list:
@@ -161,10 +161,10 @@ class RezProcessEnv(ProcessEnv):
 
     def resolveRezSubrequires(self) -> list[str]:
         """
-        Return the list of packages defined for the node execution. These execution packages are named
-        subrequires.
-        Note: If a package does not have a version number, the version is aligned with the main Meshroom
-        environment (if this package is defined).
+        Return the list of packages defined for the node execution. These execution packages are
+        named subrequires.
+        Note: If a package does not have a version number, the version is aligned with the main
+        Meshroom environment (if this package is defined).
         """
         subrequires = os.environ.get(f"{self.uri.upper()}_SUBREQUIRES", "").split(os.pathsep)
         if not subrequires:
@@ -184,8 +184,8 @@ class RezProcessEnv(ProcessEnv):
                 resolvedVersions[name] = version
         logging.debug("Packages in the current environment: " + ", ".join(currentEnvPackages))
 
-        # Take packages with the set versions for those which have one, and try to take packages in the current
-        # environment (if they are resolved in it)
+        # Take packages with the set versions for those which have one, and try to take packages
+        # in the current environment (if they are resolved in it)
         for package in subrequires:
             packageTuple = self.REZ_DELIMITER_PATTERN.split(package, maxsplit=1)
             match len(packageTuple):
@@ -201,6 +201,19 @@ class RezProcessEnv(ProcessEnv):
                 case 2:
                     # The subrequires ask for a specific version
                     packages.append(package)
+
+        def extractPackageName(packageString: str) -> str:
+            return re.split(r'[-=<>!~]+', packageString, 1)[0]
+        packageNames = [extractPackageName(package) for package in packages]
+
+        for package in _MESHROOM_COMPUTE_DEPS:
+            # For packages that are required by meshroom_compute, do not specify any version
+            # or align it with Meshroom's: the version will be found during the resolution of
+            # the environment based on the other packages.
+            # If any of these packages is already part of the environment a plugin's dependency,
+            # do not add it
+            if package not in packageNames:
+                packages.append(package)
 
         logging.debug("Packages for the execution environment: " + ", ".join(packages))
         return packages

--- a/meshroom/core/plugins.py
+++ b/meshroom/core/plugins.py
@@ -203,7 +203,7 @@ class RezProcessEnv(ProcessEnv):
                     packages.append(package)
 
         def extractPackageName(packageString: str) -> str:
-            return re.split(r'[-=<>!~]+', packageString, 1)[0]
+            return self.REZ_DELIMITER_PATTERN.split(packageString, maxsplit=1)[0]
         packageNames = [extractPackageName(package) for package in packages]
 
         for package in _MESHROOM_COMPUTE_DEPS:


### PR DESCRIPTION
## Description

This PR introduces a mechanism to ensure that required dependencies for `meshroom_compute`, specifically `psutil`, are always included in the node execution environment for rez plugins. Dependencies for `meshroom_compute` are added to the environment without specifying any version or attempting to match Meshroom's, in order for it to be set directly during the environment resolution.

**Dependency management improvements:**

* Introduced a new constant `_MESHROOM_COMPUTE_DEPS` in `meshroom/core/desc/node.py` to define required dependencies for `meshroom_compute`.
* Updated `meshroom/core/plugins.py` to import `_MESHROOM_COMPUTE_DEPS` and ensure all dependencies listed in it (currently `psutil`) are always included in the resolved execution environment for plugins, unless already present [[1]](diffhunk://#diff-1d5f2a46e59213721e5624ac787e491e5cc2333ab8838b226c6558ceb0d87913L17-R17) [[2]](diffhunk://#diff-1d5f2a46e59213721e5624ac787e491e5cc2333ab8838b226c6558ceb0d87913R197-R205).
