### PR TITLE
[qml] ExpressionTextFields: Fix unwanted value updates

### DIFF
--- a/meshroom/ui/qml/Utils/ExpressionTextField.qml
+++ b/meshroom/ui/qml/Utils/ExpressionTextField.qml
@@ -99,7 +99,7 @@ TextField {
     }
 
     onTextChanged: {
-        if (!activeFocus) {
+        if (!activeFocus && exprTextChanged) {
             refreshStatus()
         } else {
             exprTextChanged = true

--- a/meshroom/ui/qml/Utils/ExpressionTextField.qml
+++ b/meshroom/ui/qml/Utils/ExpressionTextField.qml
@@ -11,7 +11,6 @@ TextField {
 
     property bool hasExprError: false
     property bool isInt: false
-    property int decimals: 2
 
     // Overlay for error state (red border on top of default background)
     Rectangle {

--- a/meshroom/ui/qml/Utils/ExpressionTextField.qml
+++ b/meshroom/ui/qml/Utils/ExpressionTextField.qml
@@ -6,7 +6,7 @@ TextField {
 
     // evaluated numeric value (NaN if invalid)
     // It helps keeping the connection that text has so that we don't loose ability to undo/reset
-    property bool textChanged: false
+    property bool exprTextChanged: false
     property real evaluatedValue: 0
 
     property bool hasExprError: false
@@ -63,7 +63,7 @@ TextField {
             evaluatedValue = previousEvaluatedValue
             raiseError()
         }
-        textChanged = false
+        exprTextChanged = false
     }
 
     // onAccepted and onEditingFinished will break the bindings to text
@@ -72,7 +72,7 @@ TextField {
     // No need to restore the binding if the expression has an error because we don't break it
 
     onAccepted: {
-        if (textChanged)
+        if (exprTextChanged)
         {
             updateExpression()
             if (!hasExprError && !isNaN(evaluatedValue)) {
@@ -86,7 +86,7 @@ TextField {
     }
 
     onEditingFinished: {
-        if (textChanged)
+        if (exprTextChanged)
         {
             updateExpression()
             if (!hasExprError && !isNaN(evaluatedValue)) {
@@ -102,12 +102,12 @@ TextField {
         if (!activeFocus) {
             refreshStatus()
         } else {
-            textChanged = true
+            exprTextChanged = true
         }
     }
 
     Component.onDestruction: {
-        if (textChanged) {
+        if (exprTextChanged) {
             root.accepted()
         }
     }

--- a/meshroom/ui/qml/Utils/ExpressionTextField.qml
+++ b/meshroom/ui/qml/Utils/ExpressionTextField.qml
@@ -36,8 +36,6 @@ TextField {
         if (_err == false) {
             if (isInt)
                 _res = Math.round(_res)
-            else
-                _res = _res.toFixed(decimals)
             return _res
         } else {
             console.error("Error: Expression", _text, "is invalid")
@@ -80,7 +78,7 @@ TextField {
                 if (isInt)
                     root.text = Number(evaluatedValue).toFixed(0)
                 else
-                    root.text = Number(evaluatedValue).toFixed(decimals)
+                    root.text = Number(evaluatedValue)
             }
         }
     }
@@ -93,7 +91,7 @@ TextField {
                 if (isInt)
                     root.text = Number(evaluatedValue).toFixed(0)
                 else
-                    root.text = Number(evaluatedValue).toFixed(decimals)
+                    root.text = Number(evaluatedValue)
             }
         }
     }

--- a/meshroom/ui/qml/Viewer/HdrImageToolbar.qml
+++ b/meshroom/ui/qml/Viewer/HdrImageToolbar.qml
@@ -124,7 +124,6 @@ FloatingPane {
                 ToolTip.text: "Color Gain (in linear colorspace)"
 
                 text: gainValue
-                decimals: 2
                 Layout.preferredWidth: textMetrics_gainValue.width
                 selectByMouse: true
                 onAccepted: {
@@ -164,7 +163,7 @@ FloatingPane {
 
                 onClicked: {
                     gammaLabel.text = gammaDefaultValue
-                    gammaCtrl.value = gammaLabel.text;
+                    gammaCtrl.value = gammaLabel.text
                 }
             }
             ExpressionTextField {
@@ -175,7 +174,6 @@ FloatingPane {
                 ToolTip.text: "Apply Gamma (after Gain and in linear colorspace)"
 
                 text: gammaValue
-                decimals: 2
                 Layout.preferredWidth: textMetrics_gainValue.width
                 selectByMouse: true
                 onAccepted: {


### PR DESCRIPTION
## Description

This PR is a follow-up to #2836 and #2892 and prevents refreshing the status of the `ExpressionTextField` when the text field has not been changed by the user. This fixes some unwanted value updates that would occur when a field was losing the focus despite having undergone no change at all.

Additionally, floating values are not set to a fixed number of digits anymore, thus allowing to set precise floating values to attributes if desired.