### PR TITLE
[bug][node] Skip updating size on UpdateInternals

### DIFF
--- a/meshroom/core/node.py
+++ b/meshroom/core/node.py
@@ -1522,8 +1522,6 @@ class BaseNode(BaseObject):
         # Reset chunks splitting
         self._resetChunks()
 
-        self._updateNodeSize()
-
         # Retrieve current internal folder (if possible)
         try:
             folder = self.internalFolder


### PR DESCRIPTION
## Description

- Little bug from the chunk expand process
- This PR removes the size computation on `updateInternals`
  - It should not be required as it is done in the `_resetChunks` if possible anyways
- This way the `computeSize` function in the `DynamicSize` class is only called on compute

## Testing

The following should not freeze until the node starts computing

```py
class CustomNodeSize(desc.DynamicNodeSize):
    def __init__(self, param):
        self._param = param
    
    def computeSize(self, node):
        print("computeSize start")
        time.sleep(3)
        print("computeSize end")
        return self._param


class CustomSizeNode(desc.Node):
    """
    Test process no parallelization
    """
    category = 'TestPlugin'
    
    size = CustomNodeSize(5)
    parallelization = desc.Parallelization(blockSize=1)

    inputs = INPUTS
    outputs = OUTPUTS

    def processChunk(self, chunk):
        LOGGER.info(f"> [{chunk.node.name}](process) Start {chunk.range.iteration+1}/{chunk.range.nbBlocks}")
        time.sleep(1)
        LOGGER.info(f"> [{chunk.node.name}](process) Done")
```