### PR TITLE
[core] plugins: Do not use Python 3.10-and-over syntax

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -18,6 +18,7 @@ on:
 
 env:
   CI: True
+  PYTHONPATH: ${{ github.workspace }}
 
 jobs:
   build-linux:
@@ -56,6 +57,17 @@ jobs:
       uses: codecov/test-results-action@v1
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
+    - name: Set up Python 3.9 - meshroom_compute test
+      uses: actions/setup-python@v4
+      with:
+        python-version: 3.9
+    - name: Install dependencies (Python 3.9) - meshroom_compute test
+      run: |
+        python3.9 -m pip install --upgrade pip
+        python3.9 -m pip install -r requirements.txt --timeout 45
+    - name: Run imports - meshroom_compute test
+      run: |
+        python3.9 bin/meshroom_compute -h
 
   build-windows:
     runs-on: windows-latest
@@ -83,3 +95,14 @@ jobs:
       - name: Test with pytest
         run: |
           pytest tests/
+      - name: Set up Python 3.9 - meshroom_compute test
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.9
+      - name: Install dependencies (Python 3.9) - meshroom_compute test
+        run: |
+          python3 -m pip install --upgrade pip
+          python3 -m pip install -r requirements.txt --timeout 45
+      - name: Run imports - meshroom_compute test
+        run: |
+          python3 bin/meshroom_compute -h

--- a/meshroom/core/plugins.py
+++ b/meshroom/core/plugins.py
@@ -188,19 +188,18 @@ class RezProcessEnv(ProcessEnv):
         # in the current environment (if they are resolved in it)
         for package in subrequires:
             packageTuple = self.REZ_DELIMITER_PATTERN.split(package, maxsplit=1)
-            match len(packageTuple):
-                case 1:
-                    # Only the package name in the subrequires.
-                    # Search for a corresponding version in the parent environment.
-                    packageName = packageTuple[0]
-                    parentResolvedVersion = resolvedVersions.get(packageName)
-                    if parentResolvedVersion:
-                        packages.append(f"{packageName}=={parentResolvedVersion}")
-                    else:
-                        packages.append(package)
-                case 2:
-                    # The subrequires ask for a specific version
+            if len(packageTuple) == 1:
+                # Only the package name in the subrequires.
+                # Search for a corresponding version in the parent environment.
+                packageName = packageTuple[0]
+                parentResolvedVersion = resolvedVersions.get(packageName)
+                if parentResolvedVersion:
+                    packages.append(f"{packageName}=={parentResolvedVersion}")
+                else:
                     packages.append(package)
+            elif len(packageTuple) == 2:
+                # The subrequires ask for a specific version
+                packages.append(package)
 
         def extractPackageName(packageString: str) -> str:
             return self.REZ_DELIMITER_PATTERN.split(packageString, maxsplit=1)[0]


### PR DESCRIPTION
## Description

This PR removes specific code that is Python 3.10 and over-compatible in the `plugins` module. This is motivated by the fact that `meshroom_compute` imports the `plugins` module and can be executed with a Python interpreter that is older than Python 3.10 (e.g. 3.9) when in the context of plugins. Python 3.10 code will raise a `SyntaxError`, thus causing `meshroom_compute` to fail in that context.

Although Meshroom is leaning towards supporting only Python 3.10 and over, the `plugins` module needs to also be compatible with older Python versions, hence the replacement of the `match/case` syntax with `if/elif`.

To prevent introducing some version-specific syntax that may affect `meshroom_compute`, the continous integration workflow, which runs on Python 3.11, is updated to include a step that will attempt to run `meshroom_compute` (and thus run through the `import` statements that may cause syntax errors) with Python 3.9.
