### PR TITLE
[ui] Rename node

### DIFF
--- a/meshroom/common/core.py
+++ b/meshroom/common/core.py
@@ -51,7 +51,18 @@ class CoreDictModel:
         assert key not in self._objects
         self._objects[key] = obj
     
-    def rename(self, oldKey, newKey):
+    def rename(self, oldKey: str, newKey: str):
+        """ Rename an element in the dict model
+
+        Args:
+            oldKey (str): Previous key name of the element to replace.
+            newKey (str): New key name to insert in the model.
+
+        Raises:
+            KeyError: if the new name is already used.
+        """
+        if newKey in self._objects.keys():
+            raise KeyError(f"Key {newKey} is already in use in {self}")
         obj = self._objects[oldKey]
         self._objects[newKey] = obj
         del self._objects[oldKey]

--- a/meshroom/common/core.py
+++ b/meshroom/common/core.py
@@ -50,6 +50,11 @@ class CoreDictModel:
         assert key is not None
         assert key not in self._objects
         self._objects[key] = obj
+    
+    def rename(self, oldKey, newKey):
+        obj = self._objects[oldKey]
+        self._objects[newKey] = obj
+        del self._objects[oldKey]
 
     def pop(self, key):
         assert key in self._objects

--- a/meshroom/common/qt.py
+++ b/meshroom/common/qt.py
@@ -167,6 +167,13 @@ class QObjectListModel(QtCore.QAbstractListModel):
         self._objects[i] = obj
         self.dataChanged.emit(self.index(i), self.index(i), [])
 
+    def rename(self, oldKey, newKey):
+        obj = self._objectByKey[oldKey]
+        index = self.indexOf(obj)
+        self._objectByKey[newKey] = obj
+        del self._objectByKey[oldKey]
+        self.dataChanged.emit(self.index(index), self.index(index), [])
+
     def move(self, fromIndex, toIndex):
         """ Moves the item at index position from to index position to
         and notifies any views.

--- a/meshroom/common/qt.py
+++ b/meshroom/common/qt.py
@@ -167,7 +167,18 @@ class QObjectListModel(QtCore.QAbstractListModel):
         self._objects[i] = obj
         self.dataChanged.emit(self.index(i), self.index(i), [])
 
-    def rename(self, oldKey, newKey):
+    def rename(self, oldKey: str, newKey: str):
+        """ Rename an element in the model
+
+        Args:
+            oldKey (str): Previous key name of the element to replace.
+            newKey (str): New key name to insert in the model.
+
+        Raises:
+            KeyError: if the new name is already used.
+        """
+        if newKey in self._objectByKey.keys():
+            raise KeyError(f"Key {newKey} is already in use in {self}")
         obj = self._objectByKey[oldKey]
         index = self.indexOf(obj)
         self._objectByKey[newKey] = obj

--- a/meshroom/core/graph.py
+++ b/meshroom/core/graph.py
@@ -514,14 +514,23 @@ class Graph(BaseObject):
         return node
 
     def renameNode(self, node: Node, newName: str):
-        """ Rename a node in the Node Graph
+        """ Rename a node in the Node Graph.
+        If the proposed name is already assigned to a node then it will create a unique name
 
         Args:
             node (Node): Node to rename.
             newName (str): New name of the node. Must be unique in the graph.
         """
+        # Handle empty string
+        if not newName:
+            return
+        usedNames = {n._name for n in self._nodes if n != node}
+        # Make sure we rename to an available name
+        if newName in usedNames:
+            newName = self._createUniqueNodeName(newName, usedNames)
+        # Rename in the dict model
         self._nodes.rename(node._name, newName)
-        # Finally rename
+        # Finally rename the node name property and notify Qt
         node._name = newName   
         node.nodeNameChanged.emit()
 

--- a/meshroom/core/graph.py
+++ b/meshroom/core/graph.py
@@ -485,6 +485,9 @@ class Graph(BaseObject):
             self.update()
             self._updateRequested = False
 
+    def _getUniqueName(self, namePrefix):
+        return 
+
     @changeTopology
     def _addNode(self, node, uniqueName):
         """

--- a/meshroom/core/graph.py
+++ b/meshroom/core/graph.py
@@ -514,6 +514,12 @@ class Graph(BaseObject):
         return node
 
     def renameNode(self, node: Node, newName: str):
+        """ Rename a node in the Node Graph
+
+        Args:
+            node (Node): Node to rename.
+            newName (str): New name of the node. Must be unique in the graph.
+        """
         self._nodes.rename(node._name, newName)
         # Finally rename
         node._name = newName   

--- a/meshroom/core/graph.py
+++ b/meshroom/core/graph.py
@@ -485,9 +485,6 @@ class Graph(BaseObject):
             self.update()
             self._updateRequested = False
 
-    def _getUniqueName(self, namePrefix):
-        return 
-
     @changeTopology
     def _addNode(self, node, uniqueName):
         """
