### PR TITLE
ImageGallery deletion signal

### DIFF
--- a/meshroom/core/attribute.py
+++ b/meshroom/core/attribute.py
@@ -715,7 +715,7 @@ class ListAttribute(Attribute):
                         self.node.graph.removeEdge(attr)
         self._value.removeAt(index, count)
         self.requestGraphUpdate()
-        self.valueChanged.emit()
+        self.node._onAttributeChanged(self)
 
     # Override
     def _initValue(self):


### PR DESCRIPTION
Problem:

When deleting an object in the image gallery on a large project, the UI may block for 20 seconds or more.

ImageGallery model is the cameraInit viewpoints attribute (a listAttribute).
When removing an image, listAttribute remove is called.
remove emit valueChanged, which tells the imageGallery that the whole model must be invalidated and reloaded.

I propose to replace the emission of the valueChanged signal with the direct call of the slot _onAttributeChanged.

Does not break the tests, but i am not sure if it does not have any collateral effects.