### PR TITLE
[bin] `meshroom_compute`: Print an explicit message when attempting to compute `CompatibilityNodes`

### DIFF
--- a/bin/meshroom_compute
+++ b/bin/meshroom_compute
@@ -70,9 +70,15 @@ if args.cache:
 graph.update()
 
 if args.node:
-    # Execute the node
     node = graph.findNode(args.node)
     submittedStatuses = [Status.RUNNING]
+
+    if node.isCompatibilityNode:
+        print(f'{node.name} is in Compatibility Mode and cannot be computed.')
+        print(f'Compatibility issue: {node.issueDetails}')
+        sys.exit(1)
+
+    # Execute the node
     if not args.extern:
         # If running as "extern", the task is supposed to have the status SUBMITTED.
         # If not running as "extern", the SUBMITTED status should generate a warning.
@@ -106,7 +112,7 @@ if args.node:
     node.restoreLogger()
 else:
     if args.iteration != -1:
-        print('Error: "--iteration" only make sense when used with "--node".')
+        print('Error: "--iteration" only makes sense when used with "--node".')
         sys.exit(-1)
     toNodes = None
     if args.toNode:

--- a/meshroom/core/graph.py
+++ b/meshroom/core/graph.py
@@ -1665,6 +1665,11 @@ def executeGraph(graph, toNodes=None, forceCompute=False, forceStatus=False):
 
     for n, node in enumerate(nodes):
         try:
+            # If the node is in compatibility mode, it cannot be computed
+            if node.isCompatibilityNode:
+                logging.warning(f"{node.name} is in Compatibility Mode and cannot be computed: {node.issueDetails}.")
+                continue
+
             node.preprocess()
             multiChunks = len(node.chunks) > 1
             for c, chunk in enumerate(node.chunks):

--- a/meshroom/core/taskManager.py
+++ b/meshroom/core/taskManager.py
@@ -41,8 +41,8 @@ class TaskThread(Thread):
 
         for nId, node in enumerate(self._manager._nodesToProcess):
 
-            # skip already finished/running nodes
-            if node.isFinishedOrRunning():
+            # Skip already finished/running nodes or nodes in compatibility mode
+            if node.isFinishedOrRunning() or node.isCompatibilityNode:
                 continue
 
             # if a node does not exist anymore, node.chunks becomes a PySide property


### PR DESCRIPTION
## Description

This PR prevents unexplicit error messages thrown in `AttributeError` and `RuntimeError` exceptions when there is an attempt to run a `CompatibilityNode`, and replaces them with explicit messages that do not throw exceptions.

Attempting to run a `CompatibilityNode` led to exceptions that were thrown with messages such as `"NoneType" object has no attribute "preprocess"`, which did not explain that the node had no `preprocess` method because it was a `CompatibilityNode`. 
