### PR TITLE
Upgrade group parameters to commandLineGroup

### DIFF
--- a/meshroom/core/desc/geometryAttribute.py
+++ b/meshroom/core/desc/geometryAttribute.py
@@ -6,11 +6,11 @@ class Geometry(GroupAttribute):
     Base attribute for all Geometry attribute.
     Countains several attributes (inherit from GroupAttribute).
     """
-    def __init__(self, items, name, label, description, group="allParams", advanced=False, semantic="",
+    def __init__(self, items, name, label, description, commandLineGroup="allParams", advanced=False, semantic="",
                  enabled=True, visible=True, exposed=False):
         # GroupAttribute constructor
         super(Geometry, self).__init__(items=items, name=name, label=label, description=description,
-                                       group=group, advanced=advanced, semantic=semantic,
+                                       commandLineGroup=commandLineGroup, advanced=advanced, semantic=semantic,
                                        enabled=enabled, visible=visible, exposed=exposed)
 
     def getInstanceType(self):
@@ -27,19 +27,19 @@ class Size2d(Geometry):
     Size2d is a Geometry attribute that allows to specify a 2d size.
     """
     def __init__(self, name, label, description, width, height, widthRange=None, heightRange=None,
-                 keyable=False, keyType=None, group="allParams", advanced=False, semantic="",
+                 keyable=False, keyType=None, commandLineGroup="allParams", advanced=False, semantic="",
                  enabled=True, visible=True, exposed=False):
         # Geometry group desciption
         items = [
             FloatParam(name="width", label="Width", description="Width size.", value=width, range=widthRange,
-                       keyable=keyable, keyType=keyType, group=group, advanced=advanced,
+                       keyable=keyable, keyType=keyType, commandLineGroup=commandLineGroup, advanced=advanced,
                        enabled=enabled, visible=visible, exposed=exposed),
             FloatParam(name="height", label="Height", description="Height size.", value=height, range=heightRange,
-                       keyable=keyable, keyType=keyType, group=group, advanced=advanced,
+                       keyable=keyable, keyType=keyType, commandLineGroup=commandLineGroup, advanced=advanced,
                        enabled=enabled, visible=visible, exposed=exposed)
         ]
         # GeometryAttribute constructor
-        super(Size2d, self).__init__(items, name, label, description, group=None, advanced=advanced,
+        super(Size2d, self).__init__(items, name, label, description, commandLineGroup=None, advanced=advanced,
                                      semantic=semantic, enabled=enabled, visible=visible, exposed=exposed)
 
 class Vec2d(Geometry):
@@ -47,17 +47,17 @@ class Vec2d(Geometry):
     Vec2d is a Geometry attribute that allows to specify a 2d vector.
     """
     def __init__(self, name, label, description, x, y, xRange=None, yRange=None,
-                 keyable=False, keyType=None, group="allParams", advanced=False, semantic="",
+                 keyable=False, keyType=None, commandLineGroup="allParams", advanced=False, semantic="",
                  enabled=True, visible=True, exposed=False):
         # Geometry group desciption
         items = [
             FloatParam(name="x", label="X", description="X coordinate.", value=x, range=xRange,
-                       keyable=keyable, keyType=keyType, group=group, advanced=advanced,
+                       keyable=keyable, keyType=keyType, commandLineGroup=commandLineGroup, advanced=advanced,
                        enabled=enabled, visible=visible, exposed=exposed),
             FloatParam(name="y", label="Y", description="Y coordinate.", value=y, range=yRange,
-                       keyable=keyable, keyType=keyType, group=group, advanced=advanced,
+                       keyable=keyable, keyType=keyType, commandLineGroup=commandLineGroup, advanced=advanced,
                        enabled=enabled, visible=visible, exposed=exposed)
         ]
         # GeometryAttribute constructor
-        super(Vec2d, self).__init__(items, name, label, description, group=None, advanced=advanced,
+        super(Vec2d, self).__init__(items, name, label, description, commandLineGroup=None, advanced=advanced,
                                      semantic=semantic, enabled=enabled, visible=visible, exposed=exposed)

--- a/meshroom/core/desc/shapeAttribute.py
+++ b/meshroom/core/desc/shapeAttribute.py
@@ -5,20 +5,20 @@ class Shape(GroupAttribute):
     Base attribute for all Shape attribute.
     Countains several attributes (inherit from GroupAttribute).
     """
-    def __init__(self, geometryItems, name, label, description, group="allParams", advanced=False, semantic="",
+    def __init__(self, geometryItems, name, label, description, commandLineGroup="allParams", advanced=False, semantic="",
                  enabled=True, visible=True, exposed=False):
         # Shape group desciption
         items = [
             StringParam(name="userName", label="User Name", description="User shape name.", value="",
-                        group=group, advanced=advanced, enabled=enabled, visible=visible, exposed=exposed),
+                        commandLineGroup=commandLineGroup, advanced=advanced, enabled=enabled, visible=visible, exposed=exposed),
             StringParam(name="userColor", label="User Color", description="User shape color.", value="#2a82da",
-                        group=group, advanced=advanced, enabled=enabled, visible=visible, exposed=exposed),
+                        commandLineGroup=commandLineGroup, advanced=advanced, enabled=enabled, visible=visible, exposed=exposed),
             Geometry(geometryItems, name="geometry", label="Geometry", description="Shape geometry.",
-                     group=group, advanced=advanced, enabled=enabled, visible=visible, exposed=exposed)
+                     commandLineGroup=commandLineGroup, advanced=advanced, enabled=enabled, visible=visible, exposed=exposed)
         ]
         # GroupAttribute constructor
         super(Shape, self).__init__(items=items, name=name, label=label, description=description,
-                                    group=group, advanced=advanced, semantic=semantic,
+                                    commandLineGroup=commandLineGroup, advanced=advanced, semantic=semantic,
                                     enabled=enabled, visible=visible, exposed=exposed)
 
     def getInstanceType(self):
