### PR TITLE
[ui] NodeActions: fix position on swiching status

### DIFF
--- a/meshroom/ui/qml/Controls/NodeActions.qml
+++ b/meshroom/ui/qml/Controls/NodeActions.qml
@@ -106,6 +106,14 @@ Item {
             function onScaleChanged() { Qt.callLater(actionHeader.updatePosition) }
         }
 
+        // Update position when nodes are moved
+        Connections {
+            target: actionHeader.selectedNodeDelegate
+            function onXChanged() { actionHeader.updatePosition() }
+            function onYChanged() { actionHeader.updatePosition() }
+            ignoreUnknownSignals: true
+        }
+
         // 
         // ===== Manage buttons =====
         // 

--- a/meshroom/ui/qml/Controls/NodeActions.qml
+++ b/meshroom/ui/qml/Controls/NodeActions.qml
@@ -90,24 +90,20 @@ Item {
             }
         }
 
+        onHeightChanged: {
+            Qt.callLater(actionHeader.updatePosition)
+        }
+
         onWidthChanged: {
-            updatePosition()
+            Qt.callLater(actionHeader.updatePosition)
         }
 
         // Update position when the user moves on the graph
         Connections {
             target: root.draggable
-            function onXChanged()     { actionHeader.updatePosition() }
-            function onYChanged()     { actionHeader.updatePosition() }
-            function onScaleChanged() { actionHeader.updatePosition() }
-        }
-
-        // Update position when nodes are moved
-        Connections {
-            target: actionHeader.selectedNodeDelegate
-            function onXChanged() { actionHeader.updatePosition() }
-            function onYChanged() { actionHeader.updatePosition() }
-            ignoreUnknownSignals: true
+            function onXChanged()     { Qt.callLater(actionHeader.updatePosition) }
+            function onYChanged()     { Qt.callLater(actionHeader.updatePosition) }
+            function onScaleChanged() { Qt.callLater(actionHeader.updatePosition) }
         }
 
         // 

--- a/meshroom/ui/qml/Controls/NodeActions.qml
+++ b/meshroom/ui/qml/Controls/NodeActions.qml
@@ -73,15 +73,7 @@ Item {
             hoverEnabled: false
         }
 
-        // Update position
-        function updatePosition() {
-            if (!selectedNodeDelegate || !draggable) return
-            // Calculate node position in screen coordinates
-            const nodeScreenX = selectedNodeDelegate.x * draggable.scale + draggable.x
-            const nodeScreenY = selectedNodeDelegate.y * draggable.scale + draggable.y
-            // Position header above the node (fixed offset in screen pixels)
-            x = nodeScreenX + (selectedNodeDelegate.width * draggable.scale - width) / 2
-            y = nodeScreenY - height - headerOffset
+        function keepNodeActionOnWindow() {
             if (x < 0) {
                 x = 0
             }
@@ -90,12 +82,33 @@ Item {
             }
         }
 
+        // Update position
+        function updatePosition() {
+            if (width == 0 && height == 0) {  
+                actionItemsRow.visible = true  
+                return  
+            } else if (width == 0 || height == 0) {  
+                actionItemsRow.visible = false  
+                return  
+            }  
+            actionItemsRow.visible = true  
+
+            if (!selectedNodeDelegate || !draggable) return
+            // Calculate node position in screen coordinates
+            const nodeScreenX = selectedNodeDelegate.x * draggable.scale + draggable.x
+            const nodeScreenY = selectedNodeDelegate.y * draggable.scale + draggable.y
+            // Position header above the node (fixed offset in screen pixels)
+            x = nodeScreenX + (selectedNodeDelegate.width * draggable.scale - width) / 2
+            y = nodeScreenY - height - headerOffset
+            // keepNodeActionOnWindow()
+        }
+
         onHeightChanged: {
-            Qt.callLater(actionHeader.updatePosition)
+            actionHeader.updatePosition()
         }
 
         onWidthChanged: {
-            Qt.callLater(actionHeader.updatePosition)
+            actionHeader.updatePosition()
         }
 
         // Update position when the user moves on the graph

--- a/meshroom/ui/qml/GraphEditor/ChunksListView.qml
+++ b/meshroom/ui/qml/GraphEditor/ChunksListView.qml
@@ -18,7 +18,9 @@ ColumnLayout {
 
     onChunksChanged: {
         // When the list changes, ensure the current index is in the new range
-        if (currentIndex >= chunks.count)
+        if (!chunks)
+            currentIndex = -1
+        else if (chunks && currentIndex >= chunks.count)
             currentIndex = chunks.count-1
     }
 

--- a/meshroom/ui/qml/GraphEditor/ChunksListView.qml
+++ b/meshroom/ui/qml/GraphEditor/ChunksListView.qml
@@ -20,7 +20,7 @@ ColumnLayout {
         // When the list changes, ensure the current index is in the new range
         if (!chunks)
             currentIndex = -1
-        else if (chunks && currentIndex >= chunks.count)
+        else if (currentIndex >= chunks.count)
             currentIndex = chunks.count-1
     }
 


### PR DESCRIPTION
# Description of the PR

Fix a little but that occurred when we switched the status
![fail](https://github.com/user-attachments/assets/48582b44-c14b-4bfd-8d03-91b3a24ceeca)
_failing node action position_
![kindofworking](https://github.com/user-attachments/assets/647aae0e-62ce-4224-8ba5-89efbebc6004)
_-> fixed_

# Description of the bug

The event when the height is changed was not catched so what happened was :
- We launch the computation : upstream nodes are locked
- We select the node that is done, so all the buttons in the NodeActions are hidden because it is locked -> the height change to 0
- We select the computing node, buttons show up
  - The `updatePosition` is called on the delegate change and it is set before we update the height
  - The height is recomputed (to 33)
  - However we didn't have a `onHeightChanged` function therefore the NodeAction position is off

# Special point of interest during the review

I added the `onHeightChanged` which fixes the bug. However one little thing seems off to me :
- the `updatePosition` is called twice : one with `height=0` and a second time with `height=33`. We can see a small glitch because of these 2 updates. I tried to avoid that by using `Qt.callLater` but this didn't work. If you have an idea on something we could do, it would be great !