### PR TITLE
Remove deprecated `distutils` imports

### DIFF
--- a/bin/meshroom_batch
+++ b/bin/meshroom_batch
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 import argparse
-import distutils.util
 import json
 import logging
 import os
@@ -8,6 +7,7 @@ import re
 import sys
 
 import meshroom.core.graph
+from meshroom.common import strtobool
 from meshroom import setupEnvironment, logStringToPython
 
 def parseInitInputs(inputs: list[str]) -> dict[str, str]:
@@ -132,7 +132,7 @@ advanced_group.add_argument(
     help='Custom cache folder to write computation results.')
 
 advanced_group.add_argument(
-    '--compute', metavar='<yes/no>', type=lambda x: bool(distutils.util.strtobool(x)), default=True, required=False,
+    '--compute', metavar='<yes/no>', type=lambda x: bool(strtobool(x)), default=True, required=False,
     help='You can set it to <no/false/0> to disable the computation.')
 
 advanced_group.add_argument(

--- a/meshroom/__init__.py
+++ b/meshroom/__init__.py
@@ -1,4 +1,3 @@
-from distutils import util
 from enum import Enum
 import logging
 import os
@@ -36,12 +35,12 @@ if __version_status__ is VersionStatus.develop:
 
 
 # Internal imports after the definition of the version
-from .common import init, Backend
+from .common import init, Backend, strtobool
 
 # sys.frozen is initialized by cx_Freeze and identifies a release package
 isFrozen = getattr(sys, "frozen", False)
 
-useMultiChunks = util.strtobool(os.environ.get("MESHROOM_USE_MULTI_CHUNKS", "True"))
+useMultiChunks = strtobool(os.environ.get("MESHROOM_USE_MULTI_CHUNKS", "True"))
 
 
 # Logging

--- a/meshroom/__init__.py
+++ b/meshroom/__init__.py
@@ -40,7 +40,7 @@ from .common import init, Backend, strtobool
 # sys.frozen is initialized by cx_Freeze and identifies a release package
 isFrozen = getattr(sys, "frozen", False)
 
-useMultiChunks = strtobool(os.environ.get("MESHROOM_USE_MULTI_CHUNKS", "True"))
+useMultiChunks = bool(strtobool(os.environ.get("MESHROOM_USE_MULTI_CHUNKS", "True")))
 
 
 # Logging

--- a/meshroom/common/__init__.py
+++ b/meshroom/common/__init__.py
@@ -34,5 +34,21 @@ def init(backend):
         from .core import DictModel, ListModel, Slot, Signal, Property, BaseObject, Variant, VariantList, JSValue
 
 
+def strtobool(val: str):
+    """Convert a string representation of truth to true (1) or false (0).
+
+    True values are 'y', 'yes', 't', 'true', 'on', and '1'; false values
+    are 'n', 'no', 'f', 'false', 'off', and '0'.  Raises ValueError if
+    'val' is anything else.
+    """
+    val = val.lower()
+    if val in ('y', 'yes', 't', 'true', 'on', '1'):
+        return 1
+    elif val in ('n', 'no', 'f', 'false', 'off', '0'):
+        return 0
+    else:
+        raise ValueError("invalid truth value %r" % (val,))
+
+
 # Default initialization
 init(Backend.STANDALONE)

--- a/meshroom/core/desc/attribute.py
+++ b/meshroom/core/desc/attribute.py
@@ -1,9 +1,8 @@
 import ast
-import distutils.util
 import os
 from collections.abc import Iterable
 
-from meshroom.common import BaseObject, JSValue, Property, Variant, VariantList
+from meshroom.common import BaseObject, JSValue, Property, Variant, VariantList, strtobool
 
 
 class Attribute(BaseObject):
@@ -342,8 +341,7 @@ class BoolParam(Param):
             return value
         try:
             if isinstance(value, str):
-                # use distutils.util.strtobool to handle (1/0, true/false, on/off, y/n)
-                return bool(distutils.util.strtobool(value))
+                return bool(strtobool(value))
             return bool(value)
         except Exception:
             raise ValueError(f"BoolParam only supports bool value (param: {self.name}, "

--- a/meshroom/nodes/general/CopyFiles.py
+++ b/meshroom/nodes/general/CopyFiles.py
@@ -3,7 +3,6 @@ __version__ = "1.3"
 from meshroom.core import desc
 from meshroom.core.utils import VERBOSE_LEVEL
 
-import distutils.dir_util as du
 import shutil
 import glob
 import os
@@ -82,7 +81,7 @@ This node allows to copy files into a specific folder.
                 # If the input is a directory, copy the directory's content
                 if os.path.isdir(iFile):
                     chunk.logger.info(f"CopyFiles directory {iFile} into {oFile}.")
-                    du.copy_tree(iFile, oFile)
+                    shutil.copytree(iFile, oFile)
                 else:
                     chunk.logger.info(f"CopyFiles file {iFile} into {oFile}.")
                     shutil.copyfile(iFile, oFile)


### PR DESCRIPTION
## Description

This pull request removes all the imports to the `distutils` module, which is deprecated starting from Python 3.12.

It is replaced in two instances:
- For boolean string conversions, `distutils.util.strtobool` method is replaced with a locally defined `strtobool` function. The new function is implemented in `meshroom/common/__init__.py` and imported wherever needed, improving maintainability and future compatibility.
- In the `CopyFiles` node, `distutils.util.copy_tree` is replaced as is with `shutil.copytree`.
