### PR TITLE
Enable lambda with node parameter in attributes 

### DIFF
--- a/meshroom/core/attribute.py
+++ b/meshroom/core/attribute.py
@@ -6,6 +6,7 @@ import os
 import re
 import weakref
 import logging
+import inspect
 
 from collections.abc import Iterable, Sequence
 from string import Template
@@ -123,6 +124,25 @@ class Attribute(BaseObject):
         if self.node:
             self.node.updateInternalAttributes()
 
+    def executeValue(self, value):
+        """
+        Assume value is a callable
+        Analyze value signature to detect if we want to use node or attr as parameter.
+        This method may be removed when all the legacy code is transformed.
+
+        Args:
+            value (Callable): the callable to execute
+
+        Return the result value of the callable
+        """
+        # The new behavior is to provide the node to the callable.
+        # For compatibility with the old behavior providing the attribute, we check if the attribute is named "attr" and provide the attribute.
+        params = inspect.signature(value).parameters
+        if len(params) == 1 and list(params)[0] == "attr":
+            return value(self)
+        
+        return value(self.node)
+
     def _initValue(self):
         """
         Initialize the attribute value.
@@ -184,7 +204,7 @@ class Attribute(BaseObject):
             raise RuntimeError(f"Cannot set value of {self._getFullName()}, the attribute is keyable.")
         elif callable(value):
             # evaluate the function
-            self._value = value(self)
+            self._value = self.executeValue(value)
         else:
             # if we set a new value, we use the attribute descriptor validator to check the
             # validity of the value and apply some conversion if needed
@@ -292,7 +312,7 @@ class Attribute(BaseObject):
         """
         if callable(self._desc.value):
             try:
-                return self._desc.value(self)
+                return self.executeValue(self._desc.value)
             except Exception as exc:
                 if not self.node.isCompatibilityNode:
                     logging.warning(f"Failed to evaluate 'defaultValue' (node lambda) for attribute '{self.fullName}': {exc}")

