### PR TITLE
Fix loading display of thumbnails

### DIFF
--- a/meshroom/ui/components/thumbnail.py
+++ b/meshroom/ui/components/thumbnail.py
@@ -249,6 +249,15 @@ class ThumbnailCache(QObject):
 
         return None
 
+    @staticmethod
+    def _createEmptyThumbnail(path: str):
+        """ Create an empty thumbnail file on disk. """
+        try:
+            with open(path, 'a') as f:
+                os.utime(path, None)
+        except Exception as exc:
+            logging.error(f'[ThumbnailCache] Failed to create empty thumbnail at {path}: {exc}')
+
     def createThumbnail(self, imgSource, callerID):
         """
         Load an image, resize it to thumbnail dimensions and save the result in the cache directory.
@@ -276,18 +285,21 @@ class ThumbnailCache(QObject):
         img = reader.read()
         if img.isNull():
             logging.error(f'[ThumbnailCache] Error when reading image: {reader.errorString()}')
-            return ""
+            logging.error(f'[ThumbnailCache] Creating empty thumbnail for {imgPath}')
+            ThumbnailCache._createEmptyThumbnail(path)
+        else:
+            # Scale image while preserving aspect ratio
+            thumbnail = img.scaled(ThumbnailCache.thumbnailSize,
+                                aspectMode=Qt.KeepAspectRatio,
+                                mode=Qt.SmoothTransformation)
 
-        # Scale image while preserving aspect ratio
-        thumbnail = img.scaled(ThumbnailCache.thumbnailSize,
-                               aspectMode=Qt.KeepAspectRatio,
-                               mode=Qt.SmoothTransformation)
-
-        # Write thumbnail to disk and check for potential errors
-        writer = QImageWriter(path)
-        success = writer.write(thumbnail)
-        if not success:
-            logging.error(f'[ThumbnailCache] Error when writing thumbnail: {writer.errorString()}')
+            # Write thumbnail to disk and check for potential errors
+            writer = QImageWriter(path)
+            success = writer.write(thumbnail)
+            if not success:
+                logging.error(f'[ThumbnailCache] Error when writing thumbnail: {writer.errorString()}')
+                logging.error(f'[ThumbnailCache] Creating empty thumbnail for {imgPath}')
+                ThumbnailCache._createEmptyThumbnail(path)
 
         # Notify listeners
         self.thumbnailCreated.emit(imgSource, callerID)

--- a/meshroom/ui/components/thumbnail.py
+++ b/meshroom/ui/components/thumbnail.py
@@ -14,7 +14,8 @@ from multiprocessing.pool import ThreadPool
 
 
 class ThumbnailCache(QObject):
-    """ThumbnailCache provides an abstraction for the thumbnail cache on disk, available in QML.
+    """
+    ThumbnailCache provides an abstraction for the thumbnail cache on disk, available in QML.
 
     For a given image file, it ensures the corresponding thumbnail exists (by creating it if necessary)
     and gives access to it.
@@ -40,16 +41,16 @@ class ThumbnailCache(QObject):
 
     # Thumbnail cache directory
     # Cannot be initialized here as it depends on the organization and application names
-    thumbnailDir = ''
+    thumbnailDir: str = ''
 
     # Thumbnail dimensions limit (the actual dimensions of a thumbnail will depend on the aspect ratio)
-    thumbnailSize = QSize(256, 256)
+    thumbnailSize: QSize = QSize(256, 256)
 
     # Time limit for thumbnail storage on disk, expressed in days
-    storageTimeLimit = 90
+    storageTimeLimit: int = 90
 
     # Maximum number of thumbnails in the cache directory
-    maxThumbnailsOnDisk = 100000
+    maxThumbnailsOnDisk: int = 100000
 
     # Signal to notify listeners that a thumbnail was created and written on disk
     # This signal has two argument:
@@ -68,7 +69,7 @@ class ThumbnailCache(QObject):
 
     @staticmethod
     def initialize():
-        """Initialize static fields in cache class and cache directory on disk."""
+        """ Initialize static fields in cache class and cache directory on disk. """
         # Thumbnail directory: default or user specified
         dir = os.getenv('MESHROOM_THUMBNAIL_DIR')
         if dir is not None:
@@ -101,7 +102,8 @@ class ThumbnailCache(QObject):
 
     @staticmethod
     def clean():
-        """Scan the thumbnail directory and:
+        """
+        Scan the thumbnail directory and:
         1. remove all thumbnails that have not been used for more than storageTimeLimit days
         2. ensure that the number of thumbnails on disk does not exceed maxThumbnailsOnDisk.
         """
