### PR TITLE
[Shapes] `TextLayer`: Enable wrapping for large texts

### DIFF
--- a/meshroom/ui/qml/Shapes/Viewer/Layers/TextLayer.qml
+++ b/meshroom/ui/qml/Shapes/Viewer/Layers/TextLayer.qml
@@ -16,11 +16,14 @@ BaseLayer {
     id: textLayer
 
     Text {
-        x: textLayer.observation.center.x - implicitWidth * 0.5   // Center text horizontally
-        y: textLayer.observation.center.y - implicitHeight * 0.5  // Center text vertically
+        width: ShapeViewerHelper.containerWidth - textLayer.observation.center.x
+        height: ShapeViewerHelper.containerHeight - textLayer.observation.center.y
+
+        x: textLayer.observation.center.x
+        y: textLayer.observation.center.y
         text: textLayer.observation.content || "Undefined"
         color: textLayer.properties.color || textLayer.defaultColor
-        wrapMode: Text.NoWrap 
+        wrapMode: Text.Wrap
         font.family: textLayer.properties.fontFamily || "Arial"
         font.pixelSize: getScaledFontSize()
     }


### PR DESCRIPTION
## Description

This PR updates the layout for `Text` shapes to improve the display of large texts (e.g. image captions) by enabling the text wrapping. Additionally, the text is not centered anymore on the obervation's `x`- and `y`-coordinates, which now represent its top-left corner.

## Features list

- [x] Changed the calculation of `x` and `y` so that text is now positioned directly at the observation's coordinates, rather than being centered using the implicit width and height.
- [x] Set the `width` and `height` of the `Text` element to the remaining space from the observation center to the edge of the container, allowing for better text wrapping and layout.
- [x] Updated `wrapMode` from `Text.NoWrap` to `Text.Wrap` to allow text to wrap within the specified width, improving readability.