### PR TITLE
[nodes] Fix `CopyFiles` copytree parameters

### DIFF
--- a/meshroom/nodes/general/CopyFiles.py
+++ b/meshroom/nodes/general/CopyFiles.py
@@ -80,7 +80,7 @@ This node allows to copy files into a specific folder.
                 # If the input is a directory, copy the directory's content
                 if os.path.isdir(iFile):
                     chunk.logger.info(f"CopyFiles directory {iFile} into {oFile}.")
-                    shutil.copytree(iFile, oFile)
+                    shutil.copytree(iFile, oFile, dirs_exist_ok=True)
                 else:
                     chunk.logger.info(f"CopyFiles file {iFile} into {oFile}.")
                     shutil.copyfile(iFile, oFile)


### PR DESCRIPTION
This pull request updates the `CopyFiles` node to improve how directories are copied when the destination already exists. The change ensures that copying a directory into an existing destination will merge contents instead of raising an error.

**File copy behavior improvement:**

* Updated `shutil.copytree` in `CopyFiles.py` to use the `dirs_exist_ok=True` parameter, allowing directory contents to be merged into an existing destination directory without error.