### PR TITLE
[macOS] Fix Metal RHI 3D viewer crashes and enable the viewer on Apple Silicon

### DIFF
--- a/meshroom/__init__.py
+++ b/meshroom/__init__.py
@@ -171,9 +171,14 @@ def setupEnvironment(backend=Backend.STANDALONE):
 
         env = {
             "PATH": aliceVisionBinDir,
-            "QT_PLUGIN_PATH": [qtPluginsDir],
-            "QML2_IMPORT_PATH": [os.path.join(qtPluginsDir, "qml")]
         }
+
+        # Only add Qt plugin/QML paths if the directories actually exist
+        if os.path.isdir(qtPluginsDir):
+            env["QT_PLUGIN_PATH"] = [qtPluginsDir]
+            qmlImportDir = os.path.join(qtPluginsDir, "qml")
+            if os.path.isdir(qmlImportDir):
+                env["QML2_IMPORT_PATH"] = [qmlImportDir]
 
         for key, value in env.items():
             logging.debug(f"Add to {key}: {value}")
@@ -207,11 +212,16 @@ def setupEnvironment(backend=Backend.STANDALONE):
     addToEnvPath("PATH", os.environ.get("ALICEVISION_BIN_PATH", ""))
     if sys.platform == "win32":
         addToEnvPath("PATH", os.environ.get("ALICEVISION_LIBPATH", ""))
-    else:
+    elif sys.platform != "darwin":
         addToEnvPath("LD_LIBRARY_PATH", os.environ.get("ALICEVISION_LIBPATH", ""))
+    # macOS: AliceVision libraries are resolved through the rpaths embedded in the
+    # bundle, so no dynamic-linker environment variable needs to be set here.
 
 
 os.environ["QML_XHR_ALLOW_FILE_READ"] = '1'
 os.environ["QML_XHR_ALLOW_FILE_WRITE"] = '1'
 os.environ["PYSEQ_STRICT_PAD"] = '1'
-os.environ["QSG_RHI_BACKEND"] = "opengl"
+if sys.platform == "darwin":
+    os.environ.setdefault("QSG_RHI_BACKEND", "metal")
+else:
+    os.environ["QSG_RHI_BACKEND"] = "opengl"

--- a/meshroom/ui/app.py
+++ b/meshroom/ui/app.py
@@ -277,6 +277,10 @@ class MeshroomApp(QApplication):
             qInstallMessageHandler(MessageHandler.handler)
 
         self.engine.addImportPath(qmlDir)
+        # Add PySide6's bundled QML modules path (Qt3D, QtQuick.Scene3D, etc.)
+        pyside6QmlPath = os.path.join(os.path.dirname(QtCore.__file__), "Qt", "qml")
+        if os.path.isdir(pyside6QmlPath):
+            self.engine.addImportPath(pyside6QmlPath)
 
         # expose available node types that can be instantiated
         self.engine.rootContext().setContextProperty("_nodeTypes", {n: {"category": pluginManager.getRegisteredNodePlugins()[n].nodeDescriptor.category} for n in sorted(pluginManager.getRegisteredNodePlugins().keys())})

--- a/meshroom/ui/components/scene3D.py
+++ b/meshroom/ui/components/scene3D.py
@@ -1,6 +1,7 @@
+import struct
 from math import acos, pi, sqrt, atan2, cos, sin, asin
 
-from PySide6.QtCore import QObject, Slot, QSize, Signal, QPointF
+from PySide6.QtCore import QObject, Slot, QSize, Signal, QPointF, QByteArray
 from PySide6.Qt3DCore import Qt3DCore
 from PySide6.Qt3DRender import Qt3DRender
 from PySide6.QtGui import QVector3D, QQuaternion, QVector2D, QVector4D, QMatrix4x4
@@ -52,6 +53,47 @@ class Scene3DHelper(QObject):
         for geo in entity.findChildren(Qt3DCore.QGeometry):
             count += sum([attr.count() for attr in geo.attributes() if attr.name() == "vertexColor"])
         return count