@@ -515,6 +512,12 @@ class Graph(BaseObject):
         with GraphModification(self):
             node._applyExpr()
         return node
+
+    def renameNode(self, node: Node, newName: str):
+        self._nodes.rename(node._name, newName)
+        # Finally rename
+        node._name = newName   
+        node.nodeNameChanged.emit()
 
     def copyNode(self, srcNode: Node, withEdges: bool=False):
         """

--- a/meshroom/core/graph.py
+++ b/meshroom/core/graph.py
@@ -519,10 +519,13 @@ class Graph(BaseObject):
 
         Args:
             node (Node): Node to rename.
-            newName (str): New name of the node. Must be unique in the graph.
+            newName (str): New name of the node.
         """
         # Handle empty string
         if not newName:
+            return
+        if node.getLocked():
+            logging.warning(f"Cannot rename node {node} because of the locked status")
             return
         usedNames = {n._name for n in self._nodes if n != node}
         # Make sure we rename to an available name
@@ -531,7 +534,7 @@ class Graph(BaseObject):
         # Rename in the dict model
         self._nodes.rename(node._name, newName)
         # Finally rename the node name property and notify Qt
-        node._name = newName   
+        node._name = newName
         node.nodeNameChanged.emit()
 
     def copyNode(self, srcNode: Node, withEdges: bool=False):

--- a/meshroom/core/node.py
+++ b/meshroom/core/node.py
@@ -913,7 +913,7 @@ class BaseNode(BaseObject):
         Returns:
             str: the high-level label from the technical node name
         """
-        t, idx = name.split("_") if "_" in name else (name, "1")
+        t, idx = name.rsplit("_", 1) if "_" in name else (name, "1")
         return f"{t}{idx if int(idx) > 1 else ''}"
 
     def getDocumentation(self):

--- a/meshroom/core/node.py
+++ b/meshroom/core/node.py
@@ -2050,7 +2050,8 @@ class BaseNode(BaseObject):
                      attr.desc.semantic == "shapeFile"), None) is not None
 
 
-    name = Property(str, getName, constant=True)
+    nodeNameChanged = Signal()
+    name = Property(str, getName, notify=nodeNameChanged)
     defaultLabel = Property(str, getDefaultLabel, constant=True)
     nodeType = Property(str, nodeType.fget, constant=True)
     documentation = Property(str, getDocumentation, constant=True)

--- a/meshroom/core/node.py
+++ b/meshroom/core/node.py
@@ -913,7 +913,7 @@ class BaseNode(BaseObject):
         Returns:
             str: the high-level label from the technical node name
         """
-        t, idx = name.split("_")
+        t, idx = name.split("_") if "_" in name else (name, "1")
         return f"{t}{idx if int(idx) > 1 else ''}"
 
     def getDocumentation(self):

--- a/meshroom/ui/commands.py
+++ b/meshroom/ui/commands.py
@@ -152,6 +152,25 @@ class AddNodeCommand(GraphCommand):
         self.graph.removeNode(self.nodeName)
 
 
+class RenameNodeCommand(GraphCommand):
+    def __init__(self, graph, node, name, parent=None):
+        super().__init__(graph, parent)
+        self.node = node
+        self.oldName = node._name
+        self.name = name
+
+    def redoImpl(self):
+        newName = self.graph._createUniqueNodeName(self.name, [n._name for n in self.graph._nodes])
+        self.setText(f"Rename Node {self.oldName} to {newName}")
+        self.node._name = newName
+        self.node.nodeNameChanged.emit()
+        return newName
+
+    def undoImpl(self):
+        self.node._name = self.oldName
+        self.node.nodeNameChanged.emit()
+
+
 class RemoveNodeCommand(GraphCommand):
     def __init__(self, graph, node, parent=None):
         super().__init__(graph, parent)

--- a/meshroom/ui/commands.py
+++ b/meshroom/ui/commands.py
@@ -154,15 +154,20 @@ class AddNodeCommand(GraphCommand):
 
 class RenameNodeCommand(GraphCommand):
     def __init__(self, graph, node, name, parent=None):
