### PR TITLE
[core] Rename `groupDesc` to `items` for `GroupAttributes`

### DIFF
--- a/meshroom/core/attribute.py
+++ b/meshroom/core/attribute.py
@@ -998,7 +998,7 @@ class GroupAttribute(Attribute):
     def _initValue(self):
         self._value = DictModel(keyAttrName='name', parent=self)
         subAttributes = []
-        for subAttrDesc in self._desc.groupDesc:
+        for subAttrDesc in self._desc.items:
             childAttr = attributeFactory(subAttrDesc, None, self.isOutput, self.node, self)
             subAttributes.append(childAttr)
             childAttr.valueChanged.connect(self.valueChanged)
@@ -1019,9 +1019,9 @@ class GroupAttribute(Attribute):
             for key, v in value.items():
                 self._value.get(key).value = v
         elif isinstance(value, (list, tuple)):
-            if len(self._desc._groupDesc) != len(value):
+            if len(self._desc._items) != len(value):
                 raise AttributeError(f"Incorrect number of values on GroupAttribute: {str(value)}")
-            for attrDesc, v in zip(self._desc._groupDesc, value):
+            for attrDesc, v in zip(self._desc._items, value):
                 self._value.get(attrDesc.name).value = v
         else:
             raise AttributeError(f"Failed to set on GroupAttribute: {str(value)}")
@@ -1036,7 +1036,7 @@ class GroupAttribute(Attribute):
 
     # Override
     def resetToDefaultValue(self):
-        for attrDesc in self._desc._groupDesc:
+        for attrDesc in self._desc._items:
             self._value.get(attrDesc.name).resetToDefaultValue()
 
     # Override
@@ -1071,7 +1071,7 @@ class GroupAttribute(Attribute):
         spaceSep = self._desc.joinChar == ' '
         # sort values based on child attributes group description order
         sortedSubValues = [self._value.get(attr.name).getValueStr(withQuotes=spaceSep)
-                           for attr in self._desc.groupDesc]
+                           for attr in self._desc.items]
         s = self._desc.joinChar.join(sortedSubValues)
         if withQuotes and not spaceSep:
             return f'"{strBegin}{s}{strEnd}"'
@@ -1089,9 +1089,9 @@ class GroupAttribute(Attribute):
                 if key in self._value.keys():
                     self._value.get(key).upgradeValue(v)
         elif isinstance(value, (list, tuple)):
-            if len(self._desc._groupDesc) != len(value):
+            if len(self._desc._items) != len(value):
                 raise AttributeError(f"Incorrect number of values on GroupAttribute: {str(value)}")
-            for attrDesc, v in zip(self._desc._groupDesc, value):
+            for attrDesc, v in zip(self._desc._items, value):
                 self._value.get(attrDesc.name).upgradeValue(v)
         else:
             raise AttributeError(f"Failed to set on GroupAttribute: {str(value)}")

--- a/meshroom/core/desc/attribute.py
+++ b/meshroom/core/desc/attribute.py
@@ -186,12 +186,12 @@ class ListAttribute(Attribute):
 
 class GroupAttribute(Attribute):
     """ A macro Attribute composed of several Attributes """
-    def __init__(self, groupDesc, name, label, description, group="allParams", advanced=False, semantic="",
+    def __init__(self, items, name, label, description, group="allParams", advanced=False, semantic="",
                  enabled=True, joinChar=" ", brackets=None, visible=True, exposed=False):
         """
-        :param groupDesc: the description of the Attributes composing this group
+        :param items: the description of the Attributes composing this group
         """
-        self._groupDesc = groupDesc
+        self._items = items
         self._joinChar = joinChar
         self._brackets = brackets
         super(GroupAttribute, self).__init__(name=name, label=label, description=description, value={},
@@ -217,20 +217,20 @@ class GroupAttribute(Attribute):
             value = ast.literal_eval(value)
 
         if isinstance(value, dict):
-            # invalidKeys = set(value.keys()).difference([attr.name for attr in self._groupDesc])
+            # invalidKeys = set(value.keys()).difference([attr.name for attr in self._items])
             # if invalidKeys:
             #     raise ValueError(f"Value contains key that does not match group description: "
             #                      f"{invalidKeys}")
-            if self._groupDesc and value.keys():
-                commonKeys = set(value.keys()).intersection([attr.name for attr in self._groupDesc])
+            if self._items and value.keys():
+                commonKeys = set(value.keys()).intersection([attr.name for attr in self._items])
                 if not commonKeys:
                     raise ValueError(f"Value contains no key that matches with the group "
                                      f"description (name={self.name}, values={value.keys()}, "
-                                     f"desc={[attr.name for attr in self._groupDesc]})")
+                                     f"desc={[attr.name for attr in self._items]})")
         elif isinstance(value, (list, tuple, set)):
-            if len(value) != len(self._groupDesc):
+            if len(value) != len(self._items):
                 raise ValueError(f"Value contains incoherent number of values: "
-                                 f"desc size: {len(self._groupDesc)}, value size: {len(value)}")
+                                 f"desc size: {len(self._items)}, value size: {len(value)}")
         else:
             raise ValueError(f"GroupAttribute only supports dict/list/tuple input values "
                              f"(param: {self.name}, value: {value}, type: {type(value)})")
