### PR TITLE
[UI] Create a new file manager to handle save as new version

### DIFF
--- a/meshroom/core/graph.py
+++ b/meshroom/core/graph.py
@@ -1507,6 +1507,20 @@ class Graph(BaseObject):
         self.cacheDir = ""
         self.filepathChanged.emit()
 
+    @Slot(result=str)
+    def getCurrentFilename(self):
+        if os.path.exists(self._filepath):
+            return os.path.basename(self._filepath)
+        else:
+            return ""
+        
+    @Slot(result=str)
+    def getCurrentFolder(self):
+        if os.path.exists(self._filepath):
+            return os.path.dirname(self._filepath)
+        else:
+            return os.getcwd()
+
     def updateInternals(self, startNodes=None, force=False):
         nodes, edges = self.dfsOnFinish(startNodes=startNodes)
         for node in nodes:

--- a/meshroom/ui/graph.py
+++ b/meshroom/ui/graph.py
@@ -532,6 +532,7 @@ class UIGraph(QObject):
         # ensure file is saved with ".mg" extension
         if os.path.splitext(localFile)[-1] != ".mg":
             localFile += ".mg"
+        self.parent().showMessage(f"Saving file to {localFile}", "ok")
         self._graph.save(localFile, setupProjectFile=setupProjectFile, template=template)
         self._undoStack.setClean()
         # saving file on disk impacts cache folder location

--- a/meshroom/ui/palette.py
+++ b/meshroom/ui/palette.py
@@ -56,6 +56,10 @@ class PaletteManager(QObject):
         if self.qmlEngine.rootObjects():
             self.qmlEngine.reload()
         self.paletteChanged.emit()
+    
+    @Slot(result=bool)
+    def isDarkPalette(self):
+        return QApplication.instance().palette() == self.darkPalette
 
     paletteChanged = Signal()
     palette = Property(QPalette, lambda self: QApplication.instance().palette(), notify=paletteChanged)

--- a/meshroom/ui/qml/Application.qml
+++ b/meshroom/ui/qml/Application.qml
@@ -12,6 +12,7 @@ import GraphEditor 1.0
 import MaterialIcons 2.2
 import Utils 1.0
 import Controls 1.0
