### PR TITLE
[graph] Add possibility to set a specific cacheDir in the mg scene

### DIFF
--- a/bin/meshroom_batch
+++ b/bin/meshroom_batch
@@ -4,7 +4,6 @@ import json
 import logging
 import os
 import re
-import sys
 
 import meshroom.core.graph
 from meshroom.common import strtobool
@@ -122,6 +121,15 @@ advanced_group.add_argument(
     help='A JSON file containing the graph parameters override.')
 
 advanced_group.add_argument(
+    '--overrideCacheDir', metavar='STRING', type=str, default=None,
+    help=(
+        'Override the cache location for the scene. If the scene is saved, the cache will be '
+        'set as the selected location. By default the cache location will be set as a folder '
+        'named MeshroomCavhe at the project file root folder.'
+    )
+)
+
+advanced_group.add_argument(
     '--paramOverrides', metavar='NODETYPE:param=value NODEINSTANCE.param=value', type=str, default=None, nargs='*',
     help='Override specific parameters directly from the command line (by node type or by node names).')
 
@@ -175,6 +183,10 @@ with meshroom.core.graph.GraphModification(graph):
     else:
         # custom pipeline
         graph.initFromTemplate(args.pipeline, copyOutputs=True if args.output else False)
+
+    if args.overrideCacheDir is not None:
+        # Set the cache folder
+        graph.setExplicitCacheDir(args.overrideCacheDir)
 
     # Set invalidation string
     if args.setInvalidationString:

--- a/meshroom/core/graph.py
+++ b/meshroom/core/graph.py
@@ -222,8 +222,11 @@ class Graph(BaseObject):
         # Edges: use dst attribute as unique key since it can only have one input connection
         self._edges = DictModel(keyAttrName='dst', parent=self)
         self._compatibilityNodes = DictModel(keyAttrName='name', parent=self)
-        self._cacheDir: str = ''
-        self._filepath: str = ''
+        self._hasExplicitCacheDir: bool = False
+        self._absoluteCacheDir: str = ""
+        self._relativeCacheDir: str = ""
+        self._cacheDir: str = ""
+        self._filepath: str = ""
         self._fileDateVersion = 0
         self.header = {}
 
@@ -311,6 +314,9 @@ class Graph(BaseObject):
         fileVersion = Version(self.header.get(GraphIO.Keys.FileVersion, "0.0"))
         graphContent = self._normalizeGraphContent(graphData, fileVersion)
         isTemplate = self.header.get(GraphIO.Keys.Template, False)
+        explicitCachePaths = self.header.get(GraphIO.Keys.CacheDir)
+        if explicitCachePaths:
+            self._deserializeCacheDir(explicitCachePaths)
 
         with GraphModification(self):
             # iterate over nodes sorted by suffix index in their names
@@ -334,6 +340,36 @@ class Graph(BaseObject):
         # It is now possible to check whether the UIDs stored in the graph file for each node correspond to the ones
         # that were computed.
         self._evaluateUidConflicts(graphContent)
+
+    def _deserializeCacheDir(self, explicitCachePaths):
+        """ Set correct cacheDir and _relativeCacheDir if the info is set in the file """
+        if not isinstance(explicitCachePaths, dict):
+            logging.error(f"Failed to deserialize cacheDir from {explicitCachePaths}. We expect a dictionnary.")
+            return
+        absoluteCacheDir = explicitCachePaths.get("absoluteCacheDir")
+        relativeCacheDir = explicitCachePaths.get("relativeCacheDir")
+        if not all((absoluteCacheDir, relativeCacheDir)):
+            logging.error(f"Failed to deserialize cacheDir from {explicitCachePaths}. Missing key(s).")
+            return
+        # Try to get the cacheDir from the absoluteCacheDir
+        if Path(absoluteCacheDir).exists():
+            logging.info(f"Using {absoluteCacheDir} as cache directory.")
+            self.cacheDir = str(absoluteCacheDir)
+            self._hasExplicitCacheDir = True
+        elif relativeCacheDir:
+            absolutePath = Path(self._filepath).parent.absolute() / relativeCacheDir
+            if Path(absolutePath).exists():
+                logging.info(f"Using {relativeCacheDir} ({absolutePath}) as cache directory.")
+                self.cacheDir = str(absolutePath)
+                self._hasExplicitCacheDir = True
+            else:
+                logging.warning(f"Could not find a cache from relative path {relativeCacheDir}.")
+        else:
+            logging.warning(f"Could not find caches from {explicitCachePaths}.")
+        # If we managed to find an explicit cacheDir
+        if self._hasExplicitCacheDir:
+            self._absoluteCacheDir = absoluteCacheDir
+            self._relativeCacheDir = relativeCacheDir
 
     def _normalizeGraphContent(self, graphData: dict, fileVersion: Version) -> dict:
         graphContent = graphData.get(GraphIO.Keys.Graph, graphData)