@@ -245,7 +245,7 @@ class GroupAttribute(Attribute):
         the group with invalid types.
         """
         invalidParams = []
-        for attr in self.groupDesc:
+        for attr in self.items:
             name, error = attr.checkValueTypes()
             if name:
                 invalidParams.append(name)
@@ -266,7 +266,7 @@ class GroupAttribute(Attribute):
         """
         if not super(GroupAttribute, self).matchDescription(value):
             return False
-        attrMap = {attr.name: attr for attr in self._groupDesc}
+        attrMap = {attr.name: attr for attr in self._items}
 
         matchCount = 0
         for k, v in value.items():
@@ -275,17 +275,17 @@ class GroupAttribute(Attribute):
                 matchCount += 1
 
         if strict:
-            return matchCount == len(value.items()) == len(self._groupDesc)
+            return matchCount == len(value.items()) == len(self._items)
 
         return matchCount > 0
 
     def retrieveChildrenInvalidations(self):
         allInvalidations = []
-        for desc in self._groupDesc:
+        for desc in self._items:
             allInvalidations.append(desc.invalidate)
         return allInvalidations
 
-    groupDesc = Property(Variant, lambda self: self._groupDesc, constant=True)
+    items = Property(Variant, lambda self: self._items, constant=True)
     invalidate = Property(Variant, retrieveChildrenInvalidations, constant=True)
     joinChar = Property(str, lambda self: self._joinChar, constant=True)
     brackets = Property(str, lambda self: self._brackets, constant=True)

--- a/meshroom/core/desc/geometryAttribute.py
+++ b/meshroom/core/desc/geometryAttribute.py
@@ -6,10 +6,10 @@ class Geometry(GroupAttribute):
     Base attribute for all Geometry attribute.
     Countains several attributes (inherit from GroupAttribute).
     """
-    def __init__(self, groupDesc, name, label, description, group="allParams", advanced=False, semantic="",
+    def __init__(self, items, name, label, description, group="allParams", advanced=False, semantic="",
                  enabled=True, visible=True, exposed=False):
         # GroupAttribute constructor
-        super(Geometry, self).__init__(groupDesc=groupDesc, name=name, label=label, description=description,
+        super(Geometry, self).__init__(items=items, name=name, label=label, description=description,
                                        group=group, advanced=advanced, semantic=semantic,
                                        enabled=enabled, visible=visible, exposed=exposed)
 
@@ -30,7 +30,7 @@ class Size2d(Geometry):
                  keyable=False, keyType=None, group="allParams", advanced=False, semantic="",
                  enabled=True, visible=True, exposed=False):
         # Geometry group desciption
-        groupDesc = [
+        items = [
             FloatParam(name="width", label="Width", description="Width size.", value=width, range=widthRange,
                        keyable=keyable, keyType=keyType, group=group, advanced=advanced,
                        enabled=enabled, visible=visible, exposed=exposed),
@@ -39,7 +39,7 @@ class Size2d(Geometry):
                        enabled=enabled, visible=visible, exposed=exposed)
         ]
         # GeometryAttribute constructor
-        super(Size2d, self).__init__(groupDesc, name, label, description, group=None, advanced=advanced,
+        super(Size2d, self).__init__(items, name, label, description, group=None, advanced=advanced,
                                      semantic=semantic, enabled=enabled, visible=visible, exposed=exposed)
 
 class Vec2d(Geometry):
@@ -50,7 +50,7 @@ class Vec2d(Geometry):
                  keyable=False, keyType=None, group="allParams", advanced=False, semantic="",
                  enabled=True, visible=True, exposed=False):
         # Geometry group desciption
-        groupDesc = [
+        items = [
             FloatParam(name="x", label="X", description="X coordinate.", value=x, range=xRange,
                        keyable=keyable, keyType=keyType, group=group, advanced=advanced,
                        enabled=enabled, visible=visible, exposed=exposed),
@@ -59,5 +59,5 @@ class Vec2d(Geometry):
                        enabled=enabled, visible=visible, exposed=exposed)
         ]
         # GeometryAttribute constructor
-        super(Vec2d, self).__init__(groupDesc, name, label, description, group=None, advanced=advanced,
+        super(Vec2d, self).__init__(items, name, label, description, group=None, advanced=advanced,
                                      semantic=semantic, enabled=enabled, visible=visible, exposed=exposed)

--- a/meshroom/core/desc/shapeAttribute.py
+++ b/meshroom/core/desc/shapeAttribute.py
@@ -5,19 +5,19 @@ class Shape(GroupAttribute):
     Base attribute for all Shape attribute.
     Countains several attributes (inherit from GroupAttribute).
     """