+import Dialogs 1.0
 
 Page {
     id: root
@@ -135,49 +136,32 @@ Page {
     }
 
     // File dialogs
-    Platform.FileDialog {
+
+    MrFileDialog {
         id: saveFileDialog
+        saveMode: true
+        nameFilters: ["*"]
+        property string fileToSave: ""
 
-        property var _callback: undefined
-
-        signal closed(var result)
-
-        title: "Save File"
-        nameFilters: ["Meshroom Graphs (*.mg)"]
-        defaultSuffix: ".mg"
-        fileMode: Platform.FileDialog.SaveFile
+        onFileSelected: (path) => {
+            fileToSave = path.toString().replace("file://", "")
+            // Do something with the file path
+        }
+        
         onAccepted: {
-            if (!validateFilepathForSave(currentFile, saveFileDialog))
+            if (!validateFilepathForSave(fileToSave, saveFileDialog))
             {
                 return;
             }
 
             // Only save a valid file
-            _currentScene.saveAs(currentFile)
-            MeshroomApp.addRecentProjectFile(currentFile.toString())
-            closed(Platform.Dialog.Accepted)
-            fireCallback(Platform.Dialog.Accepted)
+            _currentScene.saveAs("file://" + fileToSave)
+            MeshroomApp.addRecentProjectFile(fileToSave.toString())
         }
-        onRejected: {
-            closed(Platform.Dialog.Rejected)
-            fireCallback(Platform.Dialog.Rejected)
-        }
-
-        function fireCallback(rc)
-        {
-            // Call the callback and reset it
-            if (_callback)
-                _callback(rc)
-            _callback = undefined
-        }
-
-        // Open the unsaved dialog warning with an optional
-        // callback to fire when the dialog is accepted/discarded
-        function prompt(callback)
-        {
-            _callback = callback
-            open()
-        }
+        
+        // onRejected: {
+        //     console.log("File not saved")
+        // }
     }
 
     Platform.FileDialog {

--- a/meshroom/ui/qml/Dialogs/MrFileDialog.qml
+++ b/meshroom/ui/qml/Dialogs/MrFileDialog.qml
@@ -1,0 +1,739 @@
+import QtQuick
+import QtCore
+import QtQuick.Controls
+import QtQuick.Layouts
+
+import Qt.labs.folderlistmodel
+
+import MaterialIcons 2.2
+import Utils 1.0
+
+Window {
+    id: root
+    width: 850
+    height: 600
+    modality: Qt.ApplicationModal
+    flags: Qt.Dialog
+    
+    property string currentFolder: StandardPaths.writableLocation(StandardPaths.DocumentsLocation)
+    property string selectedFile: ""
+    property bool saveMode: false // false = Open, true = Save
+    property var nameFilters: ["*"]
+    property var activePalette: Colors.sysPalette
+    
+    signal fileSelected(string filePath)
+    signal accepted()
+    signal rejected()
+    
+    title: saveMode ? "Save File" : "Open File"
+
+    color: activePalette.base
+    
+    Settings {
+        id: settings
+        category: "MeshroomFileDialog"
+        property string favorites: ""
+        property real sidebarWidth: 200
+    }
+    
+    function loadFavorites() {
+        if (settings.favorites) {
+            return JSON.parse(settings.favorites)
+        }
+        return []
+    }
+    
+    function saveFavorites(favs) {
+        settings.favorites = JSON.stringify(favs)
+    }
+    
+    function addFavorite(name, path) {
+        var favs = loadFavorites()
+        // Check if already exists
+        for (var i = 0; i < favs.length; i++) {
+            if (favs[i].path === path) {
+                return // Already in favorites
+            }
+        }
+        favs.push({name: name, path: path})
+        saveFavorites(favs)
+        favoritesModel.clear()
+        loadFavoritesIntoModel()
+    }
+    
+    function removeFavorite(index) {
+        var favs = loadFavorites()
+        favs.splice(index, 1)
+        saveFavorites(favs)
+        favoritesModel.clear()
+        loadFavoritesIntoModel()
+    }
+    
+    function loadFavoritesIntoModel() {
+        var favs = loadFavorites()
+        for (var i = 0; i < favs.length; i++) {
+            favoritesModel.append(favs[i])
+        }
+    }
+    
+    function accept() {
+        accepted()
+        close()
+    }
+    
+    function reject() {
+        rejected()
+        close()
+    }
+    
+    function open() {
+        show()
+        raise()
+        requestActivate()
+    }
+
+    Component.onCompleted: {
+        const currentFilename = _reconstruction.graph.getCurrentFilename()
+        selectedFile = _reconstruction.graph.filepath
+        filenameField.text = currentFilename
+        currentFolder = _reconstruction.graph.getCurrentFolder()
+        loadFavoritesIntoModel()
+    }
+    
+    ListModel {
+        id: favoritesModel
+    }
+
+    component DialogButton: Button {
+        flat: true
+        property string buttonIcon: MaterialIcons.circle
+        property int size: 18
+        property color iconColor: root.activePalette.text
+        property color backgroundColor:  "transparent"
+        property color backgroundColorHovered: root.activePalette.accent
+        
+        // Icon
+        contentItem: Label {
+            text: parent.buttonIcon
+            font.family: MaterialIcons.fontFamily
+            font.pixelSize: parent.size
+            color: parent.iconColor
+        }
+        
+        background: Rectangle {
+            color: parent.hovered ? parent.backgroundColorHovered : parent.backgroundColor
+            radius: 3
+        }
+    }
+
+    // function filepathExists(path): {
+    //     var xhr = new XMLHttpRequest();
+    //     xhr.open("HEAD", path, false); // synchronous
+    //     try {
+    //         xhr.send();
+    //         return xhr.status === 200 || xhr.status === 0; // 0 for local files
+    //     } catch (e) {
+    //         return false;
+    //     }
+    // }
+    
+    // Custom title bar
+    // Could be used to add options and menus
+    // For now only the name of the mode (Opn/Save and a close UI button)
+    Rectangle {
+        id: titleBar
+        width: parent.width
+        height: 40
+        color: Qt.lighter(root.activePalette.base, 1.4)
+        z: 100
+        
+        RowLayout {
+            anchors.fill: parent
+            anchors.leftMargin: 15
+            anchors.rightMargin: 10
+            spacing: 10
+            
+            Label {
+                text: root.title
+                font.bold: true
+                font.pixelSize: 13
+                color: root.activePalette.text
+                Layout.fillWidth: true
+            }
+            
+            DialogButton {
+                buttonIcon: MaterialIcons.close
+                ToolTip.text: "Close"
+                onClicked: root.reject()
+            }
+        }
+    }
+    
+    RowLayout {
+        anchors.fill: parent
+        anchors.topMargin: 40
+        spacing: 0
+        
+        // LEFT SIDEBAR
+        Rectangle {
+            id: sidebar
+            Layout.fillHeight: true
+            Layout.preferredWidth: settings.sidebarWidth
+            Layout.minimumWidth: 150
+            Layout.maximumWidth: 400
+            color: Qt.darker(root.activePalette.base, 1.4)
+            
+            ColumnLayout {
+                anchors.fill: parent
+                anchors.margins: 10
+                spacing: 8
+                
+                // System folders
+                Label {
+                    text: "System"
+                    font.bold: true
+                    font.pixelSize: 11
+                    color: Qt.darker(root.activePalette.text, 1.4)
+                }
+                
+                Repeater {
+                    model: [
+                        {
+                            name: "Home", 
+                            icon: MaterialIcons.home, 
+                            path: StandardPaths.writableLocation(StandardPaths.HomeLocation)
+                        },
+                        {
+                            name: "Desktop", 
+                            icon: MaterialIcons.desktop_windows, 
+                            path: StandardPaths.writableLocation(StandardPaths.DesktopLocation)
+                        },
+                        {
+                            name: "Documents", 
+                            icon: MaterialIcons.description, 
+                            path: StandardPaths.writableLocation(StandardPaths.DocumentsLocation)
+                        },
+                        {
+                            name: "Downloads", 
+                            icon: MaterialIcons.download, 
+                            path: StandardPaths.writableLocation(StandardPaths.DownloadLocation)
+                        },
+                        {
+                            name: "Pictures", 
+                            icon: MaterialIcons.image, 
+                            path: StandardPaths.writableLocation(StandardPaths.PicturesLocation)
+                        }
+                    ]
+
+                    Button {
+                        Layout.fillWidth: true
+                        flat: true
+                        
+                        contentItem: RowLayout {
+                            spacing: 8
+                            Label {
+                                text: modelData.icon
+                                font.family: MaterialIcons.fontFamily
+                                font.pixelSize: 18
+                                color: root.activePalette.text
+                            }
+                            Label {
+                                text: modelData.name
+                                color: root.activePalette.text
+                                Layout.fillWidth: true
+                            }
+                        }
+                        
+                        background: Rectangle {
+                            color: parent.hovered ? root.activePalette.accent : "transparent"
+                            radius: 3
+                        }
+                        onClicked: folderModel.customFolder = modelData.path
+                    }
+                }
+                
+                // Separator
+                Rectangle {
+                    Layout.fillWidth: true
+                    height: 1
+                    color: Qt.lighter(root.activePalette.base, 1.4)
+                    Layout.topMargin: 8
+                    Layout.bottomMargin: 8
+                }
+                
+                // Favorites section
+                RowLayout {
+                    Layout.fillWidth: true
+                    
+                    Label {
+                        text: "Favorites"
+                        font.bold: true
+                        font.pixelSize: 11
+                        color: Qt.darker(root.activePalette.text, 1.4)
+                        Layout.fillWidth: true
+                    }
+
+                    DialogButton {
+                        buttonIcon: MaterialIcons.add
+                        onClicked: {
+                            var path = folderModel.folder.toString().replace("file://", "")
+                            var name = path.split("/").pop() || "Root"
+                            addFavorite(name, path)
+                        }
+                    }
+                }
+                
+                // Drop area for favorites
+                Rectangle {
+                    Layout.fillWidth: true
+                    Layout.fillHeight: true
+                    color: favDropArea.containsDrag ? root.activePalette.base : "transparent"
+                    border.color: favDropArea.containsDrag ? root.activePalette.accent : "transparent"
+                    border.width: 2
+                    radius: 3
+                    
+                    DropArea {
+                        id: favDropArea
+                        anchors.fill: parent
+                        
+                        onDropped: (drop) => {
+                            if (drop.hasUrls) {
+                                for (var i = 0; i < drop.urls.length; i++) {
+                                    var url = drop.urls[i].toString()
+                                    var path = url.replace("file://", "")
+                                    var name = path.split("/").pop()
+                                    addFavorite(name, path)
+                                }
+                            }
+                        }
+                    }
+                    
+                    ScrollView {
+                        anchors.fill: parent
+                        clip: true
+                        
+                        ListView {
+                            id: favoritesListView
+                            model: favoritesModel
+                            spacing: 2
+                            
+                            delegate: Button {
+                                width: ListView.view.width
+                                flat: true
+                                
+                                contentItem: RowLayout {
+                                    spacing: 5
+                                    
+                                    Label {
+                                        text: MaterialIcons.star
+                                        font.family: MaterialIcons.fontFamily
+                                        font.pixelSize: 16
+                                        color: root.activePalette.text
+                                    }
+                                    
+                                    Label {
+                                        text: model.name
+                                        color: root.activePalette.text
+                                        elide: Text.ElideRight
+                                        Layout.fillWidth: true
+                                    }
+                                    
+                                    DialogButton {
+                                        buttonIcon: MaterialIcons.close
+                                        backgroundColorHovered: Qt.darker(Colors.red, 1.4)
+                                        onClicked: removeFavorite(model.index)
+                                    }
+                                }
+                                
+                                background: Rectangle {
+                                    color: parent.hovered ? root.activePalette.accent : "transparent"
+                                    radius: 3
+                                }
+                                
+                                onClicked: folderModel.customFolder = model.path
+                            }
+                        }
+                    }
+                    
+                    Label {
+                        anchors.centerIn: parent
+                        text: "Drop folders here"
+                        color: Colors.grey
+                        visible: favoritesModel.count === 0 && !favDropArea.containsDrag
+                        font.pixelSize: 11
+                    }
+                }
+            }
+        }
+        
+        // Resize left section
+        Rectangle {
+            Layout.fillHeight: true
+            width: 4
+            color: resizeArea.containsMouse ? root.activePalette.accent : Qt.lighter(root.activePalette.base, 1.4)
+            
+            MouseArea {
+                id: resizeArea
+                anchors.fill: parent
+                hoverEnabled: true
+                cursorShape: Qt.SizeHorCursor
+                
+                property real startX: 0
+                property real startWidth: 0
+                
+                onPressed: (mouse) => {
+                    startX = mouse.x
+                    startWidth = sidebar.Layout.preferredWidth
+                }
+                
+                onPositionChanged: (mouse) => {
+                    if (pressed) {
+                        var delta = mouse.x - startX
+                        var newWidth = startWidth + delta
+                        if (newWidth >= sidebar.Layout.minimumWidth && newWidth <= sidebar.Layout.maximumWidth) {
+                            sidebar.Layout.preferredWidth = newWidth
+                            settings.sidebarWidth = newWidth
+                        }
+                    }
+                }
+            }
+        }
+        
+        // Right section
+        ColumnLayout {
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+            spacing: 0
+            
+            // Toolbar with search bar
+            Rectangle {
+                Layout.fillWidth: true
+                Layout.preferredHeight: 50
+                color: Qt.lighter(root.activePalette.base, 1.4)
+                
+                RowLayout {
+                    anchors.fill: parent
+                    anchors.margins: 8
+                    spacing: 8
+                    
+                    DialogButton {
+                        buttonIcon: MaterialIcons.arrow_upward
+                        ToolTip.text: "Go up one level"
+                        onClicked: {
+                            var url = folderModel.folder.toString()
+                            var parentPath = url.substring(0, url.lastIndexOf("/"))
+                            if (parentPath.length > 7) // more than "file://"
+                                folderModel.customFolder = parentPath
+                        }
+                    }
+                    
+                    TextField {
+                        id: pathField
+                        Layout.fillWidth: true
+                        text: folderModel.folder.toString().replace("file://", "")
+                        selectByMouse: true
+                        color: root.activePalette.text
+                        background: Rectangle {
+                            color: root.activePalette.base
+                            border.color: pathField.activeFocus ? root.activePalette.accent : Qt.darker(root.activePalette.base, 1.4)
+                            border.width: 1
+                            radius: 3
+                        }
+                        onAccepted: folderModel.customFolder = text
+                    }
+                    
+                    DialogButton {
+                        buttonIcon: MaterialIcons.refresh
+                        ToolTip.text: "Refresh"
+                        onClicked: {
+                            var temp = folderModel.folder
+                            folderModel.folder = ""
+                            folderModel.folder = temp
+                        }
+                    }
+                }
+            }
+            
+            // File list header
+            Rectangle {
+                Layout.fillWidth: true
+                height: 30
+                color: root.activePalette.base
+                
+                RowLayout {
+                    anchors.fill: parent
+                    anchors.leftMargin: 10
+                    spacing: 10
+                    
+                    Label { 
+                        text: "Name"
+                        Layout.fillWidth: true
+                        font.bold: true
+                        color: Qt.darker(root.activePalette.text, 1.4)
+                    }
+
+                    Label {
+                        text: "Date Modified"
+                        Layout.preferredWidth: 150
+                        font.bold: true
+                        color: Qt.darker(root.activePalette.text, 1.4)
+                    }
+
+                    Label {
+                        text: "Size"
+                        Layout.preferredWidth: 80
+                        font.bold: true
+                        color: Qt.darker(root.activePalette.text, 1.4)
+                    }
+                }
+            }
+            
+            // File list view
+            ScrollView {
+                Layout.fillWidth: true
+                Layout.fillHeight: true
+                
+                ListView {
+                    id: fileListView
+                    clip: true
+                    
+                    model: FolderListModel {
+                        id: folderModel
+                        showDirs: true
+                        showDirsFirst: true
+                        nameFilters: root.nameFilters
+
+                        property string customFolder: ""
+                        onCustomFolderChanged: {
+                            if (customFolder != "")
+                                folder = customFolder.startsWith("file://") ? customFolder : "file://" + customFolder
+                        }
+
+                        Component.onCompleted: {
+                            customFolder = root.currentFolder
+                        }
+                    }
+                    
+                    delegate: ItemDelegate {
+                        width: ListView.view.width
+                        height: 35
+
+                        function isCurrentItemSelected() {
+                            const currentModelFile = model.fileURL.toString().replace("file://", "")
+                            if (currentModelFile === root.selectedFile) {
+                                fileListView.currentIndex = model.index
+                                return true
+                            }
+                            return false
+                        }
+
+                        highlighted: fileListView.currentIndex == -1 ? isCurrentItemSelected() : ListView.isCurrentItem
+
+                        // Enable drag for folders
+                        Drag.active: model.fileIsDir && dragArea.drag.active
+                        Drag.dragType: Drag.Automatic
+                        Drag.supportedActions: Qt.CopyAction
+                        Drag.mimeData: { "text/uri-list": model.fileURL.toString() }
+                        
+                        background: Rectangle {
+                            color: highlighted ? root.activePalette.accent : (model.index % 2 ? root.activePalette.base : Qt.darker(root.activePalette.base, 1.2))
+                        }
+                        
+                        RowLayout {
+                            anchors.fill: parent
+                            anchors.leftMargin: 10
+                            spacing: 10
+                            
+                            Label {
+                                text: model.fileIsDir ? MaterialIcons.folder : MaterialIcons.insert_drive_file
+                                font.family: MaterialIcons.fontFamily
+                                font.pixelSize: 18
+                                color: Colors.getFileColor(model.fileIsDir ? "" : model.fileName)
+                            }
+                            
+                            Label {
+                                text: model.fileName
+                                Layout.fillWidth: true
+                                elide: Text.ElideRight
+                                color: root.activePalette.text
+                            }
+                            
+                            Label {
+                                text: Qt.formatDateTime(model.fileModified, "dd MMM yyyy hh:mm")
+                                Layout.preferredWidth: 150
+                                color: Qt.darker(root.activePalette.text, 1.2)
+                                font.pixelSize: 11
+                            }
+                            
+                            Label {
+                                text: model.fileIsDir ? "" : (model.fileSize / 1024).toFixed(1) + " KB"
+                                Layout.preferredWidth: 80
+                                color: Qt.darker(root.activePalette.text, 1.2)
+                                font.pixelSize: 11
+                            }
+                        }
+                        
+                        MouseArea {
+                            id: dragArea
+                            anchors.fill: parent
+                            drag.target: model.fileIsDir ? parent : null
+                            
+                            onClicked: {
+                                fileListView.currentIndex = model.index
+                                if (model.fileIsDir) {
+                                    if (!saveMode) {
+                                        filenameField.text = ""
+                                    }
+                                } else {
+                                    filenameField.text = model.fileName
+                                }
+                            }
+                            
+                            onDoubleClicked: {
+                                if (model.fileIsDir) {
+                                    folderModel.folder = model.fileURL
+                                } else {
+                                    if (!saveMode) {
+                                        root.selectedFile = model.fileURL.toString()
+                                        root.fileSelected(selectedFile)
+                                        root.accept()
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            
+            // File selection bar
+            Rectangle {
+                id: selectionBar
+
+                Layout.fillWidth: true
+                Layout.preferredHeight: 60
+                color: Qt.lighter(root.activePalette.base, 1.4)
+
+                function getSelectedPath() {
+                    return folderModel.folder.toString().replace("file://", "") + "/" + filenameField.text
+                }
+
+                function selectedPathExists() {
+                    return Filepath.exists(getSelectedPath())
+                } 
+                
+                RowLayout {
+                    anchors.fill: parent
+                    anchors.margins: 10
+                    spacing: 10
+                    
+                    Rectangle {
+                        Layout.fillWidth: true
+                        height: filenameField.implicitHeight
+                        color: selectionBar.selectedPathExists() ? Qt.darker(Colors.red, 2): root.activePalette.base
+                        border.color: filenameField.activeFocus ? root.activePalette.accent : Qt.darker(root.activePalette.base, 1.4)
+                        border.width: 1
+                        radius: 5
+
+                        RowLayout {
+                            anchors.fill: parent
+                            anchors.margins: 0
+                            spacing: 0
+
+                            TextField {
+                                id: filenameField
+                                Layout.fillWidth: true
+                                placeholderText: saveMode ? "Enter filename" : "Select a file"
+                                selectByMouse: true
+                                color: root.activePalette.text
+                                font.pointSize: 9
+                                background: Rectangle {
+                                    color: "transparent"
+                                }
+                            }
+
+                            DialogButton {
+                                Layout.fillHeight: true
+                                buttonIcon: MaterialIcons.add
+                                ToolTip.text: "Increment version"
+                                font.pointSize: 9
+                                // font.bold: true
+                                onClicked: {
+                                    var filename = filenameField.text
+                                    if (filename === "") return
+
+                                    // Split filename and extension
+                                    var lastDotIndex = filename.lastIndexOf(".")
+                                    var baseName = ""
+                                    var extension = ""
+                                    
+                                    if (lastDotIndex > 0) {
+                                        baseName = filename.substring(0, lastDotIndex)
+                                        extension = filename.substring(lastDotIndex)
+                                    } else {
+                                        baseName = filename
+                                    }
+
+                                    // Extract number at the end of basename
+                                    var match = baseName.match(/^(.*?)(\d+)$/)
+                                    if (match) {
+                                        var prefix = match[1]
+                                        var number = parseInt(match[2])
+                                        filenameField.text = prefix + (number + 1) + extension
+                                    } else {
+                                        filenameField.text = baseName + "1" + extension
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    
+                    Button {
+                        text: "Cancel"
+                        background: Rectangle {
+                            color: parent.hovered ? root.activePalette.accent : Qt.darker(root.activePalette.base, 1.4)
+                            border.color: Qt.lighter(root.activePalette.base, 1.4)
+                            border.width: 1
+                            radius: 5
+                        }
+                        contentItem: Text {
+                            text: parent.text
+                            padding: 3
+                            font.pointSize: 9
+                            color: root.activePalette.text
+                            horizontalAlignment: Text.AlignHCenter
+                            verticalAlignment: Text.AlignVCenter
+                        }
+                        onClicked: root.reject()
+                    }
+                    
+                    Button {
+                        text: saveMode ? "Save" : "Open"
+                        highlighted: true
+                        enabled: filenameField.text !== ""
+                        background: Rectangle {
+                            color: enabled ? (
+                                parent.hovered ? root.activePalette.accent : Qt.darker(root.activePalette.base, 1.4)
+                            ) : Qt.darker(root.activePalette.base, 2)
+                            radius: 5
+                        }
+                        contentItem: Text {
+                            text: parent.text
+                            padding: 3
+                            font.pointSize: 9
+                            color: enabled ? root.activePalette.text : Qt.darker(root.activePalette.text, 2)
+                            horizontalAlignment: Text.AlignHCenter
+                            verticalAlignment: Text.AlignVCenter
+                            font.bold: true
+                        }
+                        onClicked: {
+                            var path = selectionBar.getSelectedPath()
+                            root.selectedFile = path
+                            root.fileSelected(path)
+                            root.accept()
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/meshroom/ui/qml/Dialogs/MrFileDialog.qml
+++ b/meshroom/ui/qml/Dialogs/MrFileDialog.qml
@@ -529,8 +529,10 @@ Window {
 
                         highlighted: fileListView.currentIndex == -1 ? isCurrentItemSelected() : ListView.isCurrentItem
 
+
                         // Enable drag for folders
-                        Drag.active: model.fileIsDir && dragArea.drag.active
+                        property bool isDragging: false
+                        Drag.active: isDragging
                         Drag.dragType: Drag.Automatic
                         Drag.supportedActions: Qt.CopyAction
                         Drag.mimeData: { "text/uri-list": model.fileURL.toString() }
@@ -574,10 +576,19 @@ Window {
                         }
                         
                         MouseArea {
-                            id: dragArea
                             anchors.fill: parent
                             drag.target: model.fileIsDir ? parent : null
-                            
+
+                            onPressed: {
+                                if (model.fileIsDir) {
+                                    parent.isDragging = true
+                                }
+                            }
+
+                            onReleased: {
+                                parent.isDragging = false
+                            }
+
                             onClicked: {
                                 fileListView.currentIndex = model.index
                                 if (model.fileIsDir) {
@@ -619,7 +630,9 @@ Window {
 
                 function selectedPathExists() {
                     return Filepath.exists(getSelectedPath())
-                } 
+                }
+
+                property color fileExistsColor: _PaletteManager.isDarkPalette() ? Qt.darker(Colors.red, 2) : Qt.lighter(Colors.red, 1.5)
                 
                 RowLayout {
                     anchors.fill: parent
@@ -629,7 +642,7 @@ Window {
                     Rectangle {
                         Layout.fillWidth: true
                         height: filenameField.implicitHeight
-                        color: selectionBar.selectedPathExists() ? Qt.darker(Colors.red, 2): root.activePalette.base
+                        color: selectionBar.selectedPathExists() ? selectionBar.fileExistsColor : root.activePalette.base
                         border.color: filenameField.activeFocus ? root.activePalette.accent : Qt.darker(root.activePalette.base, 1.4)
                         border.width: 1
                         radius: 5

--- a/meshroom/ui/qml/Dialogs/qmldir
+++ b/meshroom/ui/qml/Dialogs/qmldir
@@ -1,0 +1,3 @@
+module Dialogs
+
+MrFileDialog 1.0 MrFileDialog.qml

--- a/meshroom/ui/qml/Utils/Colors.qml
+++ b/meshroom/ui/qml/Utils/Colors.qml
@@ -115,4 +115,19 @@ QtObject {
             }
         }
     }
+
+    function getFileColor(filename) {
+        const fileExt = filename.split('.').pop()
+        switch (fileExt) {
+            case "": {
+                return "#ffa726"
+            }
+            // case "txt": {
+            //     return "#90caf9"
+            // }
+            default: {
+                return "#90caf9"
+            }
+        }
+    }
 }

--- a/meshroom/ui/qml/main.qml
+++ b/meshroom/ui/qml/main.qml
@@ -6,6 +6,8 @@ import QtQuick.Dialogs
 
 import Qt.labs.platform as Platform
 
+import Dialogs 1.0
+
 ApplicationWindow {
     id: _window
 
@@ -118,19 +120,26 @@ ApplicationWindow {
             }
         }
 
-        dialog.folder = folder
+        dialog.currentFolder = folder
     }
 
-    Platform.FileDialog {
+    MrFileDialog {
         id: openFileDialog
-        title: "Open File"
-        nameFilters: ["Meshroom Graphs (*.mg)"]
+        saveMode: false
+        nameFilters: ["*.mg"]
+        property string fileToSave: ""
+
+        onFileSelected: (path) => {
+            fileToSave = path.toString().replace("file://", "")
+            // Do something with the file path
+        }
+        
         onAccepted: {
             if (mainStack.currentItem instanceof Homepage) {
                 mainStack.push("Application.qml")
             }
-            if (_currentScene.load(currentFile)) {
-                MeshroomApp.addRecentProjectFile(currentFile.toString())
+            if (_currentScene.load(selectedFile)) {
+                MeshroomApp.addRecentProjectFile(selectedFile.toString())
             }
         }
     }


### PR DESCRIPTION
## Why this PR ?
- Having a way to save as a new version without overriding the current file
- Having a more modern save UI standardized through different platforms

I was mainly inspired by Blender save UI :
<img width="869" height="437" alt="image" src="https://github.com/user-attachments/assets/ba2e00f1-c468-4ff3-a46e-d7090fc1295a" />

## Description of the content

Create a new file manager :
- Left part with standard directories and favourites
- Add right part with
  - search toolbar
  - file list view
  - open/save toolbar
- the bottom toolbar is the main new addition :
  - there's a "+" sign that changes the name of the file to add an index so that we can save a new version
  - if the file exists the rectangle is colored in red to have a visual  feedback

![Peek 2025-12-09 09-54](https://github.com/user-attachments/assets/b8aa0579-e5a0-4b29-965c-6c7277fd3eac)

## Next steps
If reviewers are okay with this proposal there's a few changes to add still :
- Replace all the file dialogs with this UI by default, test all
- Add buttons to go to previous location, create folder
- Add button to filter files and filter to ".mg" by default
- tests
- ...