+        """ Command to rename a node. The new name should not be used yet.
+        """
         super().__init__(graph, parent)
         self.node = node
         self.oldName = node._name
         self.name = name
 
     def redoImpl(self):
-        newName = self.graph._createUniqueNodeName(self.name, [n._name for n in self.graph._nodes])
+        newName = self.name
+        usedNames = {n._name for n in self.graph._nodes}
+        if newName in usedNames:
+            newName = self.graph._createUniqueNodeName(self.name, usedNames)
         self.setText(f"Rename Node {self.oldName} to {newName}")
-        self.graph.renameNode(self.node, newName)
+        self.graph.renameNode(self.node, self.name)
         return newName
 
     def undoImpl(self):

--- a/meshroom/ui/commands.py
+++ b/meshroom/ui/commands.py
@@ -162,13 +162,9 @@ class RenameNodeCommand(GraphCommand):
         self.name = name
 
     def redoImpl(self):
-        newName = self.name
-        usedNames = {n._name for n in self.graph._nodes}
-        if newName in usedNames:
-            newName = self.graph._createUniqueNodeName(self.name, usedNames)
-        self.setText(f"Rename Node {self.oldName} to {newName}")
+        self.setText(f"Rename Node {self.oldName} to {self.name}")
         self.graph.renameNode(self.node, self.name)
-        return newName
+        return self.node._name
 
     def undoImpl(self):
         self.graph.renameNode(self.node, self.oldName)

--- a/meshroom/ui/commands.py
+++ b/meshroom/ui/commands.py
@@ -162,13 +162,11 @@ class RenameNodeCommand(GraphCommand):
     def redoImpl(self):
         newName = self.graph._createUniqueNodeName(self.name, [n._name for n in self.graph._nodes])
         self.setText(f"Rename Node {self.oldName} to {newName}")
-        self.node._name = newName
-        self.node.nodeNameChanged.emit()
+        self.graph.renameNode(self.node, newName)
         return newName
 
     def undoImpl(self):
-        self.node._name = self.oldName
-        self.node.nodeNameChanged.emit()
+        self.graph.renameNode(self.node, self.oldName)
 
 
 class RemoveNodeCommand(GraphCommand):

--- a/meshroom/ui/graph.py
+++ b/meshroom/ui/graph.py
@@ -941,13 +941,32 @@ class UIGraph(QObject):
         return self.push(commands.AddNodeCommand(self._graph, nodeType, position=position, **kwargs))
 
     @Slot(Node, str, result=str)
-    def renameNode(self, node, newName):
+    def renameNode(self, node: Node, newName: str):
+        """ Triggers the node renaming.
+        
+        The name we send here doesn't need to be unique here because we will ensure this later in 
+        the RenameNodeCommand. In this function the last `_N` index is removed, then all special characters
+        (everything except letters and numbers) are removed. Then a `_N` index will be added to
+        ensure the node name unicity.
+        
+        As we remove all special characters, only one underscore is allowed in the node name. 
+        Label can be used if multiple underscores are needed.
+
+        Args:
+            node (Node): Node to rename.
+            newName (str): New name to set.
+
+        Returns:
+            str: The final name of the node.
+        """
         newName = "_".join(newName.split("_")[:-1]) if "_" in newName else newName
         # Eliminate all characters except digits and letters
         newName = re.sub(r"[^0-9a-zA-Z]", "", newName)
-        if not newName:
+        # Create unique name
+        uniqueName = self._graph._createUniqueNodeName(newName, {n._name for n in self._graph._nodes if n != node})
+        if not newName or uniqueName == node._name:
             return ""
-        return self.push(commands.RenameNodeCommand(self._graph, node, newName))
+        return self.push(commands.RenameNodeCommand(self._graph, node, uniqueName))
 
     def moveNode(self, node: Node, position: Position):
         """

--- a/meshroom/ui/graph.py
+++ b/meshroom/ui/graph.py
@@ -2,6 +2,7 @@
 from collections.abc import Iterable
 import logging
 import os
+import re
 import json
 from enum import Enum
 from threading import Thread, Event, Lock
@@ -941,6 +942,11 @@ class UIGraph(QObject):
 
     @Slot(Node, str, result=str)
     def renameNode(self, node, newName):
+        newName = "_".join(newName.split("_")[:-1]) if "_" in newName else newName
+        # Eliminate all characters except digits and letters
+        newName = re.sub(r"[^0-9a-zA-Z]", "", newName)
+        if not newName:
+            return ""
         return self.push(commands.RenameNodeCommand(self._graph, node, newName))
 
     def moveNode(self, node: Node, position: Position):

--- a/meshroom/ui/graph.py
+++ b/meshroom/ui/graph.py
@@ -944,13 +944,11 @@ class UIGraph(QObject):
     def renameNode(self, node: Node, newName: str):
         """ Triggers the node renaming.
         