-    def __init__(self, geometryGroupDesc, name, label, description, group="allParams", advanced=False, semantic="",
+    def __init__(self, geometryItems, name, label, description, group="allParams", advanced=False, semantic="",
                  enabled=True, visible=True, exposed=False):
         # Shape group desciption
-        groupDesc = [
+        items = [
             StringParam(name="userName", label="User Name", description="User shape name.", value="",
                         group=group, advanced=advanced, enabled=enabled, visible=visible, exposed=exposed),
             StringParam(name="userColor", label="User Color", description="User shape color.", value="#2a82da",
                         group=group, advanced=advanced, enabled=enabled, visible=visible, exposed=exposed),
-            Geometry(geometryGroupDesc, name="geometry", label="Geometry", description="Shape geometry.",
+            Geometry(geometryItems, name="geometry", label="Geometry", description="Shape geometry.",
                      group=group, advanced=advanced, enabled=enabled, visible=visible, exposed=exposed)
         ]
         # GroupAttribute constructor
-        super(Shape, self).__init__(groupDesc=groupDesc, name=name, label=label, description=description,
+        super(Shape, self).__init__(items=items, name=name, label=label, description=description,
                                     group=group, advanced=advanced, semantic=semantic,
                                     enabled=enabled, visible=visible, exposed=exposed)
 
@@ -57,14 +57,14 @@ class Point2d(Shape):
                  group="allParams", advanced=False, semantic="",
                  enabled=True, visible=True, exposed=False):
         # Geometry group desciption
-        geometryGroupDesc = [
+        geometryItems = [
             FloatParam(name="x", label="X", description="X coordinate.", value=-1.0, keyable=keyable, keyType=keyType,
                        group=group, advanced=advanced, enabled=enabled, visible=visible, exposed=exposed),
             FloatParam(name="y", label="Y", description="Y coordinate.", value=-1.0, keyable=keyable, keyType=keyType,
                        group=group, advanced=advanced, enabled=enabled, visible=visible, exposed=exposed)
         ]
         # ShapeAttribute constructor
-        super(Point2d, self).__init__(geometryGroupDesc, name, label, description, group=None, advanced=advanced,
+        super(Point2d, self).__init__(geometryItems, name, label, description, group=None, advanced=advanced,
                                       semantic=semantic, enabled=enabled, visible=visible, exposed=exposed)
 
 class Line2d(Shape):
@@ -75,14 +75,14 @@ class Line2d(Shape):
                  group="allParams", advanced=False, semantic="",
                  enabled=True, visible=True, exposed=False):
         # Geometry group desciption
-        geometryGroupDesc = [
+        geometryItems = [
             Vec2d(name="a", label="A", description="Line A point.", x=-1.0, y=-1.0, keyable=keyable, keyType=keyType,
                   group=group, advanced=advanced, enabled=enabled, visible=visible, exposed=exposed),
             Vec2d(name="b", label="B", description="Line B point.", x=-1.0, y=-1.0, keyable=keyable, keyType=keyType,
                   group=group, advanced=advanced, enabled=enabled, visible=visible, exposed=exposed)
         ]
         # ShapeAttribute constructor
-        super(Line2d, self).__init__(geometryGroupDesc, name, label, description, group=None, advanced=advanced,
+        super(Line2d, self).__init__(geometryItems, name, label, description, group=None, advanced=advanced,
                                      semantic=semantic, enabled=enabled, visible=visible, exposed=exposed)
 
 class Rectangle(Shape):
@@ -93,7 +93,7 @@ class Rectangle(Shape):
                  group="allParams", advanced=False, semantic="",
                  enabled=True, visible=True, exposed=False):
         # Geometry group desciption
-        geometryGroupDesc = [
+        geometryItems = [
             Vec2d(name="center", label="Center", description="Rectangle center.", x=-1.0, y=-1.0,
                   keyable=keyable, keyType=keyType, group=group, advanced=advanced,
                   enabled=enabled, visible=visible, exposed=exposed),
@@ -102,7 +102,7 @@ class Rectangle(Shape):
                    enabled=enabled, visible=visible, exposed=exposed)
         ]
         # ShapeAttribute constructor
-        super(Rectangle, self).__init__(geometryGroupDesc, name, label, description, group=None, advanced=advanced,
+        super(Rectangle, self).__init__(geometryItems, name, label, description, group=None, advanced=advanced,
                                         semantic=semantic, enabled=enabled, visible=visible, exposed=exposed)
 
 class Circle(Shape):
@@ -113,7 +113,7 @@ class Circle(Shape):
                  group="allParams", advanced=False, semantic="",
                  enabled=True, visible=True, exposed=False):
         # Geometry group desciption
-        geometryGroupDesc = [
+        geometryItems = [
             Vec2d(name="center", label="Center", description="Circle center.", x=-1.0, y=-1.0,
                   keyable=keyable, keyType=keyType, group=group, advanced=advanced,
                   enabled=enabled, visible=visible, exposed=exposed),
@@ -122,5 +122,5 @@ class Circle(Shape):
                        enabled=enabled, visible=visible, exposed=exposed)
         ]
         # ShapeAttribute constructor
-        super(Circle, self).__init__(geometryGroupDesc, name, label, description, group=None, advanced=advanced,
+        super(Circle, self).__init__(geometryItems, name, label, description, group=None, advanced=advanced,
                                      semantic=semantic, enabled=enabled, visible=visible, exposed=exposed)

--- a/meshroom/core/node.py
+++ b/meshroom/core/node.py
@@ -2526,11 +2526,11 @@ class CompatibilityNode(BaseNode):
                 eltDesc = CompatibilityNode.attributeDescFromValue("element", elt, isOutput)
                 attrDesc = desc.ListAttribute(elementDesc=eltDesc, **params)
             elif isinstance(value, dict):
-                groupDesc = []
+                items = []
                 for key, value in value.items():
                     eltDesc = CompatibilityNode.attributeDescFromValue(key, value, isOutput)
-                    groupDesc.append(eltDesc)
-                attrDesc = desc.GroupAttribute(groupDesc=groupDesc, **params)
+                    items.append(eltDesc)
+                attrDesc = desc.GroupAttribute(items=items, **params)
             # Override empty default value with
             attrDesc._value = value
             return attrDesc
@@ -2567,7 +2567,7 @@ class CompatibilityNode(BaseNode):
         # individually so that links can correctly be evaluated.
         if isinstance(attrDesc, desc.GroupAttribute):
             for k, v in value.items():
-                if CompatibilityNode.attributeDescFromName(attrDesc.groupDesc,
+                if CompatibilityNode.attributeDescFromName(attrDesc.items,
                                                            k, v, strict=True) is None:
                     return None
             return attrDesc

--- a/tests/nodes/test/Color.py
+++ b/tests/nodes/test/Color.py
@@ -8,7 +8,7 @@ class Color(desc.Node):
             label="rgb",
             description="rgb",
             exposed=True,
-            groupDesc=[
+            items=[
                 desc.FloatParam(name="r", label="r", description="r", value=0.0),
                 desc.FloatParam(name="g", label="g", description="g", value=0.0),
                 desc.FloatParam(name="b", label="b", description="b", value=0.0),
@@ -23,12 +23,12 @@ class NestedColor(desc.Node):
             label="rgb",
             description="rgb",
             exposed=True,
-            groupDesc=[
+            items=[
                 desc.FloatParam(name="r", label="r", description="r", value=0.0),
                 desc.FloatParam(name="g", label="g", description="g", value=0.0),
                 desc.FloatParam(name="b", label="b", description="b", value=0.0),
                 desc.GroupAttribute(label="test", name="test", description="",
-                    groupDesc=[
+                    items=[
                         desc.FloatParam(name="r", label="r", description="r", value=0.0),
                         desc.FloatParam(name="g", label="g", description="g", value=0.0),
                         desc.FloatParam(name="b", label="b", description="b", value=0.0),

--- a/tests/nodes/test/GroupAttributes.py
+++ b/tests/nodes/test/GroupAttributes.py
@@ -12,7 +12,7 @@ class GroupAttributes(desc.Node):
             description="Group at the root level.",
             group=None,
             exposed=True,
-            groupDesc=[
+            items=[
                 desc.IntParam(
                     name="firstGroupIntA",
                     label="Integer A",
@@ -53,7 +53,7 @@ class GroupAttributes(desc.Node):
                     description="A group within a group.",
                     group=None,
                     exposed=True,
-                    groupDesc=[
+                    items=[
                         desc.FloatParam(
                             name="nestedGroupFloat",
                             label="Floating Number",
@@ -76,7 +76,7 @@ class GroupAttributes(desc.Node):
                         description="Group in a list within a group.",
                         joinChar=":",
                         group=None,
-                        groupDesc=[
+                        items=[
                             desc.IntParam(
                                 name="listedGroupInt",
                                 label="Integer 1",
@@ -121,7 +121,7 @@ class GroupAttributes(desc.Node):
             label="Input Group",
             description="A group set as an input.",
             group=None,
-            groupDesc=[
+            items=[
                 desc.BoolParam(
                     name="inputBool",
                     label="Input Bool",
@@ -139,7 +139,7 @@ class GroupAttributes(desc.Node):
             description="A group set as an output.",
             group=None,
             exposed=True,
-            groupDesc=[
+            items=[
                 desc.BoolParam(
                     name="outputBool",
                     label="Output Bool",

--- a/tests/nodes/test/NestedTest.py
+++ b/tests/nodes/test/NestedTest.py
@@ -8,12 +8,12 @@ class NestedTest(desc.Node):
             label="xyz",
             description="xyz",
             exposed=True,
-            groupDesc=[
+            items=[
                 desc.FloatParam(name="x", label="x", description="x", value=0.0),
                 desc.FloatParam(name="y", label="z", description="z", value=0.0),
                 desc.FloatParam(name="z", label="z", description="z", value=0.0),
                 desc.GroupAttribute(label="test", name="test", description="",
-                    groupDesc=[
+                    items=[
                         desc.StringParam(name="x", label="x", description="x", value="test"),
                         desc.FloatParam(name="y", label="z", description="z", value=0.0),
                         desc.FloatParam(name="z", label="z", description="z", value=0.0),

--- a/tests/nodes/test/Position.py
+++ b/tests/nodes/test/Position.py
@@ -8,7 +8,7 @@ class Position(desc.Node):
             label="xyz",
             description="xyz",
             exposed=True,
-            groupDesc=[
+            items=[
                 desc.FloatParam(name="x", label="x", description="x", value=0.0),
                 desc.FloatParam(name="y", label="y", description="y", value=0.0),
                 desc.FloatParam(name="z", label="z", description="z", value=0.0),
@@ -23,12 +23,12 @@ class NestedPosition(desc.Node):
             label="xyz",
             description="xyz",
             exposed=True,
-            groupDesc=[
+            items=[
                 desc.FloatParam(name="x", label="x", description="x", value=0.0),
                 desc.FloatParam(name="y", label="y", description="y", value=0.0),
                 desc.FloatParam(name="z", label="z", description="z", value=0.0),
                 desc.GroupAttribute(label="test", name="test", description="",
-                    groupDesc=[
+                    items=[
                         desc.FloatParam(name="x", label="x", description="x", value=0.0),
                         desc.FloatParam(name="y", label="y", description="y", value=0.0),
                         desc.FloatParam(name="z", label="z", description="z", value=0.0),

--- a/tests/test_compatibility.py
+++ b/tests/test_compatibility.py
@@ -32,7 +32,7 @@ SampleGroupV2 = [
     desc.ListAttribute(
         name="b",
         elementDesc=desc.GroupAttribute(name="p", label="",
-                                        description="", groupDesc=SampleGroupV1),
+                                        description="", items=SampleGroupV1),
         label="b",
         description="",
     )
@@ -46,7 +46,7 @@ SampleGroupV3 = [
     desc.ListAttribute(
         name="b",
         elementDesc=desc.GroupAttribute(name="p", label="",
-                                        description="", groupDesc=SampleGroupV1),
+                                        description="", items=SampleGroupV1),
         label="b",
         description="",
     )
@@ -101,7 +101,7 @@ class SampleNodeV4(desc.Node):
         desc.File(name="in", label="Input", description="", value=""),
         desc.ListAttribute(name="paramA", label="ParamA",
                            elementDesc=desc.GroupAttribute(
-                               groupDesc=SampleGroupV1, name="gA", label="gA", description=""),
+                               items=SampleGroupV1, name="gA", label="gA", description=""),
                            description="")
     ]
     outputs = [
@@ -118,7 +118,7 @@ class SampleNodeV5(desc.Node):
         desc.File(name="in", label="Input", description="", value=""),
         desc.ListAttribute(name="paramA", label="ParamA",
                            elementDesc=desc.GroupAttribute(
-                               groupDesc=SampleGroupV2, name="gA", label="gA", description=""),
+                               items=SampleGroupV2, name="gA", label="gA", description=""),
                            description="")
     ]
     outputs = [
@@ -135,7 +135,7 @@ class SampleNodeV6(desc.Node):
         desc.File(name="in", label="Input", description="", value=""),
         desc.ListAttribute(name="paramA", label="ParamA",
                            elementDesc=desc.GroupAttribute(
-                               groupDesc=SampleGroupV3, name="gA", label="gA", description=""),
+                               items=SampleGroupV3, name="gA", label="gA", description=""),
                            description="")
     ]
     outputs = [
@@ -309,7 +309,7 @@ def test_description_conflict():
 
             assert isinstance(groupAttribute, desc.GroupAttribute)
             # Check that Compatibility node respect SampleGroupV1 description
-            for elt in groupAttribute.groupDesc:
+            for elt in groupAttribute.items:
                 assert isinstance(elt,
                                   next(a for a in SampleGroupV1 if a.name == elt.name).__class__)
 

--- a/tests/test_graphIO.py
+++ b/tests/test_graphIO.py
@@ -32,7 +32,7 @@ class NodeWithListAttributes(desc.Node):
             name="group",
             label="Group",
             description="",
-            groupDesc=[
+            items=[
                 desc.ListAttribute(
                     name="listInput",
                     label="List Input",

--- a/tests/test_nodeAttributeChangedCallback.py
+++ b/tests/test_nodeAttributeChangedCallback.py
@@ -202,7 +202,7 @@ class NodeWithCompoundAttributes(desc.BaseNode):
             name="groupInput",
             label="Group Input",
             description="GroupAttribute with a single 'IntParam' element.",
-            groupDesc=[
+            items=[
                 desc.IntParam(
                     name="int", label="Int", description="", value=0, range=None
                 )
@@ -216,7 +216,7 @@ class NodeWithCompoundAttributes(desc.BaseNode):
                 name="subGroup",
                 label="SubGroup",
                 description="",
-                groupDesc=[
+                items=[
                     desc.IntParam(
                         name="int", label="Int", description="", value=0, range=None
                     )
@@ -227,7 +227,7 @@ class NodeWithCompoundAttributes(desc.BaseNode):
             name="groupWithListInput",
             label="Group with List",
             description="GroupAttribute with a single 'ListAttribute of IntParam' element.",
-            groupDesc=[
+            items=[
                 desc.ListAttribute(
                     name="subList",
                     label="SubList",

--- a/tests/test_nodeCommandLineFormatting.py
+++ b/tests/test_nodeCommandLineFormatting.py
@@ -42,7 +42,7 @@ class NodeWithAttributesNeedingFormatting(desc.Node):
             label="First Group",
             description="Group with boolean and integer parameters.",
             joinChar=":",
-            groupDesc=[
+            items=[
                 desc.BoolParam(
                     name="enableFirstGroup",
                     label="Enable",
@@ -64,7 +64,7 @@ class NodeWithAttributesNeedingFormatting(desc.Node):
             label="Second Group",
             description="Group with boolean, choice and float parameters.",
             joinChar=",",
-            groupDesc=[
+            items=[
                 desc.BoolParam(
                     name="enableSecondGroup",
                     label="Enable",


### PR DESCRIPTION
## Description

This PR renames the `groupDesc` argument for `GroupAttributes` to `items`, and subsequently renames all the occurrences of `groupDesc` to `items` across the codebase, including in the unit tests.

Once merged, the following pull requests need to be merged straight away:
- https://github.com/alicevision/AliceVision/pull/2059
- https://github.com/meshroomHub/mrBlenderSfmRenderer/pull/2
- https://github.com/meshroomHub/mrVideoUtils/pull/2