### PR TITLE
[submitters] Fix `os.path.join` for rez binary

### DIFF
--- a/meshroom/submitters/tractorSubmitter.py
+++ b/meshroom/submitters/tractorSubmitter.py
@@ -103,7 +103,7 @@ def rezWrapCommand(cmd, useCurrentContext: bool = True, otherRezPkg: list[str] =
         if "REZ_BIN" in os.environ:
             rezBin = os.environ["REZ_BIN"]
         elif "REZ_PACKAGES_ROOT" in os.environ:
-            rezBin = os.path.join(os.environ["REZ_PACKAGES_ROOT"], "/bin/rez")
+            rezBin = os.path.join(os.environ["REZ_PACKAGES_ROOT"], "bin/rez")
         return f"{rezBin} env {packagesStr} -- {cmd}"
     return cmd
 


### PR DESCRIPTION
## Description

This PR makes a minor fix to the construction of the `rezBin` path in the `rezWrapCommand` function in `meshroom/submitters/tractorSubmitter.py`. The change corrects the path joining logic to prevent an incorrect file path.

* Fixed the path construction for `rezBin` by removing the leading slash from `"/bin/rez"` and changing it to `"bin/rez"`, ensuring `os.path.join` produces the correct path. Otherwise, `rezBin` is erroneously set to `"/bin/rez"`.
