### PR TITLE
[core] Fix dynamic attributes on loading file

### DIFF
--- a/meshroom/core/graph.py
+++ b/meshroom/core/graph.py
@@ -321,7 +321,9 @@ class Graph(BaseObject):
 
             # Create graph edges by resolving attributes expressions
             self._applyExpr()
-            
+
+        self._resolveAllDynamicValues()
+
         # Templates are specific: they contain only the minimal amount of 
         # serialized data to describe the graph structure.
         # They are not meant to be computed: therefore, we can early return here,
@@ -334,6 +336,17 @@ class Graph(BaseObject):
         # It is now possible to check whether the UIDs stored in the graph file for each node correspond to the ones
         # that were computed.
         self._evaluateUidConflicts(graphContent)
+
+    def _resolveAllDynamicValues(self):
+        """
+        After the full graph is loaded and all edges are wired, walk nodes 
+        in topological order and resolve dynamic output attribute values.
+        """
+        nodes, _ = self.dfsOnFinish()
+        # dfsOnFinish returns leaf-to-root order; reverse for root-to-leaf
+        for node in reversed(nodes):
+            node.updateInternals()
+            node.updateOutputAttr()
 
     def _normalizeGraphContent(self, graphData: dict, fileVersion: Version) -> dict:
         graphContent = graphData.get(GraphIO.Keys.Graph, graphData)


### PR DESCRIPTION
# Description

The bug I got happened on the specific situation where we have :

```py
class NodeA(desc.Node):
    outputs = [
        desc.File(
            name="out",
            label="Output",
            value=None,
        ),
    ]
    
    def process(self, node):
        node.output._setValue(str("my_file"))


class NodeB(desc.Node):
    inputs = [
        desc.File(
            name="in",
            label="a file",
            value="",
        ),
    ]
    
    outputs = [
        desc.File(
            name="out",
            label="Out",
            value="{node.in.value}",
            # or value=lambda node: str(node.in.value),

        ),
    ]
```
And then NodeA.out -> NodeB.in

In this case what seems to happen is :
1. We launch meshroom and create the scene with `NodeA.out -> NodeB.in`.
2. NodeA.out is set to None and NodeB.in & NodeB.out is evaluated to None
3. We launch the NodeA process and therefore NodeA.out is filled, then NodeB.in and NodeB.out are filled too
4. We close meshroom and reopen the same scene
5. The param values are computed : `"{node.scene.value}"` is set to None at first because we haven't computed the upstream value yet
6. NodeA.out value is loaded from the scene, NodeB.in is correctly set but NodeB.out is not correctly updated

# Proposed fix

With this PR we force an update from internal params and output params after loading the scene. Loading internal params is enough for the bug I encountered but maybe we also need updateOutputAttr too.

Maybe there are better ways to do it if any reviewer have an idea let me know