### PR TITLE
Add roma describer type

### DIFF
--- a/meshroom/core/utils.py
+++ b/meshroom/core/utils.py
@@ -5,7 +5,7 @@ COLORSPACES = ["AUTO", "sRGB", "rec709", "Linear", "ACES2065-1", "ACEScg", "Line
                "Log3G10 REDWideGamutRGB", "Linear Venice S-Gamut3.Cine", "S-Log3 Venice S-Gamut3.Cine", "no_conversion"]
 
 DESCRIBER_TYPES = ["sift", "sift_float", "sift_upright", "dspsift", "akaze", "akaze_liop", "akaze_mldb", "cctag3",
-                   "cctag4", "sift_ocv", "akaze_ocv", "tag16h5", "survey", "unknown"]
+                   "cctag4", "sift_ocv", "akaze_ocv", "tag16h5", "survey", "roma", "unknown"]
 
 EXR_STORAGE_DATA_TYPE = ["float", "half", "halfFinite", "auto"]
 


### PR DESCRIPTION
This pull request makes a minor update to the list of available feature describer types in the `meshroom/core/utils.py` file by adding a new option.

- Feature describer types:
  * Added `"roma"` to the `DESCRIBER_TYPES` list to support an additional feature describer.