### PR TITLE
Change Python version requirement to 3.9

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -48,8 +48,8 @@ To use Meshroom nodal system without any visualization option, you can rely on a
 
 #### Python environment
 
-* Windows: Python 3 (>=3.9)
-* Linux: Python 3 (>=3.9)
+* Windows: Python 3 (==3.9)
+* Linux: Python 3 (==3.9)
 
 To install all the requirements for runtime, development and packaging, simply run:
 ```bash


### PR DESCRIPTION
Specify exact Python version required for Windows and Linux. Python 3.9 is the only version compatible with all packages in requirements.txt and dev_requirements.txt.