### PR TITLE
[core] Logging: Fix several issues on the log files

### DIFF
--- a/meshroom/core/desc/node.py
+++ b/meshroom/core/desc/node.py
@@ -158,7 +158,7 @@ class BaseNode(object):
 
     def executeChunkCommandLine(self, chunk, cmd, env=None):
         try:
-            with open(chunk.logFile, 'w') as logF:
+            with open(chunk.logFile, 'a') as logF:
                 chunk.status.commandLine = cmd
                 chunk.saveStatusFile()
                 cmdList = shlex.split(cmd)
@@ -190,6 +190,7 @@ class BaseNode(object):
                     stderr=logF,
                     cwd=chunk.node.internalFolder,
                     env=env,
+                    text=True,
                     **platformArgs,
                 )
 

--- a/meshroom/core/node.py
+++ b/meshroom/core/node.py
@@ -516,8 +516,6 @@ class NodeChunk(BaseObject):
             self.node.saveOutputAttr()
             executionStatus = Status.SUCCESS
         except Exception:
-            # with open(self.logFile, "r") as fo:
-            #     print(f"logfile:<<<{fo.read()}>>>")
             self.updateStatusFromCache()  # check if the status has been updated by another process
             if self._status.status != Status.STOPPED:
                 executionStatus = Status.ERROR

--- a/meshroom/core/node.py
+++ b/meshroom/core/node.py
@@ -243,9 +243,13 @@ class LogManager:
             self.logger.addHandler(h)
         self.logger.setLevel(self._previousLevel)
 
-    def start(self, level):
-        # Clear log file
+    def clearLogFile(self):
         open(self.logFile, 'w').close()
+
+    def start(self, level):
+        # Make sure the log file exists
+        if not os.path.exists(self.logFile):
+            self.clearLogFile()
         self.configureLogger()
         self.logger.propagate = False
         self.logger.setLevel(self.textToLevel(level))
@@ -400,26 +404,18 @@ class NodeChunk(BaseObject):
 
     @property
     def statusFile(self):
-        if self.range.blockSize == 0:
-            return os.path.join(self.node.internalFolder, "status")
-        else:
-            return os.path.join(self.node.internalFolder,
-                                str(self.index) + ".status")
+        chunkIndex = self.index if self.range.blockSize else 0
+        return os.path.join(self.node.internalFolder, str(chunkIndex) + ".status")
 
     @property
     def statisticsFile(self):
-        if self.range.blockSize == 0:
-            return os.path.join(self.node.internalFolder, "statistics")
-        else:
-            return os.path.join(self.node.internalFolder, str(self.index) + ".statistics")
+        chunkIndex = self.index if self.range.blockSize else 0
+        return os.path.join(self.node.internalFolder, str(chunkIndex) + ".statistics")
 
     @property
     def logFile(self):
-        if self.range.blockSize == 0:
-            return os.path.join(self.node.internalFolder, "log")
-        else:
-            return os.path.join(self.node.internalFolder,
-                                str(self.index) + ".log")
+        chunkIndex = self.index if self.range.blockSize else 0
+        return os.path.join(self.node.internalFolder, str(chunkIndex) + ".log")
 
     def saveStatusFile(self):
         """
@@ -514,11 +510,14 @@ class NodeChunk(BaseObject):
         self.statThread.start()
 
         try:
+            logging.info(f"[Process chunk] Start processing...")
             self.node.nodeDesc.processChunk(self)
             # NOTE: this assumes saving the output attributes for each chunk
             self.node.saveOutputAttr()
             executionStatus = Status.SUCCESS
         except Exception:
+            # with open(self.logFile, "r") as fo:
+            #     print(f"logfile:<<<{fo.read()}>>>")
             self.updateStatusFromCache()  # check if the status has been updated by another process
             if self._status.status != Status.STOPPED:
                 executionStatus = Status.ERROR
@@ -533,7 +532,7 @@ class NodeChunk(BaseObject):
 
             if executionStatus:
                 self.upgradeStatusTo(executionStatus)
-            logging.info(f" - elapsed time: {self._status.elapsedTimeStr}")
+            logging.info(f"[Process chunk] elapsed time: {self._status.elapsedTimeStr}")
             # Ask and wait for the stats thread to stop
             self.statThread.stopRequest()
             self.statThread.join()
@@ -1378,14 +1377,13 @@ class BaseNode(BaseObject):
 
     def prepareLogger(self, iteration=-1):
         # Get file handler path
-        logFileName = "log"
-        if iteration != -1:
-            chunk = self.chunks[iteration]
-            logFileName = str(chunk.index) + ".log"
+        chunkIndex = self.chunks[iteration].index if iteration != -1 else 0
+        logFileName = f"{chunkIndex}.log"
         logFile = os.path.join(self.internalFolder, logFileName)
         # Setup logger
         rootLogger = logging.getLogger()
         self._logManager = LogManager(rootLogger, logFile)
+        self._logManager.clearLogFile()
         self._logManager.start(self.getNodeLogLevel())
 
     def restoreLogger(self):

--- a/meshroom/core/taskManager.py
+++ b/meshroom/core/taskManager.py
@@ -67,7 +67,7 @@ class TaskThread(Thread):
                         stopAndRestart = True
                         break
                     else:
-                        logging.error(f"Error on node computation: {exc}.")
+                        logging.error(f"Error on node computation: {exc}")
                         nodesToRemove, _ = self._manager._graph.dfsOnDiscover(startNodes=[node], reverse=True)
                         # remove following nodes from the task queue
                         for n in nodesToRemove[1:]:  # exclude current node

--- a/tests/test_compute.py
+++ b/tests/test_compute.py
@@ -23,9 +23,7 @@ def executeChunks(node, size):
     logFiles = {}
     for chunkIndex in range(size):
         iteration = chunkIndex if size > 1 else -1
-        logFileName = "log"
-        if size > 1:
-            logFileName = f"{chunkIndex}.log"
+        logFileName = f"{chunkIndex}.log"
         logFile = Path(node.internalFolder) / logFileName
         logFiles[chunkIndex] = logFile
         logFile.touch()


### PR DESCRIPTION
## Description of the problem

We had several issues on the logs :
1. first when we had a `raise ValueError(...)` for example in the `processChunk` then on the log we only had the error and not the full log
2. also there was sometimes logs being overwritten and thus missing in the log file
3. there was additional `log` files (in addition to `0.log`) in parallelized nodes with 1 chunk
4. finally sometimes we had this kind of thing appearing in the log : 
<img width="797" height="215" alt="image" src="https://github.com/user-attachments/assets/9d0df4cb-3817-453a-9f5f-a430c5074cfd" />

## Why we had the issues and how this PR addresses them
- for (1) the reason is that the log file was opened in write mode and therefore changing it to append on `executeChunkCommandLine` fixes it
- for (2) the main reason is that we were systematically clearing the file when we call `chunk.logManager.start` 
- for (3) I made sure we never use `log`. Even on cases where we have a single chunk I think it's simply better to use `0.log` that way we have a better naming consistency anyways.
- for (4) I don't have a defenitive explanation but the logs were written in binary mode and for some reason the QML part was adding some unknown characters while writing thee log on the log tab. Changing the file opening mode to append is what fixed the issue