@@ -164,26 +166,28 @@ class ThumbnailCache(QObject):
                     logging.error(f'[ThumbnailCache] Tried to remove {path} but this file does not exist')
 
     @staticmethod
-    def thumbnailPath(imgPath):
-        """Use SHA1 hashing to associate a unique thumbnail to an image.
+    def thumbnailPath(imgPath: str) -> str:
+        """
+        Use SHA1 hashing to associate a unique thumbnail to an image.
 
         Args:
-            imgPath (str): filepath to the input image
+            imgPath: filepath to the input image
 
         Returns:
-            str: filepath to the corresponding thumbnail
+            The filepath to the corresponding thumbnail
         """
         digest = hashlib.sha1(imgPath.encode('utf-8')).hexdigest()
         path = os.path.join(ThumbnailCache.thumbnailDir, f'{digest}.jpg')
         return path
 
     @staticmethod
-    def removeOutdated(imgPath, path):
-        """Remove thumbnail if its corresponding image has been modified after thumbnail creation.
+    def removeOutdated(imgPath: str, path: str):
+        """
+        Remove thumbnail if its corresponding image has been modified after thumbnail creation.
 
         Args:
-            imgPath (str): filepath to the input image
-            path (str): filepath to the corresponding thumbnail
+            imgPath: filepath to the input image
+            path: filepath to the corresponding thumbnail
         """
         try:
             if os.path.getmtime(imgPath) > os.path.getmtime(path):
@@ -194,15 +198,15 @@ class ThumbnailCache(QObject):
             return
 
     @staticmethod
-    def checkThumbnail(path):
+    def checkThumbnail(path: str) -> bool:
         """
         Check if a thumbnail already exists on disk, and if so update its last modification time.
 
         Args:
-            path (str): filepath to the thumbnail
+            path: filepath to the thumbnail
 
         Returns:
-            (bool): whether the thumbnail exists on disk or not
+            Whether the thumbnail exists on disk or not
         """
         if os.path.exists(path):
             # Update last modification time
@@ -211,7 +215,7 @@ class ThumbnailCache(QObject):
         return False
 
     @Slot(QUrl, int, result=QUrl)
-    def thumbnail(self, imgSource, callerID):
+    def thumbnail(self, imgSource: QUrl, callerID: int) -> QUrl | None:
         """
         Retrieve the filepath of the thumbnail corresponding to a given image.
 
@@ -219,11 +223,11 @@ class ThumbnailCache(QObject):
         When this is done, the thumbnailCreated signal is emitted.
 
         Args:
-            imgSource (QUrl): location of the input image
-            callerID (int): identifier for the object that requested the thumbnail
+            imgSource: location of the input image
+            callerID: identifier for the object that requested the thumbnail
 
         Returns:
-            QUrl: location of the corresponding thumbnail if it exists, otherwise None
+            The location of the corresponding thumbnail if it exists, otherwise None
         """
         if not imgSource.isValid():
             return None
@@ -258,13 +262,16 @@ class ThumbnailCache(QObject):
         except Exception as exc:
             logging.error(f'[ThumbnailCache] Failed to create empty thumbnail at {path}: {exc}')
 
-    def createThumbnail(self, imgSource, callerID):
+    def createThumbnail(self, imgSource: QUrl, callerID: int) -> str:
         """
         Load an image, resize it to thumbnail dimensions and save the result in the cache directory.
 
         Args:
-            imgSource (QUrl): location of the input image
-            callerID (int): identifier for the object that requested the thumbnail
+            imgSource: location of the input image
+            callerID: identifier for the object that requested the thumbnail
+
+        Returns:
+            The filepath of the created thumbnail, which may be an empty file if an error happened during the process
         """
         imgPath = imgSource.toLocalFile()
         path = ThumbnailCache.thumbnailPath(imgPath)

