### PR TITLE
[ui] Add display for ROMA matcher

### DIFF
--- a/meshroom/ui/qml/Viewer/Viewer2D.qml
+++ b/meshroom/ui/qml/Viewer/Viewer2D.qml
@@ -1204,7 +1204,11 @@ FocusScope {
                                         if (activeNode) {
                                             if (activeNode.nodeType == "FeatureExtraction" && isComputed) {
                                                 result.push(activeNode.attribute("output").value)
-                                            } else if (activeNode.hasAttribute("featuresFolders")) {
+                                            } 
+                                            else if (activeNode.nodeType == "RomaReducer" && isComputed) {
+                                                result.push(activeNode.attribute("featuresFolder").value)
+                                            }
+                                            else if (activeNode.hasAttribute("featuresFolders")) {
                                                 for (let i = 0; i < activeNode.attribute("featuresFolders").value.count; i++) {
                                                     let attr = activeNode.attribute("featuresFolders").value.at(i)
                                                     result.push(attr.value)

--- a/meshroom/ui/reconstruction.py
+++ b/meshroom/ui/reconstruction.py
@@ -330,9 +330,9 @@ class Reconstruction(UIGraph):
         # All nodes generating depth map files
         "allDepthMap": ["DepthMap", "DepthMapFilter"],
         # Nodes that can be used to provide features folders to the UI
-        "featureProvider": ["FeatureExtraction", "FeatureMatching", "StructureFromMotion"],
+        "featureProvider": ["FeatureExtraction", "FeatureMatching", "StructureFromMotion", "RomaReducer"],
         # Nodes that can be used to provide matches folders to the UI
-        "matchProvider": ["FeatureMatching", "StructureFromMotion"],
+        "matchProvider": ["FeatureMatching", "StructureFromMotion", "RomaReducer"],
         # Nodes that can be used to provide tracks files to the UI
         "trackProvider": ["TracksBuilding", "SfMBootstraping", "SfMExpanding"]
     }


### PR DESCRIPTION
This pull request extends the application's support for the `RomaReducer` node, ensuring it is recognized as a provider of features and matches folders in both the backend and the UI. The changes update relevant logic to include `RomaReducer` alongside existing node types, improving consistency and functionality when handling feature and match data.

Related AliceVision PR: https://github.com/alicevision/AliceVision/pull/1922

**Backend and UI support for `RomaReducer`:**

- Added `RomaReducer` to the `featureProvider` and `matchProvider` node type lists, so it is now treated as a valid source of features and matches folders in the reconstruction pipeline (`meshroom/ui/reconstruction.py`).

**UI logic for features folders:**

- Updated the logic in `Viewer2D.qml` to recognize `RomaReducer` as a node type that provides a features folder, ensuring its output is included in the results shown in the UI (`meshroom/ui/qml/Viewer/Viewer2D.qml`).