### PR TITLE
[ui] Add support for "Force unlock" / "Clear status" on selected nodes

### DIFF
--- a/meshroom/core/graph.py
+++ b/meshroom/core/graph.py
@@ -1514,15 +1514,19 @@ class Graph(BaseObject):
                 chunk.stopProcess()
 
     @Slot()
-    def forceUnlockNodes(self):
+    @Slot(list)
+    def forceUnlockNodes(self, nodes=None):
         """ Force to unlock all the nodes. """
-        for node in self.nodes:
+        nodes = nodes if nodes else self.nodes
+        for node in nodes:
             node.setLocked(False)
 
     @Slot()
-    def clearSubmittedNodes(self):
+    @Slot(list)
+    def clearSubmittedNodes(self, nodes=None):
         """ Reset the status of already submitted nodes to Status.NONE """
-        for node in self.nodes:
+        nodes = nodes if nodes else self.nodes
+        for node in nodes:
             node.clearSubmittedChunks()
 
     def clearLocallySubmittedNodes(self):

--- a/meshroom/ui/qml/Application.qml
+++ b/meshroom/ui/qml/Application.qml
@@ -1268,11 +1268,11 @@ Page {
                                 MenuItem {
                                     text: "Clear Pending Status"
                                     enabled: _reconstruction ? !_reconstruction.computingLocally : false
-                                    onTriggered: _reconstruction.graph.clearSubmittedNodes()
+                                    onTriggered: _reconstruction.graph.clearSubmittedNodes(_reconstruction.getSelectedNodes())
                                 }
                                 MenuItem {
                                     text: "Force Unlock Nodes"
-                                    onTriggered: _reconstruction.graph.forceUnlockNodes()
+                                    onTriggered: _reconstruction.graph.forceUnlockNodes(_reconstruction.getSelectedNodes())
                                 }
 
                                 Menu {


### PR DESCRIPTION
Updates on these commands :
<img width="249" height="149" alt="image" src="https://github.com/user-attachments/assets/8339b5e2-6113-44d0-9871-9b25546b35ff" />
- clear pending status
- force unlock nodes

If nodes are selected, the commands are applied to the selected nodes only, else it will be on all nodes (like before)