### PR TITLE
Support display and connection of attributes that are part of `GroupAttributes` 

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,3 +1,5 @@
+# [core] attribute: Apply linting
+b8c173ddd490dc3bf28b193697d675e44616c6f5
 # Linting: Remove trailing whitespaces
 04a425decc1b80f0c67e8c4c98c0062d73836684
 # [core] Linting: Remove all trailing whitespaces

--- a/meshroom/core/attribute.py
+++ b/meshroom/core/attribute.py
@@ -1059,6 +1059,41 @@ class GroupAttribute(Attribute):
         for attr in self._value:
             attr.updateInternals()
 
+    # Override
+    def _getFlatStaticChildren(self) -> list[Attribute]:
+        attributes = []
+
+        # Iterate over the values and add the flat children of every child (if they exist)
+        for attribute in self.value:
+            attributes.append(attribute)
+            attributes += attribute.flatStaticChildren
+
+        return attributes
+
+    # Override
+    def _validateIncomingConnection(self, connectingAttribute: Attribute) -> bool:
+        valid = super()._validateIncomingConnection(connectingAttribute)
+
+        if not valid:  # Attributes are not of the same base type
+            return False
+
+        return self._hasMatchingStructure(connectingAttribute)
+
+    def _hasMatchingStructure(self, otherAttribute: Attribute) -> bool:
+        """
+        """
+        flatAttrs = self.flatStaticChildren
+        otherFlatAttrs = otherAttribute.flatStaticChildren
+
+        if len(flatAttrs) != len(otherFlatAttrs):
+            return False
+
+        for index, attribute in enumerate(flatAttrs):
+            if attribute.baseType != otherFlatAttrs[index].baseType:
+                return False
+
+        return True
+
     @Slot(str, result=Attribute)
     def childAttribute(self, key: str) -> Attribute:
         """
@@ -1082,7 +1117,10 @@ class GroupAttribute(Attribute):
 
     # Override value property
     value = Property(Variant, Attribute._getValue, _setValue, notify=Attribute.valueChanged)
-    isDefault = Property(bool, lambda self: all(v.isDefault for v in self.value), notify=Attribute.valueChanged)
+    # Override flatStaticChildren property
+    flatStaticChildren = Property(Variant, _getFlatStaticChildren, constant=True)
+    isDefault = Property(bool, lambda self: all(v.isDefault for v in self.value),
+                         notify=Attribute.valueChanged)
 
 
 class GeometryAttribute(GroupAttribute):

--- a/meshroom/core/attribute.py
+++ b/meshroom/core/attribute.py
@@ -529,7 +529,7 @@ class Attribute(BaseObject):
         """
         return self.baseType == connectingAttribute.baseType
 
-    def connectTo(self, dstAttribute: Attribute) -> Optional[list[Edge]]:
+    def connectTo(self, dstAttribute: Attribute) -> tuple[list[list[Attribute]], list[list[Attribute]]]:
         """
         Connect this Attribute to "dstAttribute".
 
@@ -537,10 +537,12 @@ class Attribute(BaseObject):
             dstAttribute: the destination Attribute
 
         Returns:
-            The connecting Edge object in a list and a list of all the Edge objects that were deleted during the creation.
+            A tuple containing:
+                - a list containing pairs of the source and destination Attributes (as lists) for every created edge
+                - a list containing pairs of the source and destination Attributes (as lists) for every deleted edge
         """
         if not (graph := self.node.graph):
-            return None
+            return [], []
 
         deletedEdges = []
         if isinstance(dstAttribute.root, Attribute):
@@ -1131,6 +1133,16 @@ class GroupAttribute(Attribute):
 
     def _hasMatchingStructure(self, otherAttribute: Attribute) -> bool:
         """
+        Check whether this GroupAttribute and another Attribute have matching structures.
+
+        Attributes have matching structures if they have the same number of children and if, at each position,
+        both Attributes have the same base type.
+
+        Args:
+            otherAttribute: the other Attribute to compare structure with
+
+        Returns:
+            True if both Attributes have the same structure, False otherwise
         """
         flatAttrs = self.flatStaticChildren
         otherFlatAttrs = otherAttribute.flatStaticChildren
@@ -1145,7 +1157,7 @@ class GroupAttribute(Attribute):
         return True
 
     # Override
-    def connectTo(self, dstAttribute: GroupAttribute) -> Optional[list[Edge]]:
+    def connectTo(self, dstAttribute: GroupAttribute) -> tuple[list[list[Attribute]], list[list[Attribute]]]:
         """
         Connect this GroupAttribute to "dstAttribute". The nested attributes in the group
         are automatically connected.
@@ -1154,7 +1166,9 @@ class GroupAttribute(Attribute):
             dstAttribute: the destination Attribute
 
         Returns:
-            The connecting Edge object in a list and a list of all the Edge objects that were deleted during the creation.
+            A tuple containing:
+                - a list containing pairs of the source and destination Attributes (as lists) for every created edge
+                - a list containing pairs of the source and destination Attributes (as lists) for every deleted edge
         """
         nestedDstAttributes = list(dstAttribute.value)
         connectedEdges = []

--- a/meshroom/core/attribute.py
+++ b/meshroom/core/attribute.py
@@ -252,7 +252,7 @@ class Attribute(BaseObject):
         linkNodeName, linkAttrName = "", ""
 
         try:
-            linkNodeName, linkAttrName = link.split(".")
+            linkNodeName, linkAttrName = link.split(".", 1)
         except ValueError as err:
             logging.warning('Retrieve Connected Attribute from Expression failed.')
             logging.warning(f'Expression: "{link}"\nError: "{err}".')

--- a/meshroom/core/attribute.py
+++ b/meshroom/core/attribute.py
@@ -10,7 +10,9 @@ from string import Template
 from meshroom.common import BaseObject, Property, Variant, Signal, ListModel, DictModel, Slot
 from meshroom.core import desc, hashValue
 from meshroom.core.keyValues import KeyValues
-from typing import TYPE_CHECKING
+from meshroom.core.exception import InvalidEdgeError
+
+from typing import TYPE_CHECKING, Optional
 
 if TYPE_CHECKING:
     from meshroom.core.graph import Edge
@@ -79,6 +81,7 @@ class Attribute(BaseObject):
         self._invalidationValue = ""  # invalidation value for output attributes
         self._value = None
         self._keyValues = None  # list of pairs (key, value) for keyable attribute
+        self._linkExpression: Optional[str] = None
         self._initValue()
 
     def _getFullName(self) -> str:
@@ -163,11 +166,10 @@ class Attribute(BaseObject):
         """
         if self._value == value:
             return
-        if isinstance(value, Attribute) or Attribute.isLinkExpression(value):
-            # if we set a link to another attribute
-            self._value = value
+        if self._handleLinkValue(value):
             if self.keyable:
                 self._keyValues.reset()
+            return
         elif self.keyable and isinstance(value, dict):
             # keyable attribute initialize from a dict
             self.keyValues.resetFromDict(value)
@@ -206,37 +208,67 @@ class Attribute(BaseObject):
             return self._getInputLink().keyValues
         return self._keyValues
 
+    def _handleLinkValue(self, value) -> bool:
+        """
+        Handle the assignment of a link if `value` is a serialized link expression
+        or an in-memory Attribute reference.
+
+        Returns:
+            True if the value has been handled as a link, False otherwise.
+        """
+        isAttribute = isinstance(value, Attribute)
+        isLinkExpression = Attribute.isLinkExpression(value)
+
+        if not isAttribute and not isLinkExpression:
+            return False
+
+        if isAttribute:
+            self._linkExpression = value.asLinkExpr()
+            # If the value is a direct reference to an attribute, it can directly
+            # be converted to an edge as the source attribute already exists in
+            # memory.
+            self._applyExpr()
+        elif isLinkExpression:
+            self._linkExpression = value
+        return True
+
     def _applyExpr(self):
         """
         For string parameters with an expression (when loaded from file),
         this function convert the expression into a real edge in the graph
         and clear the string value.
         """
-        v = self._value
-        g = self.node.graph
-        if not g:
+        if not self.isInput or not self._linkExpression:
             return
-        if isinstance(v, Attribute):
-            g.addEdge(v, self)
-            self.resetToDefaultValue()
-        elif self.isInput and Attribute.isLinkExpression(v):
-            # value is a link to another attribute
-            link = v[1:-1]
-            linkNodeName, linkAttrName = "", ""
-            try:
-                linkNodeName, linkAttrName = link.split('.')
-            except ValueError as err:
-                logging.warning('Retrieve Connected Attribute from Expression failed.')
-                logging.warning(f'Expression: "{link}"\nError: "{err}".')
-            try:
-                node = g.node(linkNodeName)
-                if not node:
-                    raise KeyError(f"Node '{linkNodeName}' not found")
-                g.addEdge(node.attribute(linkAttrName), self)
-            except KeyError as err:
-                logging.warning('Connect Attribute from Expression failed.')
-                logging.warning(f'Expression: "{v}"\nError: "{err}".')
-            self.resetToDefaultValue()
+
+        if not (graph := self.node.graph):
+            return
+
+        link = self._linkExpression[1:-1]
+        linkNodeName, linkAttrName = "", ""
+
+        try:
+            linkNodeName, linkAttrName = link.split(".")
+        except ValueError as err:
+            logging.warning('Retrieve Connected Attribute from Expression failed.')
+            logging.warning(f'Expression: "{link}"\nError: "{err}".')
+
+        try:
+            node = graph.node(linkNodeName)
+            if node is None:
+                raise InvalidEdgeError(self.fullName, link, "Source node does not exist.")
+            attr = node.attribute(linkAttrName)
+            if attr is None:
+                raise InvalidEdgeError(self.fullName, link, "Source attribute does not exist.")
+            graph.addEdge(attr, self)
+        except InvalidEdgeError as err:
+            logging.warning(err)
+        except Exception as err:
+            logging.warning("Unexpected error happened during edge creation.")
+            logging.warning(f"Expression '{self._linkExpression}': {err}.")
+
+        self._linkExpression = None
+        self.resetToDefaultValue()
 
     def resetToDefaultValue(self):
         """
@@ -725,9 +757,8 @@ class ListAttribute(Attribute):
     def _setValue(self, value):
         if self.node.graph:
             self.remove(0, len(self))
-        # Link to another attribute
-        if isinstance(value, ListAttribute) or Attribute.isLinkExpression(value):
-            self._value = value
+        if self._handleLinkValue(value):
+            return
         # New value
         else:
             # During initialization self._value may not be set
@@ -739,9 +770,7 @@ class ListAttribute(Attribute):
 
     # Override
     def _applyExpr(self):
-        if not self.node.graph:
-            return
-        if isinstance(self._value, ListAttribute) or Attribute.isLinkExpression(self._value):
+        if self._linkExpression:
             super()._applyExpr()
         else:
             for value in self._value:
@@ -783,11 +812,9 @@ class ListAttribute(Attribute):
 
     # Override
     def upgradeValue(self, exportedValues):
+        if self._handleLinkValue(exportedValues):
+            return
         if not isinstance(exportedValues, list):
-            if isinstance(exportedValues, ListAttribute) or \
-               Attribute.isLinkExpression(exportedValues):
-                self._setValue(exportedValues)
-                return
             raise RuntimeError("ListAttribute.upgradeValue: the given value is of type " +
                                str(type(exportedValues)) + " but a 'list' is expected.")
         attrs = []

--- a/meshroom/core/attribute.py
+++ b/meshroom/core/attribute.py
@@ -987,6 +987,10 @@ class GroupAttribute(Attribute):
         self._value.reset(subAttributes)
 
     # Override
+    def _getValue(self):
+        return self._value
+
+    # Override
     def _setValue(self, exportedValue):
         if self._handleLinkValue(exportedValue):
             return
@@ -1169,7 +1173,7 @@ class GroupAttribute(Attribute):
         return super().matchText(text) or any(c.matchText(text) for c in self._value)
 
     # Override value property