+
+    @Slot(Qt3DCore.QEntity)
+    def ensureNormals(self, entity):
+        """
+        Add default normal attributes to geometries that don't have them.
+        This prevents Metal RHI pipeline crashes when built-in Qt3D materials
+        (which require vertexNormal) are used with meshes lacking normals.
+        """
+        for geo in entity.findChildren(Qt3DCore.QGeometry):
+            hasNormals = any(attr.name() == "vertexNormal" for attr in geo.attributes())
+            if hasNormals:
+                continue
+
+            # Find the vertexPosition attribute to get vertex count
+            posAttr = None
+            for attr in geo.attributes():
+                if attr.name() == "vertexPosition":
+                    posAttr = attr
+                    break
+            if not posAttr:
+                continue
+
+            vertexCount = posAttr.count()
+
+            # Create a buffer filled with (0, 1, 0) default normals
+            normalData = QByteArray(struct.pack('<fff', 0.0, 1.0, 0.0) * vertexCount)
+            normalBuffer = Qt3DCore.QBuffer(geo)
+            normalBuffer.setData(normalData)
+
+            # Create the normal attribute
+            normalAttr = Qt3DCore.QAttribute(geo)
+            normalAttr.setName("vertexNormal")
+            normalAttr.setVertexBaseType(Qt3DCore.QAttribute.Float)
+            normalAttr.setVertexSize(3)
+            normalAttr.setAttributeType(Qt3DCore.QAttribute.VertexAttribute)
+            normalAttr.setBuffer(normalBuffer)
+            normalAttr.setByteStride(3 * 4)  # 3 floats * 4 bytes
+            normalAttr.setByteOffset(0)
+            normalAttr.setCount(vertexCount)
+
+            geo.addAttribute(normalAttr)
 
 
 class TrackballController(QObject):

--- a/meshroom/ui/qml/Viewer3D/BoundingBox.qml
+++ b/meshroom/ui/qml/Viewer3D/BoundingBox.qml
@@ -38,10 +38,18 @@ Entity {
     Entity {
         components: [edges, orangeMaterial]
 
+        // Neutralized Phong: diffuse/specular zeroed so the equation collapses
+        // to just `ambient`, giving an unlit-looking constant color. This way
+        // the (0,1,0) placeholder normals in the geometry below never affect
+        // the final shading, while we stay on the PhongMaterial code path that
+        // Metal RHI vertex-descriptor validation is happy with.
         PhongMaterial {
             id: orangeMaterial
             property color base: "#f49b2b"
             ambient: base
+            diffuse: "#000"
+            specular: "#000"
+            shininess: 0
         }
 
         GeometryRenderer {
@@ -82,6 +90,24 @@ Entity {
                             -1.0, 1.0, -1.0,
                             1.0, 1.0, -1.0
                             ])
+                    }
+                }
+                Attribute {
+                    attributeType: Attribute.VertexAttribute
+                    vertexBaseType: Attribute.Float
+                    vertexSize: 3
+                    count: 24
+                    name: defaultNormalAttributeName
+                    buffer: Buffer {
+                        data: {
+                            var f32 = new Float32Array(24 * 3)
+                            for (var i = 0; i < 24; i++) {
+                                f32[3 * i] = 0.0
+                                f32[3 * i + 1] = 1.0
+                                f32[3 * i + 2] = 0.0
+                            }
+                            return f32
+                        }
                     }
                 }
                 boundingVolumePositionAttribute: boundingBoxPosition

--- a/meshroom/ui/qml/Viewer3D/Grid3D.qml
+++ b/meshroom/ui/qml/Viewer3D/Grid3D.qml
@@ -46,13 +46,37 @@ Entity {
                         }
                     }
                 }
