### PR TITLE
[core] Split version name on the correct separator

### DIFF
--- a/meshroom/core/__init__.py
+++ b/meshroom/core/__init__.py
@@ -262,8 +262,9 @@ class Version:
             return (), ''
 
         status = ''
-        # If there is a status, it is placed after a "-"
-        splitComponents = versionName.split("-", maxsplit=1)
+        # If there is a status, it is placed after a "-" (up to Meshroom 2025.1.0) or a "+"
+        versionName = versionName.replace("-", "+")  # Keep compatibility for scenes created with 2025.1.0 or older
+        splitComponents = versionName.split("+", maxsplit=1)
         # If there is no status, splitComponents is equal to [versionName]
         if len(splitComponents) > 1:
             status = splitComponents[-1]


### PR DESCRIPTION
## Description

This pull request fixes an oversight of #2904 by updating the version parsing logic in `meshroom/core/__init__.py` to improve compatibility with different version string formats. The most important change is that the function now treats both `-` and `+` as valid separators for the status component of the version, ensuring compatibility with scenes created in Meshroom 2025.1.0 or earlier.

Version parsing compatibility:

* Updated the `toComponents` function to replace `-` with `+` in `versionName` before splitting, so that both separators are handled consistently for status extraction. This maintains compatibility with older and newer version naming conventions.
