### PR TITLE
[nodes] Add new `InputFile` input node

### DIFF
--- a/meshroom/nodes/general/InputFile.py
+++ b/meshroom/nodes/general/InputFile.py
@@ -1,0 +1,48 @@
+__version__ = "1.0"
+
+import logging
+import os
+
+from meshroom.core import desc
+
+class InputFile(desc.InputNode, desc.InitNode):
+    """
+This node is an input node that receives a File.
+"""
+    category = "Other"
+
+    inputs = [
+        desc.File(
+            name="inputFile",
+            label="Input File",
+            description="A file or folder to use as the input.",
+            value="",
+        )
+    ]
+
+    def initialize(self, node, inputs, recursiveInputs):
+        self.resetAttributes(node, ["inputFile"])
+
+        if len(inputs) >= 1:
+            if os.path.isfile(inputs[0]) or os.path.isdir(inputs[0]):
+                self.setAttributes(node, {"inputFile": inputs[0]})
+
+                if len(inputs) > 1:
+                    logging.warning(f"Several inputs were provided ({inputs}).")
+                    logging.warning(f"Only the first one ({inputs[0]}) will be used.")
+            else:
+                raise RuntimeError(f"{inputs[0]} is not a valid file or directory.")
+
+        elif len(recursiveInputs) >= 1:
+            if os.path.isfile(recursiveInputs[0]) or os.path.isdir(recursiveInputs[0]):
+                self.setAttributes(node, {"inputFile": recursiveInputs[0]})
+
+                if len(recursiveInputs) > 1:
+                    logging.warning(f"Several recursive inputs were provided ({recursiveInputs}).")
+                    logging.warning(f"Only the first valid one ({recursiveInputs[0]}) will be used.")
+
+            else:
+                raise RuntimeError(f"{recursiveInputs[0]} is not a valid file or directory.")
+
+        else:
+            raise RuntimeError("No file or directory has been set for 'inputFile'.")

--- a/tests/plugins/meshroom/pluginA/PluginAInputInitNode.py
+++ b/tests/plugins/meshroom/pluginA/PluginAInputInitNode.py
@@ -1,0 +1,27 @@
+__version__ = "1.0"
+
+from meshroom.core import desc
+
+
+class PluginAInputInitNode(desc.InputNode, desc.InitNode):
+    inputs = [
+        desc.File(
+            name="input",
+            label="Input",
+            description="",
+            value="",
+        ),
+    ]
+
+    outputs = [
+        desc.File(
+            name="output",
+            label="Output",
+            description="",
+            value="",
+        ),
+    ]
+
+    def initialize(self, node, inputs, recursiveInputs):
+        if len(inputs) >= 1:
+            self.setAttributes(node, {"input": inputs[0]})

--- a/tests/plugins/meshroom/pluginA/PluginAInputNode.py
+++ b/tests/plugins/meshroom/pluginA/PluginAInputNode.py
@@ -3,7 +3,7 @@ __version__ = "1.0"
 from meshroom.core import desc
 
 
-class PluginANodeA(desc.InputNode):
+class PluginAInputNode(desc.InputNode):
     inputs = [
         desc.File(
             name="input",

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -101,3 +101,38 @@ class TestNodeVariables:
             assert n._expVars["uid"] == n._uid
             assert n.internalFolder
             assert n.internalFolder == n._expVars["nodeCacheFolder"]
+
+
+class TestInitNode:
+    plugin = None
+
+    @classmethod
+    def setup_class(cls):
+        folder = os.path.join(os.path.dirname(__file__), "plugins", "meshroom")
+        package = "pluginA"
+        cls.plugin = Plugin(package, folder)
+        nodes = loadClassesNodes(folder, package)
+        for node in nodes:
+            cls.plugin.addNodePlugin(node)
+        pluginManager.addPlugin(cls.plugin)
+
+    @classmethod
+    def teardown_class(cls):
+        for node in cls.plugin.nodes.values():
+            pluginManager.unregisterNode(node)
+        pluginManager.removePlugin(cls.plugin)
+        cls.plugin = None
+
+    def test_initNode(self):
+        g = Graph("")
+
+        node = g.addNewNode("PluginAInputInitNode")
+
+        # Check that the init node is correctly detected
+        initNodes = g.findInitNodes()
+        assert len(initNodes) == 1 and node in initNodes
+
+        # Check that the init node's initialize method has been set
+        inputs = ["/path/to/file", "/path/to/file/2"]
+        node.nodeDesc.initialize(node, inputs, None)
+        assert node.input.value == inputs[0]


### PR DESCRIPTION
## Description

This PR adds a new basic `InputNode` that receives a file or directory as the input, and that can be used as the entry point of a graph for `meshroom_batch`.
<div display="block" align="center"><img width="300" alt="InputFile node" src="https://github.com/user-attachments/assets/b8aaf3dc-ae01-4e06-9522-ef8459b7c610" /></div>
