### PR TITLE
[Controls] NodeActions: Keep the buttons visible on the screen when the selected node moves out of the Graph Editor's view

### DIFF
--- a/meshroom/ui/qml/Controls/NodeActions.qml
+++ b/meshroom/ui/qml/Controls/NodeActions.qml
@@ -80,6 +80,9 @@ Item {
             // Position header above the node (fixed offset in screen pixels)
             x = nodeScreenX + (selectedNodeDelegate.width * draggable.scale - width) / 2
             y = nodeScreenY - height - headerOffset
+            if (y < 0) {
+                y = 0
+            }
         }
 
         onWidthChanged: {

--- a/meshroom/ui/qml/Controls/NodeActions.qml
+++ b/meshroom/ui/qml/Controls/NodeActions.qml
@@ -80,6 +80,9 @@ Item {
             // Position header above the node (fixed offset in screen pixels)
             x = nodeScreenX + (selectedNodeDelegate.width * draggable.scale - width) / 2
             y = nodeScreenY - height - headerOffset
+            if (x < 0) {
+                x = 0
+            }
             if (y < 0) {
                 y = 0
             }


### PR DESCRIPTION
## Description

This pull request introduces a small but important improvement to the positioning logic for node action headers in the `NodeActions.qml` file. The update ensures that headers are always displayed within the visible screen area by preventing them from being positioned off-screen.

* Prevented node action headers from being positioned with negative `x` or `y` coordinates, ensuring headers always remain within the visible screen area.

![nodeactions_position](https://github.com/user-attachments/assets/c5783fff-3a48-43ca-a20e-77c35ffbc687)


