### PR TITLE
[core] node: Check chunk size for nodes with dynamic sizes

### DIFF
--- a/meshroom/core/node.py
+++ b/meshroom/core/node.py
@@ -1542,7 +1542,10 @@ class BaseNode(BaseObject):
 
     @property
     def globalExecMode(self):
-        return self._chunks.at(0).execModeName
+        if len(self._chunks):
+            return self._chunks.at(0).execModeName
+        else:
+            return ExecMode.NONE
 
     def getChunks(self) -> list[NodeChunk]:
         return self._chunks


### PR DESCRIPTION
## Description

Nodes with dynamic sizes may end up in a state where they have no chunk (e.g. because there are no input images for the previous nodes). In this case, the first chunk is the list cannot be accessed as it does not exist yet, raising an `IndexError`.

We now check that there is at least an element in the chunk list before accessing it. If there is none, the default execution mode is returned instead.