### PR TITLE
[core] `executeGraph`: Create a node's dynamic chunks before processing it

### DIFF
--- a/bin/meshroom_batch
+++ b/bin/meshroom_batch
@@ -156,7 +156,7 @@ advanced_group.add_argument(
 advanced_group.add_argument(
     '--submitter',
     type=str,
-    default='SimpleFarm',
+    default='Tractor',
     help='Execute job with a specific submitter.')
 
 args = parser.parse_args()

--- a/bin/meshroom_submit
+++ b/bin/meshroom_submit
@@ -13,7 +13,7 @@ parser.add_argument('--toNode', metavar='NODE_NAME', type=str,
                     help='Process the node with its dependencies.')
 parser.add_argument('--submitter',
                     type=str,
-                    default='SimpleFarm',
+                    default='Tractor',
                     help='Execute job with a specific submitter.')
 parser.add_argument("--submitLabel",
                     type=str,

--- a/meshroom/core/graph.py
+++ b/meshroom/core/graph.py
@@ -1694,16 +1694,16 @@ def executeGraph(graph, toNodes=None, forceCompute=False, forceStatus=False):
         if chunksInConflict:
             chunksStatus = {chunk.status.status.name for chunk in chunksInConflict}
             chunksName = [node.name for node in chunksInConflict]
-            msg = 'WARNING: Some nodes are already submitted with status: {}\nNodes: {}'.format(
-                  ', '.join(chunksStatus),
-                  ', '.join(chunksName)
+            msg = "WARNING: Some nodes are already submitted with status: {}\nNodes: {}".format(
+                  ", ".join(chunksStatus),
+                  ", ".join(chunksName)
                   )
             if forceStatus:
                 print(msg)
             else:
                 raise RuntimeError(msg)
 
-    print('Nodes to execute: ', str([n.name for n in nodes]))
+    print("Nodes to execute: ", str([n.name for n in nodes]))
 
     graph.save()
 
@@ -1718,6 +1718,8 @@ def executeGraph(graph, toNodes=None, forceCompute=False, forceStatus=False):
                 continue
 
             node.preprocess()
+            if not node._chunksCreated:
+                node.createChunks()
             multiChunks = len(node.chunks) > 1
             for c, chunk in enumerate(node.chunks):
                 if multiChunks:


### PR DESCRIPTION
## Description

This PR fixes an issue that appears when calling `executeGraph` (e.g. when running `meshroom_batch` locally, for example), where dynamic chunks were never created before the call to the node's `process` function. Consequently, the node appeared to have no chunk and was thus skipped. 

With this PR, the chunks are created (if need be) before the call to `process`, solving this issue.