### PR TITLE
[core] Make `BackdropNodes` effectively uncomputable

### DIFF
--- a/bin/meshroom_compute
+++ b/bin/meshroom_compute
@@ -107,8 +107,9 @@ if args.node:
               f"See file: \"{node.nodeStatusFile}\".")
         sys.exit(-1)
 
-    if node._isInputNode():
+    if node.isInputNode:
         print(f"InputNode: No computation to do.")
+        sys.exit(0)
 
     if not args.forceStatus and not args.forceCompute:
         if args.iteration != -1:
@@ -134,12 +135,12 @@ if args.node:
     if args.iteration != -1:
         chunk = node.chunks[args.iteration]
         if chunk._status.status == Status.STOPPED:
-            print(f"Chunk {chunk} : status is STOPPED")
+            print(f"Chunk {chunk}: status is STOPPED")
             killRunningJob(node)
         chunk.process(args.forceCompute, args.inCurrentEnv)
     else:
         if node.nodeStatus.status == Status.STOPPED:
-            print(f"Node {node} : status is STOPPED")
+            print(f"Node {node}: status is STOPPED")
             killRunningJob(node)
         node.process(args.forceCompute, args.inCurrentEnv)
     node.postprocess()

--- a/meshroom/core/node.py
+++ b/meshroom/core/node.py
@@ -2379,6 +2379,8 @@ class BackdropNode(BaseNode):
     def __init__(self, nodeType: str, position=None, parent=None, uid=None, **kwargs):
         super().__init__(nodeType, position, parent=parent, uid=uid, **kwargs)
 
+        self._chunksCreated = True
+
         if not self.nodeDesc:
             raise UnknownNodeTypeError(nodeType)
 

--- a/meshroom/core/node.py
+++ b/meshroom/core/node.py
@@ -1798,14 +1798,14 @@ class BaseNode(BaseObject):
         Returns:
             Status: the node global status
         """
-        if isinstance(self.nodeDesc, desc.InputNode):
+        if self.isInputNode:
             return Status.INPUT
         if not self._chunksCreated:
             # Get status from nodeStatus
             return self._nodeStatus.status
         if not self._chunks:
             return Status.NONE
-        if len( self._chunks) == 1:
+        if len(self._chunks) == 1:
             return self._chunks[0]._status.status
 
         chunksStatus = [chunk._status.status for chunk in self._chunks]
@@ -2266,7 +2266,7 @@ class Node(BaseNode):
         """ Set chunks on the node.
         # TODO : Maybe don't delete chunks if we will recreate them as before ?
         """
-        if isinstance(self.nodeDesc, desc.InputNode):
+        if self.isInputNode:
             self._chunksCreated = True
             return
         # Disconnect signals
@@ -2354,7 +2354,7 @@ class Node(BaseNode):
         """ Create chunks when computation is about to start. """
         if self._chunksCreated:
             return
-        if isinstance(self.nodeDesc, desc.InputNode):
+        if self.isInputNode:
             self._chunksCreated = True
             self.chunksChanged.emit()
             return

--- a/meshroom/core/taskManager.py
+++ b/meshroom/core/taskManager.py
@@ -435,7 +435,7 @@ class TaskManager(BaseObject):
         computed = []
         inputNodes = []
         for node in toNodes:
-            if not node.isComputableType:
+            if node.isInputNode:
                 inputNodes.append(node)
             elif context == "COMPUTATION":
                 if graph.canComputeTopologically(node) and graph.canSubmitOrCompute(node) % 2 == 1:

--- a/meshroom/core/taskManager.py
+++ b/meshroom/core/taskManager.py
@@ -283,6 +283,7 @@ class TaskManager(BaseObject):
             if not toNodes:
                 toNodes = graph.getLeafNodes(dependenciesOnly=True)
             toNodes = list(toNodes)
+            toNodes = [node for node in toNodes if not node.isBackdropNode]
             allReady = self.checkNodesDependencies(graph, toNodes, "COMPUTATION")
 
             # At this point, toNodes is a list
@@ -425,7 +426,7 @@ class TaskManager(BaseObject):
     def checkNodesDependencies(self, graph, toNodes, context):
         """
         Check dependencies of nodes to process.
-        Update toNodes with computable/submitable nodes only.
+        Update toNodes with computable/submittable nodes only.
 
         Returns:
             bool: True if all the nodes can be processed. False otherwise.
@@ -503,6 +504,7 @@ class TaskManager(BaseObject):
         if not toNodes:
             toNodes = graph.getLeafNodes(dependenciesOnly=True)
         toNodes = list(toNodes)
+        toNodes = [node for node in toNodes if not node.isBackdropNode]
         allReady = self.checkNodesDependencies(graph, toNodes, "SUBMITTING")
 
         # At this point, toNodes is a list

--- a/meshroom/ui/graph.py
+++ b/meshroom/ui/graph.py
@@ -565,7 +565,6 @@ class UIGraph(QObject):
     @Slot(list)
     def execute(self, nodes: Optional[Union[list[Node], Node]] = None):
         nodes = [nodes] if not isinstance(nodes, Iterable) and nodes else nodes
-        nodes = [n for n in nodes if n.isComputableType]
         self.save()  # always save the graph before computing
         self._taskManager.compute(self._graph, nodes)
         self.updateLockedUndoStack()  # explicitly call the update while it is already computing


### PR DESCRIPTION
## Description

This PR fixes a bug introduced by 378b91323db9045f5622cf8e3caee8651a5daccc, which excludes non-computable nodes from the list of nodes to execute, but fails to check before-hand that the provided list of nodes is not  `None`, thus causing issues when launching the computation of the whole graph through Meshroom header's "Compute" button.

The goal of 378b91323db9045f5622cf8e3caee8651a5daccc was to prevent attempting to compute `BackdropNodes` by removing them from the list of nodes to compute before actually starting the execution process. This PR addresses this by making the `BackdropNode` core object uncomputable: chunks will never be created for it, and unlike `InputNodes` which are not computable but still need to be part of the evaluated graph dependencies, the `BackdropNodes` are removed altogether from the graph evaluation in the context of its execution (they will thus not appear in the Task Manager, for example).

Additionally, a commit is pushed to prevent attempting to compute `InputNodes` in `meshroom_compute`: such nodes were correctly detected, but instead of stopping there, the process was still going through. This would for example cause errors on `InputNodes` sent to the farm.
