### PR TITLE
[ui] Use dedicated color for "fatal" and "critical" logs

### DIFF
--- a/meshroom/ui/qml/Controls/TextFileViewer.qml
+++ b/meshroom/ui/qml/Controls/TextFileViewer.qml
@@ -285,8 +285,10 @@ Item {
                                     // Color line according to log level
                                     if (text.indexOf("[warning]") >= 0)
                                         return Colors.orange
-                                    else if(text.indexOf("[error]") >= 0)
+                                    else if (text.indexOf("[error]") >= 0)
                                         return Colors.red
+                                    else if (text.indexOf("[fatal]") >= 0 || text.indexOf("[critical]") >= 0)
+                                        return Colors.firebrick
                                     return palette.text
                                 }
                             }

--- a/meshroom/ui/qml/Controls/TextFileViewer.qml
+++ b/meshroom/ui/qml/Controls/TextFileViewer.qml
@@ -283,6 +283,10 @@ Item {
 
                                 color: {
                                     // Color line according to log level
+                                    if (text.indexOf("[trace]") >= 0)
+                                        return Qt.darker(palette.text, 2)
+                                    if (text.indexOf("[debug]") >= 0)
+                                        return Qt.darker(palette.text, 1.5)
                                     if (text.indexOf("[warning]") >= 0)
                                         return Colors.orange
                                     else if (text.indexOf("[error]") >= 0)

--- a/meshroom/ui/qml/Utils/Colors.qml
+++ b/meshroom/ui/qml/Utils/Colors.qml
@@ -14,6 +14,8 @@ QtObject {
     readonly property color orange: "#FF9800"
     readonly property color yellow: "#FFEB3B"
     readonly property color red: "#F44336"
+    readonly property color crimson: "#DC143C"
+    readonly property color firebrick: "#B22222"
     readonly property color blue: "#03A9F4"
     readonly property color cyan: "#00BCD4"
     readonly property color pink: "#E91E63"


### PR DESCRIPTION
## Description

This PR introduces a specific color for logs that are of the "fatal" or "critical" level. Prior to this, only logs up to the "error" level were colored. Past it, the used color was the same as the "info" (and below) level, making it difficult to identify critical logs.
