### PR TITLE
Add support for backdrops in the Graph 

### DIFF
--- a/meshroom/core/desc/__init__.py
+++ b/meshroom/core/desc/__init__.py
@@ -33,11 +33,13 @@ from .computation import (
     StaticNodeSize,
 )
 from .node import (
-    MrNodeType,
     AVCommandLineNode,
     BaseNode,
+    BackdropNode,
     CommandLineNode,
     InitNode,
     InputNode,
+    InternalAttributesFactory,
+    MrNodeType,
     Node,
 )

--- a/meshroom/core/desc/node.py
+++ b/meshroom/core/desc/node.py
@@ -119,6 +119,14 @@ class InternalAttributesFactory:
             description="Size of the font used to display the comments.",
             value=12,
             range=(6, 100, 1),
+            invalidate=False,
+        ),
+        ColorParam(
+            name="fontColor",
+            label="Font Color",
+            description="Color of the font used to display the comments (SVG name or hexadecimal code).",
+            value="",
+            invalidate=False,
         ),
         IntParam(
             name="nodeWidth",
@@ -126,6 +134,7 @@ class InternalAttributesFactory:
             description="Width of the node in the graph editor.",
             value=600,
             range=None,
+            invalidate=False,
             enabled=False,  # Hidden
         ),
         IntParam(
@@ -134,6 +143,7 @@ class InternalAttributesFactory:
             description="Height of the node in the graph editor.",
             value=400,
             range=None,
+            invalidate=False,
             enabled=False,  # Hidden
         ),
     ]

--- a/meshroom/core/desc/node.py
+++ b/meshroom/core/desc/node.py
@@ -15,7 +15,7 @@ from meshroom.core import cgroup
 from meshroom.core.utils import VERBOSE_LEVEL
 
 from .computation import Level, StaticNodeSize
-from .attribute import StringParam, ColorParam, ChoiceParam
+from .attribute import Attribute, ChoiceParam, ColorParam, IntParam, StringParam
 
 _MESHROOM_ROOT = Path(meshroom.__file__).parent.parent.as_posix()
 _MESHROOM_COMPUTE = (Path(_MESHROOM_ROOT) / "bin" / "meshroom_compute").as_posix()
@@ -56,29 +56,11 @@ class MrNodeType(enum.Enum):
     NODE = enum.auto()
     COMMANDLINE = enum.auto()
     INPUT = enum.auto()
