### PR TITLE
[core] node: Update status when reevaluating a node's locked status

### DIFF
--- a/meshroom/core/node.py
+++ b/meshroom/core/node.py
@@ -1603,6 +1603,11 @@ class BaseNode(BaseObject):
             return
 
         if currentStatus == Status.SUCCESS:
+            # Update the status when the lock is reevaluated while the node is
+            # successfully computed: this ensures all info reflect accurately the status
+            # (in particular with respect to dynamic output attributes)
+            self.updateStatusFromCache()
+
             # At this moment, the node is necessarily locked because of previous if statement
             inputNodes = self.getInputNodes(recursive=True, dependenciesOnly=True)
             outputNodes = self.getOutputNodes(recursive=True, dependenciesOnly=True)


### PR DESCRIPTION

## Description

This PR fixes an issue that occurs for nodes with dynamic output attributes that are computed externally: once the node's status was updated to "SUCCESS", the values of the dynamic output attributes were not refreshed, and they remained as they were prior to the computation (although they had correctly been written in the node's `values` file). This never occurred for locally-computed nodes. To work around this issue, the user needed to use the "Refresh Nodes Status" option. 

With this PR, if a node has been successfully computed and its locked status is re-evaluated, then its status is updated from the cache, ensuring all the information are correctly reflected in the Graph Editor without needing an action from the user.
