### PR TITLE
Fix issue where computation starts before the chunks are created

### DIFF
--- a/bin/meshroom_compute
+++ b/bin/meshroom_compute
@@ -103,9 +103,29 @@ if args.node:
         submittedStatuses.append(Status.SUBMITTED)
 
     if args.iteration >= 0 and not node._chunksCreated:
-        print(f"Error: Computing chunk {args.iteration} of node {node} before chunks have been created. " \
-              f"See file: \"{node.nodeStatusFile}\".")
-        sys.exit(-1)
+        # On a render farm, the nodeStatus file written by meshroom_createChunks may not be
+        # immediately visible on this blade due to NFS propagation delays.
+        # Wait for the file to appear and retry loading before giving up.
+        import time
+        retryInterval = 2    # seconds between retries
+        maxRetryTime = 10    # total seconds before giving up
+        elapsed = 0
+        while not node._chunksCreated and elapsed < maxRetryTime:
+            logging.warning(
+                f"Chunks not created from cache for node {node.name} "
+                f"(nodeStatusFile: \"{node.nodeStatusFile}\"). "
+                f"Retrying in {retryInterval}s ({elapsed}/{maxRetryTime}s elapsed)..."
+            )
+            time.sleep(retryInterval)
+            elapsed += retryInterval
+            node.updateStatusFromCache()
+
+        if not node._chunksCreated:
+            logging.error(
+                f"Computing chunk {args.iteration} of node {node} but chunks have not been "
+                f"created after waiting {maxRetryTime}s. See file: \"{node.nodeStatusFile}\"."
+            )
+            sys.exit(-1)
 
     if node.isInputNode:
         print(f"InputNode: No computation to do.")

--- a/bin/meshroom_createChunks
+++ b/bin/meshroom_createChunks
@@ -95,6 +95,8 @@ if not node._chunksCreated:
     # Create node chunks
     # Once created we don't have to do it again even if we relaunch the job
     node.createChunks()
+    if not node._chunksCreated:
+        logging.error(f"Failed to create chunks for node {node.name}.")
     # Set the chunks statuses
     for chunk in node._chunks:
         if args.forceCompute or chunk._status.status != Status.SUCCESS:
@@ -102,6 +104,10 @@ if not node._chunksCreated:
             chunk._status.setNode(node)
             chunk._status.initExternSubmit()
             chunk.upgradeStatusFile()
+        else:
+            if not args.forceCompute:
+                logging.warning(f"Chunk {chunk} status is {chunk._status.status}.")
+                logging.warning(f"The status file has not been updated for this chunk.")
 
 # Get chunks to process in the current process
 chunksToProcess = []

--- a/meshroom/core/node.py
+++ b/meshroom/core/node.py
@@ -147,10 +147,16 @@ class NodeStatusData(BaseObject):
         for _k, _v in d.items():
             if isinstance(_v, Enum):
                 d[_k] = _v.name
-        if self.chunks:
+        if self.chunks and self.chunks.nbBlocks > 0:
             d["chunksBlockSize"] = self.chunks.blockSize
             d["chunksFullSize"] = self.chunks.fullSize
             d["chunksNbBlocks"] = self.chunks.nbBlocks
+        else:
+            # Ensure we do not write chunk keys with zero/invalid values,
+            # as they would create a poisoned NodeChunkSetup(0,0,0) on reload
+            d.pop("chunksBlockSize", None)
+            d.pop("chunksFullSize", None)
+            d.pop("chunksNbBlocks", None)
         return d
 
     def fromDict(self, d):
@@ -161,7 +167,8 @@ class NodeStatusData(BaseObject):
             blockSize = int(d.pop("chunksBlockSize") or 0)
             fullSize = int(d.pop("chunksFullSize") or 0)
             nbBlocks = int(d.pop("chunksNbBlocks") or 0)
-            self.chunks = NodeChunkSetup(blockSize, fullSize, nbBlocks)
+            if nbBlocks > 0:
+                self.chunks = NodeChunkSetup(blockSize, fullSize, nbBlocks)
         if "status" in d:
             self.status: Status = Status[d.pop("status")]
         if "execMode" in d:
@@ -2317,6 +2324,12 @@ class Node(BaseNode):
         # This prevents updateLocked() from using a stale status (e.g. SUCCESS or SUBMITTED)
         # which could cause the node to be incorrectly locked.
         self._nodeStatus.status = Status.NONE
+        # Clear stale chunk setup from nodeStatus so that updateStatusFromCache()
+        # correctly detects when chunks need to be recreated from cache.
+        # Without this, the stale _nodeStatus.chunks value would match the
+        # freshly loaded value, causing chunkChanged to be False and skipping
+        # createChunksFromCache() — leaving _chunksCreated = False.
+        self._nodeStatus.resetChunkInfo()
         # Recreate list with reset values (1 chunk or the static size)
         if not self.isParallelized:
             self._chunks.setObjectList([NodeChunk(self, desc.Range())])