@@ -1498,7 +1534,10 @@ class Graph(BaseObject):
         #  * cache folder is located next to the graph file
         #  * graph name if the basename of the graph file
         self.name = os.path.splitext(os.path.basename(filepath))[0]
-        self.cacheDir = os.path.join(os.path.abspath(os.path.dirname(filepath)), meshroom.core.cacheFolderName)
+        if self._hasExplicitCacheDir:
+            self.setExplicitCacheDir(self._relativeCacheDir)
+        else:
+            self.setDefaultCacheDir()
         self.filepathChanged.emit()
 
     def _unsetFilepath(self):
@@ -1674,6 +1713,51 @@ class Graph(BaseObject):
         self.updateInternals(force=True)
         self.updateStatusFromCache(force=True)
         self.cacheDirChanged.emit()
+
+    @property
+    def defaultCacheDir(self):
+        filepath = Path(self._filepath)
+        cacheDir = filepath.parent.absolute() / meshroom.core.cacheFolderName
+        return str(cacheDir)
+
+    def setDefaultCacheDir(self):
+        """ Set the cacheDir to the default path """
+        self._hasExplicitCacheDir = False
+        self._relativeCacheDir = ""
+        self._absoluteCacheDir = ""
+        self.cacheDir = self.defaultCacheDir
+
+    def setExplicitCacheDir(self, value: str):
+        """
+        Set the cache directory to a specific folder.
+        When set this way, it will be serialized in the graph file
+        and will take priority over the default location on load.
+        """
+        if not value:
+            logging.warning("Reset the cache directory")
+            self.setDefaultCacheDir()
+            return
+
+        if Path(value).is_absolute():
+            absoluteCacheDir = value
+            # Get relative cache dir
+            base = Path(self._filepath).parent.absolute()
+            relativeCacheDir = os.path.relpath(value, base)
+        else:
+            relativeCacheDir = value
+            # Get absolute cache dir
+            base = Path(self._filepath).parent.absolute()
+            absoluteCacheDir = str((base / value).resolve())
+
+        # Create the folder
+        if not os.path.exists(absoluteCacheDir):
+            logging.info(f"Create cache folder {absoluteCacheDir}")
+            os.makedirs(absoluteCacheDir, exist_ok=True)
+
+        self.cacheDir = absoluteCacheDir
+        self._absoluteCacheDir = str(Path(absoluteCacheDir))
+        self._relativeCacheDir = str(Path(relativeCacheDir))
+        self._hasExplicitCacheDir = True
 
     @property
     def fileDateVersion(self):

--- a/meshroom/core/graphIO.py
+++ b/meshroom/core/graphIO.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
 class GraphIO:
     """Centralize Graph file keys and IO version."""
 
-    __version__ = "2.0"
+    __version__ = "2.1"
 
     class Keys:
         """File Keys."""
@@ -23,6 +23,7 @@ class GraphIO:
         NodesVersions = "nodesVersions"
         ReleaseVersion = "releaseVersion"
         FileVersion = "fileVersion"
+        CacheDir = "cacheDir"
         Graph = "graph"
         Template = "template"
 
@@ -94,6 +95,13 @@ class GraphSerializer:
         header[GraphIO.Keys.ReleaseVersion] = meshroom.__version__
         header[GraphIO.Keys.FileVersion] = GraphIO.__version__
         header[GraphIO.Keys.NodesVersions] = self._getNodeTypesVersions()
