### PR TITLE
[graph] Stop execution : clear submitted chunks

### DIFF
--- a/meshroom/core/graph.py
+++ b/meshroom/core/graph.py
@@ -1601,9 +1601,12 @@ class Graph(BaseObject):
 
     def stopExecution(self):
         """ Request graph execution to be stopped by terminating running chunks"""
-        for chunk in self.iterChunksByStatus(Status.RUNNING):
-            if not chunk.isExtern():
-                chunk.stopProcess()
+        for node in self.nodes:
+            if node.canBeStopped():
+                for chunk in node.chunks:
+                    chunk.stopProcess()
+            elif node.canBeCanceled():
+                node.clearSubmittedChunks()
 
     @Slot()
     @Slot(list)
@@ -1625,13 +1628,6 @@ class Graph(BaseObject):
         """ Reset the status of already locally submitted nodes to Status.NONE """
         for node in self.nodes:
             node.clearLocallySubmittedChunks()
-
-    def iterChunksByStatus(self, status):
-        """ Iterate over NodeChunks with the given status """
-        for node in self.nodes:
-            for chunk in node.chunks:
-                if chunk.status.status == status:
-                    yield chunk
 
     def getChunksByStatus(self, status):
         """ Return the list of NodeChunks with the given status. """

--- a/meshroom/ui/qml/Application.qml
+++ b/meshroom/ui/qml/Application.qml
@@ -1068,7 +1068,7 @@ Page {
                     border.color: Qt.darker(activePalette.window, 1.15)
                 }
 
-                onClicked: !(_currentScene.computingLocally) ? computeManager.compute(null) : _currentScene.stopExecution()
+                onClicked: _currentScene.computingLocally ? _currentScene.stopExecution() : computeManager.compute(null)
             }
 
             MaterialToolButton {
@@ -1087,7 +1087,7 @@ Page {
                     border.color: Qt.darker(activePalette.window, 1.15)
                 }
 
-                onClicked: !(_currentScene.computingExternally) ? computeManager.submit(null) : _currentScene.stopExecution()
+                onClicked: _currentScene.computingExternally ? _currentScene.stopExecution() : computeManager.submit(null)
             }
         }
 


### PR DESCRIPTION
## Description

When we clear the local computation some chunks are not properly canceled.

![aaa](https://github.com/user-attachments/assets/21a085d1-30b9-4a72-bfd9-fe494dcf5ee8)

## Issue

In the code the `stopExecution` function only iter on running chunks, so nodes with expanding chunks are completely ignored

## Fix

We use different methods for different cases
- `canBeStopped` (chunks exist) -> `chunk.stopProcess`
- `canBeCanceled` (chunks might not exist) -> `node.clearSubmittedChunks`

![bbb](https://github.com/user-attachments/assets/fc6941b2-72f4-4380-9ed2-baac7a002854)
