### PR TITLE
[core] Load valid plugins even if they contain no node

### DIFF
--- a/meshroom/core/__init__.py
+++ b/meshroom/core/__init__.py
@@ -344,7 +344,7 @@ def loadAllNodes(folder) -> list[Plugin]:
                     plugin.addNodePlugin(node)
                 nodesStr = ', '.join([node.nodeDescriptor.__name__ for node in nodePlugins])
                 logging.debug(f'Nodes loaded [{package}]: {nodesStr}')
-                plugins.append(plugin)
+            plugins.append(plugin)
     return plugins
 
 


### PR DESCRIPTION
## Description

This PR allows to properly load plugins that do not contain any nodes. As long as there is a Python package in the `meshroom` folder of the plugin, even if it is empty, the plugin will be fully loaded. This can be useful for example when wanting to load a plugin that only provides templates.
