### PR TITLE
Make label, description, and value optional on all attribute constructors

### DIFF
--- a/meshroom/core/desc/attribute.py
+++ b/meshroom/core/desc/attribute.py
@@ -1,9 +1,29 @@
 import ast
 import os
+import re
 from collections.abc import Iterable
 from enum import auto, Enum
 
 from meshroom.common import BaseObject, JSValue, Property, Variant, VariantList, strtobool
+
+
+def _labelFromName(name):
+    """Convert a camelCase or snake_case attribute name to a 'Title Case' label.
+
+    Examples:
+        >>> _labelFromName('myAttributeName')
+        'My Attribute Name'
+        >>> _labelFromName('my_attribute_name')
+        'My Attribute Name'
+        >>> _labelFromName('input')
+        'Input'
+    """
+    # Insert space before uppercase letter following a lowercase letter or digit (camelCase)
+    s = re.sub(r'([a-z\d])([A-Z])', r'\1 \2', name)
+    # Replace underscores with spaces (snake_case)
+    s = s.replace('_', ' ')
+    # Capitalize each word
+    return ' '.join(word.capitalize() for word in s.split())
 
 class ValueTypeErrors(Enum):
     NONE = auto()  # No error
@@ -20,8 +40,8 @@ class Attribute(BaseObject):
                  validValue=True, errorMessage="", visible=True, exposed=False):
         super(Attribute, self).__init__()
         self._name = name
-        self._label = label
-        self._description = description
+        self._label = label if label is not None else _labelFromName(name)
+        self._description = description if description is not None else ""
         self._value = value
         self._keyable = keyable
         self._keyType = keyType
@@ -134,7 +154,7 @@ class Attribute(BaseObject):
 
 class ListAttribute(Attribute):
     """ A list of Attributes """
