### PR TITLE
[components] Clipboard: Fix clipboard instantiation error with Qt6

### DIFF
--- a/meshroom/ui/components/clipboard.py
+++ b/meshroom/ui/components/clipboard.py
@@ -1,5 +1,5 @@
 from PySide6.QtCore import Slot, QObject
-from PySide6.QtGui import QClipboard
+from PySide6.QtGui import QGuiApplication
 
 
 class ClipboardHelper(QObject):
@@ -9,7 +9,7 @@ class ClipboardHelper(QObject):
 
     def __init__(self, parent=None):
         super(ClipboardHelper, self).__init__(parent)
-        self._clipboard = QClipboard(parent=self)
+        self._clipboard = QGuiApplication.clipboard()
 
     def __del__(self):
         # Workaround to avoid the "QXcbClipboard: Unable to receive an event from the clipboard manager

--- a/meshroom/ui/components/clipboard.py
+++ b/meshroom/ui/components/clipboard.py
@@ -11,13 +11,6 @@ class ClipboardHelper(QObject):
         super(ClipboardHelper, self).__init__(parent)
         self._clipboard = QGuiApplication.clipboard()
 
-    def __del__(self):
-        # Workaround to avoid the "QXcbClipboard: Unable to receive an event from the clipboard manager
-        # in a reasonable time" that will hold up the application when exiting if the clipboard has been
-        # used at least once and its content exceeds a certain size (on X11/XCB).
-        # The bug occurs in QClipboard and is present on all Qt5 versions.
-        self.clear()
-
     @Slot(str)
     def setText(self, value):
         self._clipboard.setText(value)


### PR DESCRIPTION
## Description

This PR fixes https://github.com/alicevision/Meshroom/issues/2960 by applying the [following patch](https://salsa.debian.org/science-team/meshroom/-/commit/99be86d991222f3dc4cb99bfaa162da79ad79535). It also removes the reimplementation of the clipboard's destructor, which was a workaround for an issue on Qt5 that is now fixed with Qt6.
