### PR TITLE
Reject `InputNodes` with dynamic outputs and add unit tests for dynamic outputs

### DIFF
--- a/meshroom/core/__init__.py
+++ b/meshroom/core/__init__.py
@@ -18,7 +18,7 @@ try:
 except Exception:
     pass
 
-from meshroom.core.plugins import NodePlugin, NodePluginManager, Plugin, processEnvFactory
+from meshroom.core.plugins import NodePlugin, NodePluginManager, Plugin, processEnvFactory, formatNodeDescriptionErrorMessage
 from meshroom.core.submitter import BaseSubmitter
 from meshroom.env import EnvVar, meshroomFolder
 from . import desc
@@ -112,8 +112,10 @@ def loadClasses(folder: str, packageName: str, classType: type) -> list[type]:
                     if classType == desc.BaseNode:
                         nodePlugin = NodePlugin(p)
                         if nodePlugin.errors:
-                            errors.append(f"  * {pluginName}: The following parameters do not have valid "
-                                          f"default values/ranges: {', '.join(nodePlugin.errors)}")
+                            explicitErrors = []
+                            for err in nodePlugin.errors:
+                                explicitErrors.append(f"\n\t - {formatNodeDescriptionErrorMessage(err)}")
+                            errors.append(f"  * {pluginName}: The following parameters have issues: {''.join(explicitErrors)}")
                         classes.append(nodePlugin)
                     else:
                         classes.append(p)

