### PR TITLE
Remove useless computeNodeSize

### DIFF
--- a/meshroom/core/node.py
+++ b/meshroom/core/node.py
@@ -2304,7 +2304,6 @@ class Node(BaseNode):
         self._nodeStatus.status = Status.NONE
         # Recreate list with reset values (1 chunk or the static size)
         if not self.isParallelized:
-            self._updateNodeSize()
             self._chunks.setObjectList([NodeChunk(self, desc.Range())])
             self._chunks[0].statusChanged.connect(self.globalStatusChanged)
             self._chunksCreated = True


### PR DESCRIPTION
This pull request makes a minor change to the `_resetChunks` method in `meshroom/core/node.py`. The update removes a call to `_updateNodeSize()` when the node is not parallelized, which simplifies the chunk reset logic and avoid a crash when such a node is added to the graph.

* Simplified chunk reset logic: Removed the `_updateNodeSize()` call from the non-parallelized branch of `_resetChunks`, ensuring that chunk creation proceeds without updating the node size.
