### PR TITLE
Set default label and description attributes

### DIFF
--- a/meshroom/core/desc/attribute.py
+++ b/meshroom/core/desc/attribute.py
@@ -1,5 +1,6 @@
 import ast
 import os
+import re
 from collections.abc import Iterable
 from enum import auto, Enum
 
@@ -21,13 +22,25 @@ class Attribute(BaseObject):
     """
     """
 
-    def __init__(self, name, label, description, value, advanced, semantic, commandLineGroup, enabled,
+    @staticmethod
+    def _generateLabel(name):
+        """Generate a human-readable label from an attribute name."""
+        
+        # Replace underscores with spaces
+        label = name.replace('_', ' ')
+        # Insert space before capital letters (for camelCase)
+        label = re.sub(r'([a-z])([A-Z])', r'\1 \2', label)
+        # Capitalize each word
+        label = ' '.join(word.capitalize() for word in label.split())
+        return label
+
+    def __init__(self, name, label=None, description=None, value=None, advanced=False, semantic="", commandLineGroup="allParams", enabled=True,
                  keyable=False, keyType=None, invalidate=True, uidIgnoreValue=None,
                  validValue=True, errorMessage="", visible=True, exposed=False):
         super(Attribute, self).__init__()
         self._name = name
-        self._label = label
-        self._description = description
+        self._label = label if label is not None else self._generateLabel(name)
+        self._description = description if description is not None else ""
         self._value = value
         self._keyable = keyable
         self._keyType = keyType
@@ -141,7 +154,7 @@ class Attribute(BaseObject):
 class ListAttribute(Attribute):
     """ A list of Attributes """
     @deprecated.depreciateParam("group", "Param 'group' on {name} should not be used anymore. Please use 'commandLineGroup' instead")
-    def __init__(self, elementDesc, name, label, description, group="allParams", commandLineGroup=_setParamSentinel, 
+    def __init__(self, elementDesc, name, label=None, description=None, group="allParams", commandLineGroup=_setParamSentinel, 
                  advanced=False, semantic="", enabled=True, joinChar=" ", visible=True, exposed=False):
         """
         :param elementDesc: the Attribute description of elements to store in that list
@@ -196,7 +209,7 @@ class ListAttribute(Attribute):
 class GroupAttribute(Attribute):
     """ A macro Attribute composed of several Attributes """
     @deprecated.depreciateParam("group", "Param 'group' on {name} should not be used anymore. Please use 'commandLineGroup' instead")
-    def __init__(self, items, name, label, description, group="allParams", commandLineGroup=_setParamSentinel, 
+    def __init__(self, items, name, label=None, description=None, group="allParams", commandLineGroup=_setParamSentinel, 
                  advanced=False, semantic="",  enabled=True, joinChar=" ", brackets=None, visible=True,
                  exposed=False):
         """
@@ -307,7 +320,7 @@ class GroupAttribute(Attribute):
 class Param(Attribute):
     """
     """
-    def __init__(self, name, label, description, value, commandLineGroup, advanced, semantic, enabled,
+    def __init__(self, name, label=None, description=None, value=None, commandLineGroup="allParams", advanced=False, semantic="", enabled=True,
                  keyable=False, keyType=None, invalidate=True, uidIgnoreValue=None,
                  validValue=True, errorMessage="", visible=True, exposed=False):
         super(Param, self).__init__(name=name, label=label, description=description, value=value,
@@ -321,7 +334,7 @@ class File(Attribute):
     """
     """
     @deprecated.depreciateParam("group", "Param 'group' on {name} should not be used anymore. Please use 'commandLineGroup' instead")
-    def __init__(self, name, label, description, value, group="allParams", commandLineGroup=_setParamSentinel, 
+    def __init__(self, name, label=None, description=None, value="", group="allParams", commandLineGroup=_setParamSentinel, 
                  advanced=False, invalidate=True, semantic="", enabled=True, visible=True, exposed=True):
         
         commandLineGroup = commandLineGroup if commandLineGroup is not _setParamSentinel else group
@@ -351,7 +364,7 @@ class BoolParam(Param):
     """
     """
     @deprecated.depreciateParam("group", "Param 'group' on {name} should not be used anymore. Please use 'commandLineGroup' instead")
-    def __init__(self, name, label, description, value, keyable=False, keyType=None,
+    def __init__(self, name, label=None, description=None, value=False, keyable=False, keyType=None,
                  group="allParams", commandLineGroup=_setParamSentinel, advanced=False, 
                  enabled=True, invalidate=True, semantic="", visible=True, exposed=False):
         
@@ -384,7 +397,7 @@ class IntParam(Param):
     """
     """
     @deprecated.depreciateParam("group", "Param 'group' on {name} should not be used anymore. Please use 'commandLineGroup' instead")
-    def __init__(self, name, label, description, value, range=None, keyable=False, keyType=None,
+    def __init__(self, name, label=None, description=None, value=0, range=None, keyable=False, keyType=None,
                  group="allParams", commandLineGroup=_setParamSentinel, advanced=False, enabled=True, 
                  invalidate=True, semantic="", validValue=True, errorMessage="", visible=True, exposed=False):
         self._range = range
@@ -422,7 +435,7 @@ class FloatParam(Param):
     """
     """
     @deprecated.depreciateParam("group", "Param 'group' on {name} should not be used anymore. Please use 'commandLineGroup' instead")
-    def __init__(self, name, label, description, value, range=None, keyable=False, keyType=None,
+    def __init__(self, name, label=None, description=None, value=0.0, range=None, keyable=False, keyType=None,
                  group="allParams", commandLineGroup=_setParamSentinel, advanced=False, enabled=True, 
                  invalidate=True, semantic="", validValue=True, errorMessage="", visible=True, exposed=False):
         self._range = range
@@ -458,7 +471,7 @@ class PushButtonParam(Param):
     """
     """
     @deprecated.depreciateParam("group", "Param 'group' on {name} should not be used anymore. Please use 'commandLineGroup' instead")
-    def __init__(self, name, label, description, group="allParams", commandLineGroup=_setParamSentinel, 
+    def __init__(self, name, label=None, description=None, group="allParams", commandLineGroup=_setParamSentinel, 
                  advanced=False, enabled=True, invalidate=True, semantic="", visible=True, exposed=False):
         
         commandLineGroup = commandLineGroup if commandLineGroup is not _setParamSentinel else group
@@ -500,7 +513,7 @@ class ChoiceParam(Param):
     _OVERRIDE_SERIALIZATION_KEY_VALUES = "__ChoiceParam_values__"
 
     @deprecated.depreciateParam("group", "Param 'group' on {name} should not be used anymore. Please use 'commandLineGroup' instead")
-    def __init__(self, name: str, label: str, description: str, value, values, exclusive=True, saveValuesOverride=False,
+    def __init__(self, name: str, label=None, description=None, value=None, values=None, exclusive=True, saveValuesOverride=False,
                  group="allParams", commandLineGroup=_setParamSentinel, joinChar=" ", advanced=False, enabled=True, 
                  invalidate=True, semantic="", validValue=True, errorMessage="", visible=True, exposed=False):
 
@@ -510,6 +523,24 @@ class ChoiceParam(Param):
                                           commandLineGroup=commandLineGroup, advanced=advanced, enabled=enabled, 
                                           invalidate=invalidate, semantic=semantic, validValue=validValue, 
                                           errorMessage=errorMessage, visible=visible, exposed=exposed)
+        
+        if values is None:
+            raise ValueError(f"ChoiceParam '{name}' requires 'values' parameter to be set, cannot be None")
+        
+        if not isinstance(values, list):
+            raise ValueError(f"ChoiceParam '{name}' requires 'values' to be a list, got {type(values).__name__}")
+        
+        if not values:
+            # Empty values list - need a valid value to infer type
+            if exclusive:
+                if value is None:
+                    raise ValueError(f"ChoiceParam '{name}' has empty 'values' list and exclusive=True, "
+                                   f"'value' cannot be None (needed for type inference)")
+            else:
+                if value is None or (isinstance(value, list) and not value):
+                    raise ValueError(f"ChoiceParam '{name}' has empty 'values' list and exclusive=False, "
+                                   f"'value' must be a non-empty list (needed for type inference)")
+        
         self._values = values
         self._saveValuesOverride = saveValuesOverride
         self._exclusive = exclusive
@@ -582,7 +613,7 @@ class StringParam(Param):
     """
     """
     @deprecated.depreciateParam("group", "Param 'group' on {name} should not be used anymore. Please use 'commandLineGroup' instead")
-    def __init__(self, name, label, description, value, group="allParams", commandLineGroup=_setParamSentinel, 
+    def __init__(self, name, label=None, description=None, value="", group="allParams", commandLineGroup=_setParamSentinel, 
                  advanced=False, enabled=True, invalidate=True, semantic="", uidIgnoreValue=None, validValue=True, 
                  errorMessage="", visible=True, exposed=False):
 
@@ -613,7 +644,7 @@ class ColorParam(Param):
     """
     """
     @deprecated.depreciateParam("group", "Param 'group' on {name} should not be used anymore. Please use 'commandLineGroup' instead")
-    def __init__(self, name, label, description, value, group="allParams", commandLineGroup=_setParamSentinel, 
+    def __init__(self, name, label=None, description=None, value="#ffffff", group="allParams", commandLineGroup=_setParamSentinel, 
                  advanced=False, enabled=True, invalidate=True, semantic="", visible=True, exposed=False):
         
         commandLineGroup = commandLineGroup if commandLineGroup is not _setParamSentinel else group

--- a/tests/test_attributes.py
+++ b/tests/test_attributes.py
@@ -1,4 +1,8 @@
 from meshroom.core.graph import Graph
+from meshroom.core.desc import (
+    IntParam, FloatParam, BoolParam, StringParam, 
+    ChoiceParam, File, ListAttribute, GroupAttribute
+)
 import pytest
 
 import logging
@@ -101,3 +105,118 @@ def test_attribute_is2D_file_semantic(givenSemantic, expected):
 
     # Then
     assert n0.input.is2dDisplayable == expected
+
+
+def test_attribute_label_auto_generation():
+    """
+    Test that attribute labels are auto-generated from attribute names when not provided
+    """
+    # Test various naming conventions
+    test_cases = [
+        ('myAttribute', 'My Attribute'),
+        ('some_attribute', 'Some Attribute'),
+        ('MyAttribute', 'My Attribute'),
+        ('ALLCAPS', 'Allcaps'),
+        ('simple', 'Simple'),
+        ('test_with_multiple_words', 'Test With Multiple Words'),
+        ('camelCaseTest', 'Camel Case Test'),
+    ]
+    
+    for attr_name, expected_label in test_cases:
+        attr = IntParam(name=attr_name, value=0)
+        assert attr.label == expected_label, f"Failed for {attr_name}: expected '{expected_label}', got '{attr.label}'"
+
+
+def test_attribute_label_explicit():
+    """
+    Test that explicit labels are preserved
+    """
+    attr = IntParam(name='myAttribute', label='Custom Label', value=0)
+    assert attr.label == 'Custom Label'
+
+
+def test_attribute_description_defaults_to_empty_string():
+    """
+    Test that description defaults to empty string when None
+    """
+    attr = IntParam(name='myParam', value=0)
+    assert attr.description == ''
+
+
+def test_attribute_description_explicit():
+    """
+    Test that explicit descriptions are preserved
+    """
+    attr = IntParam(name='myParam', description='Custom description', value=0)
+    assert attr.description == 'Custom description'
+
+
+def test_choiceparam_requires_values():
+    """
+    Test that ChoiceParam raises ValueError when values is None
+    """
+    with pytest.raises(ValueError, match="ChoiceParam 'myChoice' requires 'values' parameter to be set, cannot be None"):
+        ChoiceParam(name='myChoice', value='a', values=None)
+
+
+def test_choiceparam_with_valid_values():
+    """
+    Test that ChoiceParam works correctly when values is provided
+    """
+    attr = ChoiceParam(name='myChoice', value='a', values=['a', 'b', 'c'])
+    assert attr.values == ['a', 'b', 'c']
+    assert attr.label == 'My Choice'
+    assert attr.description == ''
+
+
+def test_various_param_types_default_label_and_description():
+    """
+    Test that all parameter types support default label and description
+    """
+    # IntParam
+    int_param = IntParam(name='intValue', value=5)
+    assert int_param.label == 'Int Value'
+    assert int_param.description == ''
+    
+    # FloatParam
+    float_param = FloatParam(name='floatValue', value=3.14)
+    assert float_param.label == 'Float Value'
+    assert float_param.description == ''
+    
+    # BoolParam
+    bool_param = BoolParam(name='enableFeature', value=True)
+    assert bool_param.label == 'Enable Feature'
+    assert bool_param.description == ''
+    
+    # StringParam
+    string_param = StringParam(name='textInput', value='hello')
+    assert string_param.label == 'Text Input'
+    assert string_param.description == ''
+    
+    # File
+    file_param = File(name='inputFile', value='')
+    assert file_param.label == 'Input File'
+    assert file_param.description == ''
+
+
+def test_list_attribute_default_label_and_description():
+    """
+    Test that ListAttribute supports default label and description
+    """
+    elem_desc = IntParam(name='elem', value=0)
+    list_attr = ListAttribute(elementDesc=elem_desc, name='myList')
+    assert list_attr.label == 'My List'
+    assert list_attr.description == ''
+
+
+def test_group_attribute_default_label_and_description():
+    """
+    Test that GroupAttribute supports default label and description
+    """
+    items = [
+        IntParam(name='x', value=0),
+        IntParam(name='y', value=0)
+    ]
+    group_attr = GroupAttribute(items=items, name='myGroup')
+    assert group_attr.label == 'My Group'
+    assert group_attr.description == ''


### PR DESCRIPTION
This pull request improves the usability and robustness of attribute classes in the `meshroom.core.desc.attribute` module by introducing automatic label and description handling, enforcing required parameters, and expanding test coverage. The changes make it easier to create attribute instances with sensible defaults, reduce boilerplate, and help prevent misconfiguration.

**Enhancements to attribute initialization and validation:**

* All attribute and parameter classes (`Attribute`, `Param`, `IntParam`, `FloatParam`, `BoolParam`, `StringParam`, `File`, `ChoiceParam`, `ListAttribute`, `GroupAttribute`, etc.) now support optional `label` and `description` arguments. If not provided, `label` is auto-generated from the attribute name (e.g., `myAttribute` → `My Attribute`), and `description` defaults to an empty string. This reduces the need for redundant arguments and ensures consistent labeling.
* The `ChoiceParam` class now raises a `ValueError` if the required `values` parameter is not provided, preventing invalid attribute creation at runtime.

**Expanded and improved test coverage:**

* Added comprehensive tests to verify:
  - Automatic label generation for various naming conventions.
  - Explicit label and description handling.
  - Defaulting of description to an empty string.
  - Enforcement of required parameters in `ChoiceParam`.
  - Correct default label/description behavior across all attribute and parameter types, including `ListAttribute` and `GroupAttribute`.
* Updated imports in the test suite to include all relevant attribute classes for testing.

These changes streamline attribute creation, enhance code safety, and ensure consistency throughout the codebase.