+        if self._graph._hasExplicitCacheDir:
+            # We store the absolute but also the relative cacheDir path (to the scene file)
+            # to make sure that if we move the scene+cacheDir we can still retrieve the cache 
+            header[GraphIO.Keys.CacheDir] = {
+                "absoluteCacheDir": self._graph._absoluteCacheDir,
+                "relativeCacheDir": self._graph._relativeCacheDir,
+            }
         return header
 
     def _getNodeTypesVersions(self) -> dict[str, str]:

--- a/tests/test_graphIO.py
+++ b/tests/test_graphIO.py
@@ -3,7 +3,7 @@ import os
 from textwrap import dedent
 from pathlib import Path
 
-from meshroom.core import desc
+from meshroom.core import desc, cacheFolderName
 from meshroom.core.graph import Graph, loadGraph
 from meshroom.core.node import CompatibilityIssue, CompatibilityNode
 
@@ -256,6 +256,35 @@ class TestGraphSave:
             graph.saveAsNewVersion()
             newScenePath = os.path.join(tmp_path, "scene1.mg")
             assert os.path.exists(newScenePath)
+    
+    def test_cacheDir(self, graphSavedOnDisk, tmp_path):
+        """ Check features related to the cacheDir
+        - default/explicit location
+        - serialization of explicit location
+        """
+        graph: Graph = graphSavedOnDisk
+        root = Path(graph._filepath).parent
+        assertPathsAreEqual(graph.cacheDir, os.path.join(root, cacheFolderName))
+        # Change cacheDir
+        newCacheDir = root / "MeshroomNewCache"
+        graph.setExplicitCacheDir(str(newCacheDir))
+        assertPathsAreEqual(graph.cacheDir, newCacheDir)
+        # Save
+        graph.save()
+        # Open in a different graph
+        # Check the cache dir is the explicit location
+        otherGraph = Graph("")
+        otherGraph.load(graph.filepath)
+        assertPathsAreEqual(otherGraph.cacheDir, newCacheDir)
+        # Remove explicit cache dir
+        # Then save and reopen
+        # Check the cache dir is the default location
+        otherGraph.setDefaultCacheDir()
+        otherGraphFilepath = os.path.join(tmp_path, "otherGraph.mg")
+        otherGraph.save(filepath=otherGraphFilepath)
+        otherGraph = Graph("")
+        otherGraph.load(otherGraphFilepath)
+        assertPathsAreEqual(otherGraph.cacheDir, os.path.join(tmp_path, cacheFolderName))
 
 
 class TestGraphPartialSerialization:


### PR DESCRIPTION
# Description

Add possibility to set a specific cache folder in the mg scene
- In `meshroom_batch` a new option enables saving the scene with a specific cache folder.
- a `_explicitCacheDir` parameter in the `Graph` tracks the explicit path we set (can be absolute or relative)
- functions were added to set the default cache path or a custom one

About the Meshroom file :
- `graphIO` : a `CacheDir` key was added to the serialized format. Serialization is designed to save the cacheDir inside the `.mg` file
- `graph` : the deserialization is designed to load the explicit cache folder if we get one, and if we don't to select the default path (`./MeshroomCache`)
- the serialized cacheDir can be a list, and in this case when deserialized we will iterate over elements and take the first one whose folder exists.

We can see the custom cache directory on the status bar :
<img width="548" height="80" alt="image" src="https://github.com/user-attachments/assets/b3fa1b31-b939-47a0-9fbb-5c8ba84948ee" />

# Tests

Here is a command that can be used to set a new cache directory in a meshroom file
```sh
ROOT="..."
MG_FILE_IN="$ROOT/scene.mg"
MG_FILE_OUT="$MG_FILE_IN"
CACHE_DIR="$ROOT/MeshroomCache-v001"
meshroom_batch -p $MG_FILE_IN -s $MG_FILE_OUT --compute no --overrideCacheDir $CACHE_DIR
```

The following steps can test this feature :
1. Create a new meshroom scene
2. Compute the graph
3. Close it
4. Follow above script to set a new custom cache
5. Open the scene
6. You should see that the nodes are considered not computed (because we changed the cache to an empty folder). The new cache folder is set and can be seen on the status bar (at the bottom)
7. Empty the previous cache folder (`MeshroomCache`)
8. Launch the process on the current (new) scene
9. It doesn't affect the original cache folder but the new cache is filled with the current scene nodes computation data