@@ -34,11 +34,11 @@ class ShapeList(ListAttribute):
     List attribute of Shape attribute.
     Countains several attributes (inherit from ListAttribute).
     """
-    def __init__(self, shape: Shape, name, label, description, group="allParams", advanced=False, semantic="",
+    def __init__(self, shape: Shape, name, label, description, commandLineGroup="allParams", advanced=False, semantic="",
                  enabled=True, visible=True, exposed=False):
         # ListAttribute constructor
         super(ShapeList, self).__init__(elementDesc=shape, name=name, label=label, description=description,
-                                        group=group, advanced=advanced, semantic=semantic,
+                                        commandLineGroup=commandLineGroup, advanced=advanced, semantic=semantic,
                                         enabled=enabled, visible=visible, exposed=exposed)
 
     def getInstanceType(self):
@@ -54,17 +54,17 @@ class Point2d(Shape):
     Point2d is a Shape attribute that allows to display and modify a 2d point.
     """
     def __init__(self, name, label, description, keyable=False, keyType=None,
-                 group="allParams", advanced=False, semantic="",
+                 commandLineGroup="allParams", advanced=False, semantic="",
                  enabled=True, visible=True, exposed=False):
         # Geometry group desciption
         geometryItems = [
             FloatParam(name="x", label="X", description="X coordinate.", value=-1.0, keyable=keyable, keyType=keyType,
-                       group=group, advanced=advanced, enabled=enabled, visible=visible, exposed=exposed),
+                       commandLineGroup=commandLineGroup, advanced=advanced, enabled=enabled, visible=visible, exposed=exposed),
             FloatParam(name="y", label="Y", description="Y coordinate.", value=-1.0, keyable=keyable, keyType=keyType,
-                       group=group, advanced=advanced, enabled=enabled, visible=visible, exposed=exposed)
+                       commandLineGroup=commandLineGroup, advanced=advanced, enabled=enabled, visible=visible, exposed=exposed)
         ]
         # ShapeAttribute constructor
