### PR TITLE
Typo fix: Replace every occurrence of "infos" with "info"

### DIFF
--- a/meshroom/core/node.py
+++ b/meshroom/core/node.py
@@ -787,32 +787,32 @@ class BaseNode(BaseObject):
         else:
             return self.nodeDesc.__doc__
     
-    def getNodeInfos(self):
+    def getNodeInfo(self):
         if not self.nodeDesc:
             return []
-        infos = OrderedDict([
+        info = OrderedDict([
             ("module", self.nodeDesc.__module__),
             ("modulePath", self.nodeDesc.plugin.path),
         ])
-        # > Infos from the plugin module
+        # > Info from the plugin module
         plugin_module = sys.modules.get(self.nodeDesc.__module__)
         if getattr(plugin_module, "__author__", None):
-            infos["author"] = plugin_module.__author__
+            info["author"] = plugin_module.__author__
         if getattr(plugin_module, "__license__", None):
-            infos["license"] = plugin_module.__license__
+            info["license"] = plugin_module.__license__
         if getattr(plugin_module, "__version__", None):
-            infos["version"] = plugin_module.__version__
+            info["version"] = plugin_module.__version__
         # > Overrides at the node-level
         if getattr(self.nodeDesc, "author", None):
-            infos["author"] = self.nodeDesc.author
+            info["author"] = self.nodeDesc.author
         if getattr(self.nodeDesc, "version", None):
-            infos["version"] = self.nodeDesc.version
-        # > Additional node infos stored in a __nodeInfo__ parameter
-        additionalNodeInfos = getattr(self.nodeDesc, "__nodeInfo__", None)
-        if additionalNodeInfos:
-            for key, value in additionalNodeInfos:
-                infos[key] = value
-        return [{"key": k, "value": v} for k, v in infos.items()]
+            info["version"] = self.nodeDesc.version
+        # > Additional node information stored in a __nodeInfo__ parameter
+        additionalNodeInfo = getattr(self.nodeDesc, "__nodeInfo__", None)
+        if additionalNodeInfo:
+            for key, value in additionalNodeInfo:
+                info[key] = value
+        return [{"key": k, "value": v} for k, v in info.items()]
     
     @property
     def packageFullName(self):
@@ -1767,7 +1767,7 @@ class BaseNode(BaseObject):
     defaultLabel = Property(str, getDefaultLabel, constant=True)
     nodeType = Property(str, nodeType.fget, constant=True)
     documentation = Property(str, getDocumentation, constant=True)
-    nodeInfos = Property(Variant, getNodeInfos, constant=True)
+    nodeInfo = Property(Variant, getNodeInfo, constant=True)
     positionChanged = Signal()
     position = Property(Variant, position.fget, position.fset, notify=positionChanged)
     x = Property(float, lambda self: self._position.x, notify=positionChanged)

--- a/meshroom/ui/components/messaging.py
+++ b/meshroom/ui/components/messaging.py
@@ -51,7 +51,7 @@ class MessageController(QObject):
         return messages
 
     def getMessages(self):
-        """ Get the messages with simple date infos.
+        """ Get the messages with simple date information.
         Reverse the list to make sure we see the most recent item on top
         """
         return self._getMessagesDict()[::-1]

--- a/meshroom/ui/qml/GraphEditor/NodeDocumentation.qml
+++ b/meshroom/ui/qml/GraphEditor/NodeDocumentation.qml
@@ -99,7 +99,7 @@ FocusScope {
                 height: childrenRect.height
                 Layout.preferredWidth: width
                 spacing: 3
-                model: node.nodeInfos
+                model: node.nodeInfo
                 delegate: nodeInfoItem
             }
 

--- a/meshroom/ui/utils.py
+++ b/meshroom/ui/utils.py
@@ -11,7 +11,7 @@ except Exception:
 
 class QmlInstantEngine(QQmlApplicationEngine):
     """
-    QmlInstantEngine is an utility class helping developing QML applications.
+    QmlInstantEngine is a utility class helping to develop QML applications.
     It reloads itself whenever one of the watched source files is modified.
     As it consumes resources, make sure to disable file watching in production mode.
     """
@@ -19,7 +19,7 @@ class QmlInstantEngine(QQmlApplicationEngine):
     def __init__(self, sourceFile="", watching=True, verbose=False, parent=None):
         """
         watching -- Defines whether the watcher is active (default: True)
-        verbose -- if True, output log infos (default: False)
+        verbose -- if True, output log information (default: False)
         """
         super().__init__(parent)
 

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -11,7 +11,7 @@ from meshroom.core.plugins import Plugin
 from .utils import registerNodeDesc
 
 
-class TestNodeInfos:
+class TestNodeInfo:
     plugin = None
 
     @classmethod
@@ -43,13 +43,13 @@ class TestNodeInfos:
 
         nodeDocumentation = node.getDocumentation()
         assert nodeDocumentation == "PluginCNodeA"
-        nodeInfos = {item["key"]: item["value"] for item in node.getNodeInfos()}
-        assert nodeInfos["module"] == "pluginC.PluginCNodeA"
+        nodeInfo = {item["key"]: item["value"] for item in node.getNodeInfo()}
+        assert nodeInfo["module"] == "pluginC.PluginCNodeA"
         pluginPath = os.path.join(self.folder, "pluginC", "PluginCNodeA.py")
-        assert nodeInfos["modulePath"] == Path(pluginPath).as_posix()  # modulePath seems to follow linux convention
-        assert nodeInfos["author"] == "testAuthor"
-        assert nodeInfos["license"] == "no-license"
-        assert nodeInfos["version"] == "1.0"
+        assert nodeInfo["modulePath"] == Path(pluginPath).as_posix()  # modulePath seems to follow Linux convention
+        assert nodeInfo["author"] == "testAuthor"
+        assert nodeInfo["license"] == "no-license"
+        assert nodeInfo["version"] == "1.0"
 
 
 class TestNodeVariables:


### PR DESCRIPTION
## Description

This PR fixes a consistent typo across Meshroom by replacing every occurence of the word "infos" with the correct word "info". 