### PR TITLE
[dev] Add TaskThread Qt debugging

### DIFF
--- a/meshroom/core/attribute.py
+++ b/meshroom/core/attribute.py
@@ -358,7 +358,11 @@ class Attribute(BaseObject):
         # ChoiceParam with multiple values should be combined
         if isinstance(self._desc, desc.ChoiceParam) and not self._desc.exclusive:
             # Ensure value is a list as expected
-            assert (isinstance(self.value, Sequence) and not isinstance(self.value, str))
+            try:
+                assert (isinstance(self.value, Sequence) and not isinstance(self.value, str))
+            except AssertionError as e:
+                logging.error(f"Attribute {self._getFullName()} value contains an error ({self.value}, {type(self.value)})")
+                raise e
             v = self._desc.joinChar.join(self._getEvalValue())
             if withQuotes and v:
                 return f'"{v}"'

--- a/meshroom/core/taskManager.py
+++ b/meshroom/core/taskManager.py
@@ -4,9 +4,10 @@ import logging
 from threading import Thread
 from PySide6.QtCore import QThread, QEventLoop, QTimer
 from enum import Enum
+from meshroom.common import strtobool
 
 DEBUGGING = False
-if os.environ.get("DEBUGGING", 0) == "1":
+if strtobool(os.environ.get("DEBUGGING", "0")):
     DEBUGGING = True
     import debugpy
 

--- a/meshroom/core/taskManager.py
+++ b/meshroom/core/taskManager.py
@@ -1,8 +1,14 @@
+import os
 import traceback
 import logging
 from threading import Thread
 from PySide6.QtCore import QThread, QEventLoop, QTimer
 from enum import Enum
+
+DEBUGGING = False
+if os.environ.get("DEBUGGING", 0) == "1":
+    DEBUGGING = True
+    import debugpy
 
 import meshroom
 from meshroom.common import BaseObject, DictModel, Property, Signal, Slot
@@ -70,6 +76,9 @@ class TaskThread(QThread):
 
     def run(self):
         """ Consume compute tasks. """
+        if DEBUGGING:
+            debugpy.debug_this_thread()
+
         self._state = State.RUNNING
         stopAndRestart = False
 


### PR DESCRIPTION
# Description

This PR adds a way to debug TaskThread.
Before this PR we cannot add a breakpoint on a TaskThread.

# Content of the PR

If a DEBUGGING env var is set to True we enable the debugging on the task thread

# How to use

In VSCode this `launch.json` can be used
```py
{
    // Use IntelliSense to learn about possible attributes.
    // Hover to view descriptions of existing attributes.
    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
    "version": "0.2.0",
    "configurations": [
        {
            "name": "Meshroom",
            "type": "debugpy",
            "request": "launch",
            "program": "meshroom/ui",
            "console": "integratedTerminal",
            "env": {
                // "MESHROOM_NODES_PATH": "${workspaceFolder}/tests/nodes",
                // "MESHROOM_PLUGINS_PATH": "/path/to/plugins",
                "MESHROOM_OUTPUT_QML_WARNINGS": "1",
                "MESHROOM_QML_DEBUG": "0",
                "MESHROOM_QML_DEBUG_PARAMS": "port:7789",
                "DEBUGGING": "1",
            },
            "args": [
                "/path/to/scene.mg"
            ],
            "subProcess": true,
        }
  }
```