### PR TITLE
[bug] Dynamic node size is not correctly transmitted

### DIFF
--- a/meshroom/core/node.py
+++ b/meshroom/core/node.py
@@ -2259,9 +2259,6 @@ class Node(BaseNode):
             'internalInputs': {k: v for k, v in internalInputs.items() if v is not None},
             'outputs': outputs,
         }
-        
-    def updateNodeSize(self):
-        self.setSize(self.nodeDesc.size.computeSize(self))
 
     def _resetChunks(self):
         """ Set chunks on the node.
@@ -2282,12 +2279,12 @@ class Node(BaseNode):
         self._nodeStatus.status = Status.NONE
         # Recreate list with reset values (1 chunk or the static size)
         if not self.isParallelized:
-            self.setSize(self.nodeDesc.size.computeSize(self))
+            self._updateNodeSize()
             self._chunks.setObjectList([NodeChunk(self, desc.Range())])
             self._chunks[0].statusChanged.connect(self.globalStatusChanged)
             self._chunksCreated = True
         elif isinstance(self.nodeDesc.size, desc.computation.StaticNodeSize):
-            self.setSize(self.nodeDesc.size.computeSize(self))
+            self._updateNodeSize()
             self._chunks.setObjectList([NodeChunk(self, desc.Range())])
             self._chunks[0].statusChanged.connect(self.globalStatusChanged)
             self._chunksCreated = True

--- a/meshroom/core/node.py
+++ b/meshroom/core/node.py
@@ -2259,6 +2259,9 @@ class Node(BaseNode):
             'internalInputs': {k: v for k, v in internalInputs.items() if v is not None},
             'outputs': outputs,
         }
+        
+    def updateNodeSize(self):
+        self.setSize(self.nodeDesc.size.computeSize(self))
 
     def _resetChunks(self):
         """ Set chunks on the node.

--- a/meshroom/core/taskManager.py
+++ b/meshroom/core/taskManager.py
@@ -89,6 +89,8 @@ class TaskThread(QThread):
                 if not self.waitForChunkCreation(node):
                     logging.error(f"Failed to create chunks for {node.name}, stopping the process")
                     break
+            else:
+                node.updateNodeSize()
 
             # if a node does not exist anymore, node.chunks becomes a PySide property
             try:

--- a/meshroom/core/taskManager.py
+++ b/meshroom/core/taskManager.py
@@ -39,7 +39,7 @@ class TaskThread(QThread):
         return self._state == State.RUNNING
 
     def waitForChunkCreation(self, node):
-        if hasattr(node, "_chunksCreated") and node._chunksCreated:
+        if node._chunksCreated:
             return True
 
         loop = QEventLoop()
@@ -60,10 +60,10 @@ class TaskThread(QThread):
         try:
             # Start the event loop - will block until signal or timeout
             loop.exec()
-            success = hasattr(node, "_chunksCreated") and node._chunksCreated
-            if not success:
+            if not node._chunksCreated:
                 logging.error(f"Timeout or failure creating chunks for {node.name}")
-            return success
+                return False
+            return True
         finally:
             self._manager.chunksCreated.disconnect(onChunksCreated)
             timer.stop()
@@ -83,14 +83,14 @@ class TaskThread(QThread):
                 continue
 
             # Request chunk creation if not already done
-            if not (hasattr(node, "_chunksCreated") and node._chunksCreated):
+            if not node._chunksCreated:
                 self.createChunksSignal.emit(node)
                 # Wait for chunk creation to complete
                 if not self.waitForChunkCreation(node):
                     logging.error(f"Failed to create chunks for {node.name}, stopping the process")
                     break
             else:
-                node.updateNodeSize()
+                node._updateNodeSize()
 
             # if a node does not exist anymore, node.chunks becomes a PySide property
             try:

--- a/tests/test_compute.py
+++ b/tests/test_compute.py
@@ -413,3 +413,92 @@ class TestLockUpdates:
         downstreamNode.input.disconnectEdge()
         self.checkNodeStatusAndLock(node, Status.SUCCESS, False)
         self.checkNodeStatusAndLock(downstreamNode, Status.NONE, False)
