### PR TITLE
[ImageGallery] IntrinsicDisplayDelegate: Do not list all properties for intrinsics' attributes

### DIFF
--- a/meshroom/ui/qml/ImageGallery/IntrinsicDisplayDelegate.qml
+++ b/meshroom/ui/qml/ImageGallery/IntrinsicDisplayDelegate.qml
@@ -12,7 +12,7 @@ RowLayout {
     property int columnIndex: model.column
     property bool readOnly: false
     property string toolTipText: {
-        if (!attribute || Object.keys(attribute).length === 0)
+        if (!attribute || attribute.label === undefined)
             return ""
         return attribute.label
     }


### PR DESCRIPTION
## Description

This PR fixes an issue with the display of intrinsics in the Image Gallery, which was raising exceptions on the Python side for calling the `keyValues` property on non-keyable attributes. It had no functional impact but was polluting the logs for no relevant reason. We now perform only the necessary calls to check whether the attriubte's label is available rather than attempting to call all its properties. 

## Implementation remarks

Using `Object.keys` lists all the properties of the attribute and executes them at once. For intrinsics attributes, the `keyValues` property exists but is supposed to raise on the Python side as these attributes are not keyable. This causes error logs. Instead of listing all the properties of the attribute to check whether it has been properly instantiated, it is enough to check that its `label` property does not return `undefined`. If it does, it is equivalent to having `Object.keys(attribute).length === 0`.