-    value = Property(Variant, Attribute._getValue, _setValue, notify=Attribute.valueChanged)
+    value = Property(Variant, _getValue, _setValue, notify=Attribute.valueChanged)
     # Override flatStaticChildren property
     flatStaticChildren = Property(Variant, _getFlatStaticChildren, constant=True)
     isDefault = Property(bool, lambda self: all(v.isDefault for v in self.value),

--- a/meshroom/core/attribute.py
+++ b/meshroom/core/attribute.py
@@ -920,6 +920,9 @@ class GroupAttribute(Attribute):
 
     # Override
     def _setValue(self, exportedValue):
+        if self._handleLinkValue(exportedValue):
+            return
+
         value = self.validateValue(exportedValue)
         if isinstance(value, dict):
             # set individual child attribute values
@@ -935,8 +938,11 @@ class GroupAttribute(Attribute):
 
     # Override
     def _applyExpr(self):
-        for value in self._value:
-            value._applyExpr()
+        if self._linkExpression:
+            super()._applyExpr()
+        else:
+            for value in self._value:
+                value._applyExpr()
 
     # Override
     def resetToDefaultValue(self):
@@ -949,6 +955,8 @@ class GroupAttribute(Attribute):
 
     # Override
     def getSerializedValue(self):
+        if self.inputLink:
+            return self.inputLink.asLinkExpr()
         return {key: attr.getSerializedValue() for key, attr in self._value.objects.items()}
 
     # Override
@@ -981,6 +989,9 @@ class GroupAttribute(Attribute):
 
     # Override
     def upgradeValue(self, exportedValue):
+        if self._handleLinkValue(exportedValue):
+            return
+
         value = self.validateValue(exportedValue)
         if isinstance(value, dict):
             # set individual child attribute values
@@ -997,6 +1008,9 @@ class GroupAttribute(Attribute):
 
     # Override
     def uid(self):
+        if self.isLink:
+            return super().uid()
+
         uids = []
         for k, v in self._value.items():
             if v.enabled and v.invalidate:

--- a/meshroom/core/attribute.py
+++ b/meshroom/core/attribute.py
@@ -537,26 +537,40 @@ class Attribute(BaseObject):
             dstAttribute: the destination Attribute
 
         Returns:
-            The connecting Edge object if the connection was successful, None otherwise.
+            The connecting Edge object in a list and a list of all the Edge objects that were deleted during the creation.
         """
         if not (graph := self.node.graph):
             return None
 
+        deletedEdges = []
         if isinstance(dstAttribute.root, Attribute):
-            dstAttribute.root.disconnectEdge()
+            deletedEdges = dstAttribute.root.disconnectEdge()
 
-        return [graph.addEdge(self, dstAttribute)]
+        connectedEdge, deletedEdge = graph.addEdge(self, dstAttribute)
+        if deletedEdge:
+            deletedEdges.append(deletedEdge)
+
+        return [connectedEdge], deletedEdges
 
     def disconnectEdge(self):
         """
+        Disconnect and remove the edge connected to this Attribute.
+
+        Returns:
+            A list of all the Edge objects that were deleted during the disconnection.
         """
         if not (graph := self.node.graph):
-            return
+            return []
 
-        graph.removeEdge(self)
+        deletedEdges = []
+        edge = graph.removeEdge(self)
+        if edge:
+            deletedEdges.append(edge)
 
         if isinstance(self.root, Attribute):
-            self.root.disconnectEdge()
+            deletedEdges += self.root.disconnectEdge()
+
+        return deletedEdges
 
     # Slots
 
@@ -1140,16 +1154,23 @@ class GroupAttribute(Attribute):
             dstAttribute: the destination Attribute
 
         Returns:
-            The connecting Edge objects if the connection was successful, None otherwise.
+            The connecting Edge object in a list and a list of all the Edge objects that were deleted during the creation.
         """
         nestedDstAttributes = list(dstAttribute.value)
-
         connectedEdges = []
+        deletedEdges = []
 
         for index, nestedAttribute in enumerate(list(self.value)):
-            connectedEdges += nestedAttribute.connectTo(nestedDstAttributes[index])
-        connectedEdges += super().connectTo(dstAttribute)
-        return connectedEdges
+            # If the attributes are already connected, do not connect them again
+            if not nestedDstAttributes[index] in nestedAttribute.outputLinks:
+                connected, deleted = nestedAttribute.connectTo(nestedDstAttributes[index])
+                connectedEdges += connected
+                deletedEdges += deleted
+        connected, deleted = super().connectTo(dstAttribute)
+        connectedEdges += connected
+        deletedEdges += deleted
+
+        return connectedEdges, deletedEdges
 
     @Slot(str, result=Attribute)
     def childAttribute(self, key: str) -> Attribute:

--- a/meshroom/core/attribute.py
+++ b/meshroom/core/attribute.py
@@ -530,6 +530,35 @@ class Attribute(BaseObject):
         """
         return self.baseType == connectingAttribute.baseType
 
+    def connectTo(self, dstAttribute: Attribute) -> Optional[Edge]:
+        """
+        Connect this Attribute to "dstAttribute".
+
+        Args:
+            dstAttribute: the destination Attribute
+
+        Returns:
+            The connecting Edge object if the connection was successful, None otherwise.
+        """
+        if not (graph := self.node.graph):
+            return None
+
+        if isinstance(dstAttribute.root, Attribute):
+            dstAttribute.root.disconnectEdge()
+
+        return graph.addEdge(self, dstAttribute)
+
+    def disconnectEdge(self):
+        """
+        """
+        if not (graph := self.node.graph):
+            return
+
+        graph.removeEdge(self)
+
+        if isinstance(self.root, Attribute):
+            self.root.disconnectEdge()
+
     # Slots
 
     @Slot()
@@ -1097,6 +1126,24 @@ class GroupAttribute(Attribute):
                 return False
 
         return True
+
+    # Override
+    def connectTo(self, dstAttribute: GroupAttribute) -> Optional[Edge]:
+        """
+        Connect this GroupAttribute to "dstAttribute". The nested attributes in the group
+        are automatically connected.
+
+        Args:
+            dstAttribute: the destination Attribute
+
+        Returns:
+            The connecting Edge object if the connection was successful, None otherwise.
+        """
+        nestedDstAttributes = list(dstAttribute.value)
+
+        for index, nestedAttribute in enumerate(list(self.value)):
+            nestedAttribute.connectTo(nestedDstAttributes[index])
+        return super().connectTo(dstAttribute)
 
     @Slot(str, result=Attribute)
     def childAttribute(self, key: str) -> Attribute:

--- a/meshroom/core/attribute.py
+++ b/meshroom/core/attribute.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 import copy
 import os
 import re
@@ -451,8 +453,8 @@ class Attribute(BaseObject):
         return self.node.graph and self.isInput and self.node.graph._edges and \
             self in self.node.graph._edges.keys()
 
-    def _getInputLink(self, recursive=False) -> "Attribute":
-        """
+    def _getInputLink(self, recursive=False) -> Attribute:
+        """ 
         Return the direct upstream connected attribute.
         :param recursive: recursive call, return the root attribute
         """
@@ -463,8 +465,8 @@ class Attribute(BaseObject):
             return linkAttribute._getInputLink(recursive)
         return linkAttribute
 
-    def _getOutputLinks(self) -> list["Attribute"]:
-        """
+    def _getOutputLinks(self) -> list[Attribute]:
+        """ 
         Return the list of direct downstream connected attributes.
         """
         # Safety check to avoid evaluation errors
@@ -472,8 +474,8 @@ class Attribute(BaseObject):
             return []
         return [edge.dst for edge in self.node.graph.edges.values() if edge.src == self]
 
-    def _getAllInputLinks(self) -> list["Attribute"]:
-        """
+    def _getAllInputLinks(self) -> list[Attribute]:
+        """ 
         Return the list of upstream connected attributes for the attribute or any of its elements.
         """
         inputLink = self._getInputLink()
@@ -481,8 +483,8 @@ class Attribute(BaseObject):
             return []
         return [inputLink]
 
-    def _getAllOutputLinks(self) -> list["Attribute"]:
-        """
+    def _getAllOutputLinks(self) -> list[Attribute]:
+        """ 
         Return the list of downstream connected attributes for the attribute or any of its elements.
         """
         return self._getOutputLinks()
@@ -846,7 +848,7 @@ class ListAttribute(Attribute):
             attr.updateInternals()
 
     # Override
-    def _getAllInputLinks(self) -> list["Attribute"]:
+    def _getAllInputLinks(self) -> list[Attribute]:
         """
         Return the list of upstream connected attributes for the attribute or any of its elements.
         """
@@ -856,7 +858,7 @@ class ListAttribute(Attribute):
         return [edge.src for edge in self.node.graph.edges.values() if edge.dst == self or edge.dst in self._value]
 
     # Override
-    def _getAllOutputLinks(self) -> list["Attribute"]:
+    def _getAllOutputLinks(self) -> list[Attribute]:
         """
         Return the list of downstream connected attributes for the attribute or any of its elements.
         """

--- a/meshroom/core/attribute.py
+++ b/meshroom/core/attribute.py
@@ -455,7 +455,7 @@ class Attribute(BaseObject):
         return bool(self.node.graph and self.isInput and self.node.graph._edges and self in self.node.graph._edges.keys())
 
     def _getInputLink(self, recursive=False) -> Attribute:
-        """ 
+        """
         Return the direct upstream connected attribute.
         :param recursive: recursive call, return the root attribute
         """
@@ -529,7 +529,7 @@ class Attribute(BaseObject):
         """
         return self.baseType == connectingAttribute.baseType
 
-    def connectTo(self, dstAttribute: Attribute) -> Optional[Edge]:
+    def connectTo(self, dstAttribute: Attribute) -> Optional[list[Edge]]:
         """
         Connect this Attribute to "dstAttribute".
 
@@ -545,7 +545,7 @@ class Attribute(BaseObject):
         if isinstance(dstAttribute.root, Attribute):
             dstAttribute.root.disconnectEdge()
 
-        return graph.addEdge(self, dstAttribute)
+        return [graph.addEdge(self, dstAttribute)]
 
     def disconnectEdge(self):
         """
@@ -1127,7 +1127,7 @@ class GroupAttribute(Attribute):
         return True
 
     # Override
-    def connectTo(self, dstAttribute: GroupAttribute) -> Optional[Edge]:
+    def connectTo(self, dstAttribute: GroupAttribute) -> Optional[list[Edge]]:
         """
         Connect this GroupAttribute to "dstAttribute". The nested attributes in the group
         are automatically connected.
@@ -1136,13 +1136,16 @@ class GroupAttribute(Attribute):
             dstAttribute: the destination Attribute
 
         Returns:
-            The connecting Edge object if the connection was successful, None otherwise.
+            The connecting Edge objects if the connection was successful, None otherwise.
         """
         nestedDstAttributes = list(dstAttribute.value)
 
+        connectedEdges = []
+
         for index, nestedAttribute in enumerate(list(self.value)):
-            nestedAttribute.connectTo(nestedDstAttributes[index])
-        return super().connectTo(dstAttribute)
+            connectedEdges += nestedAttribute.connectTo(nestedDstAttributes[index])
+        connectedEdges += super().connectTo(dstAttribute)
+        return connectedEdges
 
     @Slot(str, result=Attribute)
     def childAttribute(self, key: str) -> Attribute:

--- a/meshroom/core/attribute.py
+++ b/meshroom/core/attribute.py
@@ -466,7 +466,7 @@ class Attribute(BaseObject):
         return linkAttribute
 
     def _getOutputLinks(self) -> list[Attribute]:
-        """ 
+        """
         Return the list of direct downstream connected attributes.
         """
         # Safety check to avoid evaluation errors
@@ -475,7 +475,7 @@ class Attribute(BaseObject):
         return [edge.dst for edge in self.node.graph.edges.values() if edge.src == self]
 
     def _getAllInputLinks(self) -> list[Attribute]:
-        """ 
+        """
         Return the list of upstream connected attributes for the attribute or any of its elements.
         """
         inputLink = self._getInputLink()
@@ -484,7 +484,7 @@ class Attribute(BaseObject):
         return [inputLink]
 
     def _getAllOutputLinks(self) -> list[Attribute]:
-        """ 
+        """
         Return the list of downstream connected attributes for the attribute or any of its elements.
         """
         return self._getOutputLinks()
@@ -507,6 +507,7 @@ class Attribute(BaseObject):
             return False
         return next((edge for edge in self.node.graph.edges.values() if edge.src == self), None) is not None
 
+
     # Slots
 
     @Slot()
@@ -527,6 +528,8 @@ class Attribute(BaseObject):
     @Slot(str, result=bool)
     def matchText(self, text: str) -> bool:
         return self.label.lower().find(text.lower()) > -1
+
+    # Properties and signals
 
     # Properties and signals
 
@@ -1014,7 +1017,7 @@ class GroupAttribute(Attribute):
             return super().uid()
 
         uids = []
-        for k, v in self._value.items():
+        for _, v in self._value.items():
             if v.enabled and v.invalidate:
                 uids.append(v.uid())
         return hashValue(uids)

--- a/meshroom/core/attribute.py
+++ b/meshroom/core/attribute.py
@@ -507,6 +507,18 @@ class Attribute(BaseObject):
             return False
         return next((edge for edge in self.node.graph.edges.values() if edge.src == self), None) is not None
 
+    def _validateIncomingConnection(self, connectingAttribute: Attribute) -> bool:
+        """
+        Validation of the connection of "connectingAttribute" on this Attribute.
+        This method can be overridden.
+
+        Args:
+            connectingAttribute: the Attribute attempting to connect to this one.
+
+        Returns:
+            True if the connection is valid, False otherwise.
+        """
+        return self.baseType == connectingAttribute.baseType
 
     # Slots
 
@@ -529,7 +541,13 @@ class Attribute(BaseObject):
     def matchText(self, text: str) -> bool:
         return self.label.lower().find(text.lower()) > -1
 
-    # Properties and signals
+    @Slot(BaseObject, result=bool)
+    def validateIncomingConnection(self, connectingAttribute: Attribute) -> bool:
+        """
+        Return True if this Attribute can receive a connection from
+        "connectingAttribute", False otherwise.
+        """
+        return self._validateIncomingConnection(connectingAttribute)
 
     # Properties and signals
 

--- a/meshroom/core/attribute.py
+++ b/meshroom/core/attribute.py
@@ -79,6 +79,7 @@ class Attribute(BaseObject):
         self._desc: desc.Attribute = attributeDesc
         self._isOutput: bool = isOutput
         self._enabled: bool = True
+        self._depth: int = root.depth + 1 if root is not None else 0
         self._invalidate = False if self._isOutput else attributeDesc.invalidate
         self._invalidationValue = ""  # invalidation value for output attributes
         self._value = None
@@ -507,6 +508,14 @@ class Attribute(BaseObject):
             return False
         return next((edge for edge in self.node.graph.edges.values() if edge.src == self), None) is not None
 
+    def _getFlatStaticChildren(self) -> list[Attribute]:
+        """
+        Return a list of all the attributes that refer to this Attribute as their parent through the
+        "root" property. If no such attribute exist, return an empty list.
+        The depth difference is not taken into account in the list, which is thus always flat.
+        """
+        return []
+
     def _validateIncomingConnection(self, connectingAttribute: Attribute) -> bool:
         """
         Validation of the connection of "connectingAttribute" on this Attribute.
@@ -580,6 +589,8 @@ class Attribute(BaseObject):
     # Whether this attribute is enabled.
     enabledChanged = Signal()
     enabled = Property(bool, _getEnabled, _setEnabled, notify=enabledChanged)
+    # Depth level of this attribute.
+    depth = Property(int, lambda self: self._depth, constant=True)
 
     # Attribute value properties and signals
     valueChanged = Signal()
@@ -621,6 +632,8 @@ class Attribute(BaseObject):
     hasAnyInputLinks = Property(bool, _hasAnyInputLinks, notify=inputLinksChanged)
     # Whether the attribute or any of its elements is linked by another attribute.
     hasAnyOutputLinks = Property(bool, _hasAnyOutputLinks, notify=outputLinksChanged)
+    # The list of attributes that refer to this one as their parent.
+    flatStaticChildren = Property(Variant, _getFlatStaticChildren, constant=True)
 
     expressionApplied = Signal()
 

--- a/meshroom/core/attribute.py
+++ b/meshroom/core/attribute.py
@@ -264,11 +264,11 @@ class Attribute(BaseObject):
             attr = node.attribute(linkAttrName)
             if attr is None:
                 raise InvalidEdgeError(self.fullName, link, "Source attribute does not exist.")
-            graph.addEdge(attr, self)
+            attr.connectTo(self)
         except InvalidEdgeError as err:
             logging.warning(err)
         except Exception as err:
-            logging.warning("Unexpected error happened during edge creation.")
+            logging.warning("An unexpected error happened during edge creation.")
             logging.warning(f"Expression '{self._linkExpression}': {err}.")
 
         self._linkExpression = None
@@ -452,8 +452,7 @@ class Attribute(BaseObject):
         """
         Whether the attribute is a link to another attribute.
         """
-        return self.node.graph and self.isInput and self.node.graph._edges and \
-            self in self.node.graph._edges.keys()
+        return bool(self.node.graph and self.isInput and self.node.graph._edges and self in self.node.graph._edges.keys())
 
     def _getInputLink(self, recursive=False) -> Attribute:
         """ 

--- a/meshroom/core/attribute.py
+++ b/meshroom/core/attribute.py
@@ -80,6 +80,7 @@ class Attribute(BaseObject):
         self._isOutput: bool = isOutput
         self._enabled: bool = True
         self._depth: int = root.depth + 1 if root is not None else 0
+        self._exposed: bool = root.exposed if root is not None else attributeDesc.exposed
         self._invalidate = False if self._isOutput else attributeDesc.invalidate
         self._invalidationValue = ""  # invalidation value for output attributes
         self._value = None
@@ -591,6 +592,9 @@ class Attribute(BaseObject):
     enabled = Property(bool, _getEnabled, _setEnabled, notify=enabledChanged)
     # Depth level of this attribute.
     depth = Property(int, lambda self: self._depth, constant=True)
+    # Whether the attribute is exposed (if it has a parent, the parent's value
+    # takes precedence over the description's).
+    exposed = Property(bool, lambda self: self._exposed, constant=True)
 
     # Attribute value properties and signals
     valueChanged = Signal()

--- a/meshroom/core/exception.py
+++ b/meshroom/core/exception.py
@@ -63,3 +63,8 @@ class StopGraphVisit(GraphVisitMessage):
 class StopBranchVisit(GraphVisitMessage):
     """ Immediately stop branch visit. """
     pass
+
+
+class CyclicDependencyError(GraphVisitMessage):
+    """ Do not start visiting the graph. """
+    pass

--- a/meshroom/core/exception.py
+++ b/meshroom/core/exception.py
@@ -11,6 +11,12 @@ class GraphException(MeshroomException):
     pass
 
 
+class InvalidEdgeError(GraphException):
+    """ Raised when an edge between two attributes cannot be created. """
+    def __init__(self, srcAttrName: str, dstAttrName: str, msg: str) -> None:
+        super().__init__(f"Failed to connect {srcAttrName}->{dstAttrName}: {msg}")
+
+
 class GraphCompatibilityError(GraphException):
     """
     Raised when node compatibility issues occur when loading a graph.

--- a/meshroom/core/graph.py
+++ b/meshroom/core/graph.py
@@ -17,7 +17,7 @@ from meshroom.common import BaseObject, DictModel, Slot, Signal, Property
 from meshroom.core import Version
 from meshroom.core import submitters
 from meshroom.core.attribute import Attribute, ListAttribute, GroupAttribute
-from meshroom.core.exception import GraphCompatibilityError, InvalidEdgeError, StopGraphVisit, StopBranchVisit
+from meshroom.core.exception import GraphCompatibilityError, InvalidEdgeError, StopGraphVisit, StopBranchVisit, CyclicDependencyError
 from meshroom.core.graphIO import GraphIO, GraphSerializer, TemplateGraphSerializer, PartialGraphSerializer
 from meshroom.core.node import BaseNode, Status, Node, CompatibilityNode
 from meshroom.core.nodeFactory import nodeFactory
@@ -121,7 +121,7 @@ class Visitor:
 
     def backEdge(self, e, g):
         """ Is invoked on the back edges in the graph. """
-        pass
+        raise CyclicDependencyError("A cyclic dependency exists on the current graph.")
 
     def forwardOrCrossEdge(self, e, g):
         """

--- a/meshroom/core/graph.py
+++ b/meshroom/core/graph.py
@@ -927,11 +927,6 @@ class Graph(BaseObject):
         srcAttr.outputLinksChanged.emit()
         return edge
 
-    def addEdges(self, *edges):
-        with GraphModification(self):
-            for edge in edges:
-                self.addEdge(*edge)
-
     @changeTopology
     def removeEdge(self, dstAttr: Attribute):
         if not self.edges.get(dstAttr):

--- a/meshroom/core/graph.py
+++ b/meshroom/core/graph.py
@@ -913,30 +913,33 @@ class Graph(BaseObject):
         if not srcAttr.node.graph == dstAttr.node.graph == self:
             raise InvalidEdgeError(srcAttr.fullName, dstAttr.fullName,
                                    "Attributes do not belong to this graph.")
-        if dstAttr in self.edges.keys():
-            self.removeEdge(dstAttr)
 
         if not dstAttr.validateIncomingConnection(srcAttr):
             raise InvalidEdgeError(srcAttr.fullName, dstAttr.fullName,
                                    f"Attributes are not compatible (src base type: {srcAttr.baseType}; dst base type: {dstAttr.baseType}).")
+
+        deletedEdge = []
+        if dstAttr in self.edges.keys():
+            deletedEdge = self.removeEdge(dstAttr)
         edge = Edge(srcAttr, dstAttr)
         self.edges.add(edge)
         self.markNodesDirty(dstAttr.node)
         dstAttr.valueChanged.emit()
         dstAttr.inputLinksChanged.emit()
         srcAttr.outputLinksChanged.emit()
-        return edge
+        return [edge.src, edge.dst], deletedEdge
 
     @changeTopology
     def removeEdge(self, dstAttr: Attribute):
         if not self.edges.get(dstAttr):
-            return
+            return None
 
         edge = self.edges.pop(dstAttr)
         self.markNodesDirty(dstAttr.node)
         dstAttr.valueChanged.emit()
         dstAttr.inputLinksChanged.emit()
         edge.src.outputLinksChanged.emit()
+        return [edge.src, dstAttr]
 
     def getDepth(self, node, minimal=False):
         """ Return node's depth in this Graph.

--- a/meshroom/core/graph.py
+++ b/meshroom/core/graph.py
@@ -909,13 +909,16 @@ class Graph(BaseObject):
         return set(self._nodes) - nodesWithInputLink
 
     @changeTopology
-    def addEdge(self, srcAttr: Attribute, dstAttr: Attribute):
+    def addEdge(self, srcAttr: Attribute, dstAttr: Attribute) -> Edge:
         if not srcAttr.node.graph == dstAttr.node.graph == self:
             raise InvalidEdgeError(srcAttr.fullName, dstAttr.fullName,
                                    "Attributes do not belong to this graph.")
         if dstAttr in self.edges.keys():
+            self.removeEdge(dstAttr)
+
+        if not dstAttr.validateIncomingConnection(srcAttr):
             raise InvalidEdgeError(srcAttr.fullName, dstAttr.fullName,
-                                   "Destination is already connected.")
+                                   f"Attributes are not compatible (src base type: {srcAttr.baseType}; dst base type: {dstAttr.baseType}).")
         edge = Edge(srcAttr, dstAttr)
         self.edges.add(edge)
         self.markNodesDirty(dstAttr.node)
@@ -930,9 +933,10 @@ class Graph(BaseObject):
                 self.addEdge(*edge)
 
     @changeTopology
-    def removeEdge(self, dstAttr):
-        if dstAttr not in self.edges.keys():
-            raise RuntimeError(f'Attribute "{dstAttr.fullName}" is not connected')
+    def removeEdge(self, dstAttr: Attribute):
+        if not self.edges.get(dstAttr):
+            return
+
         edge = self.edges.pop(dstAttr)
         self.markNodesDirty(dstAttr.node)
         dstAttr.valueChanged.emit()

--- a/meshroom/core/graph.py
+++ b/meshroom/core/graph.py
@@ -909,7 +909,7 @@ class Graph(BaseObject):
         return set(self._nodes) - nodesWithInputLink
 
     @changeTopology
-    def addEdge(self, srcAttr: Attribute, dstAttr: Attribute) -> Edge:
+    def addEdge(self, srcAttr: Attribute, dstAttr: Attribute) -> tuple[list[Attribute], list[Attribute]]:
         if not srcAttr.node.graph == dstAttr.node.graph == self:
             raise InvalidEdgeError(srcAttr.fullName, dstAttr.fullName,
                                    "Attributes do not belong to this graph.")

--- a/meshroom/core/graph.py
+++ b/meshroom/core/graph.py
@@ -17,7 +17,7 @@ from meshroom.common import BaseObject, DictModel, Slot, Signal, Property
 from meshroom.core import Version
 from meshroom.core import submitters
 from meshroom.core.attribute import Attribute, ListAttribute, GroupAttribute
-from meshroom.core.exception import GraphCompatibilityError, StopGraphVisit, StopBranchVisit
+from meshroom.core.exception import GraphCompatibilityError, InvalidEdgeError, StopGraphVisit, StopBranchVisit
 from meshroom.core.graphIO import GraphIO, GraphSerializer, TemplateGraphSerializer, PartialGraphSerializer
 from meshroom.core.node import BaseNode, Status, Node, CompatibilityNode
 from meshroom.core.nodeFactory import nodeFactory
@@ -513,41 +513,38 @@ class Graph(BaseObject):
             node._applyExpr()
         return node
 
-    def copyNode(self, srcNode, withEdges=False):
+    def copyNode(self, srcNode: Node, withEdges: bool=False):
         """
         Get a copy instance of a node outside the graph.
 
         Args:
-            srcNode (Node): the node to copy
-            withEdges (bool): whether to copy edges
+            srcNode: the node to copy
+            withEdges: whether to copy edges
 
         Returns:
-            Node, dict: the created node instance,
-                        a dictionary of linked attributes with their original value (empty if withEdges is True)
+            The created node instance and the mapping of skipped edges per attribute
+            (always empty if `withEdges` is True)
         """
+        def _removeLinkExpressions(attribute: Attribute, removed: dict[Attribute, str]):
+            """ Recursively remove link expressions from the given root `attribute`. """
+            # Link expressions are only stored on input attributes
+            if attribute.isOutput:
+                return
+
+            if attribute._linkExpression:
+                removed[attribute] = attribute._linkExpression
+                attribute._linkExpression = None
+            elif isinstance(attribute, (ListAttribute, GroupAttribute)):
+                for child in attribute.value:
+                    _removeLinkExpressions(child, removed)
+
         with GraphModification(self):
-            # create a new node of the same type and with the same attributes values
-            # keep links as-is so that CompatibilityNodes attributes can be created with correct automatic description
-            # (File params for link expressions)
-            node = nodeFactory(srcNode.toDict(), srcNode.nodeType)  # use nodeType as name
-            # skip edges: filter out attributes which are links by resetting default values
+            node = nodeFactory(srcNode.toDict(), name=srcNode.nodeType)
+
             skippedEdges = {}
             if not withEdges:
-                for n, attr in node.attributes.items():
-                    if attr.isOutput:
-                        # edges are declared in input with an expression linking
-                        # to another param (which could be an output)
-                        continue
-                    # find top-level links
-                    if Attribute.isLinkExpression(attr.value):
-                        skippedEdges[attr] = attr.value
-                        attr.resetToDefaultValue()
-                    # find links in ListAttribute children
-                    elif isinstance(attr, (ListAttribute, GroupAttribute)):
-                        for child in attr.value:
-                            if Attribute.isLinkExpression(child.value):
-                                skippedEdges[child] = child.value
-                                child.resetToDefaultValue()
+                for _, attr in node.attributes.items():
+                    _removeLinkExpressions(attr, skippedEdges)
         return node, skippedEdges
 
     def duplicateNodes(self, srcNodes):
@@ -912,13 +909,13 @@ class Graph(BaseObject):
         return set(self._nodes) - nodesWithInputLink
 
     @changeTopology
-    def addEdge(self, srcAttr, dstAttr):
-        assert isinstance(srcAttr, Attribute)
-        assert isinstance(dstAttr, Attribute)
-        if srcAttr.node.graph != self or dstAttr.node.graph != self:
-            raise RuntimeError('The attributes of the edge should be part of a common graph.')
+    def addEdge(self, srcAttr: Attribute, dstAttr: Attribute):
+        if not srcAttr.node.graph == dstAttr.node.graph == self:
+            raise InvalidEdgeError(srcAttr.fullName, dstAttr.fullName,
+                                   "Attributes do not belong to this graph.")
         if dstAttr in self.edges.keys():
-            raise RuntimeError(f'Destination attribute "{dstAttr.fullName}" is already connected.')
+            raise InvalidEdgeError(srcAttr.fullName, dstAttr.fullName,
+                                   "Destination is already connected.")
         edge = Edge(srcAttr, dstAttr)
         self.edges.add(edge)
         self.markNodesDirty(dstAttr.node)

--- a/meshroom/core/node.py
+++ b/meshroom/core/node.py
@@ -2480,6 +2480,15 @@ class CompatibilityNode(BaseNode):
         if Attribute.isLinkExpression(value):
             return attrDesc
 
+        # If it is a GroupAttribute, all the attributes within the group should be matched
+        # individually so that links can correctly be evaluated.
+        if isinstance(attrDesc, desc.GroupAttribute):
+            for k, v in value.items():
+                if CompatibilityNode.attributeDescFromName(attrDesc.groupDesc,
+                                                           k, v, strict=True) is None:
+                    return None
+            return attrDesc
+
         # If it passes the 'matchDescription' test
         if attrDesc.matchDescription(value, strict):
             return attrDesc

--- a/meshroom/ui/commands.py
+++ b/meshroom/ui/commands.py
@@ -6,7 +6,7 @@ from PySide6.QtGui import QUndoCommand, QUndoStack
 from PySide6.QtCore import Property, Signal
 
 from meshroom.core.attribute import ListAttribute, Attribute
-from meshroom.core.exception import CyclicDependencyError
+from meshroom.core.exception import CyclicDependencyError,InvalidEdgeError
 from meshroom.core.graph import Graph, GraphModification
 from meshroom.core.node import Position, CompatibilityIssue
 from meshroom.core.nodeFactory import nodeFactory
@@ -428,22 +428,23 @@ class AddEdgeCommand(GraphCommand):
         super().__init__(graph, parent)
         self.srcAttr = src.fullName
         self.dstAttr = dst.fullName
-        self.setText(f"Connect '{self.srcAttr}'->'{self.dstAttr}'")
+        self.createdEdges = []  # List of all the edges that have been created at once
+        self.setText(f"Connect '{self.srcAttr}' -> '{self.dstAttr}'")
 
         if not dst.validateIncomingConnection(src):
-            raise ValueError(f"Attribute types are not compatible and cannot be connected: "
-                             f"'{self.srcAttr}'({src.baseType})->'{self.dstAttr}'({dst.baseType})")
+            raise InvalidEdgeError(src.fullName, dst.fullName, "Attributes are not compatible.")
 
     def redoImpl(self):
         try:
-            self.graph.addEdge(self.graph.attribute(self.srcAttr),
-                               self.graph.attribute(self.dstAttr))
+            self.createdEdges = self.graph.attribute(self.srcAttr).connectTo(self.graph.attribute(self.dstAttr))
         except CyclicDependencyError:
             self.graph.removeEdge(self.graph.attribute(self.dstAttr))
+            return False
         return True
 
-    def undoImpl(self):
-        self.graph.removeEdge(self.graph.attribute(self.dstAttr))
+    def undoImpl(self) -> bool:
+        for edge in self.createdEdges:
+            edge.dst.disconnectEdge()
 
 
 class RemoveEdgeCommand(GraphCommand):
@@ -451,15 +452,14 @@ class RemoveEdgeCommand(GraphCommand):
         super().__init__(graph, parent)
         self.srcAttr = edge.src.fullName
         self.dstAttr = edge.dst.fullName
-        self.setText(f"Disconnect '{self.srcAttr}'->'{self.dstAttr}'")
+        self.setText(f"Disconnect '{self.srcAttr}' -> '{self.dstAttr}'")
 
     def redoImpl(self):
-        self.graph.removeEdge(self.graph.attribute(self.dstAttr))
+        self.graph.attribute(self.dstAttr).disconnectEdge()
         return True
 
     def undoImpl(self):
-        self.graph.addEdge(self.graph.attribute(self.srcAttr),
-                           self.graph.attribute(self.dstAttr))
+        self.graph.attribute(self.srcAttr).connectTo(self.graph.attribute(self.dstAttr))
 
 
 class ListAttributeAppendCommand(GraphCommand):

--- a/meshroom/ui/commands.py
+++ b/meshroom/ui/commands.py
@@ -6,6 +6,7 @@ from PySide6.QtGui import QUndoCommand, QUndoStack
 from PySide6.QtCore import Property, Signal
 
 from meshroom.core.attribute import ListAttribute, Attribute
+from meshroom.core.exception import CyclicDependencyError
 from meshroom.core.graph import Graph, GraphModification
 from meshroom.core.node import Position, CompatibilityIssue
 from meshroom.core.nodeFactory import nodeFactory
@@ -434,7 +435,11 @@ class AddEdgeCommand(GraphCommand):
                              f"'{self.srcAttr}'({src.baseType})->'{self.dstAttr}'({dst.baseType})")
 
     def redoImpl(self):
-        self.graph.addEdge(self.graph.attribute(self.srcAttr), self.graph.attribute(self.dstAttr))
+        try:
+            self.graph.addEdge(self.graph.attribute(self.srcAttr),
+                               self.graph.attribute(self.dstAttr))
+        except CyclicDependencyError:
+            self.graph.removeEdge(self.graph.attribute(self.dstAttr))
         return True
 
     def undoImpl(self):

--- a/meshroom/ui/commands.py
+++ b/meshroom/ui/commands.py
@@ -429,8 +429,9 @@ class AddEdgeCommand(GraphCommand):
         self.dstAttr = dst.fullName
         self.setText(f"Connect '{self.srcAttr}'->'{self.dstAttr}'")
 
-        if src.baseType != dst.baseType:
-            raise ValueError(f"Attribute types are not compatible and cannot be connected: '{self.srcAttr}'({src.baseType})->'{self.dstAttr}'({dst.baseType})")
+        if not dst.validateIncomingConnection(src):
+            raise ValueError(f"Attribute types are not compatible and cannot be connected: "
+                             f"'{self.srcAttr}'({src.baseType})->'{self.dstAttr}'({dst.baseType})")
 
     def redoImpl(self):
         self.graph.addEdge(self.graph.attribute(self.srcAttr), self.graph.attribute(self.dstAttr))

--- a/meshroom/ui/commands.py
+++ b/meshroom/ui/commands.py
@@ -429,14 +429,15 @@ class AddEdgeCommand(GraphCommand):
         self.srcAttr = src.fullName
         self.dstAttr = dst.fullName
         self.createdEdges = []  # List of all the edges that have been created at once
+        self.deletedEdges = []  # List of all the edges that have been deleted to create the new edge(s)
         self.setText(f"Connect '{self.srcAttr}' -> '{self.dstAttr}'")
 
         if not dst.validateIncomingConnection(src):
             raise InvalidEdgeError(src.fullName, dst.fullName, "Attributes are not compatible.")
 
-    def redoImpl(self):
+    def redoImpl(self) -> bool:
         try:
-            self.createdEdges = self.graph.attribute(self.srcAttr).connectTo(self.graph.attribute(self.dstAttr))
+            self.createdEdges, self.deletedEdges = self.graph.attribute(self.srcAttr).connectTo(self.graph.attribute(self.dstAttr))
         except CyclicDependencyError:
             self.graph.removeEdge(self.graph.attribute(self.dstAttr))
             return False
@@ -444,7 +445,10 @@ class AddEdgeCommand(GraphCommand):
 
     def undoImpl(self) -> bool:
         for edge in self.createdEdges:
-            edge.dst.disconnectEdge()
+            edge[1].disconnectEdge()
+        for edge in self.deletedEdges:
+            edge[0].connectTo(edge[1])
+        return True
 
 
 class RemoveEdgeCommand(GraphCommand):
@@ -452,14 +456,17 @@ class RemoveEdgeCommand(GraphCommand):
         super().__init__(graph, parent)
         self.srcAttr = edge.src.fullName
         self.dstAttr = edge.dst.fullName
+        self.deletedEdges = []  # List of all the edges that have been deleted
         self.setText(f"Disconnect '{self.srcAttr}' -> '{self.dstAttr}'")
 
-    def redoImpl(self):
-        self.graph.attribute(self.dstAttr).disconnectEdge()
+    def redoImpl(self) -> bool:
+        self.deletedEdges = self.graph.attribute(self.dstAttr).disconnectEdge()
         return True
 
-    def undoImpl(self):
-        self.graph.attribute(self.srcAttr).connectTo(self.graph.attribute(self.dstAttr))
+    def undoImpl(self) -> bool:
+        for edge in self.deletedEdges:
+            edge[0].connectTo(edge[1])
+        return True
 
 
 class ListAttributeAppendCommand(GraphCommand):

--- a/meshroom/ui/graph.py
+++ b/meshroom/ui/graph.py
@@ -1172,11 +1172,11 @@ class UIGraph(QObject):
 
     @Slot(Edge)
     def removeEdge(self, edge):
-        if isinstance(edge.dst.root, ListAttribute):
-            with self.groupedGraphModification(f"Remove Edge and Delete {edge.dst.fullName}"):
+        with self.groupedGraphModification(f"Remove Edge and Delete {edge.dst.fullName}"):
+            if isinstance(edge.dst.root, ListAttribute):
                 self.push(commands.RemoveEdgeCommand(self._graph, edge))
                 self.removeAttribute(edge.dst)
-        else:
+                return
             self.push(commands.RemoveEdgeCommand(self._graph, edge))
 
     @Slot(list)

--- a/meshroom/ui/graph.py
+++ b/meshroom/ui/graph.py
@@ -1088,7 +1088,8 @@ class UIGraph(QObject):
     def canExpandForLoop(self, currentEdge):
         """ Check if the list attribute can be expanded by looking at all the edges connected to it. """
         listAttribute = currentEdge.src.root
-        if not listAttribute:
+        # Check that the parent is indeed a ListAttribute (it could be a GroupAttribute, for example)
+        if not listAttribute or not isinstance(listAttribute, ListAttribute):
             return False
         srcIndex = listAttribute.index(currentEdge.src)
         allSrc = [e.src for e in self._graph.edges.values()]

--- a/meshroom/ui/qml/GraphEditor/AttributeItemDelegate.qml
+++ b/meshroom/ui/qml/GraphEditor/AttributeItemDelegate.qml
@@ -802,7 +802,21 @@ RowLayout {
                                                    'filterText': Qt.binding(function() { return root.filterText }),
                                                })
                     obj.Layout.fillWidth = true;
-                    obj.attributeDoubleClicked.connect(function(attr) {root.doubleClicked(attr)})
+                    obj.attributeDoubleClicked.connect(
+                        function(attr) {
+                            root.doubleClicked(attr)
+                        }
+                    )
+                    obj.inAttributeClicked.connect(
+                        function(srcItem, mouse, inAttributes) {
+                            root.inAttributeClicked(srcItem, mouse, inAttributes)
+                        }
+                    )
+                    obj.outAttributeClicked.connect(
+                        function(srcItem, mouse, outAttributes) {
+                            root.outAttributeClicked(srcItem, mouse, outAttributes)
+                        }
+                    )
                 }
             }
         }

--- a/meshroom/ui/qml/GraphEditor/AttributePin.qml
+++ b/meshroom/ui/qml/GraphEditor/AttributePin.qml
@@ -339,8 +339,8 @@ RowLayout {
             anchors.fill: parent
             anchors.margins: 2
             color: {
-                if (modelData.enabled && (outputConnectMA.containsMouse || outputConnectMA.drag.active ||
-                                         (outputDropArea.containsDrag && outputDropArea.acceptableDrop)))
+                if (root.attribute.enabled && (outputConnectMA.containsMouse || outputConnectMA.drag.active ||
+                                               (outputDropArea.containsDrag && outputDropArea.acceptableDrop)))
                     return Colors.sysPalette.highlight
                 if (hasConnectedChildren)
                     return Colors.sysPalette.mid

--- a/meshroom/ui/qml/GraphEditor/AttributePin.qml
+++ b/meshroom/ui/qml/GraphEditor/AttributePin.qml
@@ -3,6 +3,7 @@ import QtQuick.Controls
 import QtQuick.Layouts
 
 import Utils 1.0
+import MaterialIcons 2.2
 
 /**
  * The representation of an Attribute on a Node.
@@ -13,6 +14,7 @@ RowLayout {
 
     property var nodeItem
     property var attribute
+    property bool expanded: false
     property bool readOnly: false
     /// Whether to display an output pin for input attribute
     property bool displayOutputPinForInput: true
@@ -25,37 +27,33 @@ RowLayout {
                                                       outputAnchor.y + outputAnchor.height / 2)
 
     readonly property bool isList: attribute && attribute.type === "ListAttribute"
+    readonly property bool isGroup: attribute && attribute.type === "GroupAttribute"
+    readonly property bool isConnected: attribute.hasAnyInputLinks || attribute.hasAnyOutputLinks
 
     signal childPinCreated(var childAttribute, var pin)
     signal childPinDeleted(var childAttribute, var pin)
 
     signal pressed(var mouse)
     signal edgeAboutToBeRemoved(var input)
+    signal clicked()
 
     objectName: attribute ? attribute.name + "." : ""
     layoutDirection: Qt.LeftToRight
     spacing: 3
 
     ToolTip {
-        text: attribute.name + ": " + attribute.type
+        text: attribute.fullName + ": " + attribute.type
         visible: nameLabel.hovered
+        delay: 500
 
-        y: nameLabel.y + nameLabel.height
         x: nameLabel.x
-    }
-
-    function updatePin(isSrc, isVisible) {
-        if (isSrc) {
-            innerOutputAnchor.linkEnabled = isVisible
-        } else {
-            innerInputAnchor.linkEnabled = isVisible
-        }
+        y: nameLabel.y + nameLabel.height
     }
 
     // Instantiate empty Items for each child attribute
     Repeater {
         id: childrenRepeater
-        model: isList && !attribute.isLink ? attribute.value : 0
+        model: root.isList && !root.attribute.isLink ? root.attribute.value : 0
         onItemAdded: function(index, item) { childPinCreated(item.childAttribute, root) }
         onItemRemoved: function(index, item) { childPinDeleted(item.childAttribute, root) }
         delegate: Item {
@@ -64,125 +62,159 @@ RowLayout {
         }
     }
 
-    Rectangle {
-        visible: !attribute.isOutput
-        id: inputAnchor
-
-        width: 8
-        height: width
-        radius: isList ? 0 : width / 2
+    Item {
+        width: childrenRect.width
         Layout.alignment: Qt.AlignVCenter
-
-        border.color: Colors.sysPalette.mid
-        color: Colors.sysPalette.base
+        Layout.fillWidth: true
+        Layout.fillHeight: true
 
         Rectangle {
-            id: innerInputAnchor
-            property bool linkEnabled: true
-            visible: inputConnectMA.containsMouse || childrenRepeater.count > 0 || (attribute && attribute.isLink && linkEnabled) || inputConnectMA.drag.active || inputDropArea.containsDrag
-            radius: isList ? 0 : 2
-            anchors.fill: parent
-            anchors.margins: 2
-            color: {
-                if (inputConnectMA.containsMouse || inputConnectMA.drag.active || (inputDropArea.containsDrag && inputDropArea.acceptableDrop))
-                    return Colors.sysPalette.highlight
-                return Colors.sysPalette.text
-            }
-        }
+            id: inputAnchor
+            visible: !root.attribute.isOutput
 
-        DropArea {
-            id: inputDropArea
+            width: 8
+            height: width
+            radius: root.isList ? 0 : width / 2
+            Layout.alignment: Qt.AlignVCenter
 
-            property bool acceptableDrop: false
+            border.color: Colors.sysPalette.mid
+            color: Colors.sysPalette.base
 
-            // Add negative margins for DropArea to make the connection zone easier to reach
-            anchors.fill: parent
-            anchors.margins: -2
-            // Add horizontal negative margins according to the current layout
-            anchors.rightMargin: -root.width * 0.3
-
-            keys: [inputDragTarget.objectName]
-            onEntered: function(drag) {
-                var validIncomingConnection = inputDragTarget.attribute.validateIncomingConnection(drag.source.attribute)
-                // Check if attributes are compatible to create a valid connection
-                if (root.readOnly                                            // Cannot connect on a read-only attribute
-                    || drag.source.objectName != inputDragTarget.objectName  // Not an edge connector
-                    || !validIncomingConnection                              // Connection is not allowed
-                    || drag.source.nodeItem === inputDragTarget.nodeItem     // Connection between attributes of the same node
-                    || (drag.source.isList && childrenRepeater.count)        // Source/target are lists but target already has children
-                    || drag.source.connectorType === "input"                 // Refuse to connect an "input pin" on another one (input attr can be connected to input attr, but not the graphical pin)
-                   ) {
-                    // Refuse attributes connection
-                    drag.accepted = false
-                } else if (inputDragTarget.attribute.isLink) {  // Already connected attribute
-                    root.edgeAboutToBeRemoved(inputDragTarget.attribute)
+            Rectangle {
+                id: innerInputAnchor
+                property bool linkEnabled: true
+                visible: inputConnectMA.containsMouse || childrenRepeater.count > 0 ||
+                        (root.attribute && root.attribute.isLink && linkEnabled) || inputConnectMA.drag.active || inputDropArea.containsDrag
+                radius: root.isList ? 0 : 2
+                anchors.fill: parent
+                anchors.margins: 2
+                color: {
+                    if (inputConnectMA.containsMouse || inputConnectMA.drag.active || (inputDropArea.containsDrag && inputDropArea.acceptableDrop))
+                        return Colors.sysPalette.highlight
+                    return Colors.sysPalette.text
                 }
-                inputDropArea.acceptableDrop = drag.accepted
             }
 
-            onExited: {
-                if (inputDragTarget.attribute.isLink) {  // Already connected attribute
+            DropArea {
+                id: inputDropArea
+
+                property bool acceptableDrop: false
+
+                // Add negative margins for DropArea to make the connection zone easier to reach
+                anchors.fill: parent
+                anchors.margins: -2
+                // Add horizontal negative margins according to the current layout
+                anchors.rightMargin: -root.width * 0.3
+
+                keys: [inputDragTarget.objectName]
+                onEntered: function(drag) {
+                    var validIncomingConnection = drag.source.attribute.validateIncomingConnection(inputDragTarget.attribute)
+                    // Check if attributes are compatible to create a valid connection
+                    if (root.readOnly                                            // Cannot connect on a read-only attribute
+                        || drag.source.objectName != inputDragTarget.objectName  // Not an edge connector
+                        || !validIncomingConnection                              // Connection is not allowed
+                        || drag.source.nodeItem === inputDragTarget.nodeItem     // Connection between attributes of the same node
+                        || drag.source.isList && childrenRepeater.count          // Source/target are lists but target already has children
+                        || drag.source.connectorType === "input"                 // Refuse to connect an "input pin" on another one (input attr can be connected to input attr, but not the graphical pin)
+                    ) {
+                        // Refuse attributes connection
+                        drag.accepted = false
+                    } else if (inputDragTarget.attribute.isLink) {  // Already connected attribute
+                        root.edgeAboutToBeRemoved(inputDragTarget.attribute)
+                    }
+                    inputDropArea.acceptableDrop = drag.accepted
+                }
+
+                onExited: {
+                    if (inputDragTarget.attribute.isLink) {  // Already connected attribute
+                        root.edgeAboutToBeRemoved(undefined)
+                    }
+                    acceptableDrop = false
+                    drag.source.dropAccepted = false
+                }
+
+                onDropped: function(drop) {
                     root.edgeAboutToBeRemoved(undefined)
+                    _reconstruction.addEdge(drag.source.attribute, inputDragTarget.attribute)
                 }
-                acceptableDrop = false
-                drag.source.dropAccepted = false
             }
 
-            onDropped: function(drop) {
-                root.edgeAboutToBeRemoved(undefined)
-                _reconstruction.addEdge(drag.source.attribute, inputDragTarget.attribute)
+            Item {
+                id: inputDragTarget
+                objectName: "edgeConnector"
+                readonly property string connectorType: "input"
+                readonly property alias attribute: root.attribute
+                readonly property alias nodeItem: root.nodeItem
+                readonly property bool isOutput: Boolean(attribute.isOutput)
+                readonly property alias isList: root.isList
+                readonly property alias isGroup: root.isGroup
+                property bool dragAccepted: false
+                anchors.verticalCenter: parent.verticalCenter
+                anchors.horizontalCenter: parent.horizontalCenter
+                width: parent.width
+                height: parent.height
+                Drag.keys: [inputDragTarget.objectName]
+                Drag.active: inputConnectMA.drag.active
+                Drag.hotSpot.x: width * 0.5
+                Drag.hotSpot.y: height * 0.5
             }
-        }
 
-        Item {
-            id: inputDragTarget
-            objectName: "edgeConnector"
-            readonly property string connectorType: "input"
-            readonly property alias attribute: root.attribute
-            readonly property alias nodeItem: root.nodeItem
-            readonly property bool isOutput: Boolean(attribute.isOutput)
-            readonly property alias isList: root.isList
-            property bool dragAccepted: false
-            anchors.verticalCenter: parent.verticalCenter
-            anchors.horizontalCenter: parent.horizontalCenter
-            width: parent.width
-            height: parent.height
-            Drag.keys: [inputDragTarget.objectName]
-            Drag.active: inputConnectMA.drag.active
-            Drag.hotSpot.x: width * 0.5
-            Drag.hotSpot.y: height * 0.5
-        }
+            MouseArea {
+                id: inputConnectMA
+                drag.target: root.attribute.isReadOnly ? undefined : inputDragTarget
+                drag.threshold: 0
+                // Move the edge's tip straight to the the current mouse position instead of waiting after the drag operation has started
+                drag.smoothed: false
+                enabled: !root.readOnly
+                anchors.fill: parent
+                hoverEnabled: root.visible
 
-        MouseArea {
-            id: inputConnectMA
-            drag.target: attribute.isReadOnly ? undefined : inputDragTarget
-            drag.threshold: 0
-            // Move the edge's tip straight to the the current mouse position instead of waiting after the drag operation has started
-            drag.smoothed: false
-            enabled: !root.readOnly
-            anchors.fill: parent
-            // Use the same negative margins as DropArea to ease pin selection
-            anchors.margins: inputDropArea.anchors.margins
-            anchors.leftMargin: inputDropArea.anchors.leftMargin
-            anchors.rightMargin: inputDropArea.anchors.rightMargin
-            onPressed: function(mouse) {
-                root.pressed(mouse)
+                // Use the same negative margins as DropArea to ease pin selection
+                anchors.margins: inputDropArea.anchors.margins
+                anchors.leftMargin: inputDropArea.anchors.leftMargin
+                anchors.rightMargin: inputDropArea.anchors.rightMargin
+
+                property bool dragTriggered: false  // An edge is being dragged from the input connector
+                property bool isPressed: false  // The mouse has been pressed but not released yet
+                property double initialX: 0.0
+                property double initialY: 0.0
+
+                onPressed: function(mouse) {
+                    root.pressed(mouse)
+                    isPressed = true
+                    initialX = mouse.x
+                    initialY = mouse.y
+                }
+
+                onReleased: {
+                    inputDragTarget.Drag.drop()
+                    isPressed = false
+                    dragTriggered = false
+                }
+
+                onClicked: function() {
+                    root.clicked()
+                }
+
+                onPositionChanged: function(mouse) {
+                    // If there has been a significant move (5px along the -X or -Y axis) while the
+                    // mouse is being pressed, then we can consider being in the dragging state
+                    if (isPressed && (Math.abs(mouse.x - initialX) >= 5.0 || Math.abs(mouse.y - initialY) >= 5.0)) {
+                        dragTriggered = true
+                    }
+                }
             }
-            onReleased: {
-                inputDragTarget.Drag.drop()
-            }
-            hoverEnabled: true
-        }
 
-        Edge {
-            id: inputConnectEdge
-            visible: false
-            point1x: inputDragTarget.x + inputDragTarget.width / 2
-            point1y: inputDragTarget.y + inputDragTarget.height / 2
-            point2x: parent.width / 2
-            point2y: parent.width / 2
-            color: palette.highlight
-            thickness: outputDragTarget.dropAccepted ? 2 : 1
+            Edge {
+                id: inputConnectEdge
+                visible: false
+                point1x: inputDragTarget.x + inputDragTarget.width / 2
+                point1y: inputDragTarget.y + inputDragTarget.height / 2
+                point2x: parent.width / 2
+                point2y: parent.width / 2
+                color: palette.highlight
+                thickness: outputDragTarget.dropAccepted ? 2 : 1
+            }
         }
     }
 
@@ -190,36 +222,79 @@ RowLayout {
     Item {
         id: nameContainer
         implicitHeight: childrenRect.height
+        implicitWidth: childrenRect.width
         Layout.fillWidth: true
+        Layout.fillHeight: true
         Layout.alignment: Qt.AlignVCenter
 
-        Label {
+        MaterialToolLabel {
             id: nameLabel
 
+            anchors.fill: parent
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+            anchors.verticalCenter: parent.verticalCenter
+            anchors.margins: 0
+            labelIconRow.layoutDirection: root.attribute.isOutput ? Qt.RightToLeft : Qt.LeftToRight
+            labelIconRow.spacing: 0
+
             enabled: !root.readOnly
-            property bool hovered: (inputConnectMA.containsMouse || inputConnectMA.drag.active || inputDropArea.containsDrag || outputConnectMA.containsMouse || outputConnectMA.drag.active || outputDropArea.containsDrag)
-            text: (attribute && attribute.label) !== undefined ? attribute.label : ""
-            elide: hovered ? Text.ElideNone : Text.ElideMiddle
-            width: hovered ? contentWidth : parent.width
-            font.pointSize: 7
-            horizontalAlignment: attribute && attribute.isOutput ? Text.AlignRight : Text.AlignLeft
-            anchors.right: attribute && attribute.isOutput ? parent.right : undefined
-            rightPadding: 0
-            color: {
-                if ((object.hasAnyOutputLinks || object.isLink) && !object.enabled)
+            visible: true
+
+            // Allow to trigger a change of state once the parent is ready, ensuring the correct width of the
+            // elements upon their first display without waiting for a mouse interaction
+            property bool parentNotReady: nameContainer.width == 0
+
+            property bool hovered: parentNotReady || (inputConnectMA.containsMouse ||
+                                                      inputConnectMA.drag.active ||
+                                                      inputDropArea.containsDrag ||
+                                                      outputConnectMA.containsMouse ||
+                                                      outputConnectMA.drag.active ||
+                                                      outputDropArea.containsDrag)
+
+            labelIconColor: {
+                if ((root.attribute.hasAnyOutputLinks || root.attribute.isLink) && !root.attribute.enabled) {
                     return Colors.lightgrey
-                return hovered ? palette.highlight : palette.text
+                } else if (hovered) {
+                    return palette.highlight
+                }
+                return palette.text
             }
+            labelIconMouseArea.enabled: false  // Prevent mixing mouse interactions between the label and the pin context
+
+            // Text
+            label.text: root.attribute.label
+            label.font.pointSize: 7
+            label.elide: hovered ? Text.ElideNone : Text.ElideMiddle
+            label.horizontalAlignment: root.attribute && root.attribute.isOutput ? Text.AlignRight : Text.AlignLeft
+            label.verticalAlignment: Text.AlignVCenter
+            label.visible: true
+
+            // Icon
+            iconText: {
+                if (root.isGroup) {
+                    return root.expanded ? MaterialIcons.expand_more : MaterialIcons.chevron_right
+                }
+                return ""
+            }
+            iconSize: 7
+            icon.horizontalAlignment: root.attribute && root.attribute.isOutput ? Text.AlignRight : Text.AlignLeft
+            icon.verticalAlignment: Text.AlignVCenter
+
+            // Handle tree view for nested attributes
+            property int groupPaddingWidth: root.attribute.depth * 10
+            icon.leftPadding: root.attribute.isOutput ? 0 : groupPaddingWidth
+            icon.rightPadding: root.attribute.isOutput ? groupPaddingWidth : 0
         }
     }
 
     Rectangle {
         id: outputAnchor
 
-        visible: displayOutputPinForInput || attribute.isOutput
+        visible: root.displayOutputPinForInput || root.attribute.isOutput
         width: 8
         height: width
-        radius: isList ? 0 : width / 2
+        radius: root.isList ? 0 : width / 2
 
         Layout.alignment: Qt.AlignVCenter
 
@@ -229,13 +304,13 @@ RowLayout {
         Rectangle {
             id: innerOutputAnchor
             property bool linkEnabled: true
-            visible: (attribute.hasAnyOutputLinks && linkEnabled) || outputConnectMA.containsMouse || outputConnectMA.drag.active || outputDropArea.containsDrag
-            radius: isList ? 0 : 2
+            visible: (root.attribute.hasAnyOutputLinks && linkEnabled) || outputConnectMA.containsMouse || outputConnectMA.drag.active || outputDropArea.containsDrag
+            radius: root.isList ? 0 : 2
             anchors.fill: parent
             anchors.margins: 2
             color: {
-                if (object.enabled && (outputConnectMA.containsMouse || outputConnectMA.drag.active ||
-                                       (outputDropArea.containsDrag && outputDropArea.acceptableDrop)))
+                if (modelData.enabled && (outputConnectMA.containsMouse || outputConnectMA.drag.active ||
+                                         (outputDropArea.containsDrag && outputDropArea.acceptableDrop)))
                     return Colors.sysPalette.highlight
                 return Colors.sysPalette.text
             }
@@ -289,6 +364,7 @@ RowLayout {
             readonly property alias nodeItem: root.nodeItem
             readonly property bool isOutput: Boolean(attribute.isOutput)
             readonly property alias isList: root.isList
+            readonly property alias isGroup: root.isGroup
             property bool dropAccepted: false
             anchors.horizontalCenter: parent.horizontalCenter
             anchors.verticalCenter: parent.verticalCenter
@@ -312,10 +388,37 @@ RowLayout {
             anchors.leftMargin: outputDropArea.anchors.leftMargin
             anchors.rightMargin: outputDropArea.anchors.rightMargin
 
-            onPressed: function(mouse) { root.pressed(mouse) }
-            onReleased: outputDragTarget.Drag.drop()
+            hoverEnabled: root.visible
 
-            hoverEnabled: true
+            property bool dragTriggered: false  // An edge is being dragged from the output connector
+            property bool isPressed: false   // The mouse has been pressed but not released yet
+            property double initialX: 0.0
+            property double initialY: 0.0
+
+            onPressed: function(mouse) {
+                root.pressed(mouse)
+                isPressed = true
+                initialX = mouse.x
+                initialY = mouse.y
+            }
+
+            onReleased: function(mouse) {
+                outputDragTarget.Drag.drop()
+                isPressed = false
+                dragTriggered = false
+            }
+
+            onClicked: function() {
+                root.clicked()
+            }
+
+            onPositionChanged: function(mouse) {
+                // If there's been a significant move (5px along the -X or -Y axis) while the mouse is being
+                // pressed, then we can consider being in the dragging state.
+                if (isPressed && (Math.abs(mouse.x - initialX) >= 5.0 || Math.abs(mouse.y - initialY) >= 5.0)) {
+                    dragTriggered = true
+                }
+            }
         }
 
         Edge {
@@ -330,7 +433,7 @@ RowLayout {
         }
     }
 
-    state: (inputConnectMA.pressed) ? "DraggingInput" : outputConnectMA.pressed ? "DraggingOutput" : ""
+    state: inputConnectMA.dragTriggered ? "DraggingInput" : outputConnectMA.dragTriggered ? "DraggingOutput" : ""
 
     states: [
         State {

--- a/meshroom/ui/qml/GraphEditor/AttributePin.qml
+++ b/meshroom/ui/qml/GraphEditor/AttributePin.qml
@@ -77,13 +77,27 @@ RowLayout {
             radius: root.isList ? 0 : width / 2
             Layout.alignment: Qt.AlignVCenter
 
-            border.color: Colors.sysPalette.mid
+            border.color: {
+                if (innerInputAnchor.hasConnectedChildren)
+                    return Colors.sysPalette.text
+                return Colors.sysPalette.mid
+            }
             color: Colors.sysPalette.base
 
             Rectangle {
                 id: innerInputAnchor
                 property bool linkEnabled: true
-                visible: inputConnectMA.containsMouse || childrenRepeater.count > 0 ||
+                property bool hasConnectedChildren: {
+                    if (!root.isGroup || root.isConnected || !attribute)
+                        return false
+                    for (var i = 0; i < attribute.flatStaticChildren.length; ++i) {
+                        if (attribute.flatStaticChildren[i].hasAnyInputLinks) {
+                            return true
+                        }
+                    }
+                    return false
+                }
+                visible: inputConnectMA.containsMouse || childrenRepeater.count > 0 || hasConnectedChildren ||
                         (root.attribute && root.attribute.isLink && linkEnabled) || inputConnectMA.drag.active || inputDropArea.containsDrag
                 radius: root.isList ? 0 : 2
                 anchors.fill: parent
@@ -91,6 +105,8 @@ RowLayout {
                 color: {
                     if (inputConnectMA.containsMouse || inputConnectMA.drag.active || (inputDropArea.containsDrag && inputDropArea.acceptableDrop))
                         return Colors.sysPalette.highlight
+                    if (hasConnectedChildren)
+                        return Colors.sysPalette.mid
                     return Colors.sysPalette.text
                 }
             }
@@ -298,13 +314,27 @@ RowLayout {
 
         Layout.alignment: Qt.AlignVCenter
 
-        border.color: Colors.sysPalette.mid
+        border.color: {
+            if (innerOutputAnchor.hasConnectedChildren)
+                return Colors.sysPalette.text
+            return Colors.sysPalette.mid
+        }
         color: Colors.sysPalette.base
 
         Rectangle {
             id: innerOutputAnchor
             property bool linkEnabled: true
-            visible: (root.attribute.hasAnyOutputLinks && linkEnabled) || outputConnectMA.containsMouse || outputConnectMA.drag.active || outputDropArea.containsDrag
+            property bool hasConnectedChildren: {
+                if (!root.isGroup || root.isConnected)
+                    return false
+                for (var i = 0; i < attribute.flatStaticChildren.length; ++i) {
+                    if (attribute.flatStaticChildren[i].hasAnyOutputLinks) {
+                        return true
+                    }
+                }
+                return false
+            }
+            visible: (root.attribute.hasAnyOutputLinks && linkEnabled) || outputConnectMA.containsMouse || outputConnectMA.drag.active || outputDropArea.containsDrag || hasConnectedChildren
             radius: root.isList ? 0 : 2
             anchors.fill: parent
             anchors.margins: 2
@@ -312,6 +342,8 @@ RowLayout {
                 if (modelData.enabled && (outputConnectMA.containsMouse || outputConnectMA.drag.active ||
                                          (outputDropArea.containsDrag && outputDropArea.acceptableDrop)))
                     return Colors.sysPalette.highlight
+                if (hasConnectedChildren)
+                    return Colors.sysPalette.mid
                 return Colors.sysPalette.text
             }
         }

--- a/meshroom/ui/qml/GraphEditor/AttributePin.qml
+++ b/meshroom/ui/qml/GraphEditor/AttributePin.qml
@@ -103,10 +103,11 @@ RowLayout {
 
             keys: [inputDragTarget.objectName]
             onEntered: function(drag) {
+                var validIncomingConnection = inputDragTarget.attribute.validateIncomingConnection(drag.source.attribute)
                 // Check if attributes are compatible to create a valid connection
                 if (root.readOnly                                            // Cannot connect on a read-only attribute
                     || drag.source.objectName != inputDragTarget.objectName  // Not an edge connector
-                    || drag.source.baseType !== inputDragTarget.baseType     // Not the same base type
+                    || !validIncomingConnection                              // Connection is not allowed
                     || drag.source.nodeItem === inputDragTarget.nodeItem     // Connection between attributes of the same node
                     || (drag.source.isList && childrenRepeater.count)        // Source/target are lists but target already has children
                     || drag.source.connectorType === "input"                 // Refuse to connect an "input pin" on another one (input attr can be connected to input attr, but not the graphical pin)
@@ -140,7 +141,6 @@ RowLayout {
             readonly property alias attribute: root.attribute
             readonly property alias nodeItem: root.nodeItem
             readonly property bool isOutput: Boolean(attribute.isOutput)
-            readonly property string baseType: attribute.baseType !== undefined ? attribute.baseType : ""
             readonly property alias isList: root.isList
             property bool dragAccepted: false
             anchors.verticalCenter: parent.verticalCenter
@@ -254,9 +254,10 @@ RowLayout {
 
             keys: [outputDragTarget.objectName]
             onEntered: function(drag) {
+                var validIncomingConnection = outputDragTarget.attribute.validateIncomingConnection(drag.source.attribute)
                 // Check if attributes are compatible to create a valid connection
                 if (drag.source.objectName != outputDragTarget.objectName   // Not an edge connector
-                    || drag.source.baseType !== outputDragTarget.baseType   // Not the same base type
+                    || !validIncomingConnection                             // Connection is not allowed
                     || drag.source.nodeItem === outputDragTarget.nodeItem   // Connection between attributes of the same node
                     || (!drag.source.isList && outputDragTarget.isList)     // Connection between a list and a simple attribute
                     || (drag.source.isList && childrenRepeater.count)       // Source/target are lists but target already has children
@@ -288,7 +289,6 @@ RowLayout {
             readonly property alias nodeItem: root.nodeItem
             readonly property bool isOutput: Boolean(attribute.isOutput)
             readonly property alias isList: root.isList
-            readonly property string baseType: attribute.baseType !== undefined ? attribute.baseType : ""
             property bool dropAccepted: false
             anchors.horizontalCenter: parent.horizontalCenter
             anchors.verticalCenter: parent.verticalCenter

--- a/meshroom/ui/qml/GraphEditor/Edge.qml
+++ b/meshroom/ui/qml/GraphEditor/Edge.qml
@@ -128,7 +128,7 @@ Item {
                 anchors.centerIn: parent
 
                 iconText: MaterialIcons.loop
-                label: (root.iteration + 1) + "/" + root.loopSize + " "
+                label.text: (root.iteration + 1) + "/" + root.loopSize + " "
 
                 labelIconColor: palette.base
                 ToolTip.text: "Foreach Loop"

--- a/meshroom/ui/qml/GraphEditor/GraphEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/GraphEditor.qml
@@ -483,13 +483,44 @@ Item {
                 model: nodeRepeater.loaded && root.graph ? root.graph.edges : undefined
 
                 delegate: Edge {
-                    property var src: root._attributeToDelegate[edge.src]
-                    property var dst: root._attributeToDelegate[edge.dst]
-                    property bool isValidEdge: src !== undefined && dst !== undefined
+                    function getAttributePin(attribute) {
+                        // Get the first visible parent of "attribute"
+                        let dstAttributeDelegate = root._attributeToDelegate[attribute]
+                        if (dstAttributeDelegate && dstAttributeDelegate.visible) {
+                            return dstAttributeDelegate
+                        }
+
+                        if (!attribute || !attribute.root) {
+                            return null
+                        }
+
+                        let index = Array.from(attribute.root.value).indexOf(attribute)
+                        let groupAttributeDelegate = null
+                        let groupAttribute = attribute
+
+                        while (groupAttribute && !groupAttributeDelegate ||
+                               (groupAttributeDelegate && !groupAttributeDelegate.visible && groupAttribute && groupAttribute.root)) {
+                            groupAttribute = groupAttribute ? groupAttribute.root : null
+
+                            if (groupAttribute) {
+                                groupAttributeDelegate = root._attributeToDelegate[groupAttribute]
+                            }
+                        }
+
+                        if (groupAttributeDelegate) {
+                            return groupAttributeDelegate
+                        }
+
+                        return dstAttributeDelegate
+                    }
+
+                    property var src: getAttributePin(edge.src)
+                    property var dst: getAttributePin(edge.dst)
+                    property bool isValidEdge: src !== null && dst !== null
                     visible: isValidEdge && src.visible && dst.visible
 
                     property bool forLoop: {
-                        if (src !== undefined && dst !== undefined) {
+                        if (src !== null && dst !== null) {
                             return src.attribute.type === "ListAttribute" && dst.attribute.type != "ListAttribute"
                         }
                         return false

--- a/meshroom/ui/qml/GraphEditor/GraphEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/GraphEditor.qml
@@ -498,8 +498,8 @@ Item {
                         let groupAttributeDelegate = null
                         let groupAttribute = attribute
 
-                        while (groupAttribute && !groupAttributeDelegate ||
-                               (groupAttributeDelegate && !groupAttributeDelegate.visible && groupAttribute && groupAttribute.root)) {
+                        while (groupAttribute && (!groupAttributeDelegate ||
+                               (groupAttributeDelegate && !groupAttributeDelegate.visible && groupAttribute && groupAttribute.root))) {
                             groupAttribute = groupAttribute ? groupAttribute.root : null
 
                             if (groupAttribute) {

--- a/meshroom/ui/qml/GraphEditor/GraphEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/GraphEditor.qml
@@ -528,18 +528,6 @@ Item {
                             }
                         }
                     }
-
-                    Component.onDestruction: {
-                        // Handles the case where the edge is destroyed while hidden because it is replaced: the pins should be re-enabled
-                        if (!_window.isClosing) {
-                            // When the window is closing, the QML context becomes invalid, which causes function calls to result in errors
-                            if (src && src !== undefined)
-                                src.updatePin(true, true)  // isSrc = true, isVisible = true
-                            if (dst && dst !== undefined)
-                                dst.updatePin(false, true)  // isSrc = false, isVisible = true
-                        }
-                    }
-
                 }
             }
 

--- a/meshroom/ui/qml/GraphEditor/Node.qml
+++ b/meshroom/ui/qml/GraphEditor/Node.qml
@@ -577,7 +577,7 @@ Item {
 
                                 delegate: Loader {
                                     id: inputLoader
-                                    active: !object.isOutput && object.desc.exposed && object.desc.visible
+                                    active: !object.isOutput && object.exposed && object.desc.visible
                                     visible: Boolean(object.enabled)
                                     width: inputs.width
 
@@ -637,7 +637,7 @@ Item {
                                     model: node ? node.attributes : undefined
                                     delegate: Loader {
                                         id: paramLoader
-                                        active: !object.isOutput && !object.desc.exposed && object.desc.visible
+                                        active: !object.isOutput && !object.exposed && object.desc.visible
                                         visible: Boolean(object.enabled || object.hasAnyInputLinks || object.hasAnyOutputLinks)
                                         property bool isFullyActive: Boolean(m.displayParams || object.hasAnyInputLinks || object.hasAnyOutputLinks)
                                         width: parent.width

--- a/meshroom/ui/qml/GraphEditor/Node.qml
+++ b/meshroom/ui/qml/GraphEditor/Node.qml
@@ -232,6 +232,63 @@ Item {
         return str
     }
 
+    function updateChildPin(attribute, parentPins, pin) {
+        /*
+         * Update the pin of a child attribute: if the attribute is enabled and its parent is
+         * a GroupAttribute, the visibility is determined based on the parent pin's "expanded" state,
+         * using the "parentPins" map to access the status.
+         * If the current pin is also a GroupAttribute and is expanded while its newly "visible" state
+         * is false, it is reset.
+         */
+        if (Boolean(attribute.enabled)) {
+            // If the parent is a GroupAttribute, use the status of the parent's pin to determine visibility
+            // UNLESS the child attribute is already connected
+            if (attribute.root && attribute.root.baseType === "GroupAttribute") {
+                var visible = Boolean(parentPins.get(attribute.root.name) ||
+                                      attribute.hasAnyOutputLinks ||
+                                      attribute.hasAnyInputLinks)
+                if (!visible && parentPins.has(attribute.name) && parentPins.get(attribute.name) === true) {
+                    parentPins.set(attribute.name, false)
+                    pin.expanded = false
+                }
+                return visible
+            }
+            return true
+        }
+        return false
+    }
+
+    function generateAttributesModel(isOutput, parentPins) {
+        if (!node) {
+            return undefined
+        }
+
+        const attributes = []
+        for (let i = 0; i < node.attributes.count; i++) {
+            let attr = node.attributes.at(i)
+            if (attr.isOutput == isOutput) {
+                // Add the attribute to the model
+                attributes.push(attr)
+                if (attr.baseType === "GroupAttribute") {
+                    // If it is a GroupAttribute, initialize its pin status
+                    parentPins.set(attr.name, false)
+                }
+
+                // Check and add any child this attribute might have
+                attr.flatStaticChildren.forEach((child) =>
+                    {
+                        attributes.push(child)
+                        if (child.baseType === "GroupAttribute") {
+                            parentPins.set(child.name, false)
+                        }
+                    }
+                )
+            }
+        }
+
+        return attributes
+    }
+
     // Main Layout
     MouseArea {
         id: mouseArea
@@ -537,26 +594,66 @@ Item {
                             width: parent.width
                             spacing: 3
 
+                            property var parentPins: new Map()
+                            signal parentPinsUpdated()
+
                             Repeater {
-                                model: node ? node.attributes : undefined
+                                model: root.generateAttributesModel(true, outputs.parentPins)  // isOutput = true
 
                                 delegate: Loader {
                                     id: outputLoader
-                                    active: Boolean(object.isOutput && object.desc.visible)
-                                    visible: Boolean(object.enabled || object.hasAnyOutputLinks)
+
+                                    active: Boolean(modelData.isOutput && modelData.desc.visible)
+                                    visible: {
+                                        if (Boolean(modelData.enabled || modelData.hasAnyOutputLinks || modelData.hasAnyInputLinks)) {
+                                            if (modelData.root && modelData.root.baseType === "GroupAttribute") {
+                                                return Boolean(outputs.parentPins.get(modelData.root.name) ||
+                                                               modelData.hasAnyOutputLinks ||
+                                                               modelData.hasAnyInputLinks)
+                                            }
+                                            return true
+                                        }
+                                        return false
+                                    }
+
                                     anchors.right: parent.right
                                     width: outputs.width
+
+                                    Connections {
+                                        target: outputs
+
+                                        function onParentPinsUpdated() {
+                                            visible = updateChildPin(modelData, outputs.parentPins, outputLoader.item)
+                                        }
+                                    }
 
                                     sourceComponent: AttributePin {
                                         id: outPin
                                         nodeItem: root
-                                        attribute: object
+                                        attribute: modelData
 
                                         property real globalX: root.x + nodeAttributes.x + outputs.x + outputLoader.x + outPin.x
                                         property real globalY: root.y + nodeAttributes.y + outputs.y + outputLoader.y + outPin.y
 
-                                        onPressed: function(mouse) { root.pressed(mouse) }
-                                        onEdgeAboutToBeRemoved: function(input) { root.edgeAboutToBeRemoved(input) }
+                                        onIsConnectedChanged: function() {
+                                            outputs.parentPinsUpdated()
+                                        }
+
+                                        onPressed: function(mouse) {
+                                            root.pressed(mouse)
+                                        }
+
+                                        onClicked: function() {
+                                            expanded = !expanded
+                                            if (outputs.parentPins.has(modelData.name)) {
+                                                outputs.parentPins.set(modelData.name, expanded)
+                                                outputs.parentPinsUpdated()
+                                            }
+                                        }
+
+                                        onEdgeAboutToBeRemoved: function(input) {
+                                            root.edgeAboutToBeRemoved(input)
+                                        }
 
                                         Component.onCompleted: attributePinCreated(attribute, outPin)
                                         onChildPinCreated: attributePinCreated(childAttribute, outPin)
@@ -572,28 +669,70 @@ Item {
                             width: parent.width
                             spacing: 3
 
+                            property var parentPins: new Map()
+                            signal parentPinsUpdated()
+
                             Repeater {
-                                model: node ? node.attributes : undefined
+                                model: root.generateAttributesModel(false, inputs.parentPins)  // isOutput = false
 
                                 delegate: Loader {
                                     id: inputLoader
-                                    active: !object.isOutput && object.exposed && object.desc.visible
-                                    visible: Boolean(object.enabled)
+
+                                    active: !modelData.isOutput && modelData.exposed && modelData.desc.visible
+                                    visible: {
+                                        if (Boolean(modelData.enabled)) {
+                                            if (modelData.root && modelData.root.baseType === "GroupAttribute") {
+                                                return Boolean(inputs.parentPins.get(modelData.root.name) ||
+                                                               modelData.hasAnyOutputLinks ||
+                                                               modelData.hasAnyInputLinks)
+                                            }
+                                            return true
+                                        }
+                                        return false
+                                    }
+
                                     width: inputs.width
+
+                                    Connections {
+                                        target: inputs
+
+                                        function onParentPinsUpdated() {
+                                            visible = updateChildPin(modelData, inputs.parentPins, inputLoader.item)
+                                        }
+                                    }
 
                                     sourceComponent: AttributePin {
                                         id: inPin
                                         nodeItem: root
-                                        attribute: object
+                                        attribute: modelData
 
                                         property real globalX: root.x + nodeAttributes.x + inputs.x + inputLoader.x + inPin.x
                                         property real globalY: root.y + nodeAttributes.y + inputs.y + inputLoader.y + inPin.y
 
+                                        onIsConnectedChanged: function() {
+                                            inputs.parentPinsUpdated()
+                                        }
+
                                         readOnly: Boolean(root.readOnly || object.isReadOnly)
                                         Component.onCompleted: attributePinCreated(attribute, inPin)
                                         Component.onDestruction: attributePinDeleted(attribute, inPin)
-                                        onPressed: function(mouse) { root.pressed(mouse) }
-                                        onEdgeAboutToBeRemoved: function(input) { root.edgeAboutToBeRemoved(input) }
+
+                                        onPressed: function(mouse) {
+                                            root.pressed(mouse)
+                                        }
+
+                                        onClicked: function() {
+                                            expanded = !expanded
+                                            if (inputs.parentPins.has(modelData.name)) {
+                                                inputs.parentPins.set(modelData.name, expanded)
+                                                inputs.parentPinsUpdated()
+                                            }
+                                        }
+
+                                        onEdgeAboutToBeRemoved: function(input) {
+                                            root.edgeAboutToBeRemoved(input)
+                                        }
+
                                         onChildPinCreated: function(childAttribute, inPin) { attributePinCreated(childAttribute, inPin) }
                                         onChildPinDeleted: function(childAttribute, inPin) { attributePinDeleted(childAttribute, inPin) }
                                     }
@@ -632,31 +771,78 @@ Item {
                                 id: inputParams
                                 width: parent.width
                                 spacing: 3
+
+                                property var parentPins: new Map()
+                                signal parentPinsUpdated()
+
                                 Repeater {
-                                    id: inputParamsRepeater
-                                    model: node ? node.attributes : undefined
+                                    model: root.generateAttributesModel(false, inputParams.parentPins)  // isOutput = false
+
                                     delegate: Loader {
                                         id: paramLoader
-                                        active: !object.isOutput && !object.exposed && object.desc.visible
-                                        visible: Boolean(object.enabled || object.hasAnyInputLinks || object.hasAnyOutputLinks)
-                                        property bool isFullyActive: Boolean(m.displayParams || object.hasAnyInputLinks || object.hasAnyOutputLinks)
+
+                                        active: !modelData.isOutput && !modelData.exposed && modelData.desc.visible
+                                        visible: {
+                                            if (Boolean(modelData.enabled || modelData.hasAnyOutputLinks || modelData.hasAnyInputLinks)) {
+                                                if (modelData.root && modelData.root.baseType === "GroupAttribute") {
+                                                    return Boolean(inputParams.parentPins.get(modelData.root.name) ||
+                                                                   modelData.hasAnyOutputLinks ||
+                                                                   modelData.hasAnyInputLinks)
+                                                }
+                                                return true
+                                            }
+                                            return false
+                                        }
+
+                                        property bool isFullyActive: Boolean(m.displayParams ||
+                                                                             modelData.hasAnyInputLinks ||
+                                                                             modelData.hasAnyOutputLinks)
                                         width: parent.width
+
+                                        Connections {
+                                            target: inputParams
+
+                                            function onParentPinsUpdated() {
+                                                visible = updateChildPin(modelData, inputParams.parentPins, paramLoader.item)
+                                            }
+                                        }
 
                                         sourceComponent: AttributePin {
                                             id: inParamsPin
                                             nodeItem: root
+                                            attribute: modelData
+
                                             property real globalX: root.x + nodeAttributes.x + inputParamsRect.x + paramLoader.x + inParamsPin.x
                                             property real globalY: root.y + nodeAttributes.y + inputParamsRect.y + paramLoader.y + inParamsPin.y
+
+                                            onIsConnectedChanged: function() {
+                                                inputParams.parentPinsUpdated()
+                                            }
 
                                             height: isFullyActive ? childrenRect.height : 0
                                             Behavior on height { PropertyAnimation {easing.type: Easing.Linear} }
                                             visible: (height == childrenRect.height)
-                                            attribute: object
-                                            readOnly: Boolean(root.readOnly || object.isReadOnly)
+
+                                            readOnly: Boolean(root.readOnly || modelData.isReadOnly)
                                             Component.onCompleted: attributePinCreated(attribute, inParamsPin)
                                             Component.onDestruction: attributePinDeleted(attribute, inParamsPin)
-                                            onPressed: function(mouse) { root.pressed(mouse) }
-                                            onEdgeAboutToBeRemoved: function(input) { root.edgeAboutToBeRemoved(input) }
+
+                                            onPressed: function(mouse) {
+                                                root.pressed(mouse)
+                                            }
+
+                                            onClicked: function() {
+                                                expanded = !expanded
+                                                if (inputParams.parentPins.has(modelData.name)) {
+                                                    inputParams.parentPins.set(modelData.name, expanded)
+                                                    inputParams.parentPinsUpdated()
+                                                }
+                                            }
+
+                                            onEdgeAboutToBeRemoved: function(input) {
+                                                root.edgeAboutToBeRemoved(input)
+                                            }
+
                                             onChildPinCreated: function(childAttribute, inParamsPin) { attributePinCreated(childAttribute, inParamsPin) }
                                             onChildPinDeleted: function(childAttribute, inParamsPin) { attributePinDeleted(childAttribute, inParamsPin) }
                                         }

--- a/meshroom/ui/qml/GraphEditor/Node.qml
+++ b/meshroom/ui/qml/GraphEditor/Node.qml
@@ -711,7 +711,7 @@ Item {
                                             inputs.parentPinsUpdated()
                                         }
 
-                                        readOnly: Boolean(root.readOnly || object.isReadOnly)
+                                        readOnly: Boolean(root.readOnly || modelData.isReadOnly)
                                         Component.onCompleted: attributePinCreated(attribute, inPin)
                                         Component.onDestruction: attributePinDeleted(attribute, inPin)
 

--- a/meshroom/ui/qml/GraphEditor/Node.qml
+++ b/meshroom/ui/qml/GraphEditor/Node.qml
@@ -242,11 +242,9 @@ Item {
          */
         if (Boolean(attribute.enabled)) {
             // If the parent is a GroupAttribute, use the status of the parent's pin to determine visibility
-            // UNLESS the child attribute is already connected
+            // UNLESS the child attribute is already connected with a visible edge
             if (attribute.root && attribute.root.baseType === "GroupAttribute") {
-                var visible = Boolean(parentPins.get(attribute.root.name) ||
-                                      attribute.hasAnyOutputLinks ||
-                                      attribute.hasAnyInputLinks)
+                var visible = Boolean(parentPins.get(attribute.root.name))
                 if (!visible && parentPins.has(attribute.name) && parentPins.get(attribute.name) === true) {
                     parentPins.set(attribute.name, false)
                     pin.expanded = false

--- a/meshroom/ui/qml/GraphEditor/NodeEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/NodeEditor.qml
@@ -402,6 +402,14 @@ Panel {
                             onAttributeDoubleClicked: function(mouse, attribute) { root.attributeDoubleClicked(mouse, attribute) }
                             onUpgradeRequest: root.upgradeRequest()
                             filterText: searchBar.text
+
+                            onInAttributeClicked: function(srcItem, mouse, inAttributes) {
+                                root.inAttributeClicked(srcItem, mouse, inAttributes)
+                            }
+
+                            onOutAttributeClicked: function(srcItem, mouse, outAttributes) {
+                                root.outAttributeClicked(srcItem, mouse, outAttributes)
+                            }
                         }
                     }
                 }

--- a/meshroom/ui/qml/MaterialIcons/MaterialToolLabel.qml
+++ b/meshroom/ui/qml/MaterialIcons/MaterialToolLabel.qml
@@ -9,27 +9,37 @@ import QtQuick.Layouts
 
 Item {
     id: control
+    property alias icon: iconItem
     property alias iconText: iconItem.text
     property alias iconSize: iconItem.font.pointSize
-    property alias label: labelItem.text
+    property alias label: labelItem
+    property alias labelIconRow: contentRow
+    property alias labelIconMouseArea: mouseArea
     property var labelIconColor: palette.text
     implicitWidth: childrenRect.width
     implicitHeight: childrenRect.height
-    anchors.rightMargin: 5
 
     RowLayout {
+        id: contentRow
+        // If we are fitting to a top container, we need to propagate the "anchors.fill: parent".
+        // Otherwise, the component defines its own size based on its children.
+        anchors.fill: control.anchors.fill ? parent : undefined
         Label {
             id: iconItem
             font.family: MaterialIcons.fontFamily
             font.pointSize: 13
             padding: 0
             text: ""
-            color: labelIconColor
+            color: control.labelIconColor
+            Layout.fillWidth: false
+            Layout.fillHeight: true
         }
         Label {
             id: labelItem
             text: ""
-            color: labelIconColor
+            color: control.labelIconColor
+            Layout.fillWidth: true
+            Layout.fillHeight: true
         }
     }
 

--- a/meshroom/ui/qml/Viewer3D/Inspector3D.qml
+++ b/meshroom/ui/qml/Viewer3D/Inspector3D.qml
@@ -241,7 +241,7 @@ FloatingPane {
 
                         MaterialToolLabel {
                             iconText: MaterialIcons.stop
-                            label: {
+                            label.text: {
                                 var id = undefined
                                 // Ensure there are entries in resectionGroups and a valid resectionId before accessing anything
                                 if (Viewer3DSettings.resectionId !== undefined && Viewer3DSettings.resectionGroups &&
@@ -259,7 +259,7 @@ FloatingPane {
 
                         MaterialToolLabel {
                             iconText: MaterialIcons.auto_awesome_motion
-                            label: {
+                            label.text: {
                                 let currentCameras = 0
                                 if (Viewer3DSettings.resectionGroups) {
                                     for (let i = 0; i <= Viewer3DSettings.resectionIdCount; i++) {
@@ -277,7 +277,7 @@ FloatingPane {
 
                         MaterialToolLabel {
                             iconText: MaterialIcons.videocam
-                            label: {
+                            label.text: {
                                 let totalCameras = 0
                                 if (Viewer3DSettings.resectionGroups) {
                                     for (let i = 0; i <= Viewer3DSettings.resectionIdCount; i++) {

--- a/tests/nodes/test/Color.py
+++ b/tests/nodes/test/Color.py
@@ -1,0 +1,39 @@
+from meshroom.core import desc
+
+
+class Color(desc.Node):
+    inputs = [
+        desc.GroupAttribute(
+            name="rgb",
+            label="rgb",
+            description="rgb",
+            exposed=True,
+            groupDesc=[
+                desc.FloatParam(name="r", label="r", description="r", value=0.0),
+                desc.FloatParam(name="g", label="g", description="g", value=0.0),
+                desc.FloatParam(name="b", label="b", description="b", value=0.0),
+            ],
+        ),
+    ]
+
+class NestedColor(desc.Node):
+    inputs = [
+        desc.GroupAttribute(
+            name="rgb",
+            label="rgb",
+            description="rgb",
+            exposed=True,
+            groupDesc=[
+                desc.FloatParam(name="r", label="r", description="r", value=0.0),
+                desc.FloatParam(name="g", label="g", description="g", value=0.0),
+                desc.FloatParam(name="b", label="b", description="b", value=0.0),
+                desc.GroupAttribute(label="test", name="test", description="",
+                    groupDesc=[
+                        desc.FloatParam(name="r", label="r", description="r", value=0.0),
+                        desc.FloatParam(name="g", label="g", description="g", value=0.0),
+                        desc.FloatParam(name="b", label="b", description="b", value=0.0),
+                    ],
+                ),
+            ],
+        ),
+    ]

--- a/tests/nodes/test/GroupAttributes.py
+++ b/tests/nodes/test/GroupAttributes.py
@@ -1,0 +1,152 @@
+from meshroom.core import desc
+
+
+class GroupAttributes(desc.Node):
+    documentation = """ Test node to connect GroupAttributes to other GroupAttributes. """
+
+    # Inputs to the node
+    inputs = [
+        desc.GroupAttribute(
+            name="firstGroup",
+            label="First Group",
+            description="Group at the root level.",
+            group=None,
+            exposed=True,
+            groupDesc=[
+                desc.IntParam(
+                    name="firstGroupIntA",
+                    label="Integer A",
+                    description="First integer in group.",
+                    value=1024,
+                    range=(-1, 2000, 10),
+                    exposed=True,
+                ),
+                desc.BoolParam(
+                    name="firstGroupBool",
+                    label="Boolean",
+                    description="Boolean in group.",
+                    value=True,
+                    advanced=True,
+                    exposed=True,
+                ),
+                desc.ChoiceParam(
+                    name="firstGroupExclusiveChoiceParam",
+                    label="Exclusive Choice Param",
+                    description="Exclusive choice parameter.",
+                    value="one",
+                    values=["one", "two", "three", "four"],
+                    exclusive=True,
+                    exposed=True,
+                ),
+                desc.ChoiceParam(
+                    name="firstGroupChoiceParam",
+                    label="ChoiceParam",
+                    description="Non-exclusive choice parameter.",
+                    value=["one", "two"],
+                    values=["one", "two", "three", "four"],
+                    exclusive=False,
+                    exposed=True
+                ),
+                desc.GroupAttribute(
+                    name="nestedGroup",
+                    label="Nested Group",
+                    description="A group within a group.",
+                    group=None,
+                    exposed=True,
+                    groupDesc=[
+                        desc.FloatParam(
+                            name="nestedGroupFloat",
+                            label="Floating Number",
+                            description="Floating number in group.",
+                            value=1.0,
+                            range=(0.0, 100.0, 0.01),
+                            exposed=True
+                        ),
+                    ],
+                ),
+                desc.ListAttribute(
+                    name="groupedList",
+                    label="Grouped List",
+                    description="List of groups within a group.",
+                    advanced=True,
+                    exposed=True,
+                    elementDesc=desc.GroupAttribute(
+                        name="listedGroup",
+                        label="Listed Group",
+                        description="Group in a list within a group.",
+                        joinChar=":",
+                        group=None,
+                        groupDesc=[
+                            desc.IntParam(
+                                name="listedGroupInt",
+                                label="Integer 1",
+                                description="Integer in a group in a list within a group.",
+                                value=12,
+                                range=(3, 24, 1),
+                                exposed=True,
+                            ),
+                        ],
+                    ),
+                ),
+                desc.ListAttribute(
+                    name="singleGroupedList",
+                    label="Grouped List With Single Element",
+                    description="List of integers within a group.",
+                    advanced=True,
+                    exposed=True,
+                    elementDesc=desc.IntParam(
+                        name="listedInt",
+                        label="Integer In List",
+                        description="Integer in a list within a group.",
+                        value=40,
+                    ),
+                ),
+            ],
+        ),
+        desc.IntParam(
+            name="exposedInt",
+            label="Exposed Integer",
+            description="Integer at the rool level, exposed.",
+            value=1000,
+            exposed=True,
+        ),
+        desc.BoolParam(
+            name="unexposedBool",
+            label="Unexposed Boolean",
+            description="Boolean at the root level, unexposed.",
+            value=True,
+        ),
+        desc.GroupAttribute(
+            name="inputGroup",
+            label="Input Group",
+            description="A group set as an input.",
+            group=None,
+            groupDesc=[
+                desc.BoolParam(
+                    name="inputBool",
+                    label="Input Bool",
+                    description="",
+                    value=False,
+                ),
+            ],
+        ),
+    ]
+
+    outputs = [
+        desc.GroupAttribute(
+            name="outputGroup",
+            label="Output Group",
+            description="A group set as an output.",
+            group=None,
+            exposed=True,
+            groupDesc=[
+                desc.BoolParam(
+                    name="outputBool",
+                    label="Output Bool",
+                    description="",
+                    value=False,
+                    exposed=True,
+                ),
+            ],
+        ),
+    ]

--- a/tests/nodes/test/GroupAttributes.py
+++ b/tests/nodes/test/GroupAttributes.py
@@ -106,7 +106,7 @@ class GroupAttributes(desc.Node):
         desc.IntParam(
             name="exposedInt",
             label="Exposed Integer",
-            description="Integer at the rool level, exposed.",
+            description="Integer at the root level, exposed.",
             value=1000,
             exposed=True,
         ),

--- a/tests/nodes/test/NestedTest.py
+++ b/tests/nodes/test/NestedTest.py
@@ -1,0 +1,24 @@
+from meshroom.core import desc
+
+
+class NestedTest(desc.Node):
+    inputs = [
+        desc.GroupAttribute(
+            name="xyz",
+            label="xyz",
+            description="xyz",
+            exposed=True,
+            groupDesc=[
+                desc.FloatParam(name="x", label="x", description="x", value=0.0),
+                desc.FloatParam(name="y", label="z", description="z", value=0.0),
+                desc.FloatParam(name="z", label="z", description="z", value=0.0),
+                desc.GroupAttribute(label="test", name="test", description="",
+                    groupDesc=[
+                        desc.StringParam(name="x", label="x", description="x", value="test"),
+                        desc.FloatParam(name="y", label="z", description="z", value=0.0),
+                        desc.FloatParam(name="z", label="z", description="z", value=0.0),
+                    ],
+                ),
+            ],
+        ),
+    ]

--- a/tests/nodes/test/Position.py
+++ b/tests/nodes/test/Position.py
@@ -1,0 +1,39 @@
+from meshroom.core import desc
+
+
+class Position(desc.Node):
+    inputs = [
+        desc.GroupAttribute(
+            name="xyz",
+            label="xyz",
+            description="xyz",
+            exposed=True,
+            groupDesc=[
+                desc.FloatParam(name="x", label="x", description="x", value=0.0),
+                desc.FloatParam(name="y", label="y", description="y", value=0.0),
+                desc.FloatParam(name="z", label="z", description="z", value=0.0),
+            ],
+        ),
+    ]
+
+class NestedPosition(desc.Node):
+    inputs = [
+        desc.GroupAttribute(
+            name="xyz",
+            label="xyz",
+            description="xyz",
+            exposed=True,
+            groupDesc=[
+                desc.FloatParam(name="x", label="x", description="x", value=0.0),
+                desc.FloatParam(name="y", label="y", description="y", value=0.0),
+                desc.FloatParam(name="z", label="z", description="z", value=0.0),
+                desc.GroupAttribute(label="test", name="test", description="",
+                    groupDesc=[
+                        desc.FloatParam(name="x", label="x", description="x", value=0.0),
+                        desc.FloatParam(name="y", label="y", description="y", value=0.0),
+                        desc.FloatParam(name="z", label="z", description="z", value=0.0),
+                    ],
+                ),
+            ],
+        ),
+    ]

--- a/tests/test_attributeChoiceParam.py
+++ b/tests/test_attributeChoiceParam.py
@@ -100,7 +100,7 @@ class TestChoiceParam:
         nodeA = graph.addNewNode(NodeWithChoiceParams.__name__)
         nodeB = graph.addNewNode(NodeWithChoiceParams.__name__)
         nodeA.choice.values = ["D", "E", "F"]
-        graph.addEdge(nodeA.choice, nodeB.choice)
+        nodeA.choice.connectTo(nodeB.choice)
 
         assert nodeB.choice.values == ["D", "E", "F"]
 
@@ -108,8 +108,8 @@ class TestChoiceParam:
         graph: Graph = graphSavedOnDisk
         nodeA = graph.addNewNode(NodeWithChoiceParams.__name__)
         nodeB = graph.addNewNode(NodeWithChoiceParams.__name__)
-        graph.addEdge(nodeA.choice, nodeB.choice)
-        graph.addEdge(nodeA.choiceMulti, nodeB.choiceMulti)
+        nodeA.choice.connectTo(nodeB.choice)
+        nodeA.choiceMulti.connectTo(nodeB.choiceMulti)
 
         graph.save()
 
@@ -160,8 +160,8 @@ class TestChoiceParamSavingCustomValues:
         graph: Graph = graphSavedOnDisk
         nodeA = graph.addNewNode(NodeWithChoiceParamsSavingValuesOverride.__name__)
         nodeB = graph.addNewNode(NodeWithChoiceParamsSavingValuesOverride.__name__)
-        graph.addEdge(nodeA.choice, nodeB.choice)
-        graph.addEdge(nodeA.choiceMulti, nodeB.choiceMulti)
+        nodeA.choice.connectTo(nodeB.choice)
+        nodeA.choiceMulti.connectTo(nodeB.choiceMulti)
 
         graph.save()
 

--- a/tests/test_attributeKeyValues.py
+++ b/tests/test_attributeKeyValues.py
@@ -220,7 +220,7 @@ class TestKeyableAttribute:
 
         # Add link:
         # nodeB.keyableInt is a link for nodeA.keyableInt
-        graph.addEdge(nodeA.keyableInt, nodeB.keyableInt)
+        nodeA.keyableInt.connectTo(nodeB.keyableInt)
 
         # Check link
         assert nodeB.keyableInt.isLink == True

--- a/tests/test_attributeShape.py
+++ b/tests/test_attributeShape.py
@@ -384,9 +384,9 @@ class TestShapeAttribute:
 
         # Add link:
         # nodeB.pointList is a link for nodeA.pointList
-        graph.addEdge(nodeA.pointList, nodeB.pointList)
+        nodeA.pointList.connectTo(nodeB.pointList)
         # nodeB.point is a link for nodeA.point
-        graph.addEdge(nodeA.point, nodeB.point)
+        nodeA.point.connectTo(nodeB.point)
 
         # Check link
         assert nodeB.pointList.isLink == True

--- a/tests/test_compatibility.py
+++ b/tests/test_compatibility.py
@@ -596,7 +596,7 @@ class TestUidConflict:
             nodeB = graph.addNewNode(UidTestingNodeV2.__name__)
 
             nodeB.param.append("")
-            graph.addEdge(nodeA.output, nodeB.param.at(0))
+            nodeA.output.connectTo(nodeB.param.at(0))
 
             graph.save()
             replaceNodeTypeDesc(UidTestingNodeV2.__name__, UidTestingNodeV3)
@@ -617,8 +617,8 @@ class TestUidConflict:
 
             # Double-connect nodeA.output to nodeB, on both a single attribute and a list attribute
             nodeB.param.append("")
-            graph.addEdge(nodeA.output, nodeB.param.at(0))
-            graph.addEdge(nodeA.output, nodeB.input)
+            nodeA.output.connectTo(nodeB.param.at(0))
+            nodeA.output.connectTo(nodeB.input)
 
             graph.save()
             replaceNodeTypeDesc(UidTestingNodeV2.__name__, UidTestingNodeV3)
@@ -647,7 +647,7 @@ class TestUidConflict:
             nodeA = graph.addNewNode(UidTestingNodeV2.__name__)
             nodeB = graph.addNewNode(UidTestingNodeV1.__name__)
 
-            graph.addEdge(nodeA.output, nodeB.input)
+            nodeA.output.connectTo(nodeB.input)
 
             graph.save()
             replaceNodeTypeDesc(UidTestingNodeV2.__name__, UidTestingNodeV3)
@@ -663,7 +663,7 @@ class TestUidConflict:
             nodeB = graph.addNewNode(UidTestingNodeV3.__name__)
 
             nodeB.param.append("")
-            graph.addEdge(nodeA.output, nodeB.param.at(0))
+            nodeA.output.connectTo(nodeB.param.at(0))
 
             graph.save()
             replaceNodeTypeDesc(UidTestingNodeV2.__name__, UidTestingNodeV3)

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -1,4 +1,7 @@
+from meshroom.core.exception import CyclicDependencyError
 from meshroom.core.graph import Graph
+
+import pytest
 
 
 def test_depth():
@@ -8,10 +11,8 @@ def test_depth():
     tB = graph.addNewNode("AppendText", inputText="echo B")
     tC = graph.addNewNode("AppendText", inputText="echo C")
 
-    graph.addEdges(
-        (tA.output, tB.input),
-        (tB.output, tC.input),
-        )
+    tA.output.connectTo(tB.input)
+    tB.output.connectTo(tC.input)
 
     assert tA.depth == 0
     assert tB.depth == 1
@@ -26,12 +27,10 @@ def test_depth_diamond_graph():
     tC = graph.addNewNode("AppendText", inputText="echo C")
     tD = graph.addNewNode("AppendFiles")
 
-    graph.addEdges(
-        (tA.output, tB.input),
-        (tA.output, tC.input),
-        (tB.output, tD.input),
-        (tC.output, tD.input2),
-    )
+    tA.output.connectTo(tB.input)
+    tA.output.connectTo(tC.input)
+    tB.output.connectTo(tD.input)
+    tC.output.connectTo(tD.input2)
 
     assert tA.depth == 0
     assert tB.depth == 1
@@ -72,16 +71,13 @@ def test_depth_diamond_graph2():
     #      \     /
     #       \   /
     #         D
-    graph.addEdges(
-        (tA.output, tB.input),
-        (tB.output, tC.input),
-        (tB.output, tD.input),
-
-        (tA.output, tE.input),
-        (tB.output, tE.input2),
-        (tC.output, tE.input3),
-        (tD.output, tE.input4),
-    )
+    tA.output.connectTo(tB.input)
+    tB.output.connectTo(tC.input)
+    tB.output.connectTo(tD.input)
+    tA.output.connectTo(tE.input)
+    tB.output.connectTo(tE.input2)
+    tC.output.connectTo(tE.input3)
+    tD.output.connectTo(tE.input4)
 
     assert tA.depth == 0
     assert tB.depth == 1
@@ -130,17 +126,13 @@ def test_transitive_reduction():
     #      \     /
     #       \   /
     #         D
-    graph.addEdges(
-        (tA.output, tE.input),
-
-        (tA.output, tB.input),
-        (tB.output, tC.input),
-        (tB.output, tD.input),
-
-        (tB.output, tE.input4),
-        (tC.output, tE.input3),
-        (tD.output, tE.input2),
-    )
+    tA.output.connectTo(tE.input)
+    tA.output.connectTo(tB.input)
+    tB.output.connectTo(tC.input)
+    tB.output.connectTo(tD.input)
+    tB.output.connectTo(tE.input4)
+    tC.output.connectTo(tE.input3)
+    tD.output.connectTo(tE.input2)
 
     flowEdges = graph.flowEdges()
     flowEdgesRes = [(tB, tA),

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -270,3 +270,18 @@ def test_duplicate_nodes():
     assert nMap[n2][0].input.inputLink == nMap[n1][0].output
     assert nMap[n3][0].input.inputLink == nMap[n1][0].output
     assert nMap[n3][0].input2.inputLink == nMap[n2][0].output
+
+
+def test_cyclic_connection_should_raise_error():
+
+    # Given
+    graph = Graph("Test cyclic connection")
+    tB = graph.addNewNode("AppendText", inputText="echo B")
+    tC = graph.addNewNode("AppendText", inputText="echo C")
+
+    tB.output.connectTo(tC.input)
+
+    # When
+    # Then
+    with pytest.raises(CyclicDependencyError):
+        tC.output.connectTo(tB.input)

--- a/tests/test_graphIO.py
+++ b/tests/test_graphIO.py
@@ -102,7 +102,7 @@ class TestImportGraphContent:
             nodeA_1 = graph.addNewNode(SimpleNode.__name__)
             nodeA_2 = graph.addNewNode(SimpleNode.__name__)
 
-            graph.addEdge(nodeA_1.output, nodeA_2.input)
+            nodeA_1.output.connectTo(nodeA_2.input)
 
             otherGraph = Graph("")
             otherGraph.importGraphContent(graph)
@@ -115,7 +115,7 @@ class TestImportGraphContent:
             nodeA_1 = graph.addNewNode(SimpleNode.__name__)
             nodeA_2 = graph.addNewNode(SimpleNode.__name__)
 
-            graph.addEdge(nodeA_1.output, nodeA_2.input)
+            nodeA_1.output.connectTo(nodeA_2.input)
 
             otherGraph = Graph("")
             otherGraph.importGraphContent(graph)
@@ -128,7 +128,7 @@ class TestImportGraphContent:
             nodeA_1 = graph.addNewNode(SimpleNode.__name__)
             nodeA_2 = graph.addNewNode(SimpleNode.__name__)
 
-            graph.addEdge(nodeA_1.output, nodeA_2.input)
+            nodeA_1.output.connectTo(nodeA_2.input)
 
         otherGraph = Graph("")
         otherGraph.importGraphContent(graph)
@@ -157,7 +157,7 @@ class TestImportGraphContent:
             nodeA_1 = graph.addNewNode(SimpleNode.__name__)
             nodeA_2 = graph.addNewNode(SimpleNode.__name__)
 
-            graph.addEdge(nodeA_1.output, nodeA_2.input)
+            nodeA_1.output.connectTo(nodeA_2.input)
 
             graph.importGraphContent(graph)
 
@@ -170,7 +170,7 @@ class TestImportGraphContent:
             nodeA_1 = graph.addNewNode(SimpleNode.__name__)
             nodeA_2 = graph.addNewNode(SimpleNode.__name__)
 
-            graph.addEdge(nodeA_1.output, nodeA_2.input)
+            nodeA_1.output.connectTo(nodeA_2.input)
             graph.save()
 
             otherGraph = Graph("")
@@ -187,7 +187,7 @@ class TestImportGraphContent:
             nodeA_1 = graph.addNewNode(SimpleNode.__name__)
             nodeA_2 = graph.addNewNode(SimpleNode.__name__)
 
-            graph.addEdge(nodeA_1.output, nodeA_2.input)
+            nodeA_1.output.connectTo(nodeA_2.input)
             graph.save()
 
         otherGraph = Graph("")
@@ -230,7 +230,7 @@ class TestGraphPartialSerialization:
             nodeA = graph.addNewNode(SimpleNode.__name__)
             nodeB = graph.addNewNode(SimpleNode.__name__)
 
-            graph.addEdge(nodeA.output, nodeB.input)
+            nodeA.output.connectTo(nodeB.input)
 
             partialSerializedGraph = graph.serializePartial([nodeA, nodeB])
             standardSerializedGraph = graph.serialize()
@@ -251,7 +251,7 @@ class TestGraphPartialSerialization:
             nodeA = graph.addNewNode(NodeWithListAttributes.__name__)
             nodeB = graph.addNewNode(NodeWithListAttributes.__name__)
 
-            graph.addEdge(nodeA.listInput, nodeB.listInput)
+            nodeA.listInput.connectTo(nodeB.listInput)
 
             otherGraph = Graph("")
             otherGraph._deserialize(graph.serializePartial([nodeA, nodeB]))
@@ -266,7 +266,7 @@ class TestGraphPartialSerialization:
             nodeA = graph.addNewNode(SimpleNode.__name__)
             nodeB = graph.addNewNode(SimpleNode.__name__)
 
-            graph.addEdge(nodeA.output, nodeB.input)
+            nodeA.output.connectTo(nodeB.input)
 
             serializedGraph = graph.serializePartial([nodeB])
 
@@ -285,7 +285,7 @@ class TestGraphPartialSerialization:
             nodeB = graph.addNewNode(NodeWithListAttributes.__name__)
 
             nodeB.listInput.append("")
-            graph.addEdge(nodeA.output, nodeB.listInput.at(0))
+            nodeA.output.connectTo(nodeB.listInput.at(0))
 
             otherGraph = Graph("")
             otherGraph._deserialize(graph.serializePartial([nodeB]))
@@ -300,7 +300,7 @@ class TestGraphPartialSerialization:
             nodeB = graph.addNewNode(NodeWithListAttributes.__name__)
 
             nodeB.group.listInput.append("")
-            graph.addEdge(nodeA.output, nodeB.group.listInput.at(0))
+            nodeA.output.connectTo(nodeB.group.listInput.at(0))
 
             otherGraph = Graph("")
             otherGraph._deserialize(graph.serializePartial([nodeB]))
@@ -316,7 +316,7 @@ class TestGraphCopy:
             nodeA = graph.addNewNode(SimpleNode.__name__)
             nodeB = graph.addNewNode(SimpleNode.__name__)
 
-            graph.addEdge(nodeA.output, nodeB.input)
+            nodeA.output.connectTo(nodeB.input)
 
             graphCopy = graph.copy()
             assert compareGraphsContent(graph, graphCopy)
@@ -328,7 +328,7 @@ class TestGraphCopy:
             nodeA = graph.addNewNode(SimpleNode.__name__)
             nodeB = graph.addNewNode(SimpleNode.__name__)
 
-            graph.addEdge(nodeA.output, nodeB.input)
+            nodeA.output.connectTo(nodeB.input)
 
         graphCopy = graph.copy()
         assert not compareGraphsContent(graph, graphCopy)

--- a/tests/test_groupAttributes.py
+++ b/tests/test_groupAttributes.py
@@ -279,3 +279,26 @@ class TestGroupAttributes:
             nestedPosition.xyz.test.y.inputLink.asLinkExpr() == nestedColor.rgb.test.g.asLinkExpr()
         assert nestedPosition.xyz.test.z.isLink and \
             nestedPosition.xyz.test.z.inputLink.asLinkExpr() == r.asLinkExpr() == nestedColor.rgb.r.asLinkExpr()
+
+
+    def test_connectGroupSubAttributesByValue(self):
+        """
+        Check that sub-attributes are connected by value and not by reference. When connected to another sub-attribute
+        through a group connection, a given sub-attribute should have an address that differs from the incoming sub-attribute.
+        """
+        graph = Graph()
+        groupA = graph.addNewNode("GroupAttributes")
+        groupB = graph.addNewNode("GroupAttributes")
+
+        groupA.firstGroup.firstGroupIntA.value = 1234
+        assert groupA.firstGroup.firstGroupIntA.value != groupB.firstGroup.firstGroupIntA.value
+
+        # Connect the groups
+        groupA.firstGroup.connectTo(groupB.firstGroup)
+
+        subAttributeA = groupA.firstGroup.firstGroupIntA
+        subAttributeB = groupB.firstGroup.firstGroupIntA
+        assert subAttributeA != subAttributeB
+        assert subAttributeB.isLink
+        assert subAttributeA.fullName != subAttributeB.fullName
+        assert groupA.firstGroup.firstGroupIntA.value == groupB.firstGroup.firstGroupIntA.value == 1234

--- a/tests/test_groupAttributes.py
+++ b/tests/test_groupAttributes.py
@@ -3,7 +3,6 @@
 
 import os
 import tempfile
-import math
 
 from meshroom.core.graph import Graph, loadGraph
 from meshroom.core.node import CompatibilityNode
@@ -144,7 +143,7 @@ class TestGroupAttributes:
         acceptedConnection = nestedPosition.xyz.validateIncomingConnection(nestedColor.rgb)
 
         # Then
-        assert acceptedConnection == True
+        assert acceptedConnection
 
 
     def test_groupAttributesWithDifferentStructures(self):
@@ -160,7 +159,7 @@ class TestGroupAttributes:
         acceptedConnection = nestedPosition.xyz.validateIncomingConnection(nestedTest.xyz)
 
         # Then
-        assert acceptedConnection == False
+        assert not acceptedConnection
 
 
     def test_connectGroupsWithSubAttributes(self):
@@ -210,6 +209,8 @@ class TestGroupAttributes:
 
         # Reload the graph
         graph = loadGraph(graphFile)
+        nestedPosition = graph.node("NestedPosition_1")
+        nestedColor = graph.node("NestedColor_1")
 
         assert nestedPosition.xyz.isLink and \
             nestedPosition.xyz.inputLink.asLinkExpr() == nestedColor.rgb.asLinkExpr()

--- a/tests/test_groupAttributes.py
+++ b/tests/test_groupAttributes.py
@@ -1,0 +1,281 @@
+#!/usr/bin/env python
+# coding:utf-8
+
+import os
+import tempfile
+import math
+
+from meshroom.core.graph import Graph, loadGraph
+from meshroom.core.node import CompatibilityNode
+from meshroom.core.attribute import GroupAttribute
+
+# 1 int, 1 exclusive choice param, 1 choice param, 1 bool, 1 group, 1 float nested in the group, 2 lists
+GROUPATTRIBUTES_FIRSTGROUP_NB_CHILDREN = 8
+
+GROUPATTRIBUTES_FIRSTGROUP_NESTED_NB_CHILDREN = 1  # 1 float
+GROUPATTRIBUTES_OUTPUTGROUP_NB_CHILDREN = 1  # 1 bool
+GROUPATTRIBUTES_FIRSTGROUP_DEPTHS = [1, 1, 1, 1, 1, 2, 1, 1]
+
+
+class TestGroupAttributes:
+    def test_saveLoadGroupDirectConnections(self):
+        """
+        Ensure that connecting GroupAttributes does not cause their nodes to have CompatibilityIssues
+        when re-opening them.
+        """
+        graph = Graph("Connections between GroupAttributes")
+
+        # Create two "GroupAttributes" nodes with their default parameters
+        nodeA = graph.addNewNode("GroupAttributes")
+        nodeB = graph.addNewNode("GroupAttributes")
+
+        # Connect attributes within groups at different depth levels
+        nodeA.firstGroup.connectTo(nodeB.firstGroup)
+
+        # Save the graph in a file
+        graphFile = os.path.join(tempfile.mkdtemp(), "test_io_group_connections.mg")
+        graph.save(graphFile)
+
+        # Reload the graph
+        graph = loadGraph(graphFile)
+
+        assert graph.node("GroupAttributes_2").firstGroup.inputLink == graph.node("GroupAttributes_1").firstGroup
+
+
+    def test_saveLoadGroupConnections(self):
+        """
+        Ensure that connecting attributes that are part of GroupAttributes does not cause their nodes to have
+        CompatibilityIssues when re-opening them.
+        """
+        graph = Graph("Connections between subattributes in GroupAttributes")
+
+        # Create two "GroupAttributes" nodes with their default parameters
+        nodeA = graph.addNewNode("GroupAttributes")
+        nodeB = graph.addNewNode("GroupAttributes")
+
+        # Connect attributes within groups at different depth levels
+        nodeA.firstGroup.firstGroupIntA.connectTo(nodeB.firstGroup.firstGroupIntA)
+        nodeA.firstGroup.nestedGroup.nestedGroupFloat.connectTo(
+            nodeB.firstGroup.nestedGroup.nestedGroupFloat)
+
+        # Save the graph in a file
+        graphFile = os.path.join(tempfile.mkdtemp(), "test_io_group_connections.mg")
+        graph.save(graphFile)
+
+        # Reload the graph
+        graph = loadGraph(graphFile)
+
+        # Ensure the nodes are not CompatibilityNodes
+        for node in graph.nodes:
+            assert not isinstance(node, CompatibilityNode)
+
+
+    def test_groupAttributesFlatChildren(self):
+        """
+        Check that the list of static flat children is correct, even with list elements.
+        """
+        graph = Graph("Children of GroupAttributes")
+
+        # Create two "GroupAttributes" nodes with their default parameters
+        node = graph.addNewNode("GroupAttributes")
+
+        intAttr = node.attribute("exposedInt")
+        assert not isinstance(intAttr, GroupAttribute)
+        assert len(intAttr.flatStaticChildren) == 0  # Not a Group, cannot have any child
+
+        inputGroup = node.attribute("firstGroup")
+        assert isinstance(inputGroup, GroupAttribute)
+        assert len(inputGroup.flatStaticChildren) == GROUPATTRIBUTES_FIRSTGROUP_NB_CHILDREN
+
+        # Add an element to a list within the group and check the number of children hasn't changed
+        groupedList = node.attribute("firstGroup.singleGroupedList")
+        groupedList.insert(0, 30)
+        assert len(groupedList.flatStaticChildren) == 0  # Not a Group, elements are not counted as children
+        assert len(inputGroup.flatStaticChildren) == GROUPATTRIBUTES_FIRSTGROUP_NB_CHILDREN
+
+        nestedGroup = node.attribute("firstGroup.nestedGroup")
+        assert isinstance(nestedGroup, GroupAttribute)
+        assert len(nestedGroup.flatStaticChildren) == GROUPATTRIBUTES_FIRSTGROUP_NESTED_NB_CHILDREN
+
+        outputGroup = node.attribute("outputGroup")
+        assert isinstance(outputGroup, GroupAttribute)
+        assert len(outputGroup.flatStaticChildren) == GROUPATTRIBUTES_OUTPUTGROUP_NB_CHILDREN
+
+
+    def test_groupAttributesDepthLevels(self):
+        """
+        Check that the depth level of children attributes is correctly set.
+        """
+        graph = Graph("Children of GroupAttributes")
+
+        # Create two "GroupAttributes" nodes with their default parameters
+        node = graph.addNewNode("GroupAttributes")
+        inputGroup = node.attribute("firstGroup")
+        assert isinstance(inputGroup, GroupAttribute)
+        assert inputGroup.depth == 0  # Root level
+
+        cnt = 0
+        for child in inputGroup.flatStaticChildren:
+            assert child.depth == GROUPATTRIBUTES_FIRSTGROUP_DEPTHS[cnt]
+            cnt = cnt + 1
+
+        outputGroup = node.attribute("outputGroup")
+        assert isinstance(outputGroup, GroupAttribute)
+        assert outputGroup.depth == 0
+        for child in outputGroup.flatStaticChildren:  # Single element in the group
+            assert child.depth == 1
+
+
+        intAttr = node.attribute("exposedInt")
+        assert not isinstance(intAttr, GroupAttribute)
+        assert intAttr.depth == 0
+
+
+    def test_groupAttributesWithMatchingStructure(self):
+        """
+        Check that two different GroupAttributes can be connected if they have a matching structure.
+        """
+        # Given
+        graph = Graph()
+        nestedPosition = graph.addNewNode("NestedPosition")
+        nestedColor = graph.addNewNode("NestedColor")
+
+        # When
+        acceptedConnection = nestedPosition.xyz.validateIncomingConnection(nestedColor.rgb)
+
+        # Then
+        assert acceptedConnection == True
+
+
+    def test_groupAttributesWithDifferentStructures(self):
+        """
+        Check that two different GroupAttributes cannot be connected if they have different structures.
+        """
+        # Given
+        graph = Graph()
+        nestedPosition = graph.addNewNode("NestedPosition")
+        nestedTest = graph.addNewNode("NestedTest")
+
+        # When
+        acceptedConnection = nestedPosition.xyz.validateIncomingConnection(nestedTest.xyz)
+
+        # Then
+        assert acceptedConnection == False
+
+
+    def test_connectGroupsWithSubAttributes(self):
+        """
+        Check that when a group is connected to another group, all the sub-attributes are connected
+        together automatically.
+        """
+        # Given
+        graph = Graph()
+
+        nestedColor = graph.addNewNode("NestedColor")
+        nestedPosition = graph.addNewNode("NestedPosition")
+
+        assert not nestedPosition.xyz.isLink
+        assert not nestedPosition.xyz.x.isLink
+        assert not nestedPosition.xyz.y.isLink
+        assert not nestedPosition.xyz.z.isLink
+        assert not nestedPosition.xyz.test.isLink
+        assert not nestedPosition.xyz.test.x.isLink
+        assert not nestedPosition.xyz.test.y.isLink
+        assert not nestedPosition.xyz.test.z.isLink
+
+        # When
+        nestedColor.rgb.connectTo(nestedPosition.xyz)
+
+        # Then
+        assert nestedPosition.xyz.isLink and \
+            nestedPosition.xyz.inputLink.asLinkExpr() == nestedColor.rgb.asLinkExpr()
+        assert nestedPosition.xyz.x.isLink and \
+            nestedPosition.xyz.x.inputLink.asLinkExpr() == nestedColor.rgb.r.asLinkExpr()
+        assert nestedPosition.xyz.y.isLink and \
+            nestedPosition.xyz.y.inputLink.asLinkExpr() == nestedColor.rgb.g.asLinkExpr()
+        assert nestedPosition.xyz.z.isLink and \
+            nestedPosition.xyz.z.inputLink.asLinkExpr() == nestedColor.rgb.b.asLinkExpr()
+        assert nestedPosition.xyz.test.isLink and \
+            nestedPosition.xyz.test.inputLink.asLinkExpr() == nestedColor.rgb.test.asLinkExpr()
+        assert nestedPosition.xyz.test.x.isLink and \
+            nestedPosition.xyz.test.x.inputLink.asLinkExpr() == nestedColor.rgb.test.r.asLinkExpr()
+        assert nestedPosition.xyz.test.y.isLink and \
+            nestedPosition.xyz.test.y.inputLink.asLinkExpr() == nestedColor.rgb.test.g.asLinkExpr()
+        assert nestedPosition.xyz.test.z.isLink and \
+            nestedPosition.xyz.test.z.inputLink.asLinkExpr() == nestedColor.rgb.test.b.asLinkExpr()
+
+        # Save the graph in a file
+        graphFile = os.path.join(tempfile.mkdtemp(), "test_io_group_connections.mg")
+        graph.save(graphFile)
+
+        # Reload the graph
+        graph = loadGraph(graphFile)
+
+        assert nestedPosition.xyz.isLink and \
+            nestedPosition.xyz.inputLink.asLinkExpr() == nestedColor.rgb.asLinkExpr()
+        assert nestedPosition.xyz.x.isLink and \
+            nestedPosition.xyz.x.inputLink.asLinkExpr() == nestedColor.rgb.r.asLinkExpr()
+        assert nestedPosition.xyz.y.isLink and \
+            nestedPosition.xyz.y.inputLink.asLinkExpr() == nestedColor.rgb.g.asLinkExpr()
+        assert nestedPosition.xyz.z.isLink and \
+            nestedPosition.xyz.z.inputLink.asLinkExpr() == nestedColor.rgb.b.asLinkExpr()
+        assert nestedPosition.xyz.test.isLink and \
+            nestedPosition.xyz.test.inputLink.asLinkExpr() == nestedColor.rgb.test.asLinkExpr()
+        assert nestedPosition.xyz.test.x.isLink and \
+            nestedPosition.xyz.test.x.inputLink.asLinkExpr() == nestedColor.rgb.test.r.asLinkExpr()
+        assert nestedPosition.xyz.test.y.isLink and \
+            nestedPosition.xyz.test.y.inputLink.asLinkExpr() == nestedColor.rgb.test.g.asLinkExpr()
+        assert nestedPosition.xyz.test.z.isLink and \
+            nestedPosition.xyz.test.z.inputLink.asLinkExpr() == nestedColor.rgb.test.b.asLinkExpr()
+
+
+    def test_connectSubAttributes(self):
+        """
+        After a group has been connected to another group, connecting individually a sub-attribute
+        should disconnect the group itself.
+        """
+        # Given
+        graph = Graph()
+
+        nestedColor = graph.addNewNode("NestedColor")
+        nestedPosition = graph.addNewNode("NestedPosition")
+
+        nestedColor.rgb.connectTo(nestedPosition.xyz)
+
+        assert nestedPosition.xyz.isLink and \
+            nestedPosition.xyz.inputLink.asLinkExpr() == nestedColor.rgb.asLinkExpr()
+        assert nestedPosition.xyz.x.isLink and \
+            nestedPosition.xyz.x.inputLink.asLinkExpr() == nestedColor.rgb.r.asLinkExpr()
+        assert nestedPosition.xyz.y.isLink and \
+            nestedPosition.xyz.y.inputLink.asLinkExpr() == nestedColor.rgb.g.asLinkExpr()
+        assert nestedPosition.xyz.z.isLink and \
+            nestedPosition.xyz.z.inputLink.asLinkExpr() == nestedColor.rgb.b.asLinkExpr()
+        assert nestedPosition.xyz.test.isLink and \
+            nestedPosition.xyz.test.inputLink.asLinkExpr() == nestedColor.rgb.test.asLinkExpr()
+        assert nestedPosition.xyz.test.x.isLink and \
+            nestedPosition.xyz.test.x.inputLink.asLinkExpr() == nestedColor.rgb.test.r.asLinkExpr()
+        assert nestedPosition.xyz.test.y.isLink and \
+            nestedPosition.xyz.test.y.inputLink.asLinkExpr() == nestedColor.rgb.test.g.asLinkExpr()
+        assert nestedPosition.xyz.test.z.isLink and \
+            nestedPosition.xyz.test.z.inputLink.asLinkExpr() == nestedColor.rgb.test.b.asLinkExpr()
+
+        # When
+        r = nestedColor.rgb.r
+        z = nestedPosition.xyz.test.z
+        r.connectTo(z)
+
+        # Then
+        assert not nestedPosition.xyz.isLink  # Disconnected because sub GroupAttribute has been disconnected
+        assert nestedPosition.xyz.x.isLink and \
+            nestedPosition.xyz.x.inputLink.asLinkExpr() == nestedColor.rgb.r.asLinkExpr()
+        assert nestedPosition.xyz.y.isLink and \
+            nestedPosition.xyz.y.inputLink.asLinkExpr() == nestedColor.rgb.g.asLinkExpr()
+        assert nestedPosition.xyz.z.isLink and \
+            nestedPosition.xyz.z.inputLink.asLinkExpr() == nestedColor.rgb.b.asLinkExpr()
+        assert not nestedPosition.xyz.test.isLink  # Disconnected because nestedPosition.xyz.test.z has been reconnected
+        assert nestedPosition.xyz.test.x.isLink and \
+            nestedPosition.xyz.test.x.inputLink.asLinkExpr() == nestedColor.rgb.test.r.asLinkExpr()
+        assert nestedPosition.xyz.test.y.isLink and \
+            nestedPosition.xyz.test.y.inputLink.asLinkExpr() == nestedColor.rgb.test.g.asLinkExpr()
+        assert nestedPosition.xyz.test.z.isLink and \
+            nestedPosition.xyz.test.z.inputLink.asLinkExpr() == r.asLinkExpr() == nestedColor.rgb.r.asLinkExpr()

--- a/tests/test_invalidation.py
+++ b/tests/test_invalidation.py
@@ -28,10 +28,8 @@ def test_output_invalidation():
     n2 = graph.addNewNode("SampleNode")
     n3 = graph.addNewNode("SampleNode")
 
-    graph.addEdges(
-        (n1.output, n2.input),
-        (n1.output, n3.input)
-    )
+    n1.output.connectTo(n2.input)
+    n1.output.connectTo(n3.input)
 
     # N1.output ----- N2.input
     #                \
@@ -60,6 +58,6 @@ def test_inputLinkInvalidation():
     n1 = graph.addNewNode("SampleNode")
     n2 = graph.addNewNode("SampleNode")
 
-    graph.addEdges((n1.input, n2.input))
+    n1.input.connectTo(n2.input)
     assert n1.input.uid() == n2.input.uid()
     assert n1.output.value == n2.output.value

--- a/tests/test_listAttribute.py
+++ b/tests/test_listAttribute.py
@@ -31,7 +31,7 @@ class TestListAttribute:
         nodeA = graph.addNewNode(NodeWithListAttribute.__name__)
         nodeB = graph.addNewNode(NodeWithListAttribute.__name__)
 
-        graph.addEdge(nodeA.listInput, nodeB.listInput)
+        nodeA.listInput.connectTo(nodeB.listInput)
 
         nodeA.listInput.append("test")
 
@@ -43,7 +43,7 @@ class TestListAttribute:
         nodeA = graph.addNewNode(NodeWithListAttribute.__name__)
         nodeB = graph.addNewNode(NodeWithListAttribute.__name__)
 
-        graph.addEdge(nodeA.listInput, nodeB.listInput)
+        nodeA.listInput.connectTo(nodeB.listInput)
 
         nodeA.listInput.extend(["A", "B", "C"])
 
@@ -56,7 +56,7 @@ class TestListAttribute:
         nodeA = graph.addNewNode(NodeWithListAttribute.__name__)
         nodeB = graph.addNewNode(NodeWithListAttribute.__name__)
 
-        graph.addEdge(nodeA.listInput, nodeB.listInput)
+        nodeA.listInput.connectTo(nodeB.listInput)
 
         nodeA.listInput.extend(["A", "B", "C"])
 

--- a/tests/test_nodeAttributeChangedCallback.py
+++ b/tests/test_nodeAttributeChangedCallback.py
@@ -87,7 +87,7 @@ class TestAttributeCallbackTriggerInGraph:
         assert nodeA.affectedInput.value == nodeB.affectedInput.value == 0
 
         nodeA.input.value = 1
-        graph.addEdge(nodeA.input, nodeB.input)
+        nodeA.input.connectTo(nodeB.input)
 
         assert nodeA.affectedInput.value == nodeB.affectedInput.value == 2
 
@@ -98,7 +98,7 @@ class TestAttributeCallbackTriggerInGraph:
 
         assert nodeA.affectedInput.value == nodeB.affectedInput.value == 0
 
-        graph.addEdge(nodeA.input, nodeB.input)
+        nodeA.input.connectTo(nodeB.input)
         nodeA.input.value = 1
 
         assert nodeA.affectedInput.value == 2
@@ -112,7 +112,7 @@ class TestAttributeCallbackTriggerInGraph:
         assert nodeA.affectedInput.value == 0
         assert nodeB.affectedInput.value == 0
 
-        graph.addEdge(nodeA.input, nodeB.input)
+        nodeA.input.connectTo(nodeB.input)
 
         assert nodeA.affectedInput.value == 0
         assert nodeB.affectedInput.value == 2
@@ -124,11 +124,9 @@ class TestAttributeCallbackTriggerInGraph:
         nodeC = graph.addNewNode(NodeWithAttributeChangedCallback.__name__)
         nodeD = graph.addNewNode(NodeWithAttributeChangedCallback.__name__)
 
-        graph.addEdges(
-            (nodeA.affectedInput, nodeB.input),
-            (nodeB.affectedInput, nodeC.input),
-            (nodeC.affectedInput, nodeD.input),
-        )
+        nodeA.affectedInput.connectTo(nodeB.input)
+        nodeB.affectedInput.connectTo(nodeC.input)
+        nodeC.affectedInput.connectTo(nodeD.input)
 
         nodeA.input.value = 5
 
@@ -142,7 +140,7 @@ class TestAttributeCallbackTriggerInGraph:
         nodeA = graph.addNewNode(NodeWithAttributeChangedCallback.__name__)
         nodeB = graph.addNewNode(NodeWithAttributeChangedCallback.__name__)
 
-        graph.addEdge(nodeA.input, nodeB.input)
+        nodeA.input.connectTo(nodeB.input)
         nodeA.input.value = 5
         assert nodeB.affectedInput.value == 10
 
@@ -171,7 +169,7 @@ class TestAttributeCallbackTriggerInGraph:
         nodeA = graph.addNewNode(NodeWithAttributeChangedCallback.__name__)
         nodeB = graph.addNewNode(NodeWithAttributeChangedCallback.__name__)
 
-        graph.addEdge(nodeA.input, nodeB.input)
+        nodeA.input.connectTo(nodeB.input)
         nodeA.input.value = 5
         assert nodeB.affectedInput.value == nodeB.input.value * 2
 
@@ -263,7 +261,7 @@ class TestAttributeCallbackBehaviorWithUpstreamCompoundAttributes:
         nodeA.listInput.append(0)
         attr = nodeA.listInput.at(0)
 
-        graph.addEdge(attr, nodeB.input)
+        attr.connectTo(nodeB.input)
 
         attr.value = 10
 
@@ -275,7 +273,7 @@ class TestAttributeCallbackBehaviorWithUpstreamCompoundAttributes:
         nodeA = graph.addNewNode(NodeWithCompoundAttributes.__name__)
         nodeB = graph.addNewNode(NodeWithAttributeChangedCallback.__name__)
 
-        graph.addEdge(nodeA.groupInput.int, nodeB.input)
+        nodeA.groupInput.int.connectTo(nodeB.input)
 
         nodeA.groupInput.int.value = 10
 
@@ -291,7 +289,7 @@ class TestAttributeCallbackBehaviorWithUpstreamCompoundAttributes:
 
         attr = nodeA.listOfGroupsInput.at(0)
 
-        graph.addEdge(attr.int, nodeB.input)
+        attr.int.connectTo(nodeB.input)
 
         attr.int.value = 10
 
@@ -307,7 +305,7 @@ class TestAttributeCallbackBehaviorWithUpstreamCompoundAttributes:
 
         attr = nodeA.groupWithListInput.subList.at(0)
 
-        graph.addEdge(attr, nodeB.input)
+        attr.connectTo(nodeB.input)
 
         attr.value = 10
 
@@ -366,7 +364,7 @@ class TestAttributeCallbackBehaviorWithUpstreamDynamicOutputs:
         nodeB = graph.addNewNode(NodeWithAttributeChangedCallback.__name__)
 
         nodeA.input.value = 10
-        graph.addEdge(nodeA.output, nodeB.input)
+        nodeA.output.connectTo(nodeB.input)
 
         assert nodeB.affectedInput.value == 0
 
@@ -380,7 +378,7 @@ class TestAttributeCallbackBehaviorWithUpstreamDynamicOutputs:
         nodeA.input.value = 10
         executeGraph(graph)
 
-        graph.addEdge(nodeA.output, nodeB.input)
+        nodeA.output.connectTo(nodeB.input)
         assert nodeA.output.value == nodeB.input.value == 20
         assert nodeB.affectedInput.value == 40
 
@@ -391,7 +389,7 @@ class TestAttributeCallbackBehaviorWithUpstreamDynamicOutputs:
         nodeA = graph.addNewNode(NodeWithDynamicOutputValue.__name__)
         nodeB = graph.addNewNode(NodeWithAttributeChangedCallback.__name__)
 
-        graph.addEdge(nodeA.output, nodeB.input)
+        nodeA.output.connectTo(nodeB.input)
         nodeA.input.value = 10
         executeGraph(graph)
 
@@ -408,7 +406,7 @@ class TestAttributeCallbackBehaviorWithUpstreamDynamicOutputs:
         nodeA.input.value = 10
         executeGraph(graph)
 
-        graph.addEdge(nodeA.output, nodeB.input)
+        nodeA.output.connectTo(nodeB.input)
 
         expectedPreClearValue = nodeA.input.value * 2 * 2
         assert nodeB.affectedInput.value == expectedPreClearValue
@@ -425,7 +423,7 @@ class TestAttributeCallbackBehaviorWithUpstreamDynamicOutputs:
         nodeB = graph.addNewNode(NodeWithAttributeChangedCallback.__name__)
 
         nodeA.input.value = 10
-        graph.addEdge(nodeA.output, nodeB.input)
+        nodeA.output.connectTo(nodeB.input)
         executeGraph(graph)
 
         assert nodeA.output.value == nodeB.input.value == 20
@@ -453,7 +451,7 @@ class TestAttributeCallbackBehaviorOnGraphImport:
         nodeA = graph.addNewNode(NodeWithAttributeChangedCallback.__name__)
         nodeB = graph.addNewNode(NodeWithAttributeChangedCallback.__name__)
 
-        graph.addEdge(nodeA.affectedInput, nodeB.input)
+        nodeA.affectedInput.connectTo(nodeB.input)
 
         nodeA.input.value = 5
         nodeB.affectedInput.value = 2


### PR DESCRIPTION
## Description

This PR replaces #2544 and #2754.

The main feature of this PR is that it adds the support of connections between attributes that are part of a GroupAttribute. Prior to this PR, these attributes could neither be connected individually, nor be displayed in the Graph Editor; they were however visible and editable in the Node Editor.

`GroupAttributes` are now displayed in the Graph Editor with a right chevron, which means they can be expanded when clicked upon. When this happens, all the children attributes of the clicked `GroupAttribute` are displayed below it, in a tree view with the indentation reflecting their depth level.

Connections between two `GroupAttributes` of a similar structure are now supported. If the `GroupAttributes` have different structures, the connection will be refused straight away and the user will not even be able to select the group's pin.

Connecting two `GroupAttributes` together explicitly connects all their children attributes together. If any of the children attributes is disconnected or reconnected to another attribute, then the connection between the groups is broken.
<img src="https://github.com/user-attachments/assets/f9b32367-c6f5-4266-ade7-63c7f1630ee6" width=500 />



## Features list

- [x] Add the notion of depth for attributes that are children of a `GroupAttribute`. An attribute that has no parent will have a depth of 0, and it will increase of 1 for every parent;
- [x] Add a `flatStaticChildren` property for every attribute that may have children that contains the flattened list of said children;
- [x] Correctly evaluate links when they reference children attributes, hence adding the support of the connection of individual attributes within groups;
- [x] Add an icon to expand or collapse `GroupAttributes` and display their children attributes in their node in the Graph Editor with a tree view. These children attributes are graphically connectable;
- [x] Display the full name of the attribute in its tooltip in the Graph Editor. If an attribute `childAttribute` is a child of a group `groupAttribute`, its name will be displayed as `groupAttribute.childAttribute`, making the relationship between the two obvious.


## Implementation remarks

Connections between attributes used to be handle directly with the `addEdge` and `removeEdge` methods. Two new methods, `connectTo` and `disconnectEdge`, are added and now directly call `addEdge` and `removeEdge` while handling all the specific connection/disconnection operations that are required when connecting `GroupAttributes` together. 