-        The name we send here doesn't need to be unique here because we will ensure this later in 
-        the RenameNodeCommand. In this function the last `_N` index is removed, then all special characters
-        (everything except letters and numbers) are removed. Then a `_N` index will be added to
-        ensure the node name unicity.
+        In this function the last `_N` index is removed, then all special characters
+        (everything except letters and numbers) are removed. 
+        The name uniqueness will be ensured later by adding a suffix (e.g. `_1`, `_2`, ...)
         
-        As we remove all special characters, only one underscore is allowed in the node name. 
-        Label can be used if multiple underscores are needed.
+        Labels can be used to have special characters in the displayed name.
 
         Args:
             node (Node): Node to rename.

--- a/meshroom/ui/graph.py
+++ b/meshroom/ui/graph.py
@@ -939,6 +939,10 @@ class UIGraph(QObject):
             position = Position(position.x(), position.y())
         return self.push(commands.AddNodeCommand(self._graph, nodeType, position=position, **kwargs))
 
+    @Slot(Node, str, result=str)
+    def renameNode(self, node, newName):
+        return self.push(commands.RenameNodeCommand(self._graph, node, newName))
+
     def moveNode(self, node: Node, position: Position):
         """
         Move `node` to the given `position`.

--- a/meshroom/ui/qml/Controls/Panel.qml
+++ b/meshroom/ui/qml/Controls/Panel.qml
@@ -16,6 +16,7 @@ Page {
     id: root
 
     property alias headerBar: headerLayout.data
+    property Component titleComponent: null  // Allow custom component for title
     property alias footerContent: footerLayout.data
     property alias icon: iconPlaceHolder.data
     property alias loading: loadingIndicator.running
@@ -62,12 +63,22 @@ Page {
             }
 
             // Title
-            Label {
-                text: root.title
-                elide: Text.ElideRight
-                topPadding: m.vPadding
-                bottomPadding: m.vPadding
+            // Either we load the custom root.titleComponent or we just put the root.title
+            Loader {
+                id: titleLoader
+                sourceComponent: root.titleComponent !== null ? root.titleComponent : defaultTitleComponent
+                Layout.fillWidth: false
             }
+            Component {
+                id: defaultTitleComponent
+                Label {
+                    text: root.title
+                    elide: Text.ElideRight
+                    topPadding: m.vPadding
+                    bottomPadding: m.vPadding
+                }
+            }
+
             Item {
                 width: 10
             }

--- a/meshroom/ui/qml/GraphEditor/Node.qml
+++ b/meshroom/ui/qml/GraphEditor/Node.qml
@@ -90,7 +90,7 @@ Item {
             root.y = root.node.y
         }
         function onNameChanged() {
-            // Make sure when the node name changes the node label is updated
+            // HACK: Make sure when the node name changes the node label is updated
             root.nodeLabel = ""
             // Restore binding to root.node.label
             root.nodeLabel = Qt.binding(function() { return root.node.label; })

--- a/meshroom/ui/qml/GraphEditor/Node.qml
+++ b/meshroom/ui/qml/GraphEditor/Node.qml
@@ -24,6 +24,8 @@ Item {
     property bool selected: false
     property bool hovered: false
     property bool dragging: mouseArea.drag.active
+    /// Node label
+    property string nodeLabel: node ? node.label : ""
     /// Combined x and y
     property point position: Qt.point(x, y)
     /// Styling
@@ -86,6 +88,12 @@ Item {
         function onPositionChanged() {
             root.x = root.node.x
             root.y = root.node.y
+        }
+        function onNameChanged() {
+            // Make sure when the node name changes the node label is updated
+            root.nodeLabel = ""
+            // Restore binding to root.node.label
+            root.nodeLabel = Qt.binding(function() { return root.node.label; })
         }
     }
 
@@ -399,7 +407,7 @@ Item {
                         Label {
                             id: nodeLabel
                             Layout.fillWidth: true
-                            text: node ? node.label : ""
+                            text: root.nodeLabel
                             padding: 4
                             color: root.mainSelected ? activePalette.highlightedText : activePalette.text
                             elide: Text.ElideMiddle

--- a/meshroom/ui/qml/GraphEditor/NodeEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/NodeEditor.qml
@@ -85,7 +85,7 @@ Panel {
     function validateNodeNameChange(name) {
         if (root.node && name.trim() !== "") {
             const newNodeName = _reconstruction.renameNode(_reconstruction.selectedNode, name.trim())
-            if (newNodeName == "") {
+            if (newNodeName === "") {
                 root.displayNodeName = root.nodeName
                 root.validatedNodeName = root.nodeName
             } else {
@@ -95,6 +95,7 @@ Panel {
         }
     }
     function cancelNodeNameChange() {
+        // HACK: Set to an empty string to force the text to be set to the previous value.
         root.displayNodeName = ""
         root.displayNodeName = root.validatedNodeName
     }
@@ -201,7 +202,7 @@ Panel {
             // Show node type if the node name does not start with "nodeType_"
             Label {
                 text: "(" + root.displayNodeType + ")"
-                visible: root.displayNodeType !== ""
+                visible: root.displayNodeType !== "" && _reconstruction.selectedNode
                 topPadding: 4
                 bottomPadding: 4
             }

--- a/meshroom/ui/qml/GraphEditor/NodeEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/NodeEditor.qml
@@ -1,5 +1,3 @@
-// NodeEditor.qml
-
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
@@ -172,12 +170,9 @@ Panel {
                 }
             }
 
-            // Show default label in parentheses if different
-            // TODO : instead, show node type
+            // Show node type if the node name does not start with "nodeType_"
             Label {
-                // text: root.node && root.node.label !== root.node.defaultLabel ? "(" + root.node.defaultLabel + ")" : ""
                 text: "(" + root.displayNodeType + ")"
-                // visible: root.node !== null && root.node.label !== root.node.defaultLabel
                 visible: root.displayNodeType !== ""
                 topPadding: 4
                 bottomPadding: 4

--- a/meshroom/ui/qml/GraphEditor/NodeEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/NodeEditor.qml
@@ -85,8 +85,13 @@ Panel {
     function validateNodeNameChange(name) {
         if (root.node && name.trim() !== "") {
             const newNodeName = _reconstruction.renameNode(_reconstruction.selectedNode, name.trim())
-            root.displayNodeName = newNodeName
-            root.validatedNodeName = newNodeName
+            if (newNodeName == "") {
+                root.displayNodeName = root.nodeName
+                root.validatedNodeName = root.nodeName
+            } else {
+                root.displayNodeName = newNodeName
+                root.validatedNodeName = newNodeName
+            }
         }
     }
     function cancelNodeNameChange() {
@@ -110,6 +115,7 @@ Panel {
                 id: nodeNameField
                 visible: root.node !== null
                 text: root.displayNodeName
+                validator: RegularExpressionValidator { regularExpression: /^[0-9A-Za-z]+$/ }
                 font.bold: true
                 readOnly: true
                 selectByMouse: false
@@ -123,6 +129,10 @@ Panel {
                     border.color: nodeNameField.readOnly ? "transparent" : root.palette.highlight
                     border.width: 1
                     radius: 2
+                }
+
+                function refreshText() {
+                    nodeNameField.text = Qt.binding(function() { return root.displayNodeName })
                 }
 
                 MouseArea {
@@ -141,6 +151,7 @@ Panel {
                 Keys.onReturnPressed: {
                     if (!readOnly) {
                         root.validateNodeNameChange(text)
+                        nodeNameField.refreshText()
                         readOnly = true
                         selectByMouse = false
                     }
@@ -149,6 +160,7 @@ Panel {
                 Keys.onEnterPressed: {
                     if (!readOnly) {
                         root.validateNodeNameChange(text)
+                        nodeNameField.refreshText()
                         readOnly = true
                         selectByMouse = false
                     }
@@ -157,6 +169,7 @@ Panel {
                 Keys.onEscapePressed: {
                     if (!readOnly) {
                         root.cancelNodeNameChange()
+                        nodeNameField.refreshText()
                         readOnly = true
                         selectByMouse = false
                     }
@@ -166,8 +179,21 @@ Panel {
                     if (!activeFocus && !readOnly) {
                         // Focus lost without pressing Enter - discard changes
                         root.cancelNodeNameChange()
+                        nodeNameField.refreshText()
                         readOnly = true
                         selectByMouse = false
+                    }
+                }
+
+                Connections {
+                    target: _reconstruction
+                    function onSelectedNodeChanged() {
+                        if (!activeFocus && !readOnly) {
+                            root.cancelNodeNameChange()
+                            nodeNameField.refreshText()
+                            nodeNameField.readOnly = true
+                            nodeNameField.selectByMouse = false
+                        }
                     }
                 }
             }

--- a/meshroom/ui/qml/GraphEditor/NodeEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/NodeEditor.qml
@@ -129,10 +129,12 @@ Panel {
                     anchors.fill: parent
                     enabled: nodeNameField.readOnly
                     onDoubleClicked: {
-                        nodeNameField.readOnly = false
-                        nodeNameField.selectByMouse = true
-                        nodeNameField.forceActiveFocus()
-                        nodeNameField.selectAll()
+                        if (root.node && !root.node.locked) {
+                            nodeNameField.readOnly = false
+                            nodeNameField.selectByMouse = true
+                            nodeNameField.forceActiveFocus()
+                            nodeNameField.selectAll()
+                        }
                     }
                 }
 

--- a/meshroom/ui/qml/GraphEditor/NodeEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/NodeEditor.qml
@@ -27,18 +27,18 @@ Panel {
     property string displayNodeType: ""
 
     function updateNodeNameDisplay() {
-        if (_reconstruction.selectedNode) {
-            const nodeName = _reconstruction.selectedNode.name
+        if (_currentScene.selectedNode) {
+            const nodeName = _currentScene.selectedNode.name
             root.displayNodeName = nodeName
             root.validatedNodeName = nodeName
             // Set the display node type only if it is not contained in the node name
-            const nodeType = _reconstruction.selectedNode.nodeType
+            const nodeType = _currentScene.selectedNode.nodeType
             root.displayNodeType = nodeName.startsWith(nodeType + "_") ? "" : nodeType
         }
     }
 
     Connections {
-        target: _reconstruction
+        target: _currentScene
         function onSelectedNodeChanged() {
             updateNodeNameDisplay()
         }
@@ -84,7 +84,7 @@ Panel {
     // Function to validate and apply node name change
     function validateNodeNameChange(name) {
         if (root.node && name.trim() !== "") {
-            const newNodeName = _reconstruction.renameNode(_reconstruction.selectedNode, name.trim())
+            const newNodeName = _currentScene.renameNode(_currentScene.selectedNode, name.trim())
             if (newNodeName === "") {
                 root.displayNodeName = root.nodeName
                 root.validatedNodeName = root.nodeName
@@ -188,7 +188,7 @@ Panel {
                 }
 
                 Connections {
-                    target: _reconstruction
+                    target: _currentScene
                     function onSelectedNodeChanged() {
                         if (!activeFocus && !readOnly) {
                             root.cancelNodeNameChange()
@@ -203,7 +203,7 @@ Panel {
             // Show node type if the node name does not start with "nodeType_"
             Label {
                 text: "(" + root.displayNodeType + ")"
-                visible: root.displayNodeType !== "" && _reconstruction.selectedNode
+                visible: root.displayNodeType !== "" && _currentScene.selectedNode
                 topPadding: 4
                 bottomPadding: 4
             }

--- a/meshroom/ui/qml/GraphEditor/NodeEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/NodeEditor.qml
@@ -1,3 +1,5 @@
+// NodeEditor.qml
+
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
@@ -20,6 +22,33 @@ Panel {
     property bool readOnly: false
     property bool isCompatibilityNode: node && node.compatibilityIssue !== undefined
     property string nodeStartDateTime: ""
+
+    property variant nodeName: node !== null ? node.name : undefined
+    property string displayNodeName: node !== null ? node.name : ""
+    property string validatedNodeName: displayNodeName
+    property string displayNodeType: ""
+
+    function updateNodeNameDisplay() {
+        if (_reconstruction.selectedNode) {
+            const nodeName = _reconstruction.selectedNode.name
+            root.displayNodeName = nodeName
+            root.validatedNodeName = nodeName
+            // Set the display node type only if it is not contained in the node name
+            const nodeType = _reconstruction.selectedNode.nodeType
+            root.displayNodeType = nodeName.startsWith(nodeType + "_") ? "" : nodeType
+        } 
+    }
+
+    Connections {
+        target: _reconstruction
+        function onSelectedNodeChanged() {
+            updateNodeNameDisplay()
+        }
+    }
+
+    onNodeNameChanged: {
+        updateNodeNameDisplay()
+    }
 
     signal attributeDoubleClicked(var mouse, var attribute)
     signal inAttributeClicked(var srcItem, var mouse, var inAttributes)
@@ -52,6 +81,108 @@ Panel {
          */
         // Reset tab bar's current index
         tabBar.currentIndex = 0;
+    }
+
+    // Function to validate and apply node name change
+    function validateNodeNameChange(name) {
+        if (root.node && name.trim() !== "") {
+            const newNodeName = _reconstruction.renameNode(_reconstruction.selectedNode, name.trim())
+            root.displayNodeName = newNodeName
+            root.validatedNodeName = newNodeName
+        }
+    }
+    function cancelNodeNameChange() {
+        root.displayNodeName = ""
+        root.displayNodeName = root.validatedNodeName
+    }
+
+    // Add custom title component for editing
+    titleComponent: Component {
+        RowLayout {
+            spacing: 4
+
+            Label {
+                text: root.node === null ? "NodeEditor" : "Node -"
+                topPadding: 4
+                bottomPadding: 4
+                rightPadding: 0
+            }
+
+            TextField {
+                id: nodeNameField
+                visible: root.node !== null
+                text: root.displayNodeName
+                font.bold: true
+                readOnly: true
+                selectByMouse: false
+                verticalAlignment: Text.AlignVCenter
+                topPadding: 4
+                bottomPadding: 4
+                leftPadding: 0
+
+                background: Rectangle {
+                    color: nodeNameField.readOnly ? "transparent" : root.palette.base
+                    border.color: nodeNameField.readOnly ? "transparent" : root.palette.highlight
+                    border.width: 1
+                    radius: 2
+                }
+
+                MouseArea {
+                    anchors.fill: parent
+                    enabled: nodeNameField.readOnly
+                    onDoubleClicked: {
+                        nodeNameField.readOnly = false
+                        nodeNameField.selectByMouse = true
+                        nodeNameField.forceActiveFocus()
+                        nodeNameField.selectAll()
+                    }
+                }
+
+                Keys.onReturnPressed: {
+                    if (!readOnly) {
+                        root.validateNodeNameChange(text)
+                        readOnly = true
+                        selectByMouse = false
+                    }
+                }
+
+                Keys.onEnterPressed: {
+                    if (!readOnly) {
+                        root.validateNodeNameChange(text)
+                        readOnly = true
+                        selectByMouse = false
+                    }
+                }
+
+                Keys.onEscapePressed: {
+                    if (!readOnly) {
+                        root.cancelNodeNameChange()
+                        readOnly = true
+                        selectByMouse = false
+                    }
+                }
+
+                onActiveFocusChanged: {
+                    if (!activeFocus && !readOnly) {
+                        // Focus lost without pressing Enter - discard changes
+                        root.cancelNodeNameChange()
+                        readOnly = true
+                        selectByMouse = false
+                    }
+                }
+            }
+
+            // Show default label in parentheses if different
+            // TODO : instead, show node type
+            Label {
+                // text: root.node && root.node.label !== root.node.defaultLabel ? "(" + root.node.defaultLabel + ")" : ""
+                text: "(" + root.displayNodeType + ")"
+                // visible: root.node !== null && root.node.label !== root.node.defaultLabel
+                visible: root.displayNodeType !== ""
+                topPadding: 4
+                bottomPadding: 4
+            }
+        }
     }
 
     headerBar: RowLayout {

--- a/meshroom/ui/qml/GraphEditor/NodeEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/NodeEditor.qml
@@ -34,7 +34,7 @@ Panel {
             // Set the display node type only if it is not contained in the node name
             const nodeType = _reconstruction.selectedNode.nodeType
             root.displayNodeType = nodeName.startsWith(nodeType + "_") ? "" : nodeType
-        } 
+        }
     }
 
     Connections {
@@ -116,6 +116,7 @@ Panel {
                 id: nodeNameField
                 visible: root.node !== null
                 text: root.displayNodeName
+                // For some reason the validator doesn't always work
                 validator: RegularExpressionValidator { regularExpression: /^[0-9A-Za-z]+$/ }
                 font.bold: true
                 readOnly: true

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -296,12 +296,12 @@ def test_rename_nodes():
     ls0 = graph.addNewNode("Ls")
     ls1 = graph.addNewNode("Ls")
     ls2 = graph.addNewNode("Ls")
-    
+
     # Test with empty string
     assert ls0.name == "Ls_1"
     graph.renameNode(ls0, "")
     assert ls0.name == "Ls_1"
-    
+
     # Rename
     graph.renameNode(ls0, "nodels")
     assert ls0.name == "nodels"
@@ -309,3 +309,8 @@ def test_rename_nodes():
     assert ls1.name == "nodels_1"
     graph.renameNode(ls2, "nodels")
     assert ls2.name == "nodels_2"
+    
+    # Check we cannot rename in locked mode
+    ls0.setLocked(True)
+    graph.renameNode(ls0, "lockedLs")
+    assert ls0.name == "nodels"

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -272,21 +272,6 @@ def test_duplicate_nodes():
     assert nMap[n3][0].input2.inputLink == nMap[n2][0].output
 
 
-def test_cyclic_connection_should_raise_error():
-
-    # Given
-    graph = Graph("Test cyclic connection")
-    tB = graph.addNewNode("AppendText", inputText="echo B")
-    tC = graph.addNewNode("AppendText", inputText="echo C")
-
-    tB.output.connectTo(tC.input)
-
-    # When
-    # Then
-    with pytest.raises(CyclicDependencyError):
-        tC.output.connectTo(tB.input)
-
-
 def test_rename_nodes():
     """
     Test renaming nodes.

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -270,3 +270,42 @@ def test_duplicate_nodes():
     assert nMap[n2][0].input.inputLink == nMap[n1][0].output
     assert nMap[n3][0].input.inputLink == nMap[n1][0].output
     assert nMap[n3][0].input2.inputLink == nMap[n2][0].output