-    def __init__(self, elementDesc, name, label, description, group="allParams", advanced=False, semantic="",
+    def __init__(self, elementDesc, name, label=None, description=None, group="allParams", advanced=False, semantic="",
                  enabled=True, joinChar=" ", visible=True, exposed=False):
         """
         :param elementDesc: the Attribute description of elements to store in that list
@@ -186,7 +206,7 @@ class ListAttribute(Attribute):
 
 class GroupAttribute(Attribute):
     """ A macro Attribute composed of several Attributes """
-    def __init__(self, items, name, label, description, group="allParams", advanced=False, semantic="",
+    def __init__(self, items, name, label=None, description=None, group="allParams", advanced=False, semantic="",
                  enabled=True, joinChar=" ", brackets=None, visible=True, exposed=False):
         """
         :param items: the description of the Attributes composing this group
@@ -294,8 +314,8 @@ class GroupAttribute(Attribute):
 class Param(Attribute):
     """
     """
-    def __init__(self, name, label, description, value, group, advanced, semantic, enabled,
-                 keyable=False, keyType=None, invalidate=True, uidIgnoreValue=None,
+    def __init__(self, name, label=None, description=None, value=None, group="allParams", advanced=False, semantic="",
+                 enabled=True, keyable=False, keyType=None, invalidate=True, uidIgnoreValue=None,
                  validValue=True, errorMessage="", visible=True, exposed=False):
         super(Param, self).__init__(name=name, label=label, description=description, value=value,
                                     keyable=keyable, keyType=keyType, group=group, advanced=advanced,
@@ -307,7 +327,7 @@ class Param(Attribute):
 class File(Attribute):
     """
     """
-    def __init__(self, name, label, description, value, group="allParams", advanced=False, invalidate=True,
+    def __init__(self, name, label=None, description=None, value="", group="allParams", advanced=False, invalidate=True,
                  semantic="", enabled=True, visible=True, exposed=True):
         super(File, self).__init__(name=name, label=label, description=description, value=value, group=group,
                                    advanced=advanced, enabled=enabled, invalidate=invalidate, semantic=semantic,
@@ -333,7 +353,7 @@ class File(Attribute):
 class BoolParam(Param):
     """
     """
-    def __init__(self, name, label, description, value, keyable=False, keyType=None,
+    def __init__(self, name, label=None, description=None, value=False, keyable=False, keyType=None,
                  group="allParams", advanced=False, enabled=True, invalidate=True,
                  semantic="", visible=True, exposed=False):
         super(BoolParam, self).__init__(name=name, label=label, description=description, value=value,
@@ -362,7 +382,7 @@ class BoolParam(Param):
 class IntParam(Param):
     """
     """
-    def __init__(self, name, label, description, value, range=None, keyable=False, keyType=None,
+    def __init__(self, name, label=None, description=None, value=0, range=None, keyable=False, keyType=None,
                  group="allParams", advanced=False, enabled=True, invalidate=True, semantic="",
                  validValue=True, errorMessage="", visible=True, exposed=False):
         self._range = range
@@ -396,7 +416,7 @@ class IntParam(Param):
 class FloatParam(Param):
     """
     """
-    def __init__(self, name, label, description, value, range=None, keyable=False, keyType=None,
+    def __init__(self, name, label=None, description=None, value=0.0, range=None, keyable=False, keyType=None,
                  group="allParams", advanced=False, enabled=True, invalidate=True, semantic="",
                  validValue=True, errorMessage="", visible=True, exposed=False):
         self._range = range
@@ -429,7 +449,7 @@ class FloatParam(Param):
 class PushButtonParam(Param):
     """
     """
-    def __init__(self, name, label, description, group="allParams", advanced=False, enabled=True,
+    def __init__(self, name, label=None, description=None, group="allParams", advanced=False, enabled=True,
                  invalidate=True, semantic="", visible=True, exposed=False):
         super(PushButtonParam, self).__init__(name=name, label=label, description=description, value=None,
                                               group=group, advanced=advanced, enabled=enabled, invalidate=invalidate,
@@ -466,7 +486,7 @@ class ChoiceParam(Param):
     _OVERRIDE_SERIALIZATION_KEY_VALUE = "__ChoiceParam_value__"
     _OVERRIDE_SERIALIZATION_KEY_VALUES = "__ChoiceParam_values__"
 
-    def __init__(self, name: str, label: str, description: str, value, values, exclusive=True, saveValuesOverride=False,
+    def __init__(self, name, label=None, description=None, value=None, values=None, exclusive=True, saveValuesOverride=False,
                  group="allParams", joinChar=" ", advanced=False, enabled=True, invalidate=True, semantic="",
                  validValue=True, errorMessage="",
                  visible=True, exposed=False):
@@ -546,7 +566,7 @@ class ChoiceParam(Param):
 class StringParam(Param):
     """
     """
-    def __init__(self, name, label, description, value, group="allParams", advanced=False, enabled=True,
+    def __init__(self, name, label=None, description=None, value="", group="allParams", advanced=False, enabled=True,
                  invalidate=True, semantic="", uidIgnoreValue=None, validValue=True, errorMessage="", visible=True,
                  exposed=False):
         super(StringParam, self).__init__(name=name, label=label, description=description, value=value,
@@ -572,7 +592,7 @@ class StringParam(Param):
 class ColorParam(Param):
     """
     """
-    def __init__(self, name, label, description, value, group="allParams", advanced=False, enabled=True,
+    def __init__(self, name, label=None, description=None, value="", group="allParams", advanced=False, enabled=True,
                  invalidate=True, semantic="", visible=True, exposed=False):
         super(ColorParam, self).__init__(name=name, label=label, description=description, value=value,
                                          group=group, advanced=advanced, enabled=enabled, invalidate=invalidate,

--- a/tests/test_attributes.py
+++ b/tests/test_attributes.py
@@ -1,4 +1,5 @@
 from meshroom.core.graph import Graph
+from meshroom.core.desc.attribute import _labelFromName, StringParam, IntParam, FloatParam, BoolParam, File, ListAttribute, GroupAttribute
 import pytest
 
 import logging
@@ -101,3 +102,43 @@ def test_attribute_is2D_file_semantic(givenSemantic, expected):
 
     # Then
     assert n0.input.is2dDisplayable == expected
+
+
+@pytest.mark.parametrize("name,expected_label", [
+    ("myAttributeName", "My Attribute Name"),
+    ("my_attribute_name", "My Attribute Name"),
+    ("input", "Input"),
+    ("outputMesh", "Output Mesh"),
+    ("nbPoints", "Nb Points"),
+    ("imageWidth", "Image Width"),
+])
+def test_label_from_name(name, expected_label):
+    """Check that _labelFromName converts camelCase/snake_case names to title case labels."""
+    assert _labelFromName(name) == expected_label
+
+
+def test_attribute_label_auto_generated_when_not_provided():
+    """Check that label is auto-generated from name when not explicitly provided."""
+    attr = StringParam(name="myAttributeName", value="")
+    assert attr.label == "My Attribute Name"
+
+    attr = IntParam(name="nb_points", value=0)
+    assert attr.label == "Nb Points"
+
+
+def test_attribute_label_uses_explicit_value_when_provided():
+    """Check that an explicitly provided label is used as-is."""
+    attr = StringParam(name="myAttributeName", label="Custom Label", value="")
+    assert attr.label == "Custom Label"
+
+
+def test_attribute_description_defaults_to_empty_string_when_not_provided():
+    """Check that description defaults to empty string when not explicitly provided."""
+    attr = StringParam(name="myAttribute", value="")
+    assert attr.description == ""
+
+
+def test_attribute_description_uses_explicit_value_when_provided():
+    """Check that an explicitly provided description is used as-is."""
+    attr = StringParam(name="myAttribute", description="My description.", value="")
+    assert attr.description == "My description."


### PR DESCRIPTION
This pull request improves the handling of attribute labels and descriptions in the `meshroom.core.desc.attribute` module by introducing automatic label generation from attribute names and by making both label and description optional for all attribute classes. Additionally, comprehensive tests are added to ensure the new behavior works as intended.

**Automatic label and description handling:**

* Introduced the `_labelFromName` function to automatically convert camelCase or snake_case attribute names into human-friendly title case labels (e.g., `myAttributeName` → `My Attribute Name`).
* Updated all attribute class constructors (e.g., `Attribute`, `Param`, `StringParam`, `IntParam`, etc.) to make `label` and `description` optional. If not provided, `label` is auto-generated using `_labelFromName`, and `description` defaults to an empty string. [[1]](diffhunk://#diff-404f3a3e9948594e15a9bb1fb666a30cfaa58630c079223cbea461eae31cb950L23-R44) [[2]](diffhunk://#diff-404f3a3e9948594e15a9bb1fb666a30cfaa58630c079223cbea461eae31cb950L137-R157) [[3]](diffhunk://#diff-404f3a3e9948594e15a9bb1fb666a30cfaa58630c079223cbea461eae31cb950L189-R209) [[4]](diffhunk://#diff-404f3a3e9948594e15a9bb1fb666a30cfaa58630c079223cbea461eae31cb950L297-R318) [[5]](diffhunk://#diff-404f3a3e9948594e15a9bb1fb666a30cfaa58630c079223cbea461eae31cb950L310-R330) [[6]](diffhunk://#diff-404f3a3e9948594e15a9bb1fb666a30cfaa58630c079223cbea461eae31cb950L336-R356) [[7]](diffhunk://#diff-404f3a3e9948594e15a9bb1fb666a30cfaa58630c079223cbea461eae31cb950L365-R385) [[8]](diffhunk://#diff-404f3a3e9948594e15a9bb1fb666a30cfaa58630c079223cbea461eae31cb950L399-R419) [[9]](diffhunk://#diff-404f3a3e9948594e15a9bb1fb666a30cfaa58630c079223cbea461eae31cb950L432-R452) [[10]](diffhunk://#diff-404f3a3e9948594e15a9bb1fb666a30cfaa58630c079223cbea461eae31cb950L469-R489) [[11]](diffhunk://#diff-404f3a3e9948594e15a9bb1fb666a30cfaa58630c079223cbea461eae31cb950L549-R569) [[12]](diffhunk://#diff-404f3a3e9948594e15a9bb1fb666a30cfaa58630c079223cbea461eae31cb950L575-R595)

**Testing improvements:**

* Added new tests in `tests/test_attributes.py` to verify:
  - `_labelFromName` correctly converts attribute names to labels.
  - Attribute classes auto-generate labels from names when not explicitly provided.
  - Explicitly provided labels and descriptions are used as-is.
  - Descriptions default to an empty string if not provided.
* Imported the necessary classes and functions for testing in `tests/test_attributes.py`.