### PR TITLE
[core] Catch exception in `_getEvalValue` when metadata contains "{"

### DIFF
--- a/meshroom/core/attribute.py
+++ b/meshroom/core/attribute.py
@@ -152,6 +152,8 @@ class Attribute(BaseObject):
                 # support of relative variables (when self.node._expVars was not used to evaluate
                 # expressions in the attribute)
                 return substituted
+            except (ValueError):
+                return ""
         return self.value
 
     def _getValue(self):


### PR DESCRIPTION
This pull request introduces a minor improvement to the error handling in the `_getEvalValue` method of the `meshroom/core/attribute.py` file. The change ensures that if a `ValueError` occurs during expression evaluation, the method returns an empty string instead of raising an exception.

An image contained a medata string with an opening '{' and no closing '}'. This was parsed (on node._buildExpVars of cameraInit) and raised an error.