--- a/tests/test_attributeLambda.py
+++ b/tests/test_attributeLambda.py
@@ -1,0 +1,125 @@
+from meshroom.core import desc
+from meshroom.core.graph import Graph
+
+from .utils import registerNodeDesc, unregisterNodeDesc
+
+
+class NodeWithCallableValue(desc.Node):
+    """Test node with callable default values to test executeValue."""
+    inputs = [
+        desc.IntParam(
+            name="fixedInput",
+            label="Fixed Input",
+            description="A simple integer input.",
+            value=10,
+            range=(0, 100, 1),
+        ),
+        desc.IntParam(
+            name="callableNodeInput",
+            label="Callable Node Input",
+            description="Input with a callable default that receives the node.",
+            value=lambda node: node.fixedInput.value * 2,
+            range=(0, 200, 1),
+        ),
+        desc.StringParam(
+            name="callableAttrInput",
+            label="Callable Attr Input (Compatibility)",
+            description="Input with a callable default that receives the attribute for compatibility with the old behavior.",
+            value=lambda attr: f"attr_{attr.name}",
+        ),
+    ]
+    outputs = [
+        desc.File(
+            name="output",
+            label="Output",
+            description="",
+            value="{nodeCacheFolder}/output.txt",
+        )
+    ]
+
+
+class TestExecuteValue:
+    """Tests for the Attribute.executeValue method and callable value handling."""
+
+    @classmethod
+    def setup_class(cls):
+        registerNodeDesc(NodeWithCallableValue)
+
+    @classmethod
+    def teardown_class(cls):
+        unregisterNodeDesc(NodeWithCallableValue)
+
+    def test_executeValue_with_node_parameter(self):
+        """executeValue should pass the node when the callable parameter is named 'node'."""
+        graph = Graph("")
+        node = graph.addNewNode("NodeWithCallableValue")
+
+        result = node.callableNodeInput.executeValue(lambda node: node.fixedInput.value + 5)
+        assert result == 15
+
+    def test_executeValue_with_attr_parameter(self):
+        """executeValue should pass the attribute when the parameter is not named 'node'."""
+        graph = Graph("")
+        node = graph.addNewNode("NodeWithCallableValue")
+
+        result = node.fixedInput.executeValue(lambda attr: attr.name)
+        assert result == "fixedInput"
+
+    def test_callable_default_value_with_node_param(self):
+        """getDefaultValue should evaluate a callable descriptor value using node parameter."""
+        graph = Graph("")
+        node = graph.addNewNode("NodeWithCallableValue")
+
+        # The default value for callableNodeInput is lambda node: node.fixedInput.value * 2
+        default = node.callableNodeInput.getDefaultValue()
+        assert default == 20  # 10 * 2
+
+    def test_callable_default_value_with_attr_param(self):
+        """getDefaultValue should evaluate a callable descriptor value using attr parameter."""
+        graph = Graph("")
+        node = graph.addNewNode("NodeWithCallableValue")
+
+        # The default value for callableAttrInput is lambda attr: f"attr_{attr.name}"
+        default = node.callableAttrInput.getDefaultValue()
+        assert default == "attr_callableAttrInput"
+
+    def test_set_value_with_callable(self):
+        """Setting a callable value should evaluate it via executeValue."""
+        graph = Graph("")
+        node = graph.addNewNode("NodeWithCallableValue")
+
+        node.fixedInput.value = lambda node: 42
+        assert node.fixedInput.value == 42
+
+    def test_set_value_with_attr_callable(self):
+        """Setting a callable value using attr parameter should evaluate correctly."""
+        graph = Graph("")
+        node = graph.addNewNode("NodeWithCallableValue")
+
+        node.fixedInput.value = lambda attr: 99
+        assert node.fixedInput.value == 99
+
+    def test_callable_default_reflects_current_state(self):
+        """Callable default values should reflect the current node state when evaluated."""
+        graph = Graph("")
+        node = graph.addNewNode("NodeWithCallableValue")
+
+        # Change the fixedInput value
+        node.fixedInput.value = 25
+
+        # Re-evaluate the callable default for callableNodeInput
+        default = node.callableNodeInput.getDefaultValue()
+        assert default == 50  # 25 * 2
+
+    def test_reset_to_default_with_callable(self):
+        """resetToDefaultValue should correctly evaluate callable defaults."""
+        graph = Graph("")
+        node = graph.addNewNode("NodeWithCallableValue")
+
+        # Change value away from default
+        node.callableAttrInput.value = "custom_value"
+        assert node.callableAttrInput.value == "custom_value"
+
+        # Reset should re-evaluate the callable
+        node.callableAttrInput.resetToDefaultValue()
+        assert node.callableAttrInput.value == "attr_callableAttrInput"


### PR DESCRIPTION
This pull request introduces a new helper method to improve how callables are executed for attribute values in `meshroom/core/attribute.py`. The main goal is to make callable evaluation more flexible by automatically determining whether to pass the attribute or its node as an argument, which helps with legacy code compatibility.

Before :

`lambda attr : attr.node.xxx`

After

`lambda node : node.xxx`

**Callable evaluation improvements:**

* Added the `executeValue` method to the attribute class, which inspects the callable's signature and decides whether to pass the attribute instance or its node when executing. This makes the code more robust and future-proof for legacy callable handling.
* Refactored `_setValue` and `getDefaultValue` methods to use the new `executeValue` helper, ensuring consistent callable execution throughout the class. [[1]](diffhunk://#diff-346bf2284498d029adfca15a85216268454d6143e70541993cd79f5ea9c8076eL187-R208) [[2]](diffhunk://#diff-346bf2284498d029adfca15a85216268454d6143e70541993cd79f5ea9c8076eL295-R316)

**Imports update:**

* Imported `inspect` to support signature analysis in the new `executeValue` method.