--- a/meshroom/core/node.py
+++ b/meshroom/core/node.py
@@ -1628,8 +1628,13 @@ class BaseNode(BaseObject):
         """ Update node status based on status file content/existence. """
         # Update nodeStatus from cache
         chunkChanged = self.updateNodeStatusFromCache()
-        # Create chunks if we found info on them on the node cache
-        if chunkChanged and self._nodeStatus.nbChunks > 0:
+        # Create chunks from cache if:
+        #  - The chunk setup has changed (normal case: nodeStatus was reloaded with new data), OR
+        #  - Chunks have not been created yet (recovery: a previous load cycle may have loaded
+        #    the nodeStatus without triggering createChunksFromCache, e.g. due to a silent error
+        #    in loadFromCache or an extra graph.update() that didn't reset the node's chunk info).
+        # In both cases, the nodeStatus must contain valid chunk information (nbChunks > 0).
+        if (chunkChanged or not self._chunksCreated) and self._nodeStatus.nbChunks > 0:
             # Update number of chunks
             try:
                 self.createChunksFromCache()

--- a/meshroom/core/node.py
+++ b/meshroom/core/node.py
@@ -1658,6 +1658,11 @@ class BaseNode(BaseObject):
         """ Write node status on disk. """
         # Make sure the node has the globalStatus before saving it
         self._nodeStatus.status = self.getGlobalStatus()
+        # Ensure chunk info is always in sync with the actual chunks before writing,
+        # as _nodeStatus.chunks can be cleared by _resetChunks/loadFromCache and may not
+        # have been restored (e.g. after createChunksFromCache which does not call setChunks).
+        if self._chunksCreated and self._chunks:
+            self._nodeStatus.setChunks(self._chunks)
         data = self._nodeStatus.toDict()
         statusFilepath = self.nodeStatusFile
         folder = os.path.dirname(statusFilepath)

--- a/meshroom/core/node.py
+++ b/meshroom/core/node.py
@@ -1671,6 +1671,12 @@ class BaseNode(BaseObject):
         hasChunkToLaunch = False
         if not self._chunksCreated:
             hasChunkToLaunch = True
+            # Clear any stale chunk info from nodeStatus so that:
+            # 1. The nodeStatus file written below does NOT contain chunk setup keys.
+            # 2. When `meshroom_createChunks` runs on the farm, its call to
+            #    `updateStatusFromCache()` will NOT recreate chunks from stale cache,
+            #    allowing `node.createChunks()` to evaluate fresh chunk parameters.
+            self._nodeStatus.resetChunkInfo()
         for chunk in self._chunks:
             if forceCompute or chunk._status.status != Status.SUCCESS:
                 hasChunkToLaunch = True
@@ -1693,6 +1699,9 @@ class BaseNode(BaseObject):
         hasChunkToLaunch = False
         if not self._chunksCreated:
             hasChunkToLaunch = True
+            # Same rationale as initStatusOnSubmit: clear stale chunk info
+            # so that the nodeStatus file does not contain outdated chunk setup.
+            self._nodeStatus.resetChunkInfo()
         for chunk in self._chunks:
             if forceCompute or (chunk._status.status not in (Status.RUNNING, Status.SUCCESS)):
                 hasChunkToLaunch = True


### PR DESCRIPTION
## Description

This PR improves the handling and synchronization of chunk setup information in the node status logic to prevent stale or invalid chunk data from being written or reloaded. The changes ensure that chunk-related fields are only present in the node status when valid, and that stale chunk information is cleared in key workflow steps to avoid errors or inconsistencies during reloads and computation.

This essentially fixes an issue that might occur on farm where tasks are created before the chunks have effectively been created, leading to the following error: 
> Error: Computing chunk x of node Y before chunks have been created.

This issue is fixed by ensuring that chunk information in the status file is always synchronized with the actual chunks before writing to disk; this prevents mismatches after cache reloads or chunk resets, and having a `nodeStatus` file that does not contain any chunk-related keys while the `.status` files for the chunks have been written on disk becomes impossible.

## Implementation remarks

In addition to the fix itself, this PR includes:
- a fallback in `meshroom_compute` that aims at pushing against filesystems propagation delays: on a render farm, there may be cases where the `nodeStatus` file has been properly updated but its changes are not immediately visible. If the `nodeStatus` file does not contain any chunk information whereas we know that chunks should have been created, we attempt to reload it every 2s (up to 10s). If the chunk information are found between the timeout, the process goes on without a hitch; otherwise, we exit with an error.
- Chunk information are only serialized if valid chunks exist, and only deserialized if they do not create an invalid chunk setup.
- Stale chunk information are cleared from the `nodeStatus` file before submitting or computing, ensuring up-to-date chunk parameters are used and preventing the re-creation of chunks from outdated cache data.
-  `updateStatusFromCache` is improved to recover from missed chunk creation by checking both for chunk setup changes and for cases where chunks haven't been created yet, ensuring chunks are recreated from cache when necessary.