-        super(Point2d, self).__init__(geometryItems, name, label, description, group=None, advanced=advanced,
+        super(Point2d, self).__init__(geometryItems, name, label, description, commandLineGroup=None, advanced=advanced,
                                       semantic=semantic, enabled=enabled, visible=visible, exposed=exposed)
 
 class Line2d(Shape):
@@ -72,17 +72,17 @@ class Line2d(Shape):
     Line2d is a Shape attribute that allows to display and modify a 2d line.
     """
     def __init__(self, name, label, description, keyable=False, keyType=None,
-                 group="allParams", advanced=False, semantic="",
+                 commandLineGroup="allParams", advanced=False, semantic="",
                  enabled=True, visible=True, exposed=False):
         # Geometry group desciption
         geometryItems = [
             Vec2d(name="a", label="A", description="Line A point.", x=-1.0, y=-1.0, keyable=keyable, keyType=keyType,
-                  group=group, advanced=advanced, enabled=enabled, visible=visible, exposed=exposed),
+                  commandLineGroup=commandLineGroup, advanced=advanced, enabled=enabled, visible=visible, exposed=exposed),
             Vec2d(name="b", label="B", description="Line B point.", x=-1.0, y=-1.0, keyable=keyable, keyType=keyType,
-                  group=group, advanced=advanced, enabled=enabled, visible=visible, exposed=exposed)
+                  commandLineGroup=commandLineGroup, advanced=advanced, enabled=enabled, visible=visible, exposed=exposed)
         ]
         # ShapeAttribute constructor
-        super(Line2d, self).__init__(geometryItems, name, label, description, group=None, advanced=advanced,
+        super(Line2d, self).__init__(geometryItems, name, label, description, commandLineGroup=None, advanced=advanced,
                                      semantic=semantic, enabled=enabled, visible=visible, exposed=exposed)
 
 class Rectangle(Shape):
@@ -90,19 +90,19 @@ class Rectangle(Shape):
     Rectangle is a Shape attribute that allows to display and modify a rectangle.
     """
     def __init__(self, name, label, description, keyable=False, keyType=None,
-                 group="allParams", advanced=False, semantic="",
+                 commandLineGroup="allParams", advanced=False, semantic="",
                  enabled=True, visible=True, exposed=False):
         # Geometry group desciption
         geometryItems = [
             Vec2d(name="center", label="Center", description="Rectangle center.", x=-1.0, y=-1.0,
-                  keyable=keyable, keyType=keyType, group=group, advanced=advanced,
+                  keyable=keyable, keyType=keyType, commandLineGroup=commandLineGroup, advanced=advanced,
                   enabled=enabled, visible=visible, exposed=exposed),
             Size2d(name="size", label="Size", description="Rectangle size.", width=-1.0, height=-1.0,
-                   keyable=keyable, keyType=keyType, group=group, advanced=advanced,
+                   keyable=keyable, keyType=keyType, commandLineGroup=commandLineGroup, advanced=advanced,
                    enabled=enabled, visible=visible, exposed=exposed)
         ]
         # ShapeAttribute constructor
-        super(Rectangle, self).__init__(geometryItems, name, label, description, group=None, advanced=advanced,
+        super(Rectangle, self).__init__(geometryItems, name, label, description, commandLineGroup=None, advanced=advanced,
                                         semantic=semantic, enabled=enabled, visible=visible, exposed=exposed)
 
 class Circle(Shape):
@@ -110,17 +110,17 @@ class Circle(Shape):
     Circle is a Shape attribute that allows to display and modify a circle.
     """
     def __init__(self, name, label, description, keyable=False, keyType=None,
-                 group="allParams", advanced=False, semantic="",
+                 commandLineGroup="allParams", advanced=False, semantic="",
                  enabled=True, visible=True, exposed=False):
         # Geometry group desciption
         geometryItems = [
             Vec2d(name="center", label="Center", description="Circle center.", x=-1.0, y=-1.0,
-                  keyable=keyable, keyType=keyType, group=group, advanced=advanced,
+                  keyable=keyable, keyType=keyType, commandLineGroup=commandLineGroup, advanced=advanced,
                   enabled=enabled, visible=visible, exposed=exposed),
             FloatParam(name="radius", label="Radius", description="Circle radius.", value=-1.0,
-                       keyable=keyable, keyType=keyType, group=group, advanced=advanced,
+                       keyable=keyable, keyType=keyType, commandLineGroup=commandLineGroup, advanced=advanced,
                        enabled=enabled, visible=visible, exposed=exposed)
         ]
         # ShapeAttribute constructor
-        super(Circle, self).__init__(geometryItems, name, label, description, group=None, advanced=advanced,
+        super(Circle, self).__init__(geometryItems, name, label, description, commandLineGroup=None, advanced=advanced,
                                      semantic=semantic, enabled=enabled, visible=visible, exposed=exposed)

--- a/meshroom/core/node.py
+++ b/meshroom/core/node.py
@@ -2539,7 +2539,7 @@ class CompatibilityNode(BaseNode):
             "name": attrName, "label": attrName,
             "description": "Incompatible parameter",
             "value": value, "invalidate": False,
-            "group": "incompatible"
+            "commandLineGroup": "incompatible"
         }
         if isinstance(value, bool):
             return desc.BoolParam(**params)

--- a/tests/nodes/test/GroupAttributes.py
+++ b/tests/nodes/test/GroupAttributes.py
@@ -10,7 +10,7 @@ class GroupAttributes(desc.Node):
             name="firstGroup",
             label="First Group",
             description="Group at the root level.",
-            group=None,
+            commandLineGroup=None,
             exposed=True,
             items=[
                 desc.IntParam(
@@ -51,7 +51,7 @@ class GroupAttributes(desc.Node):
                     name="nestedGroup",
                     label="Nested Group",
                     description="A group within a group.",
-                    group=None,
+                    commandLineGroup=None,
                     exposed=True,
                     items=[
                         desc.FloatParam(
@@ -75,7 +75,7 @@ class GroupAttributes(desc.Node):
                         label="Listed Group",
                         description="Group in a list within a group.",
                         joinChar=":",
-                        group=None,
+                        commandLineGroup=None,
                         items=[
                             desc.IntParam(
                                 name="listedGroupInt",
@@ -120,7 +120,7 @@ class GroupAttributes(desc.Node):
             name="inputGroup",
             label="Input Group",
             description="A group set as an input.",
-            group=None,
+            commandLineGroup=None,
             items=[
                 desc.BoolParam(
                     name="inputBool",
@@ -137,7 +137,7 @@ class GroupAttributes(desc.Node):
             name="outputGroup",
             label="Output Group",
             description="A group set as an output.",
-            group=None,
+            commandLineGroup=None,
             exposed=True,
             items=[
                 desc.BoolParam(

--- a/tests/test_compute.py
+++ b/tests/test_compute.py
@@ -439,7 +439,7 @@ class TestNode_SizeA(desc.BaseNode):
             label='Output',
             description='Output',
             value=os.path.join("{nodeCacheFolder}"),
-            group='',
+            commandLineGroup='',
         ),
     ]
     def processChunk(self, chunk):


### PR DESCRIPTION
This pull request refactors the attribute and parameter classes in the Meshroom codebase to consistently use the `commandLineGroup` keyword argument instead of `group` when specifying parameter grouping. This change affects both core library code and related tests, aligning the codebase with updated naming conventions and improving clarity for command-line integration.

Key changes include:

**Core attribute and parameter classes:**

* Updated constructors in `Geometry`, `Size2d`, `Vec2d`, `Shape`, `ShapeList`, `Point2d`, `Line2d`, `Rectangle`, and `Circle` classes to replace the `group` argument with `commandLineGroup`. All internal usage and parameter passing now consistently use `commandLineGroup`. [[1]](diffhunk://#diff-b24b0bac4af72ae8c04a00e908613f161149ecd6e4e1320013b1ae06a9011dbeL9-R13) [[2]](diffhunk://#diff-b24b0bac4af72ae8c04a00e908613f161149ecd6e4e1320013b1ae06a9011dbeL30-R62) [[3]](diffhunk://#diff-30e601b8d4c83925cdb07d95939031a9fb82f5d1a2cbc879e3b57fa4703701d0L8-R21) [[4]](diffhunk://#diff-30e601b8d4c83925cdb07d95939031a9fb82f5d1a2cbc879e3b57fa4703701d0L37-R41) [[5]](diffhunk://#diff-30e601b8d4c83925cdb07d95939031a9fb82f5d1a2cbc879e3b57fa4703701d0L57-R125)

**Node and parameter description utilities:**

* Modified the `attributeDescFromValue` function in `meshroom/core/node.py` to set the group as `commandLineGroup` instead of `group` for dynamically created parameter descriptions.

**Tests and example nodes:**

* Updated all relevant test cases and node definitions to use the `commandLineGroup` keyword argument in place of `group`, including in `tests/nodes/test/GroupAttributes.py` and `tests/test_compute.py`. [[1]](diffhunk://#diff-b2bd23af921eebbeab5a60a83012fd93e95bf758355fcb4fe29ca6ec44af407fL13-R13) [[2]](diffhunk://#diff-b2bd23af921eebbeab5a60a83012fd93e95bf758355fcb4fe29ca6ec44af407fL54-R54) [[3]](diffhunk://#diff-b2bd23af921eebbeab5a60a83012fd93e95bf758355fcb4fe29ca6ec44af407fL78-R78) [[4]](diffhunk://#diff-b2bd23af921eebbeab5a60a83012fd93e95bf758355fcb4fe29ca6ec44af407fL123-R123) [[5]](diffhunk://#diff-b2bd23af921eebbeab5a60a83012fd93e95bf758355fcb4fe29ca6ec44af407fL140-R140) [[6]](diffhunk://#diff-6db0acd07d1851df24a92b4549c5bef0c079f2d8a549a2de4bdc3ffc8b3bffbcL442-R442)