### PR TITLE
[ui] Shape Files : Fix reload of shape files when no selected node

### DIFF
--- a/meshroom/ui/components/shapes/shapeFilesHelper.py
+++ b/meshroom/ui/components/shapes/shapeFilesHelper.py
@@ -40,7 +40,8 @@ class ShapeFilesHelper(BaseObject):
         # clear shapeFiles model
         self._shapeFiles.clear()
         # load node shape files
-        self._loadShapeFilesFromAttributes(self._activeProject.selectedNode.attributes)
+        if self._activeProject.selectedNode:
+            self._loadShapeFilesFromAttributes(self._activeProject.selectedNode.attributes)
         self.nodeShapeFilesChanged.emit()
 
     @Slot()


### PR DESCRIPTION
## Description

In the situation where :
- we have a node with shapes
- the node has a status (like succeed)
- we change a parameter (so the node should be reset to None)
- we click on the graph editor (-> we switch to no selected node)

We have this problem :
![bug](https://github.com/user-attachments/assets/681b8dbd-725e-42f6-b2e4-6933599610e5)

So visually the chunk status disappears, behind the scene in reality, there is a bug in the shape files loader and because of this part of the QML code is not executed, and then the part supposed to set the chunk color is not executed.

So : not related to the chunk color in reality but to the shape file reload on selected node changed.