### PR TITLE
[ImageGallery] Fix: Correctly set the selected index of the gallery model

### DIFF
--- a/meshroom/ui/qml/ImageGallery/ImageGridView.qml
+++ b/meshroom/ui/qml/ImageGallery/ImageGridView.qml
@@ -54,8 +54,11 @@ GridView {
     function updateCurrentIndexFromSelectionViewId() {
         if (!sortedModel) return
         var idx = sortedModel.find(_currentScene.selectedViewId, "viewId")
-        if (idx >= 0 && root.currentIndex !== idx) {
-            root.currentIndex = idx
+        if (idx >= 0) {
+            if (root.currentIndex !== idx) {
+                root.currentIndex = idx
+            }
+            sortedModel.selectedIndex = idx
         }
     }
     

--- a/meshroom/ui/qml/ImageGallery/ImageListView.qml
+++ b/meshroom/ui/qml/ImageGallery/ImageListView.qml
@@ -55,8 +55,11 @@ ListView {
     function updateCurrentIndexFromSelectionViewId() {
         if (!sortedModel) return
         var idx = sortedModel.find(_currentScene.selectedViewId, "viewId")
-        if (idx >= 0 && root.currentIndex !== idx) {
-            root.currentIndex = idx
+        if (idx >= 0) {
+            if (root.currentIndex !== idx) {
+                root.currentIndex = idx
+            }
+            sortedModel.selectedIndex = idx
         }
     }
     


### PR DESCRIPTION
## Description

This PR fixes the update of the selected image in the Image Gallery when the update comes from an external source (e.g. from the Sequence Player's timeline, or from the selection of cameras in the 3D Viewer). The selected index was only being updated when the user clicked on an image delegate in the gallery, but never when the `selectedViewId` was changed from an external source, such as the Sequence Player or the 3D Viewer.

`currentIndex` was correctly updated (meaning the navigation index of the gallery was indeed correct, i.e. including the selected view) but `selectedIndex` itself was never updated, so the highlight remained on the previously selected image (even if it was out of the updated navigation view). `selectedIndex` is now correctly set whenever a matching view ID is found, thus ensuring the selected image in the Gallery is the correct one, regardless of whether the selection originated from the Gallery itself, the Sequence Player or the 3D Viewer.

