### PR TITLE
[tests] Improve handling of nodes and plugins registration in unit tests

### DIFF
--- a/tests/test_invalidation.py
+++ b/tests/test_invalidation.py
@@ -3,7 +3,7 @@
 from meshroom.core.graph import Graph
 from meshroom.core import desc
 
-from .utils import registerNodeDesc
+from .utils import registerNodeDesc, unregisterNodeDesc
 
 
 class SampleNode(desc.Node):
@@ -19,10 +19,8 @@ class SampleNode(desc.Node):
     ]
 
 
-registerNodeDesc(SampleNode)  # register standalone NodePlugin
-
-
 def test_output_invalidation():
+    registerNodeDesc(SampleNode)  # Register standalone NodePlugin
     graph = Graph("")
     n1 = graph.addNewNode("SampleNode", input="/tmp")
     n2 = graph.addNewNode("SampleNode")
@@ -48,12 +46,13 @@ def test_output_invalidation():
     n1.input.value = "/a/path"
     assert n2.input.uid() != n2inputUid      # => UID has changed
     assert n2.input.uid() == n3.input.uid()  # => UIDs on both node are still equal
-
+    unregisterNodeDesc(SampleNode)
 
 def test_inputLinkInvalidation():
     """
     Input links should not change the invalidation.
     """
+    registerNodeDesc(SampleNode)  # Register standalone NodePlugin
     graph = Graph("")
     n1 = graph.addNewNode("SampleNode")
     n2 = graph.addNewNode("SampleNode")
@@ -61,3 +60,4 @@ def test_inputLinkInvalidation():
     n1.input.connectTo(n2.input)
     assert n1.input.uid() == n2.input.uid()
     assert n1.output.value == n2.output.value
+    unregisterNodeDesc(SampleNode)

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -9,7 +9,7 @@ from meshroom.core import pluginManager, loadClassesNodes, initNodes
 from meshroom.core.graph import Graph, loadGraph
 from meshroom.core.plugins import Plugin
 
-from .utils import registerNodeDesc
+from .utils import registerNodeDesc, unregisterNodeDesc
 
 
 class TestNodeInfo:
@@ -29,6 +29,7 @@ class TestNodeInfo:
     def teardown_class(cls):
         for node in cls.plugin.nodes.values():
             pluginManager.unregisterNode(node)
+        pluginManager.removePlugin(cls.plugin)
         cls.plugin = None
 
     def test_loadedPlugin(self):
@@ -51,6 +52,7 @@ class TestNodeInfo:
         assert nodeInfo["author"] == "testAuthor"
         assert nodeInfo["license"] == "no-license"
         assert nodeInfo["version"] == "1.0"
+        unregisterNodeDesc(nodeType)
 
 
 class TestNodeVariables:

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -26,6 +26,7 @@ class TestPluginWithValidNodesOnly:
     def teardown_class(cls):
         for node in cls.plugin.nodes.values():
             pluginManager.unregisterNode(node)
+        pluginManager.removePlugin(cls.plugin)
         cls.plugin = None
 
     def test_loadedPlugin(self):
@@ -133,6 +134,7 @@ class TestPluginWithInvalidNodes:
     def teardown_class(cls):
         for node in cls.plugin.nodes.values():
             pluginManager.unregisterNode(node)
+        pluginManager.removePlugin(cls.plugin)
         cls.plugin = None
 
     def test_loadedPlugin(self):

--- a/tests/test_submit.py
+++ b/tests/test_submit.py
@@ -122,6 +122,7 @@ class TestNodeSubmit:
     def teardown_class(cls):
         for node in cls.plugin.nodes.values():
             pluginManager.unregisterNode(node)
+        pluginManager.removePlugin(cls.plugin)
         cls.plugin = None
 
     def setupNode(self, graph, name):


### PR DESCRIPTION
## Description

This PR improves the reliability and isolation of tests involving plugin and node registration by ensuring that all registered node descriptions and plugins are properly unregistered or removed after each test or test class. This helps prevent side effects between tests and makes the test suite more robust.

