### PR TITLE
Remove `CyclicDependencyError` on `backEdge` during the DFS process

### DIFF
--- a/meshroom/core/graph.py
+++ b/meshroom/core/graph.py
@@ -121,7 +121,7 @@ class Visitor:
 
     def backEdge(self, e, g):
         """ Is invoked on the back edges in the graph. """
-        raise CyclicDependencyError("A cyclic dependency exists on the current graph.")
+        pass
 
     def forwardOrCrossEdge(self, e, g):
         """

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -270,18 +270,3 @@ def test_duplicate_nodes():
     assert nMap[n2][0].input.inputLink == nMap[n1][0].output
     assert nMap[n3][0].input.inputLink == nMap[n1][0].output
     assert nMap[n3][0].input2.inputLink == nMap[n2][0].output
-
-
-def test_cyclic_connection_should_raise_error():
-
-    # Given
-    graph = Graph("Test cyclic connection")
-    tB = graph.addNewNode("AppendText", inputText="echo B")
-    tC = graph.addNewNode("AppendText", inputText="echo C")
-
-    tB.output.connectTo(tC.input)
-
-    # When
-    # Then
-    with pytest.raises(CyclicDependencyError):
-        tC.output.connectTo(tB.input)


### PR DESCRIPTION
## Description

This removes a partial check on cyclic dependencies in the DFS process that was introduced in #2965 and that causes erroneous exceptions even in cases where no cyclic dependency is present. 