--- a/meshroom/ui/qml/Homepage.qml
+++ b/meshroom/ui/qml/Homepage.qml
@@ -361,8 +361,25 @@ Page {
                             font.family: MaterialIcons.fontFamily
                             font.pointSize: 24
 
-                            text: modelData["path"] ? (modelData["thumbnail"] ? "" : MaterialIcons.description) : MaterialIcons.folder_open
-                            
+                            text: {
+                                if (modelData["path"]) {
+                                    // The thumbnail exists but is empty, which means there was an error when generating it (e.g. missing file, unsupported format, etc.)
+                                    if (modelData["thumbnail"] && thumbnail.status === Image.Error) {
+                                        return MaterialIcons.image_not_supported
+                                    }
+                                    // The thumbnail exists and is valid, no need to display an icon
+                                    else if (modelData["thumbnail"]) {
+                                        return ""
+                                    }
+                                    // There is no image in the file, so no thumbnail to display
+                                    else {
+                                        return MaterialIcons.description
+                                    }
+                                }
+                                // Item with no path is the "Open Project" button
+                                return MaterialIcons.folder_open
+                            }
+
                             MouseArea {
                                 anchors.fill: parent
                                 acceptedButtons: Qt.LeftButton | Qt.RightButton
@@ -378,7 +395,6 @@ Page {
                                         projectContextMenu.y = mouse.y
                                         projectContextMenu.open()
                                         return
-                                        
                                     }
                                         
                                     if (!modelData["path"]) {
@@ -393,9 +409,7 @@ Page {
                                             MeshroomApp.addRecentProjectFile(modelData["path"])
                                         }
                                     }
-                                    
                                 }
-
                             }
 
                             Menu {
@@ -451,7 +465,6 @@ Page {
                                 running: homepageGridView.visible && projectContent.thumbnailBusy
                                 visible: homepageGridView.visible && projectContent.thumbnailBusy
                             }
-
                         }
                         Label {
                             id: project

--- a/meshroom/ui/qml/Homepage.qml
+++ b/meshroom/ui/qml/Homepage.qml
@@ -313,12 +313,38 @@ Page {
                         height: homepageGridView.cellHeight
 
                         property var source: modelData["thumbnail"] ? Filepath.stringToUrl(modelData["thumbnail"]) : ""
+                        property int retryCount: 0
+                        property bool thumbnailBusy: false
 
                         function updateThumbnail() {
-                            thumbnail.source = ThumbnailCache.thumbnail(source, homepageGridView.currentIndex)
+                            thumbnail.source = ThumbnailCache.thumbnail(source, index)
                         }
 
-                        onSourceChanged: updateThumbnail()
+                        onSourceChanged: {
+                            retryCount = 0
+                            thumbnailBusy = (source != "")
+                            updateThumbnail()
+                        }
+
+                        // Periodically retry loading the thumbnail until it is available or max retries is reached.
+                        Timer {
+                            id: retryTimer
+                            interval: 2000
+                            repeat: true
+                            running: homepageGridView.visible
+                                     && projectContent.source != ""
+                                     && thumbnail.status !== Image.Ready
+                                     && thumbnail.status !== Image.Error
+                                     && projectContent.retryCount < 15
+                            onTriggered: {
+                                projectContent.retryCount++
+                                if (projectContent.retryCount >= 15) {
+                                    projectContent.thumbnailBusy = false
+                                } else {
+                                    projectContent.updateThumbnail()
+                                }
+                            }
+                        }
 
                         Button {
                             id: projectDelegate
@@ -412,12 +438,18 @@ Page {
 
                                 width: projectDelegate.width
                                 height: projectDelegate.height
+
+                                onStatusChanged: {
+                                    if (status === Image.Ready || status === Image.Error) {
+                                        projectContent.thumbnailBusy = false
+                                    }
+                                }
                             }
 
                             BusyIndicator {
                                 anchors.centerIn: parent
-                                running: homepageGridView.visible && modelData["thumbnail"] && thumbnail.status != Image.Ready
-                                visible: running
+                                running: homepageGridView.visible && projectContent.thumbnailBusy
+                                visible: homepageGridView.visible && projectContent.thumbnailBusy
                             }
 
                         }

--- a/meshroom/ui/qml/ImageGallery/ImageDelegate.qml
+++ b/meshroom/ui/qml/ImageGallery/ImageDelegate.qml
@@ -175,6 +175,12 @@ Item {
                                      && root.thumbnailSource == ""
                                      && retryTimer.running)
                     }
+                    MaterialLabel {
+                        anchors.centerIn: parent
+                        visible: grid_thumbnail.status === Image.Error
+                        text: MaterialIcons.image_not_supported
+                        font.pointSize: 20
+                    }
                 }
 
                 // Placeholder icon shown when thumbnails are disabled
@@ -257,6 +263,12 @@ Item {
                                  || (list_thumbnail.status === Image.Null
                                      && root.thumbnailSource == ""
                                      && retryTimer.running)
+                    }
+                    MaterialLabel {
+                        anchors.centerIn: parent
+                        visible: list_thumbnail.status === Image.Error
+                        text: MaterialIcons.image_not_supported
+                        font.pointSize: 20
                     }
                 }
 

