### PR TITLE
[ui] fix: Adding a node, with an expression on a 3d output file, the eye icon should be visible

### DIFF
--- a/meshroom/core/attribute.py
+++ b/meshroom/core/attribute.py
@@ -181,6 +181,7 @@ class Attribute(BaseObject):
             # validity of the value and apply some conversion if needed
             convertedValue = self.validateValue(value)
             self._value = convertedValue
+            self.expressionApplied.emit()
         # Request graph update when input parameter value is set
         # and parent node belongs to a graph
         # Output attributes value are set internally during the update process,
@@ -352,10 +353,12 @@ class Attribute(BaseObject):
         """
         if self._desc.semantic == "3d":
             return True
+
         # If the attribute is a File attribute, it is an instance of str and can be iterated over
         hasSupportedExt = isinstance(self.value, str) and any(ext in self.value for ext in Attribute.VALID_3D_EXTENSIONS)
         if hasSupportedExt:
             return True
+
         return False
 
     def uid(self) -> str:
@@ -562,6 +565,8 @@ class Attribute(BaseObject):
     hasAnyInputLinks = Property(bool, _hasAnyInputLinks, notify=inputLinksChanged)
     # Whether the attribute or any of its elements is linked by another attribute.
     hasAnyOutputLinks = Property(bool, _hasAnyOutputLinks, notify=outputLinksChanged)
+
+    expressionApplied = Signal()
 
 
 def raiseIfLink(func):

--- a/meshroom/core/node.py
+++ b/meshroom/core/node.py
@@ -1811,10 +1811,10 @@ class BaseNode(BaseObject):
     hasDuplicatesChanged = Signal()
     hasDuplicates = Property(bool, lambda self: self._hasDuplicates, notify=hasDuplicatesChanged)
 
-    outputAttrEnabledChanged = Signal()
-    hasImageOutput = Property(bool, hasImageOutputAttribute, notify=outputAttrEnabledChanged)
-    hasSequenceOutput = Property(bool, hasSequenceOutputAttribute, notify=outputAttrEnabledChanged)
-    has3DOutput = Property(bool, has3DOutputAttribute, notify=outputAttrEnabledChanged)
+    outputAttrChanged = Signal()
+    hasImageOutput = Property(bool, hasImageOutputAttribute, notify=outputAttrChanged)
+    hasSequenceOutput = Property(bool, hasSequenceOutputAttribute, notify=outputAttrChanged)
+    has3DOutput = Property(bool, has3DOutputAttribute, notify=outputAttrChanged)
     # Whether the node contains a ShapeAttribute, a ShapeListAttribute or a shape File.
     hasDisplayableShape = Property(bool, _hasDisplayableShape, constant=True)
 
@@ -1847,7 +1847,9 @@ class Node(BaseNode):
         # Declare events for specific output attributes
         for attr in self._attributes:
             if attr.isOutput and attr.desc.semantic == "image":
-                attr.enabledChanged.connect(self.outputAttrEnabledChanged)
+                attr.enabledChanged.connect(self.outputAttrChanged)
+            if attr.isOutput:
+                attr.expressionApplied.connect(self.outputAttrChanged)
 
         # List attributes per UID
         for attr in self._attributes:

--- a/meshroom/ui/qml/Application.qml
+++ b/meshroom/ui/qml/Application.qml
@@ -1217,7 +1217,7 @@ Page {
                         workspaceView.viewIn2D(attribute, mouse)
                     }
 
-                    else if (attribute.is3D) {
+                    else if (attribute.is3dDisplayable) {
                             workspaceView.viewIn3D(attribute, mouse)
                     }
 

--- a/meshroom/ui/qml/Viewer/Viewer2D.qml
+++ b/meshroom/ui/qml/Viewer/Viewer2D.qml
@@ -398,7 +398,7 @@ FocusScope {
 
     Connections {
         target: displayedNode
-        function onOutputAttrEnabledChanged() {
+        function onOutputAttrChanged() {
             tryLoadNode(displayedNode)
         }
     }


### PR DESCRIPTION


## Description
A signal is missing on attribute, to notify the parent's node that an expression has been applied. 
You can test it by adds a convertMesh node into any graph. It should have an eye visible.

<img width="375" height="161" alt="fix" src="https://github.com/user-attachments/assets/78bb4df3-1450-4b51-8ba8-97dcbe9b45bf" />

## Implementation remarks
This PR add this signal `expressionApplied` ans emit it just after an expression has been applied on the attribute.
The node eye visiblity was listening to the `outputAttrEnabledChanged`.
It has been renamed to in this PR in order to `outputAttrChanged` because now it reacts to the expressionApplied and the attributeEnabled signals.

## Features list
- [X] Fix Node-eye not visible even if an output  3d file exists in the node. 


