### PR TITLE
[core] node: Add retro-compatibility for status files of single-chunk nodes

### DIFF
--- a/meshroom/core/node.py
+++ b/meshroom/core/node.py
@@ -404,16 +404,25 @@ class NodeChunk(BaseObject):
 
     @property
     def statusFile(self):
+        # Retro-compatibility: ensure we do not lose files computed when single chunks were not prefixed
+        if os.path.exists(os.path.join(self.node.internalFolder, "status")):
+            return os.path.join(self.node.internalFolder, "status")
         chunkIndex = self.index if self.range.blockSize else 0
         return os.path.join(self.node.internalFolder, str(chunkIndex) + ".status")
 
     @property
     def statisticsFile(self):
+        # Retro-compatibility: ensure we do not lose files computed when single chunks were not prefixed
+        if os.path.exists(os.path.join(self.node.internalFolder, "statistics")):
+            return os.path.join(self.node.internalFolder, "statistics")
         chunkIndex = self.index if self.range.blockSize else 0
         return os.path.join(self.node.internalFolder, str(chunkIndex) + ".statistics")
 
     @property
     def logFile(self):
+        # Retro-compatibility: ensure we do not lose files computed when single chunks were not prefixed
+        if os.path.exists(os.path.join(self.node.internalFolder, "log")):
+            return os.path.join(self.node.internalFolder, "log")
         chunkIndex = self.index if self.range.blockSize else 0
         return os.path.join(self.node.internalFolder, str(chunkIndex) + ".log")
 


### PR DESCRIPTION
## Description

Following changes introduced in #2946, all the status/log/statistics files are always prefixed by the chunk number, if the node only has a single chunk. Before this, nodes with a single chunk had files that were not prefixed.

This causes some issues when opening scenes that were computed prior to this change, as all the nodes with a single chunk appear as though they have not been computed, despite having their status/log/statistics files on disk.

With this PR, it is possible to open a scene that contains nodes (with or without several chunks) that were computed before these changes were introduced without losing track of these files. 