+
+
+def test_cyclic_connection_should_raise_error():
+
+    # Given
+    graph = Graph("Test cyclic connection")
+    tB = graph.addNewNode("AppendText", inputText="echo B")
+    tC = graph.addNewNode("AppendText", inputText="echo C")
+
+    tB.output.connectTo(tC.input)
+
+    # When
+    # Then
+    with pytest.raises(CyclicDependencyError):
+        tC.output.connectTo(tB.input)
+
+
+def test_rename_nodes():
+    """
+    Test renaming nodes.
+    """
+
+    graph = Graph("")
+    ls0 = graph.addNewNode("Ls")
+    ls1 = graph.addNewNode("Ls")
+    ls2 = graph.addNewNode("Ls")
+    
+    # Test with empty string
+    assert ls0.name == "Ls_1"
+    graph.renameNode(ls0, "")
+    assert ls0.name == "Ls_1"
+    
+    # Rename
+    graph.renameNode(ls0, "nodels")
+    assert ls0.name == "nodels"
+    graph.renameNode(ls1, "nodels")
+    assert ls1.name == "nodels_1"
+    graph.renameNode(ls2, "nodels")
+    assert ls2.name == "nodels_2"


### PR DESCRIPTION
## Why this PR ?

We miss a way to rename the node name. Node names are usually decided when we create the node by the graph part, but there is no way to set the name.
There is a label system that was used but that has only an impact on the display, it doesn't really changes the node name
Finally now if the name differs from the **node type** the node type is displayed on parenthesis :
<img width="221" height="45" alt="image" src="https://github.com/user-attachments/assets/d9cea390-a2dd-4ee6-bb2f-fa4f302df66d" />
I find this cleaner because previously it was the "default label" (so it would have been `TestCLNode_N` here)

## Features implemented

Here is a gif that shows the new rename system
![test_rename_node](https://github.com/user-attachments/assets/5cc0c34c-256a-414f-b56d-b9a07768d36e)
_another gif to show the update on the label_
![test_rename_node_2](https://github.com/user-attachments/assets/bb86ffed-7390-49e2-9b07-0fd831c67de7)

- double click on the node editor to rename
- the name is changed
- it is added in the `GraphCommand` so undo/redo should work
- if the set name doesn't start with the node type (like "NodeType_") then the node type is precised in a label after
- On the graph editor if no specific label is set, then the label is updated to the new node name

## Special point of attention for reviewers

- **Compute/Submit :** When the node is locked, the node renaming is supposed to be locked so this should prevent most issues
- **Graph editor :** Renaming the node should set the correct label too
- try to close/reopen meshroom to make sure everything works well
- `NodeEditor.qml cancelNodeNameChange` : is it ok to set an empty string to force the update ? I haven't found a better way to make this work but Copilot flagged it as a fragile workaround. I'm open to suggestions on this point

## Remaining TODOs

- [x] add tests