+    BACKDROP = enum.auto()
 
 
-class BaseNode(object):
-    """
-    """
-    cpu = Level.NORMAL
-    gpu = Level.NONE
-    ram = Level.NORMAL
-    packageName = ""
-    internalInputs = [
-        StringParam(
-            name="invalidation",
-            label="Invalidation Message",
-            description="A message that will invalidate the node's output folder.\n"
-                        "This is useful for development, we can invalidate the output of the node "
-                        "when we modify the code.\n"
-                        "It is displayed in bold font in the invalidation/comment messages "
-                        "tooltip.",
-            value="",
-            semantic="multiline",
-            advanced=True,
-            uidIgnoreValue="",  # If the invalidation string is empty, it does not participate to the node's UID
-        ),
+class InternalAttributesFactory:
+    BASIC = [
         StringParam(
             name="comment",
             label="Comments",
@@ -113,6 +95,74 @@ class BaseNode(object):
             invalidate=False,
         )
     ]
+
+    INVALIDATION = [
+        StringParam(
+            name="invalidation",
+            label="Invalidation Message",
+            description="A message that will invalidate the node's output folder.\n"
+                        "This is useful for development, we can invalidate the output of the node "
+                        "when we modify the code.\n"
+                        "It is displayed in bold font in the invalidation/comment messages "
+                        "tooltip.",
+            value="",
+            semantic="multiline",
+            advanced=True,
+            uidIgnoreValue="",  # If the invalidation string is empty, it does not participate to the node's UID
+        ),
+    ]
+
+    RESIZABLE = [
+        IntParam(
+            name="fontSize",
+            label="Font Size",
+            description="Size of the font used to display the comments.",
+            value=12,
+            range=(6, 100, 1),
+        ),
+        IntParam(
+            name="nodeWidth",
+            label="Node Width",
+            description="Width of the node in the graph editor.",
+            value=600,
+            range=None,
+            enabled=False,  # Hidden
+        ),
+        IntParam(
+            name="nodeHeight",
+            label="Node Height",
+            description="Height of the node in the graph editor.",
+            value=400,
+            range=None,
+            enabled=False,  # Hidden
+        ),
+    ]
+
+    @classmethod
+    def getInternalAttributes(cls, mrNodeType: MrNodeType) -> list[Attribute]:
+        paramMap = {
+            MrNodeType.NONE: cls.BASIC,
+            MrNodeType.BASENODE: cls.INVALIDATION + cls.BASIC,
+            MrNodeType.NODE: cls.INVALIDATION + cls.BASIC,
+            MrNodeType.COMMANDLINE: cls.INVALIDATION + cls.BASIC,
+            MrNodeType.INPUT: cls.BASIC,
+            MrNodeType.BACKDROP: cls.BASIC + cls.RESIZABLE,
+        }
+
+        return paramMap.get(mrNodeType)
+
+
+class BaseNode(object):
+    """
+    """
+    cpu = Level.NORMAL
+    gpu = Level.NONE
+    ram = Level.NORMAL
+    packageName = ""
+    _mrNodeType: MrNodeType = MrNodeType.BASENODE
+
+    internalInputs = InternalAttributesFactory.getInternalAttributes(_mrNodeType)
+
     inputs = []
     outputs = []
     size = StaticNodeSize(1)
@@ -130,7 +180,7 @@ class BaseNode(object):
         self.sourceCodeFolder = Path(getfile(self.__class__)).parent.resolve().as_posix()
 
     def getMrNodeType(self):
-        return MrNodeType.BASENODE
+        return self._mrNodeType
 
     def upgradeAttributeValues(self, attrValues, fromVersion):
         return attrValues
@@ -286,24 +336,50 @@ class InputNode(BaseNode):
     """
     Node that does not need to be processed, it is just a placeholder for inputs.
     """
+    _mrNodeType: MrNodeType = MrNodeType.INPUT
+    internalInputs = InternalAttributesFactory.getInternalAttributes(_mrNodeType)
+
     def __init__(self):
         super(InputNode, self).__init__()
 
     def getMrNodeType(self):
-        return MrNodeType.INPUT
+        return self._mrNodeType
 
     def processChunk(self, chunk):
+        pass
+
+    def process(self, node):
+        pass
+
+class BackdropNode(BaseNode):
+    """
+    Node that does not need to be processed, it is just a placeholder for grouping other nodes.
+    """
+    _mrNodeType: MrNodeType = MrNodeType.BACKDROP
+    internalInputs = InternalAttributesFactory.getInternalAttributes(_mrNodeType)
+
+    def __init__(self):
+        super(BackdropNode, self).__init__()
+
+    def getMrNodeType(self):
+        return self._mrNodeType
+
+    def processChunk(self, chunk):
+        pass
+
+    def process(self, node):
         pass
 
 
 class Node(BaseNode):
     pythonExecutable = "python"
+    _mrNodeType: MrNodeType = MrNodeType.NODE
 
     def __init__(self):
         super(Node, self).__init__()
 
     def getMrNodeType(self):
-        return MrNodeType.NODE
+        return self._mrNodeType
 
     def processChunkInEnvironment(self, chunk):
         meshroomComputeCmd = f"{chunk.node.nodeDesc.pythonExecutable} {_MESHROOM_COMPUTE}" + \
@@ -326,12 +402,13 @@ class CommandLineNode(BaseNode):
     commandLine = ""  # need to be defined on the node
     parallelization = None
     commandLineRange = ""
+    _mrNodeType: MrNodeType = MrNodeType.COMMANDLINE
 
     def __init__(self):
         super(CommandLineNode, self).__init__()
 
     def getMrNodeType(self):
-        return MrNodeType.COMMANDLINE
+        return self._mrNodeType
 
     def buildCommandLine(self, chunk) -> str:
         cmdLineVars = chunk.node.createCmdLineVars()

--- a/meshroom/core/graph.py
+++ b/meshroom/core/graph.py
@@ -20,7 +20,7 @@ from meshroom.core.attribute import Attribute, ListAttribute, GroupAttribute
 from meshroom.core.exception import GraphCompatibilityError, InvalidEdgeError, StopGraphVisit, StopBranchVisit, CyclicDependencyError
 from meshroom.core.graphIO import GraphIO, GraphSerializer, TemplateGraphSerializer, PartialGraphSerializer
 from meshroom.core.node import BaseNode, Status, Node, CompatibilityNode
-from meshroom.core.nodeFactory import nodeFactory
+from meshroom.core.nodeFactory import nodeFactory, getNodeConstructor
 from meshroom.core.mtyping import PathLike
 from meshroom.core.submitter import BaseSubmittedJob, jobManager
 
@@ -693,7 +693,7 @@ class Graph(BaseObject):
         if name and name in self._nodes.keys():
             name = self._createUniqueNodeName(name)
 
-        node = self.addNode(Node(nodeType, position=position, **kwargs), uniqueName=name)
+        node = self.addNode(getNodeConstructor(nodeType, position=position, **kwargs), uniqueName=name)
         node.updateInternals()
         self._triggerNodeCreatedCallback([node])
         return node

--- a/meshroom/core/graphIO.py
+++ b/meshroom/core/graphIO.py
@@ -184,8 +184,9 @@ class PartialGraphSerializer(GraphSerializer):
 
         # Override input attributes with custom serialization logic, to handle attributes
         # connected to nodes that are not in the list of nodes to serialize.
-        for attributeName in nodeData["inputs"]:
-            nodeData["inputs"][attributeName] = self._serializeAttribute(node.attribute(attributeName))
+        if nodeData.get("inputs", None):
+            for attributeName in nodeData["inputs"]:
+                nodeData["inputs"][attributeName] = self._serializeAttribute(node.attribute(attributeName))
 
         # Clear UID for non-compatibility nodes, as the custom attribute serialization
         # can be impacting the UID by removing connections to missing nodes.

--- a/meshroom/core/node.py
+++ b/meshroom/core/node.py
@@ -1271,7 +1271,7 @@ class BaseNode(BaseObject):
         """
         # Ambiguous case for NONE, which could be used for compatibility nodes if we don't have
         # any information about the node descriptor.
-        return self.getMrNodeType() != MrNodeType.INPUT
+        return self.getMrNodeType() != MrNodeType.INPUT and self.getMrNodeType() != MrNodeType.BACKDROP
 
     def clearData(self):
         """ Delete this Node internal folder.

--- a/meshroom/core/node.py
+++ b/meshroom/core/node.py
@@ -916,6 +916,15 @@ class BaseNode(BaseObject):
             return self.internalAttribute("fontSize").value
         return 0
 
+    def getFontColor(self) -> str:
+        """
+        Returns:
+            The color of the font from the node if it exists, empty string otherwise.
+        """
+        if self.hasInternalAttribute("fontColor"):
+            return self.internalAttribute("fontColor").value.strip()
+        return ""
+
     def getNodeWidth(self) -> int:
         """
         Returns:
@@ -2102,6 +2111,7 @@ class BaseNode(BaseObject):
     invalidation = Property(str, getInvalidationMessage, notify=internalAttributesChanged)
     comment = Property(str, getComment, notify=internalAttributesChanged)
     fontSize = Property(int, getFontSize, notify=internalAttributesChanged)
+    fontColor = Property(str, getFontColor, notify=internalAttributesChanged)
     nodeWidth = Property(int, getNodeWidth, notify=internalAttributesChanged)
     nodeHeight = Property(int, getNodeHeight, notify=internalAttributesChanged)
     internalFolderChanged = Signal()

--- a/meshroom/core/node.py
+++ b/meshroom/core/node.py
@@ -2365,6 +2365,38 @@ class Node(BaseNode):
         self.upgradeStatusFile()
 
 
+class BackdropNode(BaseNode):
+    def __init__(self, nodeType: str, position=None, parent=None, uid=None, **kwargs):
+        super().__init__(nodeType, position, parent=parent, uid=uid, **kwargs)
+
+        if not self.nodeDesc:
+            raise UnknownNodeTypeError(nodeType)
+
+        self.packageName = self.nodeDesc.packageName
+
+        for attrDesc in self.nodeDesc.internalInputs:
+            self._internalAttributes.add(attributeFactory(attrDesc, kwargs.get(attrDesc.name, None),
+                                                          isOutput=False, node=self))
+
+    def _isBackdropNode(self) -> bool:
+        return True
+
+    def toDict(self):
+        internalInputs = {k: v.getSerializedValue() for k, v in self._internalAttributes.objects.items()}
+
+        return {
+            'nodeType': self.nodeType,
+            'position': self._position,
+            'parallelization': {
+                'blockSize': 0,
+                'size': 0,
+                'split': 0
+            },
+            'uid': self._uid,
+            'internalInputs': {k: v for k, v in internalInputs.items() if v is not None},
+        }
+
+
 class CompatibilityIssue(Enum):
     """
     Enum describing compatibility issues when deserializing a Node.

--- a/meshroom/core/node.py
+++ b/meshroom/core/node.py
@@ -860,10 +860,10 @@ class BaseNode(BaseObject):
     def getDefaultLabel(self):
         return self.nameToLabel(self._name)
 
-    def getLabel(self):
+    def getLabel(self) -> str:
         """
         Returns:
-            str: the user-provided label if it exists, the high-level label of this node otherwise
+            The user-provided label if it exists, the high-level label of this node otherwise
         """
         if self.hasInternalAttribute("label"):
             label = self.internalAttribute("label").value.strip()
@@ -871,41 +871,69 @@ class BaseNode(BaseObject):
                 return label
         return self.getDefaultLabel()
 
-    def getNodeLogLevel(self):
+    def getNodeLogLevel(self) -> str:
         """
         Returns:
-            str: the user-provided log level used for logging on process launched by this node
+            The user-provided log level used for logging on process launched by this node
         """
         if self.hasInternalAttribute("nodeDefaultLogLevel"):
             return self.internalAttribute("nodeDefaultLogLevel").value.strip()
         return "info"
 
-    def getColor(self):
+    def getColor(self) -> str:
         """
         Returns:
-            str: the user-provided custom color of the node if it exists, empty string otherwise
+            The user-provided custom color of the node if it exists, empty string otherwise
         """
         if self.hasInternalAttribute("color"):
             return self.internalAttribute("color").value.strip()
         return ""
 
-    def getInvalidationMessage(self):
+    def getInvalidationMessage(self) -> str:
         """
         Returns:
-            str: the invalidation message on the node if it exists, empty string otherwise
+            The invalidation message on the node if it exists, empty string otherwise
         """
         if self.hasInternalAttribute("invalidation"):
             return self.internalAttribute("invalidation").value
         return ""
 
-    def getComment(self):
+    def getComment(self) -> str:
         """
         Returns:
-            str: the comments on the node if they exist, empty string otherwise
+            The comments on the node if they exist, empty string otherwise
         """
         if self.hasInternalAttribute("comment"):
             return self.internalAttribute("comment").value
         return ""
+
+    def getFontSize(self) -> int:
+        """
+        Returns:
+            The font size from the node if it exists, 0 otherwise.
+        """
+        if self.hasInternalAttribute("fontSize"):
+            return self.internalAttribute("fontSize").value
+        return 0
+
+    def getNodeWidth(self) -> int:
+        """
+        Returns:
+            The width of the node if it has a user-set width, 0 otherwise.
+        """
+        if self.hasInternalAttribute("nodeWidth"):
+            return self.internalAttribute("nodeWidth").value
+        return 0
+
+    def getNodeHeight(self) -> int:
+        """
+        Returns:
+            The height of the node if it has a user-set height, 0 otherwise.
+        """
+        if self.hasInternalAttribute("nodeHeight"):
+            return self.internalAttribute("nodeHeight").value
+        return 0
+
 
     @Slot(str, result=str)
     def nameToLabel(self, name):
@@ -1811,6 +1839,9 @@ class BaseNode(BaseObject):
     def _isInputNode(self):
         return isinstance(self.nodeDesc, desc.InputNode)
 
+    def _isBackdropNode(self) -> bool:
+        return False
+
     @property
     def globalExecMode(self):
         if not self._chunksCreated:
@@ -2070,6 +2101,9 @@ class BaseNode(BaseObject):
     color = Property(str, getColor, notify=internalAttributesChanged)
     invalidation = Property(str, getInvalidationMessage, notify=internalAttributesChanged)
     comment = Property(str, getComment, notify=internalAttributesChanged)
+    fontSize = Property(int, getFontSize, notify=internalAttributesChanged)
+    nodeWidth = Property(int, getNodeWidth, notify=internalAttributesChanged)
+    nodeHeight = Property(int, getNodeHeight, notify=internalAttributesChanged)
     internalFolderChanged = Signal()
     internalFolder = Property(str, internalFolder.fget, notify=internalFolderChanged)
     valuesFile = Property(str, valuesFile.fget, notify=internalFolderChanged)
@@ -2090,9 +2124,9 @@ class BaseNode(BaseObject):
     elapsedTime = Property(float, lambda self: self.getFusedStatus().elapsedTime, notify=globalStatusChanged)
     recursiveElapsedTime = Property(float, lambda self: self.getRecursiveFusedStatus().elapsedTime,
                                     notify=globalStatusChanged)
-    # isCompatibilityNode: need lambda to evaluate the virtual function
     isCompatibilityNode = Property(bool, lambda self: self._isCompatibilityNode(), constant=True)
     isInputNode = Property(bool, lambda self: self._isInputNode(), constant=True)
+    isBackdropNode = Property(bool, lambda self: self._isBackdropNode(), constant=True)
 
     globalExecMode = Property(str, globalExecMode.fget, notify=globalStatusChanged)
     jobName = Property(str, lambda self: self._getJobName(), notify=globalStatusChanged)

--- a/meshroom/core/nodeFactory.py
+++ b/meshroom/core/nodeFactory.py
@@ -4,7 +4,7 @@ from collections.abc import Iterable
 
 import meshroom.core
 from meshroom.core import Version, desc
-from meshroom.core.node import CompatibilityIssue, CompatibilityNode, BackdropNode, Node, Position
+from meshroom.core.node import BackdropNode, CompatibilityIssue, CompatibilityNode, Node, Position
 
 
 def nodeFactory(
@@ -12,7 +12,7 @@ def nodeFactory(
     name: Optional[str] = None,
     inTemplate: bool = False,
     expectedUid: Optional[str] = None,
-) -> Union[Node, CompatibilityNode]:
+) -> Union[Node, BackdropNode, CompatibilityNode]:
     """
     Create a node instance by deserializing the given node data.
     If the serialized data matches the corresponding node type description, a Node instance is created.
@@ -65,7 +65,7 @@ class _NodeCreator:
         if meshroom.core.pluginManager.isRegistered(self.nodeType):
             self.nodeDesc = meshroom.core.pluginManager.getRegisteredNodePlugin(self.nodeType).nodeDescriptor
 
-    def create(self) -> Union[Node, CompatibilityNode]:
+    def create(self) -> Union[Node, BackdropNode, CompatibilityNode]:
         compatibilityIssue = self._checkCompatibilityIssues()
         if compatibilityIssue:
             node = self._createCompatibilityNode(compatibilityIssue)
@@ -179,12 +179,12 @@ class _NodeCreator:
             for attrName, value in attributesDict.items()
         )
 
-    def _createNode(self) -> Node:
+    def _createNode(self) -> Union[BackdropNode, Node]:
         logging.info(f"Creating node '{self.name}'")
         # TODO: user inputs/outputs may conflicts with internal names (like logLevel, position, uid)
         # The line below can cause UI issues but at least prevent crashes
         internalInputs = {k: v for k, v in self.internalInputs.items() if k not in self.inputs.keys()}
-        return Node(
+        return getNodeConstructor(
             self.nodeType,
             position=self.position,
             uid=self.uid,

--- a/meshroom/core/nodeFactory.py
+++ b/meshroom/core/nodeFactory.py
@@ -4,7 +4,7 @@ from collections.abc import Iterable
 
 import meshroom.core
 from meshroom.core import Version, desc
-from meshroom.core.node import CompatibilityIssue, CompatibilityNode, Node, Position
+from meshroom.core.node import CompatibilityIssue, CompatibilityNode, BackdropNode, Node, Position
 
 
 def nodeFactory(
@@ -28,6 +28,14 @@ def nodeFactory(
         The created Node instance.
     """
     return _NodeCreator(nodeData, name, inTemplate, expectedUid).create()
+
+
+def getNodeConstructor(nodeType: str, position: Optional[Position]=None, **kwargs) -> Union[BackdropNode, Node]:
+    constructors = {
+        "Backdrop": BackdropNode,
+    }
+    constructor = constructors.get(nodeType, Node)
+    return constructor(nodeType, position=position, **kwargs)
 
 
 class _NodeCreator:

--- a/meshroom/nodes/general/Backdrop.py
+++ b/meshroom/nodes/general/Backdrop.py
@@ -1,0 +1,8 @@
+__version__ = "1.0"
+
+from meshroom.core import desc
+
+class Backdrop(desc.BackdropNode):
+    """ Backdrop node. Any node can be placed inside a backdrop to group them visually. """
+
+    category = "Utils"

--- a/meshroom/ui/components/geom2D.py
+++ b/meshroom/ui/components/geom2D.py
@@ -4,5 +4,18 @@ from PySide6.QtCore import QObject, Slot, QRectF
 class Geom2D(QObject):
     @Slot(QRectF, QRectF, result=bool)
     def rectRectIntersect(self, rect1: QRectF, rect2: QRectF) -> bool:
-        """Check if two rectangles intersect."""
+        """ Check if two rectangles intersect. """
         return rect1.intersects(rect2)
+
+    @Slot(QRectF, QRectF, result=bool)
+    def rectRectFullIntersect(self, rect1: QRectF, rect2: QRectF) -> bool:
+        """ Check if two rectangles intersect fully. i.e. rect1 fully holds rect2 inside it."""
+        intersected = rect1.intersected(rect2)
+
+        # They don't intersect at all
+        if not intersected:
+            return False
+
+        # Validate that intersected rect is same as rect2
+        # If both are same, that implies it fully lies inside of rect1
+        return intersected == rect2

--- a/meshroom/ui/graph.py
+++ b/meshroom/ui/graph.py
@@ -565,6 +565,7 @@ class UIGraph(QObject):
     @Slot(list)
     def execute(self, nodes: Optional[Union[list[Node], Node]] = None):
         nodes = [nodes] if not isinstance(nodes, Iterable) and nodes else nodes
+        nodes = [n for n in nodes if n.isComputableType]
         self.save()  # always save the graph before computing
         self._taskManager.compute(self._graph, nodes)
         self.updateLockedUndoStack()  # explicitly call the update while it is already computing

--- a/meshroom/ui/graph.py
+++ b/meshroom/ui/graph.py
@@ -32,7 +32,7 @@ from meshroom.core.graphIO import GraphIO
 from meshroom.core.taskManager import TaskManager
 from meshroom.core.submitter import jobManager
 
-from meshroom.core.node import NodeChunk, Node, Status, ExecMode, CompatibilityNode, Position
+from meshroom.core.node import NodeChunk, Node, Status, ExecMode, CompatibilityNode, BackdropNode, Position
 from meshroom.core import submitters, MrNodeType
 from meshroom.ui import commands
 from meshroom.ui.utils import makeProperty
@@ -975,6 +975,40 @@ class UIGraph(QObject):
             position: The target position.
         """
         self.push(commands.MoveNodeCommand(self._graph, node, position))
+
+    @Slot(BackdropNode, int, int)
+    def resizeNode(self, node, width, height):
+        """ Resize `node` to the given `width` and `height`.
+
+        Args:
+            node: The node to resize.
+            width: The target width.
+            height: The target height.
+        """
+        with self.groupedGraphModification("Resize Node"):
+            if node.hasInternalAttribute("nodeWidth"):
+                self.setAttribute(node.internalAttribute("nodeWidth"), width)
+            if node.hasInternalAttribute("nodeHeight"):
+                self.setAttribute(node.internalAttribute("nodeHeight"), height)
+
+    @Slot(BackdropNode, int, int, QPoint)
+    def resizeAndMoveNode(self, node, width, height, position=None):
+        """ Resize `node` to the given `width` and `height`, and move it to the given `position`.
+
+        Args:
+            node: The node to resize and move.
+            width: The target width.
+            height: The target height.
+            position: The target position.
+        """
+        with self.groupedGraphModification("Resize and Move Node"):
+            if node.hasInternalAttribute("nodeWidth"):
+                self.setAttribute(node.internalAttribute("nodeWidth"), width)
+            if node.hasInternalAttribute("nodeHeight"):
+                self.setAttribute(node.internalAttribute("nodeHeight"), height)
+
+            if position:
+                self.moveNode(node, Position(position.x(), position.y()))
 
     @Slot(QPoint)
     def moveSelectedNodesBy(self, offset: QPoint):

--- a/meshroom/ui/qml/Controls/DelegateSelectionBox.qml
+++ b/meshroom/ui/qml/Controls/DelegateSelectionBox.qml
@@ -22,6 +22,8 @@ SelectionBox {
         const mappedSelectionRect = mapToItem(container, selectionRect)
         for (var i = 0; i < modelInstantiator.count; ++i) {
             const delegate = modelInstantiator.getItemAt(i)
+            if (!delegate)
+                continue
             const delegateRect = Qt.rect(delegate.x, delegate.y, delegate.width, delegate.height)
             if (Geom2D.rectRectIntersect(mappedSelectionRect, delegateRect)) {
                 selectedIndices.push(i)
@@ -29,7 +31,9 @@ SelectionBox {
                 if (delegate.isBackdropNode) {
                     let children = delegate.getChildrenIndices(true)
                     for (var child = 0; child < children.length; ++child) {
-                        selectedIndices.push(children[child])
+                        if (selectedIndices.indexOf(children[child]) === -1) {
+                            selectedIndices.push(children[child])
+                        }
                     }
                 }
             }

--- a/meshroom/ui/qml/Controls/DelegateSelectionBox.qml
+++ b/meshroom/ui/qml/Controls/DelegateSelectionBox.qml
@@ -19,14 +19,21 @@ SelectionBox {
 
     onSelectionEnded: function(selectionRect, modifiers) {
         let selectedIndices = [];
-        const mappedSelectionRect = mapToItem(container, selectionRect);
+        const mappedSelectionRect = mapToItem(container, selectionRect)
         for (var i = 0; i < modelInstantiator.count; ++i) {
-            const delegate = modelInstantiator.itemAt(i);
-            const delegateRect = Qt.rect(delegate.x, delegate.y, delegate.width, delegate.height);
+            const delegate = modelInstantiator.getItemAt(i)
+            const delegateRect = Qt.rect(delegate.x, delegate.y, delegate.width, delegate.height)
             if (Geom2D.rectRectIntersect(mappedSelectionRect, delegateRect)) {
-                selectedIndices.push(i);
+                selectedIndices.push(i)
+
+                if (delegate.isBackdropNode) {
+                    let children = delegate.getChildrenIndices(true)
+                    for (var child = 0; child < children.length; ++child) {
+                        selectedIndices.push(children[child])
+                    }
+                }
             }
         }
-        delegateSelectionEnded(selectedIndices, modifiers);
+        delegateSelectionEnded(selectedIndices, modifiers)
     }
 }

--- a/meshroom/ui/qml/Controls/NodeActions.qml
+++ b/meshroom/ui/qml/Controls/NodeActions.qml
@@ -34,8 +34,8 @@ Item {
         if (!nodeRepeater) 
             return null
         for (var i = 0; i < nodeRepeater.count; ++i) {
-            if (nodeRepeater.itemAt(i).node === node)
-                return nodeRepeater.itemAt(i)
+            if (nodeRepeater.getItemAt(i).node === node)
+                return nodeRepeater.getItemAt(i)
         }
         return null
     }

--- a/meshroom/ui/qml/GraphEditor/AttributeItemDelegate.qml
+++ b/meshroom/ui/qml/GraphEditor/AttributeItemDelegate.qml
@@ -511,16 +511,22 @@ RowLayout {
                 CheckBox {
                     id: colorCheckbox
                     Layout.alignment: Qt.AlignLeft
-                    checked: node && node.color === "" ? false : true
+                    checked: attribute.value === "" ? false : true
                     checkable: root.editable
                     text: "Custom Color"
+                    property string previousColor: ""
                     onClicked: {
                         if (checked) {
-                            if (colorText.text == "")
-                                _currentScene.setAttribute(attribute, "#0000FF")
+                            if (colorText.text == "") {
+                                if (previousColor != "")
+                                    _currentScene.setAttribute(attribute, previousColor)
+                                else
+                                    _currentScene.setAttribute(attribute, "#0000FF")
+                            }
                             else
                                 _currentScene.setAttribute(attribute, colorText.text)
                         } else {
+                            previousColor = attribute.value
                             _currentScene.setAttribute(attribute, "")
                         }
                     }

--- a/meshroom/ui/qml/GraphEditor/Backdrop.qml
+++ b/meshroom/ui/qml/GraphEditor/Backdrop.qml
@@ -1,0 +1,444 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import Qt5Compat.GraphicalEffects
+
+import Utils 1.0
+
+import Meshroom.Helpers
+
+/**
+ * Visual representation of a Graph Backdrop Node.
+ */
+
+Item {
+    id: root
+
+    /// The underlying Node object
+    property variant node
+
+    /// Mouse related states
+    property bool mainSelected: false
+    property bool selected: false
+    property bool hovered: false
+
+    // The Item instantiating the delegates.
+    property Item modelInstantiator: undefined
+
+    readonly property bool isBackdrop: true
+    // Node Children for the Backdrop
+    property var children: []
+    property var childrenIndices: []
+
+    property bool dragging: mouseArea.drag.active
+    property bool resizing: leftDragger.drag.active || topDragger.drag.active
+    /// Combined x and y
+    property point position: Qt.point(x, y)
+    /// Styling
+    property color shadowColor: "#cc000000"
+    readonly property color defaultColor: node.color === "" ? "#fffb85" : node.color
+    property color baseColor: defaultColor
+
+    readonly property int minimumWidth: 200
+    readonly property int minumumHeight: 200
+
+    property point mousePosition: Qt.point(mouseArea.mouseX, mouseArea.mouseY)
+
+    // Mouse interaction related signals
+    signal pressed(var mouse)
+    signal released(var mouse)
+    signal clicked(var mouse)
+    signal doubleClicked(var mouse)
+    signal moved(var position)
+    signal entered()
+    signal exited()
+
+    // Size signal
+    signal resized(var width, var height)
+    signal resizedAndMoved(var width, var height, var position)
+
+    // Already connected attribute with another edge in DropArea
+    signal edgeAboutToBeRemoved(var input)
+
+    /// Emitted when child attribute pins are created
+    signal attributePinCreated(var attribute, var pin)
+    /// Emitted when child attribute pins are deleted
+    signal attributePinDeleted(var attribute, var pin)
+
+    // use node name as object name to simplify debugging
+    objectName: node ? node.name : ""
+
+    // initialize position with node coordinates
+    x: root.node ? root.node.x : undefined
+    y: root.node ? root.node.y : undefined
+
+    // The backdrop node always needs to be at the back
+    z: -1
+
+    width: root.node ? root.node.nodeWidth : 300;
+    height: root.node ? root.node.nodeHeight : 200;
+
+    implicitHeight: childrenRect.height
+
+    SystemPalette { id: activePalette }
+
+    Connections {
+        target: root.node
+        // update x,y when node position changes
+        function onPositionChanged() {
+            root.x = root.node.x
+            root.y = root.node.y
+        }
+
+        function onInternalAttributesChanged() {
+            root.width = root.node.nodeWidth;
+            root.height = root.node.nodeHeight;
+        }
+    }
+
+    // When the node is selected, update the children for it
+    // For node to consider another ndoe, it needs to be fully inside the backdrop area
+    onSelectedChanged: {
+        if (selected) {
+            updateChildren()
+        }
+    }
+
+    onPressed: {
+        updateChildren();
+    }
+
+    function updateChildren() {
+        let indices = [];
+        let nodes = [];
+        const backdropRect = Qt.rect(root.node.x, root.node.y, root.node.nodeWidth, root.node.nodeHeight);
+
+        for (var i = 0; i < modelInstantiator.count; ++i) {
+            const delegate = modelInstantiator.itemAt(i).item;
+            if (delegate === this)
+                continue
+
+            const delegateRect = Qt.rect(delegate.x, delegate.y, delegate.width, delegate.height);
+            if (Geom2D.rectRectFullIntersect(backdropRect, delegateRect)) {
+                indices.push(i);
+                nodes.push(delegate);
+            }
+        }
+        childrenIndices = indices;
+        children = nodes;
+    }
+
+    function getChildrenNodes(refresh = false) {
+        /**
+         * Returns the current nodes which are a part of the Backdrop.
+         */
+        // Update the children if required
+        if (refresh) {
+            updateChildren();
+        }
+        return children;
+    }
+
+    function getChildrenIndices(refresh = false) {
+        /**
+         * Returns the current nodes' indices which are a part of the Backdrop.
+         */
+        // Update the children if required
+        if (refresh) {
+            updateChildren();
+        }
+        return childrenIndices;
+    }
+
+    // Main Layout
+    MouseArea {
+        id: mouseArea
+        width: root.width;
+        height: root.height;
+        drag.target: root
+        // Small drag threshold to avoid moving the node by mistake
+        drag.threshold: 2
+        hoverEnabled: true
+        acceptedButtons: Qt.LeftButton | Qt.RightButton
+        onPressed: (mouse) => root.pressed(mouse)
+        onReleased: (mouse) => root.released(mouse)
+        onClicked: (mouse) => root.clicked(mouse)
+        onDoubleClicked: (mouse) => root.doubleClicked(mouse)
+        onEntered: root.entered()
+        onExited: root.exited()
+        drag.onActiveChanged: {
+            if (!drag.active) {
+                root.moved(Qt.point(root.x, root.y))
+            }
+        }
+
+        cursorShape: drag.active ? Qt.ClosedHandCursor : Qt.ArrowCursor
+
+        /// Backdrop Resize Controls ???
+        ///
+        /// Resize Right Side
+        ///
+        Rectangle {
+            width: 4
+            height: nodeContent.height
+
+            color: baseColor
+            opacity: 0
+
+            anchors.horizontalCenter: parent.right
+
+            // This mouse area serves as the dragging rectangle    
+            MouseArea {
+                id: rightDragger
+
+                cursorShape: Qt.SizeHorCursor
+                anchors.fill: parent
+
+                drag { target: parent; axis: Drag.XAxis }
+
+                onMouseXChanged: {
+                    if (drag.active) {
+                        // Update the area width
+                        root.width = root.width + mouseX;
+
+                        // Ensure we have a minimum width always
+                        if (root.width < root.minimumWidth) {
+                            root.width = root.minimumWidth;
+                        }
+                    }
+                }
+
+                onReleased: {
+                    // emit the width and height
+                    root.resized(root.width, nodeContent.height);
+                }
+            }
+        }
+
+        ///
+        /// Resize Left Side
+        ///
+        Rectangle {
+            width: 4
+            height: nodeContent.height
+
+            color: baseColor
+            opacity: 0
+
+            anchors.horizontalCenter: parent.left
+
+            // This mouse area serves as the dragging rectangle
+            MouseArea {
+                id: leftDragger
+
+                cursorShape: Qt.SizeHorCursor
+                anchors.fill: parent
+
+                drag { target: parent; axis: Drag.XAxis }
+
+                onMouseXChanged: {
+                    if (drag.active) {
+                        // Width of the Area
+                        let w = 0
+
+                        // Update the area width
+                        w = root.width - mouseX
+
+                        // Ensure we have a minimum width always
+                        if (w > root.minimumWidth) {
+                            // Update the node's x position and the width
+                            root.x = root.x + mouseX
+                            root.width = w;
+                        }
+                    }
+                }
+
+                onReleased: {
+                    // emit the node width and height along with the root position
+                    // Dragging from the left moves the node as well
+                    root.resizedAndMoved(root.width, root.height, Qt.point(root.x, root.y));
+                }
+            }
+        }
+
+        ///
+        /// Resize Bottom
+        ///
+        Rectangle {
+            width: mouseArea.width
+            height: 4
+
+            color: baseColor
+            opacity: 0
+
+            anchors.verticalCenter: nodeContent.bottom
+
+            MouseArea {
+                id: bottomDragger
+
+                cursorShape: Qt.SizeVerCursor
+                anchors.fill: parent
+
+                drag{ target: parent; axis: Drag.YAxis }
+
+                onMouseYChanged: {
+                    if (drag.active) {
+                        // Update the height
+                        root.height = root.height + mouseY;
+
+                        // Ensure a minimum height
+                        if (root.height < root.minumumHeight) {
+                            root.height = root.minumumHeight;
+                        }
+                    }
+                }
+
+                onReleased: {
+                    // emit the width and height for it to be updated
+                    root.resized(mouseArea.width, root.height);
+                }
+            }
+        }
+
+        ///
+        /// Resize Top
+        ///
+        Rectangle {
+            width: mouseArea.width
+            height: 4
+            
+            color: baseColor
+            opacity: 0
+
+            anchors.verticalCenter: parent.top
+
+            MouseArea {
+                id: topDragger
+
+                cursorShape: Qt.SizeVerCursor
+                anchors.fill: parent
+
+                drag{ target: parent; axis: Drag.YAxis }
+
+                onMouseYChanged: {
+                    if (drag.active) {
+                        let h = root.height - mouseY;
+
+                        // Ensure a minimum height
+                        if (h > root.minumumHeight) {
+                            // Update the node's y position and the height
+                            root.y = root.y + mouseY;
+                            root.height = h;
+                        }
+                    }
+                }
+
+                onReleased: {
+                    // emit the node width and height along with the root position
+                    // Dragging from the top moves the node as well
+                    root.resizedAndMoved(root.width, root.height, Qt.point(root.x, root.y));
+                }
+            }
+        }
+
+        // Selection border
+        Rectangle {
+            anchors.fill: nodeContent
+            anchors.margins: -border.width
+            visible: root.mainSelected || root.hovered || root.selected
+            border.width: {
+                if(root.mainSelected)
+                    return 3
+                if(root.selected)
+                    return 2.5
+                return 2
+            }
+            border.color: {
+                if(root.mainSelected)
+                    return activePalette.highlight
+                if(root.selected)
+                    return Qt.darker(activePalette.highlight, 1.2)
+                return Qt.lighter(activePalette.base, 3)
+            }
+            opacity: 0.9
+            radius: background.radius + border.width
+            color: "transparent"
+        }
+
+        Rectangle {
+            id: background
+            anchors.fill: nodeContent
+            color: Qt.darker(baseColor, 1.2)
+            layer.enabled: true
+            layer.effect: DropShadow { radius: 3; color: shadowColor }
+            radius: 3
+            opacity: 0.7
+        }
+
+        Rectangle {
+            id: nodeContent
+            width: parent.width
+            height: parent.height
+            color: "transparent"
+
+            // Data Layout
+            Column {
+                id: body
+                width: parent.width
+
+                // Header
+                Rectangle {
+                    id: header
+                    width: parent.width
+                    height: headerLayout.height
+                    color: root.baseColor
+                    radius: background.radius
+
+                    // Fill header's bottom radius
+                    Rectangle {
+                        width: parent.width
+                        height: parent.radius
+                        anchors.bottom: parent.bottom
+                        color: parent.color
+                        z: -1
+                    }
+
+                    // Header Layout
+                    RowLayout {
+                        id: headerLayout
+                        width: parent.width
+                        spacing: 0
+
+                        // Node Name
+                        Label {
+                            id: nodeLabel
+                            Layout.fillWidth: true
+                            text: node ? node.label : ""
+                            padding: 4
+                            color: "#2b2b2b"
+                            elide: Text.ElideMiddle
+                            font.pointSize: 8
+                        }
+                    }
+                }
+
+                // Vertical Spacer
+                Item { width: parent.width; height: 2 }
+
+                // Node Comments Text which is visible on the backdrop
+                Rectangle {
+                    y: header.height
+
+                    // Show only when we have a comment
+                    visible: node.comment
+
+                    Text {
+                        text: node.comment
+                        padding: 4
+                        font.pointSize: node.fontSize
+                    }
+                }
+            }
+        }
+    }
+}

--- a/meshroom/ui/qml/GraphEditor/Backdrop.qml
+++ b/meshroom/ui/qml/GraphEditor/Backdrop.qml
@@ -14,27 +14,27 @@ import Meshroom.Helpers
 Item {
     id: root
 
-    /// The underlying Node object
+    // The underlying Node object
     property variant node
 
-    /// Mouse related states
+    // Mouse related states
     property bool mainSelected: false
     property bool selected: false
     property bool hovered: false
 
-    // The Item instantiating the delegates.
+    // The item instantiating the delegates
     property Item modelInstantiator: undefined
 
     readonly property bool isBackdrop: true
-    // Node Children for the Backdrop
+    // Node children for the Backdrop
     property var children: []
     property var childrenIndices: []
 
     property bool dragging: mouseArea.drag.active
     property bool resizing: leftDragger.drag.active || topDragger.drag.active
-    /// Combined x and y
+    // Combined x and y
     property point position: Qt.point(x, y)
-    /// Styling
+    // Styling
     property color shadowColor: "#cc000000"
     readonly property color defaultColor: node.color === "" ? "#fffb85" : node.color
     property color baseColor: defaultColor
@@ -60,12 +60,12 @@ Item {
     // Already connected attribute with another edge in DropArea
     signal edgeAboutToBeRemoved(var input)
 
-    /// Emitted when child attribute pins are created
+    // Emitted when child attribute pins are created
     signal attributePinCreated(var attribute, var pin)
-    /// Emitted when child attribute pins are deleted
+    // Emitted when child attribute pins are deleted
     signal attributePinDeleted(var attribute, var pin)
 
-    // use node name as object name to simplify debugging
+    // Use node name as object name to simplify debugging
     objectName: node ? node.name : ""
 
     // initialize position with node coordinates
@@ -75,8 +75,8 @@ Item {
     // The backdrop node always needs to be at the back
     z: -1
 
-    width: root.node ? root.node.nodeWidth : 300;
-    height: root.node ? root.node.nodeHeight : 200;
+    width: root.node ? root.node.nodeWidth : 300
+    height: root.node ? root.node.nodeHeight : 200
 
     implicitHeight: childrenRect.height
 
@@ -84,15 +84,15 @@ Item {
 
     Connections {
         target: root.node
-        // update x,y when node position changes
+
         function onPositionChanged() {
             root.x = root.node.x
             root.y = root.node.y
         }
 
         function onInternalAttributesChanged() {
-            root.width = root.node.nodeWidth;
-            root.height = root.node.nodeHeight;
+            root.width = root.node.nodeWidth
+            root.height = root.node.nodeHeight
         }
     }
 
@@ -105,49 +105,43 @@ Item {
     }
 
     onPressed: {
-        updateChildren();
+        updateChildren()
     }
 
     function updateChildren() {
-        let indices = [];
-        let nodes = [];
-        const backdropRect = Qt.rect(root.node.x, root.node.y, root.node.nodeWidth, root.node.nodeHeight);
+        let indices = []
+        let nodes = []
+        const backdropRect = Qt.rect(root.node.x, root.node.y, root.node.nodeWidth, root.node.nodeHeight)
 
         for (var i = 0; i < modelInstantiator.count; ++i) {
-            const delegate = modelInstantiator.itemAt(i).item;
+            const delegate = modelInstantiator.itemAt(i).item
             if (delegate === this)
                 continue
 
             const delegateRect = Qt.rect(delegate.x, delegate.y, delegate.width, delegate.height);
             if (Geom2D.rectRectFullIntersect(backdropRect, delegateRect)) {
-                indices.push(i);
-                nodes.push(delegate);
+                indices.push(i)
+                nodes.push(delegate)
             }
         }
-        childrenIndices = indices;
-        children = nodes;
+        childrenIndices = indices
+        children = nodes
     }
 
     function getChildrenNodes(refresh = false) {
-        /**
-         * Returns the current nodes which are a part of the Backdrop.
-         */
-        // Update the children if required
+        // Returns the current nodes which are a part of the Backdrop
         if (refresh) {
-            updateChildren();
+            updateChildren()
         }
-        return children;
+        return children
     }
 
     function getChildrenIndices(refresh = false) {
-        /**
-         * Returns the current nodes' indices which are a part of the Backdrop.
-         */
-        // Update the children if required
+        // Returns the current nodes' indices which are a part of the Backdrop
         if (refresh) {
-            updateChildren();
+            updateChildren()
         }
-        return childrenIndices;
+        return childrenIndices
     }
 
     // Main Layout
@@ -174,10 +168,8 @@ Item {
 
         cursorShape: drag.active ? Qt.ClosedHandCursor : Qt.ArrowCursor
 
-        /// Backdrop Resize Controls ???
-        ///
-        /// Resize Right Side
-        ///
+        // --- Backdrop Resize Controls
+        // Resize: right side
         Rectangle {
             width: 4
             height: nodeContent.height
@@ -199,25 +191,22 @@ Item {
                 onMouseXChanged: {
                     if (drag.active) {
                         // Update the area width
-                        root.width = root.width + mouseX;
+                        root.width = root.width + mouseX
 
                         // Ensure we have a minimum width always
                         if (root.width < root.minimumWidth) {
-                            root.width = root.minimumWidth;
+                            root.width = root.minimumWidth
                         }
                     }
                 }
 
                 onReleased: {
-                    // emit the width and height
                     root.resized(root.width, nodeContent.height);
                 }
             }
         }
 
-        ///
-        /// Resize Left Side
-        ///
+        // Resize: left size
         Rectangle {
             width: 4
             height: nodeContent.height
@@ -248,22 +237,19 @@ Item {
                         if (w > root.minimumWidth) {
                             // Update the node's x position and the width
                             root.x = root.x + mouseX
-                            root.width = w;
+                            root.width = w
                         }
                     }
                 }
 
                 onReleased: {
-                    // emit the node width and height along with the root position
                     // Dragging from the left moves the node as well
-                    root.resizedAndMoved(root.width, root.height, Qt.point(root.x, root.y));
+                    root.resizedAndMoved(root.width, root.height, Qt.point(root.x, root.y))
                 }
             }
         }
 
-        ///
-        /// Resize Bottom
-        ///
+        // Resize: bottom
         Rectangle {
             width: mouseArea.width
             height: 4
@@ -284,25 +270,22 @@ Item {
                 onMouseYChanged: {
                     if (drag.active) {
                         // Update the height
-                        root.height = root.height + mouseY;
+                        root.height = root.height + mouseY
 
                         // Ensure a minimum height
                         if (root.height < root.minumumHeight) {
-                            root.height = root.minumumHeight;
+                            root.height = root.minumumHeight
                         }
                     }
                 }
 
                 onReleased: {
-                    // emit the width and height for it to be updated
-                    root.resized(mouseArea.width, root.height);
+                    root.resized(mouseArea.width, root.height)
                 }
             }
         }
 
-        ///
-        /// Resize Top
-        ///
+        // Resize: top
         Rectangle {
             width: mouseArea.width
             height: 4
@@ -322,19 +305,18 @@ Item {
 
                 onMouseYChanged: {
                     if (drag.active) {
-                        let h = root.height - mouseY;
+                        let h = root.height - mouseY
 
                         // Ensure a minimum height
                         if (h > root.minumumHeight) {
                             // Update the node's y position and the height
-                            root.y = root.y + mouseY;
-                            root.height = h;
+                            root.y = root.y + mouseY
+                            root.height = h
                         }
                     }
                 }
 
                 onReleased: {
-                    // emit the node width and height along with the root position
                     // Dragging from the top moves the node as well
                     root.resizedAndMoved(root.width, root.height, Qt.point(root.x, root.y));
                 }

--- a/meshroom/ui/qml/GraphEditor/Backdrop.qml
+++ b/meshroom/ui/qml/GraphEditor/Backdrop.qml
@@ -34,7 +34,7 @@ Item {
     // Combined x and y
     property point position: Qt.point(x, y)
     // Styling
-    property color shadowColor: "#cc000000"
+    property color shadowColor: "#000000"
     readonly property color defaultColor: node.color === "" ? "#fffb85" : node.color
     property color baseColor: defaultColor
 
@@ -168,6 +168,58 @@ Item {
         cursorShape: drag.active ? Qt.ClosedHandCursor : Qt.ArrowCursor
 
         // --- Backdrop Resize Controls
+        // Resize: diagonal bottom-right
+        Rectangle {
+            width: 8
+            height: 8
+
+            color: baseColor
+            opacity: 0
+
+            anchors.horizontalCenter: parent.right
+            anchors.verticalCenter: parent.bottom
+
+            MouseArea {
+                id: diagonalDragger
+
+                cursorShape: Qt.SizeFDiagCursor
+                anchors.fill: parent
+
+                drag {
+                    target: parent
+                    axis: Drag.XAndYAxis
+                }
+
+                onMouseXChanged: {
+                    if (drag.active) {
+                        // Update the area width
+                        root.width = root.width + mouseX
+
+                        // Ensure we have a minimum width always
+                        if (root.width < root.minimumWidth) {
+                            root.width = root.minimumWidth
+                        }
+                    }
+                }
+
+                onMouseYChanged: {
+                    if (drag.active) {
+                        // Update the height
+                        root.height = root.height + mouseY
+
+                        // Ensure a minimum height
+                        if (root.height < root.minimumHeight) {
+                            root.height = root.minimumHeight
+                        }
+                    }
+                }
+
+                onReleased: {
+                    root.resized(root.width, root.height)
+                }
+            }
+        }
+
         // Resize: right side
         Rectangle {
             width: 4

--- a/meshroom/ui/qml/GraphEditor/Backdrop.qml
+++ b/meshroom/ui/qml/GraphEditor/Backdrop.qml
@@ -474,20 +474,20 @@ Item {
                 }
 
                 // Node Comments Text which is visible on the backdrop
-                Rectangle {
+                Text {
+                    visible: node.comment
+                    text: node.comment
+                    font.pointSize: node.fontSize
+
                     y: header.height
 
-                    // Show only when we have a comment
-                    visible: node.comment
-                    width: parent.width
+                    padding: 4
 
-                    Text {
-                        text: node.comment
-                        padding: 4
-                        font.pointSize: node.fontSize
-                        width: parent.width
-                        wrapMode: Text.Wrap
-                    }
+                    width: parent.width
+                    height: nodeContent.height - header.height
+
+                    wrapMode: Text.Wrap
+                    elide: Text.ElideRight
                 }
             }
         }

--- a/meshroom/ui/qml/GraphEditor/Backdrop.qml
+++ b/meshroom/ui/qml/GraphEditor/Backdrop.qml
@@ -185,7 +185,10 @@ Item {
                 cursorShape: Qt.SizeHorCursor
                 anchors.fill: parent
 
-                drag { target: parent; axis: Drag.XAxis }
+                drag {
+                    target: parent
+                    axis: Drag.XAxis
+                }
 
                 onMouseXChanged: {
                     if (drag.active) {
@@ -222,7 +225,10 @@ Item {
                 cursorShape: Qt.SizeHorCursor
                 anchors.fill: parent
 
-                drag { target: parent; axis: Drag.XAxis }
+                drag {
+                    target: parent
+                    axis: Drag.XAxis
+                }
 
                 onMouseXChanged: {
                     if (drag.active) {
@@ -264,7 +270,10 @@ Item {
                 cursorShape: Qt.SizeVerCursor
                 anchors.fill: parent
 
-                drag{ target: parent; axis: Drag.YAxis }
+                drag {
+                    target: parent
+                    axis: Drag.YAxis
+                }
 
                 onMouseYChanged: {
                     if (drag.active) {
@@ -288,7 +297,7 @@ Item {
         Rectangle {
             width: mouseArea.width
             height: 4
-            
+
             color: baseColor
             opacity: 0
 
@@ -300,7 +309,10 @@ Item {
                 cursorShape: Qt.SizeVerCursor
                 anchors.fill: parent
 
-                drag{ target: parent; axis: Drag.YAxis }
+                drag {
+                    target: parent
+                    axis: Drag.YAxis
+                }
 
                 onMouseYChanged: {
                     if (drag.active) {
@@ -328,16 +340,16 @@ Item {
             anchors.margins: -border.width
             visible: root.mainSelected || root.hovered || root.selected
             border.width: {
-                if(root.mainSelected)
+                if (root.mainSelected)
                     return 3
-                if(root.selected)
+                if (root.selected)
                     return 2.5
                 return 2
             }
             border.color: {
-                if(root.mainSelected)
+                if (root.mainSelected)
                     return activePalette.highlight
-                if(root.selected)
+                if (root.selected)
                     return Qt.darker(activePalette.highlight, 1.2)
                 return Qt.lighter(activePalette.base, 3)
             }
@@ -404,7 +416,10 @@ Item {
                 }
 
                 // Vertical Spacer
-                Item { width: parent.width; height: 2 }
+                Item {
+                    width: parent.width
+                    height: 2
+                }
 
                 // Node Comments Text which is visible on the backdrop
                 Rectangle {

--- a/meshroom/ui/qml/GraphEditor/Backdrop.qml
+++ b/meshroom/ui/qml/GraphEditor/Backdrop.qml
@@ -413,11 +413,14 @@ Item {
 
                     // Show only when we have a comment
                     visible: node.comment
+                    width: parent.width
 
                     Text {
                         text: node.comment
                         padding: 4
                         font.pointSize: node.fontSize
+                        width: parent.width
+                        wrapMode: Text.Wrap
                     }
                 }
             }

--- a/meshroom/ui/qml/GraphEditor/Backdrop.qml
+++ b/meshroom/ui/qml/GraphEditor/Backdrop.qml
@@ -478,6 +478,7 @@ Item {
                     visible: node.comment
                     text: node.comment
                     font.pointSize: node.fontSize
+                    color: node.fontColor === "" ? "#000000" : node.fontColor
 
                     y: header.height
 

--- a/meshroom/ui/qml/GraphEditor/Backdrop.qml
+++ b/meshroom/ui/qml/GraphEditor/Backdrop.qml
@@ -25,7 +25,6 @@ Item {
     // The item instantiating the delegates
     property Item modelInstantiator: undefined
 
-    readonly property bool isBackdrop: true
     // Node children for the Backdrop
     property var children: []
     property var childrenIndices: []
@@ -40,7 +39,7 @@ Item {
     property color baseColor: defaultColor
 
     readonly property int minimumWidth: 200
-    readonly property int minumumHeight: 200
+    readonly property int minimumHeight: 200
 
     property point mousePosition: Qt.point(mouseArea.mouseX, mouseArea.mouseY)
 
@@ -97,7 +96,7 @@ Item {
     }
 
     // When the node is selected, update the children for it
-    // For node to consider another ndoe, it needs to be fully inside the backdrop area
+    // For node to consider another node, it needs to be fully inside the backdrop area
     onSelectedChanged: {
         if (selected) {
             updateChildren()
@@ -114,11 +113,11 @@ Item {
         const backdropRect = Qt.rect(root.node.x, root.node.y, root.node.nodeWidth, root.node.nodeHeight)
 
         for (var i = 0; i < modelInstantiator.count; ++i) {
-            const delegate = modelInstantiator.itemAt(i).item
-            if (delegate === this)
+            const delegate = modelInstantiator.getItemAt(i)
+            if (!delegate || delegate === this)
                 continue
 
-            const delegateRect = Qt.rect(delegate.x, delegate.y, delegate.width, delegate.height);
+            const delegateRect = Qt.rect(delegate.x, delegate.y, delegate.width, delegate.height)
             if (Geom2D.rectRectFullIntersect(backdropRect, delegateRect)) {
                 indices.push(i)
                 nodes.push(delegate)
@@ -147,8 +146,8 @@ Item {
     // Main Layout
     MouseArea {
         id: mouseArea
-        width: root.width;
-        height: root.height;
+        width: root.width
+        height: root.height
         drag.target: root
         // Small drag threshold to avoid moving the node by mistake
         drag.threshold: 2
@@ -201,12 +200,12 @@ Item {
                 }
 
                 onReleased: {
-                    root.resized(root.width, nodeContent.height);
+                    root.resized(root.width, nodeContent.height)
                 }
             }
         }
 
-        // Resize: left size
+        // Resize: left side
         Rectangle {
             width: 4
             height: nodeContent.height
@@ -273,8 +272,8 @@ Item {
                         root.height = root.height + mouseY
 
                         // Ensure a minimum height
-                        if (root.height < root.minumumHeight) {
-                            root.height = root.minumumHeight
+                        if (root.height < root.minimumHeight) {
+                            root.height = root.minimumHeight
                         }
                     }
                 }
@@ -308,7 +307,7 @@ Item {
                         let h = root.height - mouseY
 
                         // Ensure a minimum height
-                        if (h > root.minumumHeight) {
+                        if (h > root.minimumHeight) {
                             // Update the node's y position and the height
                             root.y = root.y + mouseY
                             root.height = h
@@ -318,7 +317,7 @@ Item {
 
                 onReleased: {
                     // Dragging from the top moves the node as well
-                    root.resizedAndMoved(root.width, root.height, Qt.point(root.x, root.y));
+                    root.resizedAndMoved(root.width, root.height, Qt.point(root.x, root.y))
                 }
             }
         }

--- a/meshroom/ui/qml/GraphEditor/GraphEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/GraphEditor.qml
@@ -53,8 +53,8 @@ Item {
     /// Get node delegate for the given node object
     function nodeDelegate(node) {
         for(var i = 0; i < nodeRepeater.count; ++i) {
-            if (nodeRepeater.itemAt(i).node === node)
-                return nodeRepeater.itemAt(i)
+            if (nodeRepeater.getItemAt(i).node === node)
+                return nodeRepeater.getItemAt(i)
         }
         return undefined
     }
@@ -867,7 +867,6 @@ Item {
                                 nodeMenu.close()
                             }
                         }
-
                     }
                 }
             }
@@ -1291,7 +1290,7 @@ Item {
                         "deleteFollowing": false
                     }
                 );
-                dialog.open(); 
+                dialog.open()
             }
             else {
                 uigraph.clearSelectedNodesData()
@@ -1459,13 +1458,13 @@ Item {
 
             function nextItem() {
                 // Compute bounding box
-                var node = nodeRepeater.itemAt(filteredNodes.itemAt(navigation.currentIndex).index_)
+                var node = nodeRepeater.getItemAt(filteredNodes.itemAt(navigation.currentIndex).index_)
                 var bbox = Qt.rect(node.x, node.y, node.width, node.height)
                 // Rescale to fit the bounding box in the view, zoom is limited to prevent huge text
                 draggable.scale = Math.min(Math.min(root.width / bbox.width, root.height / bbox.height),maxZoom)
                 // Recenter
-                draggable.x = bbox.x*draggable.scale * -1 + (root.width - bbox.width * draggable.scale) * 0.5
-                draggable.y = bbox.y*draggable.scale * -1 + (root.height - bbox.height * draggable.scale) * 0.5
+                draggable.x = bbox.x * draggable.scale * -1 + (root.width - bbox.width * draggable.scale) * 0.5
+                draggable.y = bbox.y * draggable.scale * -1 + (root.height - bbox.height * draggable.scale) * 0.5
             }
         }
     }
@@ -1503,13 +1502,13 @@ Item {
          * Maximum x,y postion of the selected nodes.
          */
         var firstIdx = uigraph.nodeSelection.selectedIndexes[0]
-        const first = nodeRepeater.itemAt(firstIdx.row)
+        const first = nodeRepeater.getItemAt(firstIdx.row)
         // Bounding box of the first selected item
         var bbox = Qt.rect(first.x, first.y, first.x + first.width, first.y + first.height)
         // Iterate over the remaining items in the selection
         uigraph.nodeSelection.selectedIndexes.forEach(function(idx) {
             if(idx != firstIdx) {
-                const item = nodeRepeater.itemAt(idx.row)
+                const item = nodeRepeater.getItemAt(idx.row)
                 bbox.x = Math.min(bbox.x, item.x)
                 bbox.y = Math.min(bbox.y, item.y)
                 bbox.width = Math.max(bbox.width, item.x + item.width)

--- a/meshroom/ui/qml/GraphEditor/GraphEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/GraphEditor.qml
@@ -911,150 +911,174 @@ Item {
                 property bool updateSelectionOnClick: false
                 property var temporaryEdgeAboutToBeRemoved: undefined
 
-                delegate: Node {
-                    id: nodeDelegate
+                function getItemAt(index) {
+                    const loader = itemAt(index)
+                    if (loader && loader.item)
+                        return loader.item
+                    return null
+                }
 
-                    node: object
-                    width: uigraph.layout.nodeWidth
+                delegate: Loader {
+                    id: nodeLoader
+                    Component {
+                        id: nodeComponent
+                        Node {
+                            id: nodeDelegate
 
-                    mainSelected: uigraph.selectedNode === node
-                    hovered: uigraph.hoveredNode === node
+                            node: object
+                            width: uigraph.layout.nodeWidth
 
-                    // ItemSelectionModel.hasSelection triggers updates anytime the selectionChanged() signal is emitted.
-                    selected: uigraph.nodeSelection.hasSelection ? uigraph.nodeSelection.isRowSelected(index) : false
+                            mainSelected: uigraph.selectedNode === node
+                            hovered: uigraph.hoveredNode === node
 
-                    onAttributePinCreated: function(attribute, pin) { registerAttributePin(attribute, pin) }
-                    onAttributePinDeleted: function(attribute, pin) { unregisterAttributePin(attribute, pin) }
+                            // ItemSelectionModel.hasSelection triggers updates anytime the selectionChanged() signal is emitted.
+                            selected: uigraph.nodeSelection.hasSelection ? uigraph.nodeSelection.isRowSelected(index) : false
 
-                    onShaked: {
-                        uigraph.disconnectSelectedNodes();
-                    }
+                            onAttributePinCreated: function(attribute, pin) { registerAttributePin(attribute, pin) }
+                            onAttributePinDeleted: function(attribute, pin) { unregisterAttributePin(attribute, pin) }
 
-                    onPressed: function(mouse) {
-                        nodeRepeater.updateSelectionOnClick = true;
-                        nodeRepeater.ongoingDrag = true;
-
-                        let selectionMode = ItemSelectionModel.NoUpdate;
-
-                        if(!selected) {
-                            selectionMode = ItemSelectionModel.ClearAndSelect;
-                        }
-
-                        if (mouse.button === Qt.LeftButton) {
-                            if(mouse.modifiers & Qt.ShiftModifier) {
-                                selectionMode = ItemSelectionModel.Select;
+                            onShaked: {
+                                uigraph.disconnectSelectedNodes();
                             }
-                            if(mouse.modifiers & Qt.ControlModifier) {
-                                selectionMode = ItemSelectionModel.Toggle;
-                            }
-                            if(mouse.modifiers & Qt.AltModifier) {
-                                let selectFollowingMode = ItemSelectionModel.ClearAndSelect;
-                                if(mouse.modifiers & Qt.ShiftModifier) {
-                                    selectFollowingMode = ItemSelectionModel.Select;
+
+                            onPressed: function(mouse) {
+                                nodeRepeater.updateSelectionOnClick = true;
+                                nodeRepeater.ongoingDrag = true;
+
+                                let selectionMode = ItemSelectionModel.NoUpdate;
+
+                                if(!selected) {
+                                    selectionMode = ItemSelectionModel.ClearAndSelect;
                                 }
-                                uigraph.selectFollowing(node, selectFollowingMode);
-                                // Indicate selection has been dealt with by setting conservative Select mode.
-                                selectionMode = ItemSelectionModel.Select;
+
+                                if (mouse.button === Qt.LeftButton) {
+                                    if(mouse.modifiers & Qt.ShiftModifier) {
+                                        selectionMode = ItemSelectionModel.Select;
+                                    }
+                                    if(mouse.modifiers & Qt.ControlModifier) {
+                                        selectionMode = ItemSelectionModel.Toggle;
+                                    }
+                                    if(mouse.modifiers & Qt.AltModifier) {
+                                        let selectFollowingMode = ItemSelectionModel.ClearAndSelect;
+                                        if(mouse.modifiers & Qt.ShiftModifier) {
+                                            selectFollowingMode = ItemSelectionModel.Select;
+                                        }
+                                        uigraph.selectFollowing(node, selectFollowingMode);
+                                        // Indicate selection has been dealt with by setting conservative Select mode.
+                                        selectionMode = ItemSelectionModel.Select;
+                                    }
+                                }
+                                else if (mouse.button === Qt.RightButton) {
+                                    if(selected) {
+                                        // Keep the full selection when right-clicking on an already selected node.
+                                        nodeRepeater.updateSelectionOnClick = false;
+                                    }
+                                }
+
+                                if(selectionMode != ItemSelectionModel.NoUpdate) {
+                                    nodeRepeater.updateSelectionOnClick = false;
+                                    uigraph.selectNodeByIndex(index, selectionMode);
+                                }
+
+                                // If the node is selected after this, make it the active selected node.
+                                if(selected) {
+                                    uigraph.selectedNode = node;
+                                }
+
+                                // Open the node context menu once selection has been updated.
+                                if(mouse.button == Qt.RightButton) {
+                                    nodeMenuLoader.load(node)
+                                }
+
+                            }
+
+                            onReleased: function(mouse, wasDragged) {
+                                nodeRepeater.ongoingDrag = false;
+                            }
+
+                            // Only called when the node has not been dragged.
+                            onClicked: function(mouse) {
+                                if(!nodeRepeater.updateSelectionOnClick) {
+                                    return;
+                                }
+                                uigraph.selectNodeByIndex(index);
+                            }
+
+                            onDoubleClicked: function(mouse) { root.nodeDoubleClicked(mouse, node) }
+
+                            onEntered: uigraph.hoveredNode = node
+                            onExited: uigraph.hoveredNode = null
+
+                            onEdgeAboutToBeRemoved: function(input) {
+                                /*
+                                * Sometimes the signals are not in the right order because of weird Qt/QML update order
+                                * (next DropArea entered signal before previous DropArea exited signal) so edgeAboutToBeRemoved
+                                * must be set to undefined before it can be set to another attribute object.
+                                */
+                                if (input === undefined) {
+                                    if (nodeRepeater.temporaryEdgeAboutToBeRemoved === undefined) {
+                                        root.edgeAboutToBeRemoved = input
+                                    } else {
+                                        root.edgeAboutToBeRemoved = nodeRepeater.temporaryEdgeAboutToBeRemoved
+                                        nodeRepeater.temporaryEdgeAboutToBeRemoved = undefined
+                                    }
+                                } else {
+                                    if (root.edgeAboutToBeRemoved === undefined) {
+                                        root.edgeAboutToBeRemoved = input
+                                    } else {
+                                        nodeRepeater.temporaryEdgeAboutToBeRemoved = input
+                                    }
+                                }
+                            }
+
+                            // Interactive dragging: move the visual delegates
+                            onPositionChanged: {
+                                if(!selected || !dragging) {
+                                    return;
+                                }
+
+                                // Check for shake on the node
+                                checkForShake();
+
+                                // Compute offset between the delegate and the stored node position.
+                                const offset = Qt.point(x - node.x, y - node.y);
+
+                                uigraph.nodeSelection.selectedIndexes.forEach(function(idx) {
+                                    if (idx != index) {
+                                        const delegate = nodeRepeater.getItemAt(idx.row);
+                                        delegate.x = delegate.node.x + offset.x;
+                                        delegate.y = delegate.node.y + offset.y;
+                                    }
+                                });
+                            }
+
+                            // After drag: apply the final offset to all selected nodes
+                            onMoved: function(position) {
+                                const offset = Qt.point(position.x - node.x, position.y - node.y);
+                                uigraph.moveSelectedNodesBy(offset);
+                            }
+
+                            Behavior on x {
+                                enabled: !nodeRepeater.ongoingDrag
+                                NumberAnimation { duration: 100 }
+                            }
+                            Behavior on y {
+                                enabled: !nodeRepeater.ongoingDrag
+                                NumberAnimation { duration: 100 }
                             }
                         }
-                        else if (mouse.button === Qt.RightButton) {
-                            if(selected) {
-                                // Keep the full selection when right-clicking on an already selected node.
-                                nodeRepeater.updateSelectionOnClick = false;
-                            }
-                        }
-
-                        if(selectionMode != ItemSelectionModel.NoUpdate) {
-                            nodeRepeater.updateSelectionOnClick = false;
-                            uigraph.selectNodeByIndex(index, selectionMode);
-                        }
-
-                        // If the node is selected after this, make it the active selected node.
-                        if(selected) {
-                            uigraph.selectedNode = node;
-                        }
-
-                        // Open the node context menu once selection has been updated.
-                        if(mouse.button == Qt.RightButton) {
-                            nodeMenuLoader.load(node)
-                        }
-
                     }
 
-                    onReleased: function(mouse, wasDragged) {
-                        nodeRepeater.ongoingDrag = false;
-                    }
-
-                    // Only called when the node has not been dragged.
-                    onClicked: function(mouse) {
-                        if(!nodeRepeater.updateSelectionOnClick) {
-                            return;
-                        }
-                        uigraph.selectNodeByIndex(index);
-                    }
-
-                    onDoubleClicked: function(mouse) { root.nodeDoubleClicked(mouse, node) }
-
-                    onEntered: uigraph.hoveredNode = node
-                    onExited: uigraph.hoveredNode = null
-
-                    onEdgeAboutToBeRemoved: function(input) {
-                        /*
-                         * Sometimes the signals are not in the right order because of weird Qt/QML update order
-                         * (next DropArea entered signal before previous DropArea exited signal) so edgeAboutToBeRemoved
-                         * must be set to undefined before it can be set to another attribute object.
-                         */
-                        if (input === undefined) {
-                            if (nodeRepeater.temporaryEdgeAboutToBeRemoved === undefined) {
-                                root.edgeAboutToBeRemoved = input
-                            } else {
-                                root.edgeAboutToBeRemoved = nodeRepeater.temporaryEdgeAboutToBeRemoved
-                                nodeRepeater.temporaryEdgeAboutToBeRemoved = undefined
-                            }
-                        } else {
-                            if (root.edgeAboutToBeRemoved === undefined) {
-                                root.edgeAboutToBeRemoved = input
-                            } else {
-                                nodeRepeater.temporaryEdgeAboutToBeRemoved = input
-                            }
+                    Component {
+                        id: backdropComponent
+                        Backdrop {
+                            id: backdropDelegate
+                            node: object
+                            modelInstantiator: nodeRepeater
                         }
                     }
 
-                    // Interactive dragging: move the visual delegates
-                    onPositionChanged: {
-                        if(!selected || !dragging) {
-                            return;
-                        }
-
-                        // Check for shake on the node
-                        checkForShake();
-
-                        // Compute offset between the delegate and the stored node position.
-                        const offset = Qt.point(x - node.x, y - node.y);
-
-                        uigraph.nodeSelection.selectedIndexes.forEach(function(idx) {
-                            if(idx != index) {
-                                const delegate = nodeRepeater.itemAt(idx.row);
-                                delegate.x = delegate.node.x + offset.x;
-                                delegate.y = delegate.node.y + offset.y;
-                            }
-                        });
-                    }
-
-                    // After drag: apply the final offset to all selected nodes
-                    onMoved: function(position) {
-                        const offset = Qt.point(position.x - node.x, position.y - node.y);
-                        uigraph.moveSelectedNodesBy(offset);
-                    }
-
-                    Behavior on x {
-                        enabled: !nodeRepeater.ongoingDrag
-                        NumberAnimation { duration: 100 }
-                    }
-                    Behavior on y {
-                        enabled: !nodeRepeater.ongoingDrag
-                        NumberAnimation { duration: 100 }
-                    }
+                    sourceComponent: object.isBackdropNode ? backdropComponent : nodeComponent
                 }
             }
         }
@@ -1332,13 +1356,13 @@ Item {
     }
 
     function boundingBox() {
-        var first = nodeRepeater.itemAt(0)
+        var first = nodeRepeater.getItemAt(0)
         if (first === null) {
             return Qt.rect(0, 0, 0, 0)
         }
         var bbox = Qt.rect(first.x, first.y, first.x + first.width, first.y + first.height)
         for (var i = 0; i < root.graph.nodes.count; ++i) {
-            var item = nodeRepeater.itemAt(i)
+            var item = nodeRepeater.getItemAt(i)
             bbox.x = Math.min(bbox.x, item.x)
             bbox.y = Math.min(bbox.y, item.y)
             bbox.width = Math.max(bbox.width, item.x + item.width)
@@ -1346,7 +1370,7 @@ Item {
         }
         bbox.width -= bbox.x
         bbox.height -= bbox.y
-        return bbox;
+        return bbox
     }
 
     function selectionBoundingBox() {
@@ -1355,35 +1379,35 @@ Item {
          * The returned bounding box starts from the Minumum x,y position to the 
          * Maximum x,y postion of the selected nodes.
          */
-        var firstIdx = uigraph.nodeSelection.selectedIndexes[0];
-        const first = nodeRepeater.itemAt(firstIdx.row);
+        var firstIdx = uigraph.nodeSelection.selectedIndexes[0]
+        const first = nodeRepeater.itemAt(firstIdx.row)
         // Bounding box of the first selected item
-        var bbox = Qt.rect(first.x, first.y, first.x + first.width, first.y + first.height);
+        var bbox = Qt.rect(first.x, first.y, first.x + first.width, first.y + first.height)
         // Iterate over the remaining items in the selection
         uigraph.nodeSelection.selectedIndexes.forEach(function(idx) {
             if(idx != firstIdx) {
-                const item = nodeRepeater.itemAt(idx.row);
-                bbox.x = Math.min(bbox.x, item.x);
-                bbox.y = Math.min(bbox.y, item.y);
-                bbox.width = Math.max(bbox.width, item.x + item.width);
-                bbox.height = Math.max(bbox.height, item.y + item.height);
+                const item = nodeRepeater.itemAt(idx.row)
+                bbox.x = Math.min(bbox.x, item.x)
+                bbox.y = Math.min(bbox.y, item.y)
+                bbox.width = Math.max(bbox.width, item.x + item.width)
+                bbox.height = Math.max(bbox.height, item.y + item.height)
             }
-        });
+        })
 
-        bbox.width -= bbox.x;
-        bbox.height -= bbox.y;
-        return bbox;
+        bbox.width -= bbox.x
+        bbox.height -= bbox.y
+        return bbox
     }
 
     // Fit graph to fill root
     function fit() {
-        var bbox;
+        var bbox
         // Compute bounding box
         if (uigraph.nodeSelection.hasSelection) {
-            bbox = selectionBoundingBox();
+            bbox = selectionBoundingBox()
         }
         else {
-            bbox = boundingBox();
+            bbox = boundingBox()
         }
         // Rescale to fit the bounding box in the view, zoom is limited to prevent huge text
         draggable.scale = Math.min(Math.min(root.width / bbox.width, root.height / bbox.height), maxZoom)

--- a/meshroom/ui/qml/GraphEditor/GraphEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/GraphEditor.qml
@@ -1173,7 +1173,7 @@ Item {
 
                                 uigraph.nodeSelection.selectedIndexes.forEach(function(idx) {
                                     if (idx != index) {
-                                        const delegate = nodeRepeater.itemAt(idx.row).item
+                                        const delegate = nodeRepeater.getItemAt(idx.row)
                                         delegate.x = delegate.node.x + offset.x
                                         delegate.y = delegate.node.y + offset.y
                                     }

--- a/meshroom/ui/qml/GraphEditor/GraphEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/GraphEditor.qml
@@ -82,18 +82,18 @@ Item {
 
     /// Paste content of clipboard to graph editor and create new node if valid
     function pasteNodes() {
-        let finalPosition = undefined;
+        let finalPosition = undefined
         if (mouseArea.containsMouse) {
-            finalPosition = mapToItem(draggable, mouseArea.mouseX, mouseArea.mouseY);
+            finalPosition = mapToItem(draggable, mouseArea.mouseX, mouseArea.mouseY)
         } else {
-            finalPosition = getCenterPosition();
+            finalPosition = getCenterPosition()
         }
 
-        const copiedContent = Clipboard.getText();
-        const nodes = uigraph.pasteNodes(copiedContent, finalPosition);
+        const copiedContent = Clipboard.getText()
+        const nodes = uigraph.pasteNodes(copiedContent, finalPosition)
         if (nodes.length > 0) {
-            uigraph.selectedNode = nodes[0];
-            uigraph.selectNodes(nodes);
+            uigraph.selectedNode = nodes[0]
+            uigraph.selectNodes(nodes)
         }
     }
 
@@ -147,7 +147,7 @@ Item {
         id: mouseArea
         anchors.fill: parent
         property double factor: 1.15
-        property bool removingEdges: false;
+        property bool removingEdges: false
         // Activate multisampling for edges antialiasing
         layer.enabled: true
         layer.samples: 8
@@ -176,22 +176,22 @@ Item {
                 uigraph.clearNodeSelection()
             }
             if (mouse.button == Qt.LeftButton && (mouse.modifiers == Qt.NoModifier || mouse.modifiers & (Qt.ControlModifier | Qt.ShiftModifier))) {
-                nodeSelectionBox.startSelection(mouse);
+                nodeSelectionBox.startSelection(mouse)
             }
             if (mouse.button == Qt.MiddleButton || (mouse.button == Qt.LeftButton && mouse.modifiers & Qt.AltModifier)) {
                 drag.target = draggable // start drag
             }
             if (mouse.button == Qt.LeftButton && (mouse.modifiers & Qt.ControlModifier) && (mouse.modifiers & Qt.AltModifier)) {
-                edgeSelectionLine.startSelection(mouse);
-                removingEdges = true;
+                edgeSelectionLine.startSelection(mouse)
+                removingEdges = true
             }
         }
 
         onReleased: {
-            removingEdges = false;
+            removingEdges = false
             edgeSelectionLine.endSelection()
-            nodeSelectionBox.endSelection();
-            drag.target = null;
+            nodeSelectionBox.endSelection()
+            drag.target = null
             root.forceActiveFocus()
             workspaceClicked()
         }
@@ -222,8 +222,8 @@ Item {
                 // If it is not a pipeline to import, then it must be a node
                 if (!importPipeline(nodeType)) {
                     // Add node via the proper command in uigraph
-                    var node = uigraph.addNewNode(nodeType, spawnPosition);
-                    uigraph.selectedNode = node;
+                    var node = uigraph.addNewNode(nodeType, spawnPosition)
+                    uigraph.selectedNode = node
                     uigraph.selectNodes([node])
                 }
                 close()
@@ -243,9 +243,9 @@ Item {
             function parseCategories() {
                 // Organize nodes based on their category
                 // {"category1": ["node1", "node2"], "category2": ["node3", "node4"]}
-                let categories = {};
+                let categories = {}
                 for (const [name, data] of Object.entries(root.nodeTypesModel)) {
-                    let category = data["category"];
+                    let category = data["category"]
                     if (categories[category] === undefined) {
                         categories[category] = []
                     }
@@ -288,7 +288,7 @@ Item {
                     // even if this delegate took the activeFocus due to mouse hovering
                     Keys.forwardTo: [searchBar.textField]
                     Keys.onPressed: function(event) {
-                        event.accepted = false;
+                        event.accepted = false
                         switch (event.key) {
                             case Qt.Key_Return:
                             case Qt.Key_Enter:
@@ -306,7 +306,7 @@ Item {
                         }
                     }
                     // Set the priority ordering of the keys to be Item's own Key Handling > ForwardTo
-                    Keys.priority: Keys.AfterItem;
+                    Keys.priority: Keys.AfterItem
                     // Create node on mouse click
                     onClicked: newNodeMenu.createNode(modelData)
 
@@ -569,25 +569,25 @@ Item {
                 sourceComponent: nodeMenuComponent
 
                 function load(node) {
-                    currentNode = node;
+                    currentNode = node
                 }
 
                 function unload() {
-                    currentNode = null;
+                    currentNode = null
                 }
 
                 function showDataDeletionDialog(deleteFollowing: bool, callback) {
-                    uigraph.forceNodesStatusUpdate();
+                    uigraph.forceNodesStatusUpdate()
                     const dialog = deleteDataDialog.createObject(
                         root,
                         {
                             "node": currentNode,
                             "deleteFollowing": deleteFollowing
                         }
-                    );
-                    dialog.open();
+                    )
+                    dialog.open()
                     if(callback)
-                        dialog.dataDeleted.connect(callback);
+                        dialog.dataDeleted.connect(callback)
                 }
             }
 
@@ -600,53 +600,53 @@ Item {
 
                     // Cache computatibility/submitability status of each selected node.
                     readonly property var nodeSubmitOrComputeStatus: {
-                        var collectedStatus = ({});
+                        var collectedStatus = ({})
                         uigraph.nodeSelection.selectedIndexes.forEach(function(idx) {
-                            const node = uigraph.graph.nodes.at(idx.row);
-                            collectedStatus[node] = uigraph.graph.canSubmitOrCompute(node);
-                        });
-                        return collectedStatus;
+                            const node = uigraph.graph.nodes.at(idx.row)
+                            collectedStatus[node] = uigraph.graph.canSubmitOrCompute(node)
+                        })
+                        return collectedStatus
                     }
 
                     readonly property bool isSelectionFullyComputed: {
                         return uigraph.nodeSelection.selectedIndexes.every(function(idx) {
-                            const node = uigraph.graph.nodes.at(idx.row);
-                            return node.isComputed;
-                        });
+                            const node = uigraph.graph.nodes.at(idx.row)
+                            return node.isComputed
+                        })
                     }
 
                     // Selection contains only compatibility nodes
                     readonly property bool isSelectionFullyCompatibility: {
                         return uigraph.nodeSelection.selectedIndexes.every(function(idx) {
-                            const node = uigraph.graph.nodes.at(idx.row);
-                            return node.isCompatibilityNode;
-                        });
+                            const node = uigraph.graph.nodes.at(idx.row)
+                            return node.isCompatibilityNode
+                        })
                     }
 
                     // Selection contains at least one computable node type
                     readonly property bool selectionContainsComputableNodeType: {
                         return uigraph.nodeSelection.selectedIndexes.some(function(idx) {
-                            const node = uigraph.graph.nodes.at(idx.row);
-                            return node.isComputableType;
-                        });
+                            const node = uigraph.graph.nodes.at(idx.row)
+                            return node.isComputableType
+                        })
                     }
 
                     readonly property bool canSelectionBeComputed: {
                         if(!selectionContainsComputableNodeType)
-                            return false;
+                            return false
                         if(isSelectionFullyCompatibility)
-                            return false;
+                            return false
                         if(isSelectionFullyComputed)
-                            return true;
+                            return true
                         var b = uigraph.nodeSelection.selectedIndexes.every(function(idx) {
-                            const node = uigraph.graph.nodes.at(idx.row);
+                            const node = uigraph.graph.nodes.at(idx.row)
                             return (
                                 node.isComputed ||
                                 (uigraph.graph.canComputeTopologically(node) &&
                                 // canCompute if canSubmitOrCompute == 1(can compute) or 3(can compute & submit)
                                 nodeSubmitOrComputeStatus[node] % 2 == 1)
-                            );
-                        });
+                            )
+                        })
                         return b
                     }
 
@@ -654,20 +654,20 @@ Item {
 
                     readonly property bool canSelectionBeSubmitted: {
                         if(!selectionContainsComputableNodeType)
-                            return false;
+                            return false
                         if(isSelectionFullyCompatibility)
-                            return false;
+                            return false
                         if(isSelectionFullyComputed)
-                            return true;
+                            return true
                         return uigraph.nodeSelection.selectedIndexes.every(function(idx) {
-                            const node = uigraph.graph.nodes.at(idx.row);
+                            const node = uigraph.graph.nodes.at(idx.row)
                             return (
                                 node.isComputed ||
                                 (uigraph.graph.canComputeTopologically(node) &&
                                  // canSubmit if canSubmitOrCompute == 2(can submit) or 3(can compute & submit)
                                  nodeSubmitOrComputeStatus[node] > 1)
                             )
-                        });
+                        })
                     }
 
                     width: 220
@@ -687,11 +687,11 @@ Item {
                                 nodeMenuLoader.showDataDeletionDialog(
                                     false, 
                                     function(request, uigraph) {
-                                        request(uigraph.getSelectedNodes());
+                                        request(uigraph.getSelectedNodes())
                                     }.bind(null, computeRequest, uigraph)
-                                );
+                                )
                             } else {
-                                computeRequest(uigraph.getSelectedNodes());
+                                computeRequest(uigraph.getSelectedNodes())
                             }
                         }
                     }
@@ -708,11 +708,11 @@ Item {
                                 nodeMenuLoader.showDataDeletionDialog(
                                     false, 
                                     function(request, uigraph) {
-                                        request(uigraph.getSelectedNodes());
+                                        request(uigraph.getSelectedNodes())
                                     }.bind(null, submitRequest, uigraph)
-                                );
+                                )
                             } else {
-                                submitRequest(uigraph.getSelectedNodes());
+                                submitRequest(uigraph.getSelectedNodes())
                             }
                         }
                     }
@@ -788,11 +788,11 @@ Item {
                         }
                     }
                     MenuItem {
-                        text: "Disconnect Node(s)";
-                        enabled: true;
-                        ToolTip.text: "Disconnect all edges from the selected Node(s)";
-                        ToolTip.visible: hovered;
-                        onTriggered: uigraph.disconnectSelectedNodes();
+                        text: "Disconnect Node(s)"
+                        enabled: true
+                        ToolTip.text: "Disconnect all edges from the selected Node(s)"
+                        ToolTip.visible: hovered
+                        onTriggered: uigraph.disconnectSelectedNodes()
                     }
                     MenuItem {
                         text: "Duplicate Node(s)" + (duplicateFollowingButton.hovered ? " From Here" : "")
@@ -863,8 +863,8 @@ Item {
                             height: parent.height
                             text: MaterialIcons.fast_forward
                             onClicked: {
-                                nodeMenuLoader.showDataDeletionDialog(true);
-                                nodeMenu.close();
+                                nodeMenuLoader.showDataDeletionDialog(true)
+                                nodeMenu.close()
                             }
                         }
 
@@ -891,10 +891,10 @@ Item {
 
                     onAccepted: {
                         if (deleteFollowing)
-                            uigraph.clearDataFrom(uigraph.getSelectedNodes());
+                            uigraph.clearDataFrom(uigraph.getSelectedNodes())
                         else
-                            uigraph.clearSelectedNodesData();
-                        dataDeleted();
+                            uigraph.clearSelectedNodesData()
+                        dataDeleted()
                     }
                     onClosed: destroy()
                 }
@@ -982,7 +982,7 @@ Item {
 
                                 // If the node is selected after this, make it the active selected node.
                                 if (selected) {
-                                    uigraph.selectedNode = node;
+                                    uigraph.selectedNode = node
                                 }
 
                                 // Open the node context menu once selection has been updated.
@@ -1010,10 +1010,10 @@ Item {
 
                             onEdgeAboutToBeRemoved: function(input) {
                                 /*
-                                * Sometimes the signals are not in the right order because of weird Qt/QML update order
-                                * (next DropArea entered signal before previous DropArea exited signal) so edgeAboutToBeRemoved
-                                * must be set to undefined before it can be set to another attribute object.
-                                */
+                                 * Sometimes the signals are not in the right order because of weird Qt/QML update order
+                                 * (next DropArea entered signal before previous DropArea exited signal) so edgeAboutToBeRemoved
+                                 * must be set to undefined before it can be set to another attribute object.
+                                 */
                                 if (input === undefined) {
                                     if (nodeRepeater.temporaryEdgeAboutToBeRemoved === undefined) {
                                         root.edgeAboutToBeRemoved = input
@@ -1032,29 +1032,29 @@ Item {
 
                             // Interactive dragging: move the visual delegates
                             onPositionChanged: {
-                                if(!selected || !dragging) {
-                                    return;
+                                if (!selected || !dragging) {
+                                    return
                                 }
 
                                 // Check for shake on the node
-                                checkForShake();
+                                checkForShake()
 
                                 // Compute offset between the delegate and the stored node position.
-                                const offset = Qt.point(x - node.x, y - node.y);
+                                const offset = Qt.point(x - node.x, y - node.y)
 
                                 uigraph.nodeSelection.selectedIndexes.forEach(function(idx) {
                                     if (idx != index) {
-                                        const delegate = nodeRepeater.getItemAt(idx.row);
-                                        delegate.x = delegate.node.x + offset.x;
-                                        delegate.y = delegate.node.y + offset.y;
+                                        const delegate = nodeRepeater.getItemAt(idx.row)
+                                        delegate.x = delegate.node.x + offset.x
+                                        delegate.y = delegate.node.y + offset.y
                                     }
-                                });
+                                })
                             }
 
                             // After drag: apply the final offset to all selected nodes
                             onMoved: function(position) {
-                                const offset = Qt.point(position.x - node.x, position.y - node.y);
-                                uigraph.moveSelectedNodesBy(offset);
+                                const offset = Qt.point(position.x - node.x, position.y - node.y)
+                                uigraph.moveSelectedNodesBy(offset)
                             }
 
                             Behavior on x {
@@ -1173,7 +1173,7 @@ Item {
 
                                 uigraph.nodeSelection.selectedIndexes.forEach(function(idx) {
                                     if (idx != index) {
-                                        const delegate = nodeRepeater.itemAt(idx.row).item;
+                                        const delegate = nodeRepeater.itemAt(idx.row).item
                                         delegate.x = delegate.node.x + offset.x
                                         delegate.y = delegate.node.y + offset.y
                                     }
@@ -1212,13 +1212,13 @@ Item {
             modelInstantiator: nodeRepeater
             container: draggable
             onDelegateSelectionEnded: function(selectedIndices, modifiers) {
-                let selectionMode = ItemSelectionModel.ClearAndSelect;
+                let selectionMode = ItemSelectionModel.ClearAndSelect
                 if(modifiers & Qt.ShiftModifier) {
-                    selectionMode = ItemSelectionModel.Select;
+                    selectionMode = ItemSelectionModel.Select
                 } else if(modifiers & Qt.ControlModifier) {
-                    selectionMode = ItemSelectionModel.Deselect;
+                    selectionMode = ItemSelectionModel.Deselect
                 }
-                uigraph.selectNodesByIndices(selectedIndices, selectionMode);
+                uigraph.selectNodesByIndices(selectedIndices, selectionMode)
             }
         }
 
@@ -1228,7 +1228,7 @@ Item {
             modelInstantiator: edgesRepeater
             container: draggable
             onDelegateSelectionEnded: function(selectedIndices, modifiers) {
-                uigraph.deleteEdgesByIndices(selectedIndices);
+                uigraph.deleteEdgesByIndices(selectedIndices)
             }
         }
 

--- a/meshroom/ui/qml/GraphEditor/GraphEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/GraphEditor.qml
@@ -938,70 +938,69 @@ Item {
                             onAttributePinDeleted: function(attribute, pin) { unregisterAttributePin(attribute, pin) }
 
                             onShaked: {
-                                uigraph.disconnectSelectedNodes();
+                                uigraph.disconnectSelectedNodes()
                             }
 
                             onPressed: function(mouse) {
-                                nodeRepeater.updateSelectionOnClick = true;
-                                nodeRepeater.ongoingDrag = true;
+                                nodeRepeater.updateSelectionOnClick = true
+                                nodeRepeater.ongoingDrag = true
 
-                                let selectionMode = ItemSelectionModel.NoUpdate;
+                                let selectionMode = ItemSelectionModel.NoUpdate
 
-                                if(!selected) {
-                                    selectionMode = ItemSelectionModel.ClearAndSelect;
+                                if (!selected) {
+                                    selectionMode = ItemSelectionModel.ClearAndSelect
                                 }
 
                                 if (mouse.button === Qt.LeftButton) {
-                                    if(mouse.modifiers & Qt.ShiftModifier) {
-                                        selectionMode = ItemSelectionModel.Select;
+                                    if (mouse.modifiers & Qt.ShiftModifier) {
+                                        selectionMode = ItemSelectionModel.Select
                                     }
-                                    if(mouse.modifiers & Qt.ControlModifier) {
-                                        selectionMode = ItemSelectionModel.Toggle;
+                                    if (mouse.modifiers & Qt.ControlModifier) {
+                                        selectionMode = ItemSelectionModel.Toggle
                                     }
-                                    if(mouse.modifiers & Qt.AltModifier) {
-                                        let selectFollowingMode = ItemSelectionModel.ClearAndSelect;
-                                        if(mouse.modifiers & Qt.ShiftModifier) {
-                                            selectFollowingMode = ItemSelectionModel.Select;
+                                    if (mouse.modifiers & Qt.AltModifier) {
+                                        let selectFollowingMode = ItemSelectionModel.ClearAndSelect
+                                        if (mouse.modifiers & Qt.ShiftModifier) {
+                                            selectFollowingMode = ItemSelectionModel.Select
                                         }
-                                        uigraph.selectFollowing(node, selectFollowingMode);
+                                        uigraph.selectFollowing(node, selectFollowingMode)
                                         // Indicate selection has been dealt with by setting conservative Select mode.
-                                        selectionMode = ItemSelectionModel.Select;
+                                        selectionMode = ItemSelectionModel.Select
                                     }
                                 }
                                 else if (mouse.button === Qt.RightButton) {
-                                    if(selected) {
+                                    if (selected) {
                                         // Keep the full selection when right-clicking on an already selected node.
-                                        nodeRepeater.updateSelectionOnClick = false;
+                                        nodeRepeater.updateSelectionOnClick = false
                                     }
                                 }
 
-                                if(selectionMode != ItemSelectionModel.NoUpdate) {
-                                    nodeRepeater.updateSelectionOnClick = false;
-                                    uigraph.selectNodeByIndex(index, selectionMode);
+                                if (selectionMode != ItemSelectionModel.NoUpdate) {
+                                    nodeRepeater.updateSelectionOnClick = false
+                                    uigraph.selectNodeByIndex(index, selectionMode)
                                 }
 
                                 // If the node is selected after this, make it the active selected node.
-                                if(selected) {
+                                if (selected) {
                                     uigraph.selectedNode = node;
                                 }
 
                                 // Open the node context menu once selection has been updated.
-                                if(mouse.button == Qt.RightButton) {
+                                if (mouse.button == Qt.RightButton) {
                                     nodeMenuLoader.load(node)
                                 }
-
                             }
 
                             onReleased: function(mouse, wasDragged) {
-                                nodeRepeater.ongoingDrag = false;
+                                nodeRepeater.ongoingDrag = false
                             }
 
                             // Only called when the node has not been dragged.
                             onClicked: function(mouse) {
-                                if(!nodeRepeater.updateSelectionOnClick) {
-                                    return;
+                                if (!nodeRepeater.updateSelectionOnClick) {
+                                    return
                                 }
-                                uigraph.selectNodeByIndex(index);
+                                uigraph.selectNodeByIndex(index)
                             }
 
                             onDoubleClicked: function(mouse) { root.nodeDoubleClicked(mouse, node) }

--- a/meshroom/ui/qml/GraphEditor/GraphEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/GraphEditor.qml
@@ -1095,7 +1095,7 @@ Item {
                                         selectionMode = ItemSelectionModel.Select
                                     }
                                     if (mouse.modifiers & Qt.ControlModifier) {
-                                        selectionMode = ItemSelectionModel.Toggle
+                                        selectionMode = ItemSelectionModel.Clear
                                     }
                                     if (mouse.modifiers & Qt.AltModifier) {
                                         let selectFollowingMode = ItemSelectionModel.ClearAndSelect

--- a/meshroom/ui/qml/GraphEditor/GraphEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/GraphEditor.qml
@@ -1074,10 +1074,28 @@ Item {
                             id: backdropDelegate
                             node: object
                             modelInstantiator: nodeRepeater
+
+                            mainSelected: uigraph.selectedNode === node
+                            hovered: uigraph.hoveredNode === node
+
+                            // ItemSelectionModel.hasSelection triggers updates anytime the selectionChanged() signal is emitted.
+                            selected: uigraph.nodeSelection.hasSelection ? uigraph.nodeSelection.isRowSelected(index) : false
+
+                            onResized: function(width, height) {
+                                uigraph.resizeNode(node, width, height)
+                            }
+                            onResizedAndMoved: function(width, height, position) {
+                                uigraph.resizeAndMoveNode(node, width, height, position)
+                            }
+
                         }
                     }
 
                     sourceComponent: object.isBackdropNode ? backdropComponent : nodeComponent
+
+                    onLoaded: {
+                        nodeLoader.z = nodeLoader.item.z
+                    }
                 }
             }
         }

--- a/meshroom/ui/qml/GraphEditor/GraphEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/GraphEditor.qml
@@ -1081,6 +1081,77 @@ Item {
                             // ItemSelectionModel.hasSelection triggers updates anytime the selectionChanged() signal is emitted.
                             selected: uigraph.nodeSelection.hasSelection ? uigraph.nodeSelection.isRowSelected(index) : false
 
+                            onPressed: function(mouse) {
+                                nodeRepeater.updateSelectionOnClick = true
+                                nodeRepeater.ongoingDrag = true
+
+                                let selectionMode = ItemSelectionModel.NoUpdate
+
+                                if (!selected) {
+                                    selectionMode = ItemSelectionModel.ClearAndSelect
+                                }
+
+                                if (mouse.button === Qt.LeftButton) {
+                                    if (mouse.modifiers & Qt.ShiftModifier) {
+                                        selectionMode = ItemSelectionModel.Select
+                                    }
+                                    if (mouse.modifiers & Qt.ControlModifier) {
+                                        selectionMode = ItemSelectionModel.Toggle
+                                    }
+                                    if (mouse.modifiers & Qt.AltModifier) {
+                                        let selectFollowingMode = ItemSelectionModel.ClearAndSelect
+                                        if (mouse.modifiers & Qt.ShiftModifier) {
+                                            selectFollowingMode = ItemSelectionModel.Select
+                                        }
+                                        uigraph.selectFollowing(node, selectFollowingMode)
+                                        // Indicate selection has been dealt with by setting conservative Select mode.
+                                        selectionMode = ItemSelectionModel.Select
+                                    }
+                                } else if (mouse.button === Qt.RightButton) {
+                                    if (selected) {
+                                        // Keep the full selection when right-clicking on an already selected node.
+                                        nodeRepeater.updateSelectionOnClick = false
+                                    }
+                                }
+
+                                if (selectionMode != ItemSelectionModel.NoUpdate) {
+                                    nodeRepeater.updateSelectionOnClick = false
+                                    uigraph.selectNodeByIndex(index, selectionMode)
+                                }
+
+                                // If the node is selected after this, make it the active selected node.
+                                if (selected) {
+                                    uigraph.selectedNode = node
+                                }
+
+                                if (!(mouse.modifiers & Qt.AltModifier)) {
+                                    uigraph.selectNodesByIndices(childrenIndices, ItemSelectionModel.Select)
+                                }
+
+                                // Open the node context menu once selection has been updated.
+                                if (mouse.button == Qt.RightButton) {
+                                    nodeMenuLoader.load(node)
+                                }
+                            }
+
+                            onReleased: function(mouse, wasDragged) {
+                                nodeRepeater.ongoingDrag = false
+                            }
+
+                            // Only called when the node has not been dragged.
+                            onClicked: function(mouse) {
+                                if (!nodeRepeater.updateSelectionOnClick) {
+                                    return
+                                }
+                                uigraph.selectNodeByIndex(index)
+
+                                if (!(mouse.modifiers & Qt.AltModifier)) {
+                                    uigraph.selectNodesByIndices(childrenIndices, ItemSelectionModel.Select)
+                                }
+                            }
+
+                            onDoubleClicked: function(mouse) { root.nodeDoubleClicked(mouse, node) }
+
                             onResized: function(width, height) {
                                 uigraph.resizeNode(node, width, height)
                             }
@@ -1088,6 +1159,41 @@ Item {
                                 uigraph.resizeAndMoveNode(node, width, height, position)
                             }
 
+                            onEntered: uigraph.hoveredNode = node
+                            onExited: uigraph.hoveredNode = null
+
+                            // Interactive dragging: move the visual delegates
+                            onPositionChanged: {
+                                if (!selected || !dragging) {
+                                    return
+                                }
+
+                                // Compute offset between the delegate and the stored node position.
+                                const offset = Qt.point(x - node.x, y - node.y)
+
+                                uigraph.nodeSelection.selectedIndexes.forEach(function(idx) {
+                                    if (idx != index) {
+                                        const delegate = nodeRepeater.itemAt(idx.row).item;
+                                        delegate.x = delegate.node.x + offset.x
+                                        delegate.y = delegate.node.y + offset.y
+                                    }
+                                })
+                            }
+
+                            // After drag: apply the final offset to all selected nodes
+                            onMoved: function(position) {
+                                const offset = Qt.point(position.x - node.x, position.y - node.y)
+                                uigraph.moveSelectedNodesBy(offset)
+                            }
+
+                            Behavior on x {
+                                enabled: !nodeRepeater.ongoingDrag && !resizing && !uigraph.animationsDisabled
+                                NumberAnimation { duration: 100 }
+                            }
+                            Behavior on y {
+                                enabled: !nodeRepeater.ongoingDrag && !resizing && !uigraph.animationsDisabled
+                                NumberAnimation { duration: 100 }
+                            }
                         }
                     }
 

--- a/meshroom/ui/qml/GraphEditor/Node.qml
+++ b/meshroom/ui/qml/GraphEditor/Node.qml
@@ -19,7 +19,6 @@ Item {
     property bool readOnly: node.locked
     /// Whether the node is in compatibility mode
     readonly property bool isCompatibilityNode: node ? node.hasOwnProperty("compatibilityIssue") : false
-    readonly property bool isBackdropNode: node ? node.isBackdropNode : false
     /// Mouse related states
     property bool mainSelected: false
     property bool selected: false

--- a/meshroom/ui/qml/GraphEditor/Node.qml
+++ b/meshroom/ui/qml/GraphEditor/Node.qml
@@ -19,6 +19,7 @@ Item {
     property bool readOnly: node.locked
     /// Whether the node is in compatibility mode
     readonly property bool isCompatibilityNode: node ? node.hasOwnProperty("compatibilityIssue") : false
+    readonly property bool isBackdropNode: node ? node.isBackdropNode : false
     /// Mouse related states
     property bool mainSelected: false
     property bool selected: false

--- a/meshroom/ui/qml/GraphEditor/NodeEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/NodeEditor.qml
@@ -577,9 +577,10 @@ Panel {
             visible: root.node !== null
 
             property bool isComputableType: root.node !== null && root.node.isComputableType
+            property bool isBackdropNode: root.node !== null && root.node.isBackdropNode
 
             // The indices of the tab bar which can be shown for incomputable nodes
-            readonly property var nonComputableTabIndices: [0, 4, 5];
+            readonly property var nonComputableTabIndices: [0, 4, 5]
 
             Layout.fillWidth: true
             width: childrenRect.width
@@ -587,6 +588,18 @@ Panel {
             currentIndex: 0
             TabButton {
                 text: "Attributes"
+                visible: !tabBar.isBackdropNode
+                width: {
+                    if (!visible)
+                        return 0
+                    else {
+                        if (tabBar.isComputableType)
+                            return tabBar.width / tabBar.count
+                        else {
+                            return tabBar.width / tabBar.nonComputableTabIndices.length
+                        }
+                    }
+                }
                 padding: 4
                 leftPadding: 8
                 rightPadding: leftPadding
@@ -628,7 +641,12 @@ Panel {
                 // If we have a node selected and the node is not Computable
                 // Reset the currentIndex to 0, if the current index is not allowed for an incomputable node
                 if ((root.node && !root.node.isComputableType) && (nonComputableTabIndices.indexOf(tabBar.currentIndex) === -1)) {
-                    tabBar.currentIndex = 0;
+                    if (root.node.isBackdropNode) {
+                        // Backdrop nodes can only show the Documentation & Notes tabs
+                        tabBar.currentIndex = 4 // Notes tab
+                    } else {
+                        tabBar.currentIndex = 0
+                    }
                 }
             }
         }

--- a/meshroom/ui/qml/GraphEditor/qmldir
+++ b/meshroom/ui/qml/GraphEditor/qmldir
@@ -5,6 +5,7 @@ NodeEditor 1.0 NodeEditor.qml
 Node 1.0 Node.qml
 NodeChunks 1.0 NodeChunks.qml
 Edge 1.0 Edge.qml
+Backdrop 1.0 Backdrop.qml
 AttributePin 1.0 AttributePin.qml
 AttributeEditor 1.0 AttributeEditor.qml
 AttributeItemDelegate 1.0 AttributeItemDelegate.qml

--- a/tests/test_compatibility.py
+++ b/tests/test_compatibility.py
@@ -361,11 +361,12 @@ def test_upgradeAllNodes():
     os.remove(graphFile)
 
     # Both nodes are CompatibilityNodes
-    assert len(g.compatibilityNodes) == 4
+    assert len(g.compatibilityNodes) == 3
     assert g.node(n1Name).canUpgrade      # description conflict
     assert not g.node(n2Name).canUpgrade  # unknown type
-    assert g.node(n3Name).canUpgrade      # description conflict
     assert not g.node(n4Name).canUpgrade  # unknown type
+    # Input node with a description conflict and no invalidating attribute: the upgrade can be done automatically
+    assert not g.node(n3Name).isCompatibilityNode
 
     # Upgrade all upgradable nodes
     g.upgradeAllNodes()

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -3,9 +3,10 @@
 
 import os
 from pathlib import Path
+import tempfile
 
-from meshroom.core import pluginManager, loadClassesNodes
-from meshroom.core.graph import Graph
+from meshroom.core import pluginManager, loadClassesNodes, initNodes
+from meshroom.core.graph import Graph, loadGraph
 from meshroom.core.plugins import Plugin
 
 from .utils import registerNodeDesc
@@ -136,3 +137,117 @@ class TestInitNode:
         inputs = ["/path/to/file", "/path/to/file/2"]
         node.nodeDesc.initialize(node, inputs, None)
         assert node.input.value == inputs[0]
+
+
+class TestBackdropNode:
+    loadedPlugins = pluginManager.getPlugins()
+
+    @classmethod
+    def setup_class(cls):
+        initNodes()
+
+    @classmethod
+    def teardown_class(cls):
+        for plugin in pluginManager.getPlugins():
+            if plugin not in cls.loadedPlugins:
+                for node in plugin.nodes.values():
+                    pluginManager.unregisterNode(node)
+                pluginManager.removePlugin(plugin)
+
+    def test_backdropNode(self):
+        """ Test that a backdrop node can be added to a graph with its expected default values. """
+        g = Graph("Default Backdrop node")
+        backdrop = g.addNewNode("Backdrop")
+
+        # Check that the default values for backdrop are as expected
+        assert backdrop is not None
+        assert backdrop.nodeWidth == 600
+        assert backdrop.nodeHeight == 400
+        assert backdrop.fontSize == 12
+        assert backdrop.color == ""
+        assert backdrop.comment == ""
+
+        # Add a non-backdrop node and check that its default values are not backdrop's ones
+        node = g.addNewNode("CopyFiles")
+        assert node is not None
+        assert node.nodeWidth == 0
+        assert node.nodeHeight == 0
+        assert node.fontSize == 0
+        assert node.color == ""
+        assert node.comment == ""
+
+    def test_backdropNode_customAttributes(self):
+        """ Test that a backdrop node's attributes can be correctly updated. """
+        g = Graph("Backdrop node with custom values")
+        backdrop = g.addNewNode("Backdrop")
+
+        # Set custom values for backdrop and assert the properties are correctly updated
+        width = backdrop.internalAttribute("nodeWidth")
+        width.value = 400
+        assert backdrop.nodeWidth == 400
+
+        height = backdrop.internalAttribute("nodeHeight")
+        height.value = 200
+        assert backdrop.nodeHeight == 200
+
+        fontSize = backdrop.internalAttribute("fontSize")
+        fontSize.value = 10
+        assert backdrop.fontSize == 10
+
+        color = backdrop.internalAttribute("color")
+        color.value = "#FF0000"
+        assert backdrop.color == "#FF0000"
+
+        comment = backdrop.internalAttribute("comment")
+        comment.value = "hello world"
+        assert backdrop.comment == "hello world"
+
+    def test_backdropNode_defaultSerialization(self):
+        """ Test that a backdrop node with default values is correctly serialized and deserialized. """
+        g = Graph("Backdrop node default serialization")
+        backdrop = g.addNewNode("Backdrop")
+
+        # Save the graph in a file
+        graphFile = os.path.join(tempfile.mkdtemp(), "test_backdrop_serialization.mg")
+        g.save(graphFile)
+
+        # Reload the graph and check the values for the backdrop node are the default ones
+        g = loadGraph(graphFile)
+        backdrop = g.node("Backdrop_1")
+        assert backdrop is not None
+        assert backdrop.nodeWidth == 600
+        assert backdrop.nodeHeight == 400
+        assert backdrop.fontSize == 12
+        assert backdrop.color == ""
+        assert backdrop.comment == ""
+
+    def test_backdropNode_customSerialization(self):
+        """ Test that a backdrop node with custom values is correctly serialized and deserialized. """
+        g = Graph("Backdrop node custom serialization")
+        backdrop = g.addNewNode("Backdrop")
+
+        # Set custom values for backdrop
+        width = backdrop.internalAttribute("nodeWidth")
+        width.value = 400
+        height = backdrop.internalAttribute("nodeHeight")
+        height.value = 200
+        fontSize = backdrop.internalAttribute("fontSize")
+        fontSize.value = 10
+        color = backdrop.internalAttribute("color")
+        color.value = "#FF0000"
+        comment = backdrop.internalAttribute("comment")
+        comment.value = "hello world"
+
+        # Save the graph in a file
+        graphFile = os.path.join(tempfile.mkdtemp(), "test_backdrop_serialization.mg")
+        g.save(graphFile)
+
+        # Reload the graph and check the values for the backdrop node are the default ones
+        g = loadGraph(graphFile)
+        backdrop = g.node("Backdrop_1")
+        assert backdrop is not None
+        assert backdrop.nodeWidth == 400
+        assert backdrop.nodeHeight == 200
+        assert backdrop.fontSize == 10
+        assert backdrop.color == "#FF0000"
+        assert backdrop.comment == "hello world"

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -164,6 +164,7 @@ class TestBackdropNode:
         assert backdrop.nodeWidth == 600
         assert backdrop.nodeHeight == 400
         assert backdrop.fontSize == 12
+        assert backdrop.fontColor == ""
         assert backdrop.color == ""
         assert backdrop.comment == ""
 
@@ -173,6 +174,7 @@ class TestBackdropNode:
         assert node.nodeWidth == 0
         assert node.nodeHeight == 0
         assert node.fontSize == 0
+        assert node.fontColor == ""
         assert node.color == ""
         assert node.comment == ""
 
@@ -193,6 +195,10 @@ class TestBackdropNode:
         fontSize = backdrop.internalAttribute("fontSize")
         fontSize.value = 10
         assert backdrop.fontSize == 10
+
+        fontColor = backdrop.internalAttribute("fontColor")
+        fontColor.value = "#00FF00"
+        assert backdrop.fontColor == "#00FF00"
 
         color = backdrop.internalAttribute("color")
         color.value = "#FF0000"
@@ -218,6 +224,7 @@ class TestBackdropNode:
         assert backdrop.nodeWidth == 600
         assert backdrop.nodeHeight == 400
         assert backdrop.fontSize == 12
+        assert backdrop.fontColor == ""
         assert backdrop.color == ""
         assert backdrop.comment == ""
 
@@ -233,6 +240,8 @@ class TestBackdropNode:
         height.value = 200
         fontSize = backdrop.internalAttribute("fontSize")
         fontSize.value = 10
+        fontColor = backdrop.internalAttribute("fontColor")
+        fontColor.value = "#00FF00"
         color = backdrop.internalAttribute("color")
         color.value = "#FF0000"
         comment = backdrop.internalAttribute("comment")
@@ -249,5 +258,6 @@ class TestBackdropNode:
         assert backdrop.nodeWidth == 400
         assert backdrop.nodeHeight == 200
         assert backdrop.fontSize == 10
+        assert backdrop.fontColor == "#00FF00"
         assert backdrop.color == "#FF0000"
         assert backdrop.comment == "hello world"


### PR DESCRIPTION
## Description

This PR is a replacement for #2574. 

It introduces a new "Backdrop" node type to Meshroom's core and UI, allowing users to visually group nodes in the graph editor. 

Backdrops are a specific type of node that can be instantiated as any other node type, but have no input or output attributes. They only possess internal attributes, including their size (width and height) as they can be resized. Backdrops can be given custom names, colors, and display any comment that was added by the user (with an adjustable font size).

Visually, backdrops are always placed behind any non-backdrop node they may be overlapping with. Whenever a node is *fully contained* within a backdrop node, it is automatically "attached" to it: moving the backdrop will move the node as well. Conversely, moving a node that is contained within a backdrop will not move the backdrop. As selecting a backdrop adds the nodes that are contained in it to the selection, two new controls are added when clicking on a backdrop:
- Ctrl + Clic: only select the nodes contained in the backdrop
- Alt + Clic: only select the backdrop and not the nodes that are contained in it. This is especially useful to "detach" the backdrop from the nodes it contains and move it on its own or remove it from the graph altogether without removing the other nodes.

![backdrops](https://github.com/user-attachments/assets/2a0b28e0-791b-44b0-bfb6-ece7d1b3cfe6)


## Features list

- [x] Add a new core `BackdropNode` type of node which is non-computable and only has internal attributes.
- [x] Add a new `Backdrop` node description to make backdrops instantiable.
- [x] Add a new `Backdrop` QML component.  

## Implementation remarks

**Backdrop Node Support:**

* Added a new `BackdropNode` class in both `desc.node` and `core.node`, representing a non-computable node for grouping other nodes visually. The Backdrop node has its own internal attributes and serialization logic. (F2d2396aL336R336, [[1]](diffhunk://#diff-a9e65d402c922897d6a13963b45db2b469b20423b6f5f382c12c9d2b25fbe669R2367-R2398) [[2]](diffhunk://#diff-c947c9c3aa16553cbd53b812daf9393dab65cccf423c5d6994ebef95da000d73R1-R8)
* Updated the node factory logic and graph logic to support creating and deserializing Backdrop nodes, including a new `getNodeConstructor` utility. [[1]](diffhunk://#diff-52876c21ca411283395cab46e190c42d10774eb296c7adff4168f89654d1f39dL7-R15) [[2]](diffhunk://#diff-52876c21ca411283395cab46e190c42d10774eb296c7adff4168f89654d1f39dR33-R40) [[3]](diffhunk://#diff-52876c21ca411283395cab46e190c42d10774eb296c7adff4168f89654d1f39dL60-R68) [[4]](diffhunk://#diff-52876c21ca411283395cab46e190c42d10774eb296c7adff4168f89654d1f39dL174-R187) [[5]](diffhunk://#diff-2d59866c4dac3f42a0a1415a1d6dd6725c569069094ca22c9b46b9ef29b07075L23-R23) [[6]](diffhunk://#diff-2d59866c4dac3f42a0a1415a1d6dd6725c569069094ca22c9b46b9ef29b07075L672-R672)
* Extended the `MrNodeType` enum and related type-handling logic to recognize the new BACKDROP node type. [[1]](diffhunk://#diff-83c9e7e855754f69c91aee1b493d07db586fc5f011b4721a41899c9ffbbc99cbR59-R63) [[2]](diffhunk://#diff-f51c9aee6058d6e8e3c34338a041f83695bf8f38e8d0d228751752279925f626L36-R43) [[3]](diffhunk://#diff-83c9e7e855754f69c91aee1b493d07db586fc5f011b4721a41899c9ffbbc99cbR98-R165) [[4]](diffhunk://#diff-83c9e7e855754f69c91aee1b493d07db586fc5f011b4721a41899c9ffbbc99cbR339-R382) [[5]](diffhunk://#diff-83c9e7e855754f69c91aee1b493d07db586fc5f011b4721a41899c9ffbbc99cbL133-R183) [[6]](diffhunk://#diff-83c9e7e855754f69c91aee1b493d07db586fc5f011b4721a41899c9ffbbc99cbR405-R411)

**Node Internal Attributes & Display Properties:**

* Refactored internal node attributes into an `InternalAttributesFactory`, with attribute sets for basic, invalidation, and resizable (font size, width, height) properties. [[1]](diffhunk://#diff-83c9e7e855754f69c91aee1b493d07db586fc5f011b4721a41899c9ffbbc99cbR59-R63) [[2]](diffhunk://#diff-83c9e7e855754f69c91aee1b493d07db586fc5f011b4721a41899c9ffbbc99cbR98-R165)
* Added new getter methods and Qt properties to `Node` for `fontSize`, `nodeWidth`, and `nodeHeight`, enabling UI customization for nodes, especially Backdrop nodes. [[1]](diffhunk://#diff-a9e65d402c922897d6a13963b45db2b469b20423b6f5f382c12c9d2b25fbe669L863-R937) [[2]](diffhunk://#diff-a9e65d402c922897d6a13963b45db2b469b20423b6f5f382c12c9d2b25fbe669R2103-R2105)
* Updated node type checks and properties to distinguish Backdrop nodes from computable and input nodes, including new `isBackdropNode` property. [[1]](diffhunk://#diff-a9e65d402c922897d6a13963b45db2b469b20423b6f5f382c12c9d2b25fbe669L1246-R1274) [[2]](diffhunk://#diff-a9e65d402c922897d6a13963b45db2b469b20423b6f5f382c12c9d2b25fbe669R1842-R1844) [[3]](diffhunk://#diff-a9e65d402c922897d6a13963b45db2b469b20423b6f5f382c12c9d2b25fbe669L2092-R2128)

