### PR TITLE
[ui] Add support to initialize projects with templates including `CopyOutputs` nodes

### DIFF
--- a/meshroom/ui/app.py
+++ b/meshroom/ui/app.py
@@ -183,6 +183,14 @@ Additional Resources:
         action='store_true',
         help=argparse.SUPPRESS  # This hides the option from the help message
     )
+    project_group.add_argument(
+        '-o', '--output',
+        metavar='OUTPUT_FOLDER',
+        type=str,
+        required=False,
+        nargs='*',
+        help='Set the output folder for the CopyFiles nodes.'
+    )
 
     # Pipeline Options
     pipeline_group = parser.add_argument_group('Pipeline Options')
@@ -320,7 +328,16 @@ class MeshroomApp(QApplication):
                 self._activeProject.load(project)
                 self.addRecentProjectFile(project)
         elif getattr(args, "import", None) or args.importRecursive or args.save or args.pipeline:
-            self._activeProject.new()
+            if args.output:
+                # Initialize the template and keep the "CopyFiles" nodes
+                self._activeProject.newWithCopyOutputs()
+                # Use the provided output paths to initialize the "CopyFiles" nodes
+                copyNodes = self._activeProject.graph.nodesOfType("CopyFiles")
+                if len(copyNodes) > 0:
+                    for index, node in enumerate(copyNodes):
+                        node.output.value = args.output[index] if index < len(args.output) else args.output[0]
+            else:
+                self._activeProject.new()
 
         # import is a python keyword, so we have to access the attribute by a string
         if getattr(args, "import", None):

--- a/meshroom/ui/graph.py
+++ b/meshroom/ui/graph.py
@@ -468,7 +468,8 @@ class UIGraph(QObject):
                 os.mkdir(g.cacheDir)
         self.setGraph(g)
 
-    @Slot(str, bool, result=bool)
+    @Slot(str)
+    @Slot(str, bool)
     def initFromTemplate(self, filepath, copyOutputs=False):
         graph = Graph("")
         if filepath:

--- a/meshroom/ui/reconstruction.py
+++ b/meshroom/ui/reconstruction.py
@@ -457,17 +457,30 @@ class Reconstruction(UIGraph):
         self._graph.reloadNodePlugins(nodeTypes)
         self.parent().showMessage("Plugins reloaded!", "ok")
 
-    @Slot()
-    @Slot(str)
+    @Slot(result=bool)
+    @Slot(str, result=bool)
     def new(self, pipeline=None):
         """ Create a new pipeline. """
-        p = pipeline if pipeline != None else self._defaultPipeline
+        p = pipeline if pipeline is not None else self._defaultPipeline
         # Lower the input and the dictionary keys to make sure that all input types can be found:
         # - correct pipeline name but the case does not match (e.g. panoramaHDR instead of panoramaHdr)
         # - lowercase pipeline name given through the "New Pipeline" menu
         loweredPipelineTemplates = {k.lower(): v for k, v in meshroom.core.pipelineTemplates.items()}
         filepath = loweredPipelineTemplates.get(p.lower(), p)
         return self._loadWithErrorReport(self.initFromTemplate, filepath)
+
+    def _initFromTemplateWithCopyOutputs(self, filepath):
+        self.initFromTemplate(filepath, copyOutputs=True)
+
+    @Slot(result=bool)
+    @Slot(str, result=bool)
+    def newWithCopyOutputs(self, pipeline=None):
+        """ Create a new pipeline with all the "CopyFiles" nodes included if the provided template has any. """
+        p = pipeline if pipeline is not None else self._defaultPipeline
+        loweredPipelineTemplates = {k.lower(): v for k, v in meshroom.core.pipelineTemplates.items()}
+        filepath = loweredPipelineTemplates.get(p.lower(), p)
+        return self._loadWithErrorReport(self._initFromTemplateWithCopyOutputs, filepath)
+
 
     @Slot(str, result=bool)
     @Slot(QUrl, result=bool)


### PR DESCRIPTION
## Description

This PR adds an `--output` argument to Meshroom's command line. By using this argument and providing one or more output paths, Meshroom initializes a pipeline using a template and **includes** its `CopyFiles` nodes (if it has any). Previously, `CopyFiles` nodes were automatically excluded from the pipeline initialization.

This fixes #2934.

## Features list

- [x] Add a new `newWithCopyOutputs` slot that initializes a project from a template and includes the template's `CopyFiles` nodes.
- [x] Add a new "--output" option to the command line for Meshroom that allows to initialize a project with provided values for the `CopyFiles` nodes.

## Implementation remarks

The `newWithCopyOutputs` is created as such to be able to initialize a project from a template seemlessly with the error report (through `_loadWithErrorReport`). This prevents modifying the API to include a `copyOutputs` boolean that would have to be added everywhere, including in cases where we want to perform a `load()` rather than a `new()`.