### PR TITLE
[core] use callable instead of checking for FunctionType instance type

### DIFF
--- a/meshroom/core/attribute.py
+++ b/meshroom/core/attribute.py
@@ -158,7 +158,7 @@ class Attribute(BaseObject):
         if isinstance(value, Attribute) or Attribute.isLinkExpression(value):
             # if we set a link to another attribute
             self._value = value
-        elif isinstance(value, types.FunctionType):
+        elif callable(value):
             # evaluate the function
             self._value = value(self)
         else:
@@ -216,7 +216,7 @@ class Attribute(BaseObject):
         """
         Get the attribute default value.
         """
-        if isinstance(self._desc.value, types.FunctionType):
+        if callable(self._desc.value):
             try:
                 return self._desc.value(self)
             except Exception as e:
@@ -282,7 +282,7 @@ class Attribute(BaseObject):
             - If it is a function, execute it and return the result
             - Otherwise, simply return true
         """
-        if isinstance(self._desc.validValue, types.FunctionType):
+        if callable(self._desc.validValue):
             try:
                 return self._desc.validValue(self.node)
             except Exception:
@@ -343,7 +343,7 @@ class Attribute(BaseObject):
         self._setEnabled(self._getEnabled())
 
     def _getEnabled(self) -> bool:
-        if isinstance(self._desc.enabled, types.FunctionType):
+        if callable(self._desc.enabled):
             try:
                 return self._desc.enabled(self.node)
             except Exception:

--- a/meshroom/core/attribute.py
+++ b/meshroom/core/attribute.py
@@ -3,7 +3,6 @@ import copy
 import os
 import re
 import weakref
-import types
 import logging
 
 from collections.abc import Iterable, Sequence

--- a/meshroom/core/desc/attribute.py
+++ b/meshroom/core/desc/attribute.py
@@ -29,7 +29,7 @@ class Attribute(BaseObject):
         self._visible = visible
         self._exposed = exposed
         self._isExpression = (isinstance(self._value, str) and "{" in self._value) \
-            or isinstance(self._value, types.FunctionType)
+            or callable(self._value)
         self._isDynamicValue = (self._value is None)
         self._valueType = None
 

--- a/meshroom/core/desc/attribute.py
+++ b/meshroom/core/desc/attribute.py
@@ -1,7 +1,6 @@
 import ast
 import distutils.util
 import os
-import types
 from collections.abc import Iterable
 
 from meshroom.common import BaseObject, JSValue, Property, Variant, VariantList

--- a/meshroom/core/node.py
+++ b/meshroom/core/node.py
@@ -963,7 +963,7 @@ class BaseNode(BaseObject):
         def _buildAttributeCmdVars(cmdVars, name, attr):
             if attr.enabled:
                 group = attr.desc.group(attr.node) \
-                        if isinstance(attr.desc.group, types.FunctionType) else attr.desc.group
+                        if callable(attr.desc.group) else attr.desc.group
                 if group is not None:
                     # If there is a valid command line "group"
                     v = attr.getValueStr(withQuotes=True)

--- a/meshroom/core/node.py
+++ b/meshroom/core/node.py
@@ -10,7 +10,6 @@ import platform
 import re
 import shutil
 import time
-import types
 import uuid
 from collections import namedtuple, OrderedDict
 from enum import Enum, auto


### PR DESCRIPTION
This pull request updates several places in the codebase to use the more general `callable()` function instead of checking specifically for `types.FunctionType`. This change improves compatibility and flexibility when determining if an object can be called like a function.
