### PR TITLE
[tests] Fix test_submit when launched through a rez env

### DIFF
--- a/meshroom/submitters/localFarmSubmitter.py
+++ b/meshroom/submitters/localFarmSubmitter.py
@@ -204,6 +204,7 @@ class LocalFarmSubmitter(BaseSubmitter):
 
     dryRun = False
     environment = {}
+    disabled_rez = False
 
     def __init__(self, parent=None):
         super().__init__(parent=parent)
@@ -235,13 +236,13 @@ class LocalFarmSubmitter(BaseSubmitter):
                 it = [Chunk(i, item[0], item[-1]) for i, item in enumerate(slices) if i not in ignoreIterations]
         return it
 
-    @staticmethod
-    def getExpandWrappedCmd(cmdArgs, rezPackages):
+    def getExpandWrappedCmd(self, cmdArgs, rezPackages):
         # Wrap with create_chunks
         cmdBin = wrapMeshroomBin("meshroom_createChunks")
         cmd = f"{cmdBin} --submitter LocalFarm {cmdArgs}"
         # Wrap with rez
-        cmd = rezWrapCommand(cmd, otherRezPkg=rezPackages)
+        if not self.disabled_rez:
+            cmd = rezWrapCommand(cmd, otherRezPkg=rezPackages)
         return cmd
 
     def __createChunkTasks(self, job: Job, parentTask: Task, children: List[Task], chunkParams: dict) -> Task:
@@ -253,7 +254,8 @@ class LocalFarmSubmitter(BaseSubmitter):
             meta["iteration"] = c.iteration
             cmdBin = wrapMeshroomBin("meshroom_compute")
             cmd = f"{cmdBin} {cmdArgs} --iteration {c.iteration}"
-            cmd = rezWrapCommand(cmd, otherRezPkg=self.reqPackages)
+            if not self.disabled_rez:
+                cmd = rezWrapCommand(cmd, otherRezPkg=self.reqPackages)
             chunkTask = Task(name=name, command=cmd, metadata=meta, env=self.jobEnv)
             job.addTask(chunkTask)
             for child in children:
@@ -286,7 +288,8 @@ class LocalFarmSubmitter(BaseSubmitter):
         else:
             cmdBin = wrapMeshroomBin("meshroom_compute")
             cmd = f"{cmdBin} {cmdArgs} --iteration 0"
-            cmd = rezWrapCommand(cmd, otherRezPkg=self.reqPackages)
+            if not self.disabled_rez:
+                cmd = rezWrapCommand(cmd, otherRezPkg=self.reqPackages)
             task = Task(name=node.name, command=cmd, metadata=metadata, env=self.jobEnv)
             task = CreatedTask(task, None)
 

--- a/tests/test_submit.py
+++ b/tests/test_submit.py
@@ -76,6 +76,7 @@ def processSubmit(node: Node, graph, tmp_path):
     try:
         print(f"submit {node}")
         submitter = get_submitter()
+        submitter.disabled_rez = True
         submitter.setFarmPath(tmp_path)
         submitter.setJobEnv(getJobEnv())
         nodesToProcess, edgesToProcess = [node], []
@@ -102,16 +103,9 @@ def processSubmit(node: Node, graph, tmp_path):
 
 class TestNodeSubmit:
     __test__ = IS_LINUX
-    __env__ = {}
-    
+
     @classmethod
     def setup_class(cls):
-        cls.__env__ = {}
-        for var in ["REZ_REQUEST", "REZ_RESOLVE", "REZ_USED_REQUEST", "REZ_MESHROOM_VERSION"]:
-            if var in os.environ:
-                cls.__env__[var] = os.environ[var]
-                del os.environ[var]
-
         # meshroom.core.initSubmitters()
         submitters = loadSubmitters(meshroomFolder, "submitters")
         for submitter in submitters:
@@ -127,9 +121,6 @@ class TestNodeSubmit:
 
     @classmethod
     def teardown_class(cls):
-        for var, value in cls.__env__.items():
-            os.environ[var] = value
-
         for node in cls.plugin.nodes.values():
             pluginManager.unregisterNode(node)
         pluginManager.removePlugin(cls.plugin)

--- a/tests/test_submit.py
+++ b/tests/test_submit.py
@@ -102,9 +102,16 @@ def processSubmit(node: Node, graph, tmp_path):
 
 class TestNodeSubmit:
     __test__ = IS_LINUX
-
+    __env__ = {}
+    
     @classmethod
     def setup_class(cls):
+        cls.__env__ = {}
+        for var in ["REZ_REQUEST", "REZ_RESOLVE", "REZ_USED_REQUEST", "REZ_MESHROOM_VERSION"]:
+            if var in os.environ:
+                cls.__env__[var] = os.environ[var]
+                del os.environ[var]
+
         # meshroom.core.initSubmitters()
         submitters = loadSubmitters(meshroomFolder, "submitters")
         for submitter in submitters:
@@ -120,6 +127,9 @@ class TestNodeSubmit:
 
     @classmethod
     def teardown_class(cls):
+        for var, value in cls.__env__.items():
+            os.environ[var] = value
+
         for node in cls.plugin.nodes.values():
             pluginManager.unregisterNode(node)
         pluginManager.removePlugin(cls.plugin)


### PR DESCRIPTION
# Description

When we launched the `test_submit` test from a rez env we have a Compatibility issue error :
- the test registers the submitters
- the local farm submitter is initialized
- we list local packages
- if we are on a rez env then we will wrap all commands with rez

Then when the task launches :
- before the task, the farm sets the `MESHROOM_PLUGINS_PATH`
- But when the command executes, it starts with a `rez env` command
- If one of the packages in the env have a `env.MESHROOM_PLUGINS_PATH.append(...)` then it starts by _resetting_ the `MESHROOM_PLUGINS_PATH` env variable, and we loose the content that we set here from the farm process.

# Fix

The way I fixed the issue is by resetting rez variables before the test process, and therefore when the submitter is registered in the test, tasks are created without rez. And then, we have the correct value for `MESHROOM_PLUGINS_PATH` and the test succeeds.