### PR TITLE
[ui] Add copy path feature on the homepage

### DIFF
--- a/meshroom/ui/qml/Homepage.qml
+++ b/meshroom/ui/qml/Homepage.qml
@@ -387,6 +387,14 @@ Page {
                                 }
 
                                 MenuItem {
+                                    text: "Copy path"
+                                    onTriggered: {                                        
+                                        Clipboard.clear()
+                                        Clipboard.setText(modelData["path"])
+                                    }
+                                }
+
+                                MenuItem {
                                     text: "Delete"
                                     onTriggered: {
                                         MeshroomApp.removeRecentProjectFile(modelData["path"])

--- a/meshroom/ui/qml/Homepage.qml
+++ b/meshroom/ui/qml/Homepage.qml
@@ -387,7 +387,7 @@ Page {
                                 }
 
                                 MenuItem {
-                                    text: "Copy path"
+                                    text: "Copy Path"
                                     onTriggered: {                                        
                                         Clipboard.clear()
                                         Clipboard.setText(modelData["path"])


### PR DESCRIPTION
# Description
Add a "Copy path" menu button on the homepage.
Useful to retrieve scene paths
![copy_path](https://github.com/user-attachments/assets/fc20e7f0-e624-431a-b970-2cb6e1888208)