--- a/meshroom/ui/qml/ImageGallery/ImageDelegate.qml
+++ b/meshroom/ui/qml/ImageGallery/ImageDelegate.qml
@@ -34,6 +34,7 @@ Item {
     // Internal properties to hold thumbnail source & loading status
     property url thumbnailSource: ""
     property int thumbnailStatus: Image.Null
+    property int retryCount: 0
 
     // Retrieve viewpoints inner data
     QtObject {
@@ -51,24 +52,32 @@ Item {
         root.thumbnailSource = ThumbnailCache.thumbnail(root.source, root.cellID)
     }
     onSourceChanged: {
+        root.retryCount = 0
         updateThumbnail()
     }
     onDisplayThumbnailChanged: {
-        if (displayThumbnail)
+        if (displayThumbnail) {
+            root.retryCount = 0
             updateThumbnail()
-        else
+        } else {
             root.thumbnailSource = ""
+        }
     }
 
-    // Send a new request after 5 seconds if thumbnail is not loaded
-    // This is meant to avoid deadlocks in case there is a synchronization problem
+    // Periodically retry loading the thumbnail until it is available or max retries is reached.
+    // This acts as a safety net in case the thumbnailCreated signal emitted from the background
+    // thread is not properly delivered to QML.
     Timer {
-        interval: 5000
-        running: true
+        id: retryTimer
+        interval: 2000
+        repeat: true
+        running: root.displayThumbnail
+                 && root.thumbnailStatus !== Image.Ready
+                 && root.thumbnailStatus !== Image.Error
+                 && root.retryCount < 15
         onTriggered: {
-            if (root.thumbnailStatus == Image.Null) {
-                updateThumbnail()
-            }
+            root.retryCount++
+            updateThumbnail()
         }
     }
 

--- a/meshroom/ui/qml/ImageGallery/ImageDelegate.qml
+++ b/meshroom/ui/qml/ImageGallery/ImageDelegate.qml
@@ -170,7 +170,10 @@ Item {
                     }
                     BusyIndicator {
                         anchors.centerIn: parent
-                        running: grid_thumbnail.status != Image.Ready
+                        running: grid_thumbnail.status === Image.Loading
+                                 || (grid_thumbnail.status === Image.Null
+                                     && root.thumbnailSource == ""
+                                     && retryTimer.running)
                     }
                 }
 
@@ -250,7 +253,10 @@ Item {
                     }
                     BusyIndicator {
                         anchors.centerIn: parent
-                        running: list_thumbnail.status != Image.Ready
+                        running: list_thumbnail.status === Image.Loading
+                                 || (list_thumbnail.status === Image.Null
+                                     && root.thumbnailSource == ""
+                                     && retryTimer.running)
                     }
                 }
 


### PR DESCRIPTION
## Description

This PR improves the reliability and user experience of thumbnail loading in the Meshroom UI, both in the Python backend and QML frontend. It introduces more robust handling of failed thumbnail generation, type annotations for better code clarity, and a retry mechanism in the UI to ensure thumbnails are displayed whenever possible.

This fixes a common issue where, especially for EXR/RAW images, the thumbnails would appear to load indefinitely in the Image Gallery while the view was on them. When thumbnails were stuck in such a state, the only workaround was to scroll up or down in the Image Gallery to get them out of view, and then bring them back. By moving them out of view and then bringing them back in, the timer was reset and the thumbnail display updated, whereas the thumbnail was never displayed even if it had successfully been created (if it had not been created fast enough) while it remained in focus.

A similar problem occurred on the homepage, when loading the "Projects" tab. 

In both cases, a 2s-long timer is now used to attempt displaying the thumbnail with a retry count of 15 attempts, meaning that we wait at most for 30s for the thumbnail to be created/found; past 30s, the thumbnail is considered as "in error", and the busy indicator stops being displayed.

Additionally, the thumbnail Python component now handles failed thumbnail creation differently: images that permanently fail thumbnail creation are tracked, and a signal is emitted even on failure (prior to this PR, on failure, no signal was emitted, meaning the UI could never get this information). When the thumbnail failed to be created, trying to access it returns the original image source as a fallback, rather than re-queuing an asynchronous request that will fail again. This also allows the QML `Image` element to either display the source image, or report the `Image.Error` status.