+                Attribute {
+                    id: gridNormal
+                    attributeType: Attribute.VertexAttribute
+                    vertexBaseType: Attribute.Float
+                    vertexSize: 3
+                    count: gridPosition.count
+                    name: defaultNormalAttributeName
+                    buffer: Buffer {
+                        data: {
+                            var f32 = new Float32Array(gridPosition.count * 3)
+                            for (var i = 0; i < gridPosition.count; i++) {
+                                f32[3 * i] = 0.0
+                                f32[3 * i + 1] = 1.0
+                                f32[3 * i + 2] = 0.0
+                            }
+                            return f32
+                        }
+                    }
+                }
                 boundingVolumePositionAttribute: gridPosition
             }
         },
+        // Neutralized Phong: diffuse/specular zeroed so the equation collapses
+        // to just `ambient`, giving an unlit-looking constant color. This way
+        // the (0,1,0) placeholder normals in the geometry above never affect
+        // the final shading, while we stay on the PhongMaterial code path that
+        // Metal RHI vertex-descriptor validation is happy with.
         PhongMaterial {
             ambient: "#FFF"
-            diffuse: "#222"
-            specular: diffuse
+            diffuse: "#000"
+            specular: "#000"
             shininess: 0
         }
     ]

--- a/meshroom/ui/qml/Viewer3D/Locator3D.qml
+++ b/meshroom/ui/qml/Viewer3D/Locator3D.qml
@@ -35,6 +35,23 @@ Entity {
                     vertexBaseType: Attribute.Float
                     vertexSize: 3
                     count: 6
+                    name: defaultNormalAttributeName
+                    buffer: Buffer {
+                        data: new Float32Array([
+                            0.0, 1.0, 0.0,
+                            0.0, 1.0, 0.0,
+                            0.0, 1.0, 0.0,
+                            0.0, 1.0, 0.0,
+                            0.0, 1.0, 0.0,
+                            0.0, 1.0, 0.0
+                            ])
+                    }
+                }
+                Attribute {
+                    attributeType: Attribute.VertexAttribute
+                    vertexBaseType: Attribute.Float
+                    vertexSize: 3
+                    count: 6
                     name: defaultColorAttributeName
                     buffer: Buffer {
                         data: new Float32Array([

--- a/meshroom/ui/qml/Viewer3D/Materials/shaders/SphericalHarmonics.frag
+++ b/meshroom/ui/qml/Viewer3D/Materials/shaders/SphericalHarmonics.frag
@@ -1,6 +1,6 @@
 #version 450 core
 
-layout(location = 0) in vec3 normal;
+layout(location = 0) in vec3 worldPos;
 layout(location = 0) out vec4 fragColor;
 
 layout(std140, binding = 0) uniform qt3d_render_view_uniforms {
@@ -47,18 +47,19 @@ vec3 resolveSH_Opt(vec3 premulCoefficients[9], vec3 dir)
     result += premulCoefficients[5] * (dir.x * dir.z);
     result += premulCoefficients[6] * (dir.y * dir.z);
     result += premulCoefficients[7] * (dirSq.x - dirSq.y);
-    result += premulCoefficients[8] * (3 * dirSq.z - 1);
+    result += premulCoefficients[8] * (3.0 * dirSq.z - 1.0);
     return result;
 }
 
 void main()
 {
-    if(displayNormals) {
-        // Display normals mode
+    // Compute flat face normal from screen-space position derivatives
+    vec3 normal = normalize(cross(dFdx(worldPos), dFdy(worldPos)));
+
+    if (displayNormals) {
         fragColor = vec4(normal, 1.0);
     }
     else {
-        // Calculate the color from spherical harmonics coeffs
         fragColor = vec4(resolveSH_Opt(shCoeffs, normal), 1.0);
     }
 }

--- a/meshroom/ui/qml/Viewer3D/Materials/shaders/SphericalHarmonics.vert
+++ b/meshroom/ui/qml/Viewer3D/Materials/shaders/SphericalHarmonics.vert
@@ -1,9 +1,8 @@
 #version 450 core
 
 layout(location = 0) in vec3 vertexPosition;
-layout(location = 1) in vec3 vertexNormal;
 
-layout(location = 0) out vec3 normal;
+layout(location = 0) out vec3 worldPos;
 
 layout(std140, binding = 0) uniform qt3d_render_view_uniforms {
     mat4 viewMatrix;
@@ -35,6 +34,6 @@ layout(std140, binding = 1) uniform qt3d_command_uniforms {
 
 void main()
 {
-    normal = vertexNormal;
+    worldPos = (modelMatrix * vec4(vertexPosition, 1.0)).xyz;
     gl_Position = mvp * vec4(vertexPosition, 1.0);
 }

--- a/meshroom/ui/qml/Viewer3D/MediaLoader.qml
+++ b/meshroom/ui/qml/Viewer3D/MediaLoader.qml
@@ -195,6 +195,10 @@ import Utils 1.0
     // instantiate a MaterialSwitcher instead. Returns the faceCount
     function sceneLoaderPostProcess(rootEntity)
     {
+        // Ensure all geometries have normal attributes to prevent
+        // Metal RHI pipeline crashes with built-in Qt3D materials
+        Scene3DHelper.ensureNormals(rootEntity)
+
         var materials = Scene3DHelper.findChildrenByProperty(rootEntity, "diffuse")
         var entities = []
         var texCount = 0


### PR DESCRIPTION

## Description

Adds macOS support for Meshroom's Qt 3D viewer on the **Metal RHI** backend. On macOS the Qt Quick scene graph runs on Metal, whose pipeline-state creation strictly validates that every vertex-shader input is satisfied by the geometry's vertex descriptor. Several viewer geometries provide only `vertexPosition`, while the built-in Qt3D materials they use declare `vertexNormal` — so on Metal the pipeline fails to build and the app crashes. OpenGL tolerates this, which is why it only surfaces on macOS.

This PR makes the viewer build valid Metal pipelines with **no behavioral change on other platforms**, plus the macOS-specific environment setup needed to run against a PySide6 wheel. It builds on the now-merged macOS support in AliceVision (alicevision/AliceVision#2019). The 3D SfM/camera/depth overlays additionally need a small companion fix in QtAliceVision (plugin rpaths + descriptor normals) — see the linked QtAliceVision PR.

## Features list

- [x] **SphericalHarmonics material** — drop the `vertexNormal` input; reconstruct a flat normal from `dFdx`/`dFdy` of world position in the fragment shader.
- [x] **Widget geometries** (Grid3D, BoundingBox, Locator3D) — attach a constant normal to satisfy Metal's vertex descriptor, and neutralize the Phong terms (`diffuse`/`specular` = black) so the constant normal can't produce wrong shading; widgets render unlit, as before.
- [x] **Loaded meshes** — `Scene3DHelper.ensureNormals()` adds default normals to OBJ/PLY geometries lacking them, so built-in lit materials build valid pipelines.
- [x] **QML modules** — add PySide6's bundled QML path so Qt3D / QtQuick.Scene3D resolve from a PySide6 wheel.
- [x] **setupEnvironment** — guard the Qt plugin/QML paths behind existence checks; default the RHI backend to Metal on macOS (overridable); rely on the bundle's rpaths for library resolution (no dynamic-linker env var).

## Implementation remarks

All changes are additive and platform-guarded — Linux/Windows are unaffected (the shader normal reconstruction is valid on every backend; the env changes are macOS-only).

Addresses the earlier review: the `DYLD_FALLBACK_LIBRARY_PATH` / `AV_BUNDLE` handling, the `cgroup` change, the speculative OpenGL fallback techniques, and the out-of-scope `groupDesc` commit have all been removed; the branch is rebased onto current `develop`.

Tested on macOS / Apple Silicon (PySide6 6.10.2, Qt 6.10.2, Metal RHI) against a clean upstream AliceVision `develop` build: the 3D viewer opens and resizes without crashing, and SfM points + cameras, the textured mesh (EXR), and per-view depth maps all render; the full SfM → DepthMap → Meshing → Texturing pipeline runs.

Thanks to @philippremy for the AliceVision macOS support (#2019) and to the @alicevision team.