+
+
+class TestNode_SizeA(desc.BaseNode):
+    __test__ = False
+    size = desc.DynamicNodeSize("nbChunks")
+    parallelization = desc.Parallelization(blockSize=1)
+    inputs = [
+        desc.IntParam(
+            name="nbChunks",
+            label="nbChunks",
+            description="number of chunks",
+            value=2,
+        ),
+        desc.File(
+            name="nodeInput",
+            label="Node Input",
+            description="",
+            value="",
+        ),
+    ]
+    outputs = [
+        desc.File(
+            name='output',
+            label='Output',
+            description='Output',
+            value=os.path.join("{nodeCacheFolder}"),
+            group='',
+        ),
+    ]
+    def processChunk(self, chunk):
+        pass
+
+class TestNode_SizeB(TestNode_SizeA):
+    """ Inherit the linked node size but not parallelized """
+    size = desc.DynamicNodeSize("nodeInput")
+    parallelization = False
+
+class TestNode_SizeC(TestNode_SizeA):
+    """ Inherit the linked node size and parallelized """
+    size = desc.DynamicNodeSize("nodeInput")
+    parallelization = desc.Parallelization(blockSize=1)
+
+
+class TestSizeUpdate:
+    plugin = None
+
+    @classmethod
+    def setup_class(cls):
+        registerNodeDesc(TestNode_SizeA)
+        registerNodeDesc(TestNode_SizeB)
+        registerNodeDesc(TestNode_SizeC)
+
+    @classmethod
+    def teardown_class(cls):
+        unregisterNodeDesc(TestNode_SizeA)
+        unregisterNodeDesc(TestNode_SizeB)
+        unregisterNodeDesc(TestNode_SizeC)
+    
+    @staticmethod
+    def checkNodeSizeAndStatus(node, nodeSize, nbChunks, status):
+        assert node.size == nodeSize
+        assert len(node._chunks) == nbChunks
+        assert node.globalStatus == status.name
+
+    def test_correctSizeUpdate(self, graphSavedOnDisk):
+        graph: Graph = graphSavedOnDisk
+        nodeA = graph.addNewNode("TestNode_SizeA")
+        nodeB = graph.addNewNode("TestNode_SizeB")
+        nodeA.output.connectTo(nodeB.nodeInput)
+        nodeC = graph.addNewNode("TestNode_SizeC")
+        nodeB.output.connectTo(nodeC.nodeInput)
+        graph.save()
+        
+        # A
+        self.checkNodeSizeAndStatus(nodeA, 0, 0, Status.NONE)
+        nodeA.createChunks()
+        nodeA.process(inCurrentEnv=True)
+        self.checkNodeSizeAndStatus(nodeA, 2, 2, Status.SUCCESS)
+        # B
+        self.checkNodeSizeAndStatus(nodeB, 0, 1, Status.NONE)
+        nodeB.createChunks()
+        nodeB.updateNodeSize()
+        nodeB.process(inCurrentEnv=True)
+        self.checkNodeSizeAndStatus(nodeB, 2, 1, Status.SUCCESS)
+        # C
+        self.checkNodeSizeAndStatus(nodeC, 0, 0, Status.NONE)
+        nodeC.createChunks()
+        nodeC.process(inCurrentEnv=True)
+        self.checkNodeSizeAndStatus(nodeC, 2, 2, Status.SUCCESS)

--- a/tests/test_compute.py
+++ b/tests/test_compute.py
@@ -494,7 +494,7 @@ class TestSizeUpdate:
         # B
         self.checkNodeSizeAndStatus(nodeB, 0, 1, Status.NONE)
         nodeB.createChunks()
-        nodeB.updateNodeSize()
+        nodeB._updateNodeSize()
         nodeB.process(inCurrentEnv=True)
         self.checkNodeSizeAndStatus(nodeB, 2, 1, Status.SUCCESS)
         # C


### PR DESCRIPTION
## Description

Dynamic node size is not correctly transmitted.

## What was the issue 

Example with 3 nodes (`A - B - C`):
- A : dynamic size that will be set to 2
- B : no parallelization (so 1 chunk) but inherit previous node size
- C : parallelized, inherit previous node size

When we launch the process :
1. A size is 0 by default
2. B size is set to A size so 0
3. C size is set to B size so 0
4. We launch the process
5. A expands and 2 chunks are created
6. B processing starts, still 0 chunk
7. C processing starts, still 0 chunks

## Changes

Explicitely call a function that will set the correct size before processing the node.

Now here would be the modified steps if we reuse the same example :
6. B processing starts, we set the size again so B size becomes 2
7. C processing starts, we set the size again so C size becomes 2