--- a/meshroom/core/desc/__init__.py
+++ b/meshroom/core/desc/__init__.py
@@ -10,6 +10,7 @@ from .attribute import (
     ListAttribute,
     PushButtonParam,
     StringParam,
+    ValueTypeErrors,
 )
 from .geometryAttribute import (
     Geometry,

--- a/meshroom/core/desc/attribute.py
+++ b/meshroom/core/desc/attribute.py
@@ -1,9 +1,15 @@
 import ast
 import os
 from collections.abc import Iterable
+from enum import auto, Enum
 
 from meshroom.common import BaseObject, JSValue, Property, Variant, VariantList, strtobool
 
+class ValueTypeErrors(Enum):
+    NONE = auto()  # No error
+    TYPE = auto()  # Invalid type
+    RANGE = auto()  # Invalid range
+    DYNAMIC_OUTPUT = auto()  # Dynamic output not supported
 
 class Attribute(BaseObject):
     """
@@ -240,14 +246,14 @@ class GroupAttribute(Attribute):
         """
         invalidParams = []
         for attr in self.groupDesc:
-            name = attr.checkValueTypes()
+            name, error = attr.checkValueTypes()
             if name:
                 invalidParams.append(name)
         if invalidParams:
             # In group "group", if parameters "x" and "y" (with "y" in nested group "subgroup") are invalid, the
             # returned string will be: "group:x, group:subgroup:y"
-            return self.name + ":" + str(", " + self.name + ":").join(invalidParams)
-        return ""
+            return self.name + ":" + str(", " + self.name + ":").join(invalidParams), error
+        return "", ValueTypeErrors.NONE
 
     def matchDescription(self, value, strict=True):
         """
@@ -320,8 +326,8 @@ class File(Attribute):
         # Some File values are functions generating a string: check whether the value is a string or if it
         # is a function (but there is no way to check that the function's output is indeed a string)
         if not isinstance(self.value, str) and not callable(self.value):
-            return self.name
-        return ""
+            return self.name, ValueTypeErrors.TYPE
+        return "", ValueTypeErrors.NONE
 
 
 class BoolParam(Param):
@@ -349,8 +355,8 @@ class BoolParam(Param):
 
     def checkValueTypes(self):
         if not isinstance(self.value, bool):
-            return self.name
-        return ""
+            return self.name, ValueTypeErrors.TYPE
+        return "", ValueTypeErrors.NONE
 
 
 class IntParam(Param):
@@ -378,9 +384,11 @@ class IntParam(Param):
                              f"{value}, type: {type(value)})")
 
     def checkValueTypes(self):
-        if not isinstance(self.value, int) or (self.range and not all([isinstance(r, int) for r in self.range])):
-            return self.name
-        return ""
+        if not isinstance(self.value, int):
+            return self.name, ValueTypeErrors.TYPE
+        if (self.range and not all([isinstance(r, int) for r in self.range])):
+            return self.name, ValueTypeErrors.RANGE
+        return "", ValueTypeErrors.NONE
 
     range = Property(VariantList, lambda self: self._range, constant=True)
 
@@ -409,9 +417,11 @@ class FloatParam(Param):
                              f"{value}, type:{type(value)})")
 
     def checkValueTypes(self):
-        if not isinstance(self.value, float) or (self.range and not all([isinstance(r, float) for r in self.range])):
-            return self.name
-        return ""
+        if not isinstance(self.value, float):
+            return self.name, ValueTypeErrors.TYPE
+        if (self.range and not all([isinstance(r, float) for r in self.range])):
+            return self.name, ValueTypeErrors.RANGE
+        return "", ValueTypeErrors.NONE
 
     range = Property(VariantList, lambda self: self._range, constant=True)
 
@@ -435,7 +445,7 @@ class PushButtonParam(Param):
         return value
 
     def checkValueTypes(self):
-        pass
+        return "", ValueTypeErrors.NONE
 
 
 class ChoiceParam(Param):
@@ -513,20 +523,20 @@ class ChoiceParam(Param):
     def checkValueTypes(self):
         # Check that the values have been provided as a list
         if not isinstance(self._values, list):
-            return self.name
+            return self.name, ValueTypeErrors.TYPE
 
         # If the choices are not exclusive, check that 'value' is a list, and check that it does not contain values that
         # are not available
         elif not self.exclusive and (not isinstance(self._value, list) or
                                      not all(val in self._values for val in self._value)):
-            return self.name
+            return self.name, ValueTypeErrors.RANGE
 
         # If the choices are exclusive, the value should NOT be a list but it can contain any value that is not in the
         # list of possible ones
         elif self.exclusive and isinstance(self._value, list):
-            return self.name
+            return self.name, ValueTypeErrors.TYPE
 
-        return ""
+        return "", ValueTypeErrors.NONE
 
     values = Property(VariantList, lambda self: self._values, constant=True)
     exclusive = Property(bool, lambda self: self._exclusive, constant=True)
@@ -555,8 +565,8 @@ class StringParam(Param):
 
     def checkValueTypes(self):
         if not isinstance(self.value, str):
-            return self.name
-        return ""
+            return self.name, ValueTypeErrors.TYPE
+        return "", ValueTypeErrors.NONE
 
 
 class ColorParam(Param):

--- a/meshroom/core/plugins.py
+++ b/meshroom/core/plugins.py
@@ -14,10 +14,11 @@ from pathlib import Path
 
 from meshroom.common import BaseObject
 from meshroom.core import desc
+from meshroom.core.desc.attribute import ValueTypeErrors
 from meshroom.core.desc.node import _MESHROOM_ROOT, _MESHROOM_COMPUTE_DEPS
 
 
-def validateNodeDesc(nodeDesc: desc.Node) -> list:
+def validateNodeDesc(nodeDesc: desc.BaseNode) -> list[tuple[str, ValueTypeErrors]]:
     """
     Check that the node has a valid description before being loaded. For the description
     to be valid, the default value of every parameter needs to correspond to the type
@@ -37,16 +38,16 @@ def validateNodeDesc(nodeDesc: desc.Node) -> list:
     errors = []
 
     for param in nodeDesc.inputs:
-        err = param.checkValueTypes()
-        if err:
-            errors.append(err)
+        errMsg, errType = param.checkValueTypes()
+        if errMsg:
+            errors.append((errMsg, errType))
 
     for param in nodeDesc.outputs:
         if param.value is None:
             continue
-        err = param.checkValueTypes()
-        if err:
-            errors.append(err)
+        errMsg, errType = param.checkValueTypes()
+        if errMsg:
+            errors.append((errMsg, errType))
 
     return errors
 
@@ -437,15 +438,15 @@ class NodePlugin(BaseObject):
                    modified
     """
 
-    def __init__(self, nodeDesc: desc.Node, plugin: Plugin = None):
+    def __init__(self, nodeDesc: desc.BaseNode, plugin: Plugin = None):
         super().__init__()
         self.plugin: Plugin = plugin
         self.path: str = Path(getfile(nodeDesc)).resolve().as_posix()
-        self.nodeDescriptor: desc.Node = nodeDesc
+        self.nodeDescriptor: desc.BaseNode = nodeDesc
         self.nodeDescriptor.plugin = self
 
         self.status: NodePluginStatus = NodePluginStatus.NOT_LOADED
-        self.errors: list[str] = validateNodeDesc(nodeDesc)
+        self.errors: list[tuple[str, ValueTypeErrors]] = validateNodeDesc(nodeDesc)
 
         if self.errors:
             self.status = NodePluginStatus.DESC_ERROR

--- a/meshroom/core/plugins.py
+++ b/meshroom/core/plugins.py
@@ -44,6 +44,8 @@ def validateNodeDesc(nodeDesc: desc.BaseNode) -> list[tuple[str, ValueTypeErrors
 
     for param in nodeDesc.outputs:
         if param.value is None:
+            if issubclass(nodeDesc, desc.InputNode):
+                errors.append((f"{param.name}", ValueTypeErrors.DYNAMIC_OUTPUT))
             continue
         errMsg, errType = param.checkValueTypes()
         if errMsg:

--- a/meshroom/core/plugins.py
+++ b/meshroom/core/plugins.py
@@ -30,10 +30,10 @@ def validateNodeDesc(nodeDesc: desc.BaseNode) -> list[tuple[str, ValueTypeErrors
     "group", is invalid, then it will be added to the list as "group:x".
 
     Args:
-        nodeDesc: description of the node.
+        nodeDesc: Description of the node.
 
     Returns:
-        errors: the list of invalid parameters if there are any, empty list otherwise
+        errors: The list of invalid parameters if there are any, empty list otherwise.
     """
     errors = []
 
@@ -52,6 +52,26 @@ def validateNodeDesc(nodeDesc: desc.BaseNode) -> list[tuple[str, ValueTypeErrors
             errors.append((errMsg, errType))
 
     return errors
+
+def formatNodeDescriptionErrorMessage(error: tuple[str, ValueTypeErrors]) -> str:
+    """
+    Format a node description error message from a tuple containing the error message (name of the attribute) and type.
+
+    Args:
+        error: Tuple containing the name of the parameter that was rejected, and the type of the error.
+
+    Returns:
+        str: Formatted error message.
+    """
+    errMsg, errType = error
+
+    if errType == ValueTypeErrors.TYPE:
+        return f"'value': Invalid type for parameter '{errMsg}'."
+    if errType == ValueTypeErrors.RANGE:
+        return f"'range': Invalid range value for parameter '{errMsg}'."
+    if errType == ValueTypeErrors.DYNAMIC_OUTPUT:
+        return f"'value': Unsupported dynamic output for parameter '{errMsg}'."
+    return f"Unknown error for parameter '{errMsg}'."
 
 
 class ProcessEnvType(Enum):

--- a/tests/nodes/test/InputDynamicOutputs.py
+++ b/tests/nodes/test/InputDynamicOutputs.py
@@ -1,0 +1,20 @@
+from meshroom.core import desc
+
+class InputDynamicOutputs(desc.InputNode):
+    inputs = [
+        desc.File(
+            name="fileInput",
+            label="File Input",
+            description="A file input.",
+            value="testFile",
+        ),
+    ]
+
+    outputs = [
+        desc.File(
+            name="fileOutput",
+            label="File Output",
+            description="A file Output.",
+            value=None,
+        ),
+    ]

--- a/tests/test_nodeDynamicOutputs.py
+++ b/tests/test_nodeDynamicOutputs.py
@@ -1,0 +1,222 @@
+import pytest
+
+from meshroom.core import desc
+from meshroom.core import pluginManager
+from meshroom.core.exception import UnknownNodeTypeError
+from meshroom.core.graph import Graph, loadGraph
+from meshroom.core.plugins import NodePluginStatus
+
+from .utils import registerNodeDesc, unregisterNodeDesc
+
+
+class NodeWithDynamicOutputs(desc.Node):
+    inputs = [
+        desc.BoolParam(
+            name="boolInput",
+            label="Bool Input",
+            description="A boolean input.",
+            value=False,
+        ),
+        desc.File(
+            name="fileInput",
+            label="File Input",
+            description="A file input.",
+            value="testFile",
+        ),
+        desc.StringParam(
+            name="stringInput",
+            label="String Input",
+            description="A string input.",
+            value="testString",
+        ),
+        desc.IntParam(
+            name="intInput",
+            label="Int Input",
+            description="An integer input.",
+            value=1,
+        ),
+        desc.FloatParam(
+            name="floatInput",
+            label="Float Input",
+            description="A floating input.",
+            value=5.0,
+        ),
+    ]
+
+    outputs = [
+        desc.BoolParam(
+            name="boolOutput",
+            label="Bool Output",
+            description="A boolean output.",
+            value=None,
+        ),
+        desc.File(
+            name="fileOutput",
+            label="File Output",
+            description="A file Output.",
+            value=None,
+        ),
+        desc.StringParam(
+            name="stringOutput",
+            label="String Output",
+            description="A string output.",
+            value=None,
+        ),
+        desc.IntParam(
+            name="intOutput",
+            label="Int Output",
+            description="An integer output.",
+            value=None,
+        ),
+        desc.FloatParam(
+            name="floatOutput",
+            label="Float Output",
+            description="A floating output.",
+            value=None,
+        ),
+    ]
+
+    def process(self, node):
+        print("Processing NodeWithDynamicOutputs")
+        node.boolOutput.value = not node.boolInput.value
+        node.fileOutput.value = node.fileInput.value + ".ext"
+        node.stringOutput.value = node.stringInput.value.upper()
+        node.intOutput.value = node.intInput.value + 1
+        node.floatOutput.value = node.floatInput.value * 2.0
+
+
+class InputNodeWithDynamicOutputs(desc.InputNode):
+    inputs = [
+        desc.File(
+            name="fileInput",
+            label="File Input",
+            description="A file input.",
+            value="testFile",
+        ),
+    ]
+
+    outputs = [
+        desc.File(
+            name="fileOutput",
+            label="File Output",
+            description="A file Output.",
+            value=None,
+        ),
+    ]
+
+
+class TestNodesWithDynamicOutputs:
+    @classmethod
+    def setup_class(cls):
+        registerNodeDesc(NodeWithDynamicOutputs)
+
+    @classmethod
+    def teardown_class(cls):
+        unregisterNodeDesc(NodeWithDynamicOutputs)
+
+    def test_processWithDynamicOutputs(self, graphSavedOnDisk):
+        graph: Graph = graphSavedOnDisk
+        node = graph.addNewNode(NodeWithDynamicOutputs.__name__)
+
+        # Execute the node to compute dynamic outputs
+        node.process(inCurrentEnv=True)
+
+        assert node.boolOutput.value
+        assert node.fileOutput.value == "testFile.ext"
+        assert node.stringOutput.value == "TESTSTRING"
+        assert node.intOutput.value == 2
+        assert node.floatOutput.value == 10.0
+
+    def test_processWithDynamicOutputsNonDefaultInputs(self, graphSavedOnDisk):
+        graph: Graph = graphSavedOnDisk
+        node = graph.addNewNode(NodeWithDynamicOutputs.__name__)
+
+        node.boolInput.value = True
+        node.fileInput.value = "anotherTestFile"
+        node.stringInput.value = "anotherTestString"
+        node.intInput.value = 10
+        node.floatInput.value = 3.5
+
+        # Execute the node to compute dynamic outputs
+        node.process(inCurrentEnv=True)
+
+        assert not node.boolOutput.value
+        assert node.fileOutput.value == "anotherTestFile.ext"
+        assert node.stringOutput.value == "ANOTHERTESTSTRING"
+        assert node.intOutput.value == 11
+        assert node.floatOutput.value == 7.0
+
+    def test_loadGraphWithUncomputedDynamicOutputs(self, graphSavedOnDisk):
+        graph: Graph = graphSavedOnDisk
+        node = graph.addNewNode(NodeWithDynamicOutputs.__name__)
+        graph.save()
+
+        loadedGraph = loadGraph(graph.filepath)
+        loadedNode = loadedGraph.node(node.name)
+
+        assert loadedNode
+        assert loadedNode.boolOutput.value is None
+        assert loadedNode.fileOutput.value is None
+        assert loadedNode.stringOutput.value is None
+        assert loadedNode.intOutput.value is None
+        assert loadedNode.floatOutput.value is None
+
+    def test_loadGraphWithComputedDynamicOutputs(self, graphSavedOnDisk):
+        graph: Graph = graphSavedOnDisk
+        node = graph.addNewNode(NodeWithDynamicOutputs.__name__)
+        name = node.name
+        graph.save()
+
+        # Execute the node to compute dynamic outputs
+        node.process(inCurrentEnv=True)
+
+        # Check that the values have been correctly set
+        assert node.boolOutput.value
+        assert node.fileOutput.value == "testFile.ext"
+        assert node.stringOutput.value == "TESTSTRING"
+        assert node.intOutput.value == 2
+        assert node.floatOutput.value == 10.0
+
+        # Reload the graph from disk
+        loadedGraph = loadGraph(graph.filepath)
+        loadedNode = loadedGraph.node(name)
+
+        # Check that the dynamic outputs have been correctly deserialized
+        assert loadedNode
+        assert loadedNode.boolOutput.value
+        assert loadedNode.fileOutput.value == "testFile.ext"
+        assert loadedNode.stringOutput.value == "TESTSTRING"
+        assert loadedNode.intOutput.value == 2
+        assert loadedNode.floatOutput.value == 10.0
+
+
+class TestInputNodeWithDynamicOutputs:
+    def test_registerInputNodeWithDynamicOutputs(self):
+        """
+        Force the registration of a node with an invalid description and check that its description is rejected
+        and its status states it clearly.
+        """
+        registerNodeDesc(InputNodeWithDynamicOutputs)
+
+        # Check that the plugin has been correctly registered (there has been attempt to load it)
+        assert pluginManager.isRegistered(InputNodeWithDynamicOutputs.__name__)
+
+        # Check that the plugin's status is DESC_ERROR, since the node description is invalid
+        # Additionally, the list of errors should include an error about having a dynamic output in an InputNode
+        plugin = pluginManager.getRegisteredNodePlugin(InputNodeWithDynamicOutputs.__name__)
+        assert plugin
+        assert plugin.status == NodePluginStatus.DESC_ERROR
+        assert len(plugin.errors) == 1
+        errType = plugin.errors[0][1]
+        assert errType == desc.ValueTypeErrors.DYNAMIC_OUTPUT
+
+        unregisterNodeDesc(InputNodeWithDynamicOutputs)
+
+    def test_registerInputNodeWithDynamicOutputsV2(self):
+        """" Check that an input node with dynamic outputs has not been registered because it is invalid. """
+        graph = Graph("")
+        with pytest.raises(UnknownNodeTypeError):
+            # InputDynamicOutputs is located in tests/nodes/test/InputDynamicOutputs.py
+            # InputDynamicOutputs has the same description as InputNodeWithDynamicOutputs: had it been valid, it would
+            # have been loaded and registered by the plugin manager at the upper level of the test suite.
+            graph.addNewNode("InputDynamicOutputs")

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -37,15 +37,13 @@ def registerNodeDesc(nodeDesc: desc.Node):
     name = nodeDesc.__name__
     if not pluginManager.isRegistered(name):
         pluginManager._nodePlugins[name] = NodePlugin(nodeDesc)
-        pluginManager._nodePlugins[name].status = NodePluginStatus.LOADED
 
 
 def unregisterNodeDesc(nodeDesc: desc.Node):
     name = nodeDesc.__name__
     if pluginManager.isRegistered(name):
-        plugin = pluginManager.getRegisteredNodePlugin(name)
-        plugin.status = NodePluginStatus.NOT_LOADED
         del pluginManager._nodePlugins[name]
+
 
 @contextmanager
 def registeredPlugins(folder: str):


### PR DESCRIPTION
## Description

This pull request introduces a more robust error handling and reporting system for node parameter type validation in the Meshroom core, with a focus on distinguishing error types and improving error messages. It also adds tests to ensure correct behavior for nodes with dynamic outputs, especially for `InputNodes`, which are now explicitly rejected if they have dynamic outputs.

**Error Handling and Reporting Improvements:**

* Introduced the `ValueTypeErrors` enum in `desc/attribute.py` to categorize parameter validation errors (type, range, dynamic output, none) and updated all relevant `checkValueTypes` methods to return both the parameter name and the error type. [[1]](diffhunk://#diff-404f3a3e9948594e15a9bb1fb666a30cfaa58630c079223cbea461eae31cb950R4-R12) [[2]](diffhunk://#diff-404f3a3e9948594e15a9bb1fb666a30cfaa58630c079223cbea461eae31cb950L323-R330) [[3]](diffhunk://#diff-404f3a3e9948594e15a9bb1fb666a30cfaa58630c079223cbea461eae31cb950L352-R359) [[4]](diffhunk://#diff-404f3a3e9948594e15a9bb1fb666a30cfaa58630c079223cbea461eae31cb950L381-R391) [[5]](diffhunk://#diff-404f3a3e9948594e15a9bb1fb666a30cfaa58630c079223cbea461eae31cb950L412-R424) [[6]](diffhunk://#diff-404f3a3e9948594e15a9bb1fb666a30cfaa58630c079223cbea461eae31cb950L438-R448) [[7]](diffhunk://#diff-404f3a3e9948594e15a9bb1fb666a30cfaa58630c079223cbea461eae31cb950L516-R539) [[8]](diffhunk://#diff-404f3a3e9948594e15a9bb1fb666a30cfaa58630c079223cbea461eae31cb950L558-R569)
* Refactored the node description validation logic in `plugins.py` to use the new error type system, including special handling and error reporting for dynamic outputs in input nodes. Added the `formatNodeDescriptionErrorMessage` function for improved error message formatting. [[1]](diffhunk://#diff-1d5f2a46e59213721e5624ac787e491e5cc2333ab8838b226c6558ceb0d87913R17-R21) [[2]](diffhunk://#diff-1d5f2a46e59213721e5624ac787e491e5cc2333ab8838b226c6558ceb0d87913L32-R75)
* Updated the plugin system (`NodePlugin` and related imports) to store and propagate the new error format, ensuring that plugin status and error lists accurately reflect validation results. [[1]](diffhunk://#diff-297ebdd03e879077e859d3277a3cd6af795ec020fd810d709b5654f0d24823eaL21-R21) [[2]](diffhunk://#diff-1d5f2a46e59213721e5624ac787e491e5cc2333ab8838b226c6558ceb0d87913L440-R471)

**Testing and Validation of Dynamic Outputs:**

* Added comprehensive tests (`test_nodeDynamicOutputs.py`) for nodes with dynamic outputs, including validation of correct registration, error reporting, and graph serialization/deserialization. Specifically, tests ensure that input nodes with dynamic outputs are rejected and flagged with the correct error type. [[1]](diffhunk://#diff-87674adfd453ed64177f3187ec880e0b17214b9d7b6cbd397c7f23eef6369d40R1-R201) [[2]](diffhunk://#diff-64a5223134f380afb9ba873c8d9c755b5da218516d8e8c51aa66327a82736696R1-R20)
* Updated test utilities to align with the new plugin error handling, removing forced status overrides and ensuring that plugin status is determined by validation logic.

These changes collectively improve the reliability and clarity of node parameter validation, especially around the nuanced case of dynamic outputs, and ensure that errors are communicated and tested effectively.
