### PR TITLE
[ui] NodeActions: Update the buttons' color for submitted nodes

### DIFF
--- a/meshroom/ui/qml/Controls/NodeActions.qml
+++ b/meshroom/ui/qml/Controls/NodeActions.qml
@@ -210,13 +210,13 @@ Item {
                 ToolTip.delay: 1000
                 visible: actionHeader.computeButtonState != NodeActions.ButtonState.DELETABLE
                 enabled: actionHeader.computeButtonState % 2 == 1  // Launchable & Stoppable
+                // Icon color
+                textColor: (!enabled && actionHeader.nodeSubmitted) ? Colors.statusColors["SUBMITTED"] : (checked ? palette.highlight : palette.text)
+                // Background color
                 background: Rectangle {
                     color: {
-                        if (!computeButton.enabled) {
-                            if (actionHeader.nodeSubmitted) 
-                                return Qt.darker(Colors.statusColors["SUBMITTED"], 1.2)
+                        if (!computeButton.enabled)
                             return activePalette.button
-                        }
                         if (actionHeader.computeButtonState == NodeActions.ButtonState.STOPPABLE)
                             return computeButton.hovered ? Colors.orange : Qt.darker(Colors.orange, 1.3)
                         return computeButton.hovered ? activePalette.highlight : activePalette.button
@@ -272,13 +272,13 @@ Item {
                 ToolTip.delay: 1000
                 visible: root.uigraph ? root.uigraph.canSubmit : false
                 enabled: actionHeader.submitButtonState != NodeActions.ButtonState.DISABLED
+                // Icon color
+                textColor: (!enabled && actionHeader.nodeSubmitted) ? Colors.statusColors["SUBMITTED"] : (checked ? palette.highlight : palette.text)
+                // Background color
                 background: Rectangle {
                     color: {
-                        if (!submitButton.enabled) {
-                            if (actionHeader.nodeSubmitted) 
-                                return Qt.darker(Colors.statusColors["SUBMITTED"], 1.2)
+                        if (!submitButton.enabled)
                             return activePalette.button
-                        }
                         return submitButton.hovered ? activePalette.highlight : activePalette.button
                     }
                     opacity: submitButton.hovered ? 1 : root._opacity

--- a/meshroom/ui/qml/MaterialIcons/MaterialToolButton.qml
+++ b/meshroom/ui/qml/MaterialIcons/MaterialToolButton.qml
@@ -14,9 +14,13 @@ ToolButton {
     font.pointSize: 13
     ToolTip.visible: ToolTip.text && hovered
     ToolTip.delay: 100
+    
+    property color textColor: checked ? palette.highlight : palette.text
+    
     Component.onCompleted:  {
-        contentItem.color = Qt.binding(function() { return checked ? palette.highlight : palette.text })
+        contentItem.color = Qt.binding(function() { return textColor })
     }
+    
     background: Rectangle {
         color: {
             if (enabled && (pressed || checked || hovered)) {


### PR DESCRIPTION
## Description

This PR updates the color of the Node Actions buttons for submitted nodes.

Previously, they looked like this:
<img width="182" height="155" alt="image" src="https://github.com/user-attachments/assets/fb7b0bb8-401d-4122-a533-71ad868ef6f0" />

With this PR, they look like this:
<img width="182" height="155" alt="image" src="https://github.com/user-attachments/assets/6fccd3dd-81b6-4154-a86b-fdbf9562abee" />

