### PR TITLE
[core] Fix: Correctly serialize backdrop nodes for templates

### DIFF
--- a/meshroom/core/graphIO.py
+++ b/meshroom/core/graphIO.py
@@ -135,12 +135,8 @@ class TemplateGraphSerializer(GraphSerializer):
         # For now, implemented as a post-process to update the default serialization.
         nodeData = super().serializeNode(node)
 
-        inputKeys = list(nodeData["inputs"].keys())
-
-        internalInputKeys = []
-        internalInputs = nodeData.get("internalInputs", None)
-        if internalInputs:
-            internalInputKeys = list(internalInputs.keys())
+        inputKeys = list(nodeData.get("inputs", {}).keys())
+        internalInputKeys = list(nodeData.get("internalInputs", {}).keys())
 
         for attrName in inputKeys:
             attribute = node.attribute(attrName)
@@ -158,9 +154,9 @@ class TemplateGraphSerializer(GraphSerializer):
         if len(nodeData["internalInputs"]) == 0:
             del nodeData["internalInputs"]
 
-        del nodeData["outputs"]
-        del nodeData["uid"]
-        del nodeData["parallelization"]
+        nodeData.pop("outputs", None)
+        nodeData.pop("uid", None)
+        nodeData.pop("parallelization", None)
 
         return nodeData
 

--- a/tests/test_graphIO.py
+++ b/tests/test_graphIO.py
@@ -408,3 +408,43 @@ class TestImportGraphContentFromMinimalGraphData:
             }
             """)
             graph._deserialize(json.loads(sampleGraphContent))
+
+
+class TestTemplateSerialization:
+
+    def test_templateSerializationStripsOutputsUidAndParallelization(self):
+        """Test that template serialization removes outputs, uid, and parallelization."""
+        with registeredNodeTypes([SimpleNode]):
+            graph = Graph("")
+            graph.addNewNode("SimpleNode")
+
+            data = graph.serialize(asTemplate=True)
+            nodeData = data["graph"]["SimpleNode_1"]
+
+            assert "outputs" not in nodeData
+            assert "uid" not in nodeData
+            assert "parallelization" not in nodeData
+
+    def test_templateSerializationStripsDefaultInputs(self):
+        """Test that default-valued inputs are stripped from template serialization."""
+        with registeredNodeTypes([SimpleNode]):
+            graph = Graph("")
+            graph.addNewNode("SimpleNode")
+
+            data = graph.serialize(asTemplate=True)
+            nodeData = data["graph"]["SimpleNode_1"]
+
+            # All inputs are at default, so inputs should be empty or absent
+            assert nodeData.get("inputs", {}) == {}
+
+    def test_templateSerializationPreservesNonDefaultInputs(self):
+        """Test that non-default attribute values are preserved in template serialization."""
+        with registeredNodeTypes([SimpleNode]):
+            graph = Graph("")
+            node = graph.addNewNode("SimpleNode")
+            node.attribute("input").value = "/some/path"
+
+            data = graph.serialize(asTemplate=True)
+            nodeData = data["graph"]["SimpleNode_1"]
+
+            assert nodeData["inputs"]["input"] == "/some/path"

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -269,6 +269,38 @@ class TestBackdropNode:
         assert backdrop.color == "#FF0000"
         assert backdrop.comment == "hello world"
 
+    def test_backdropNode_templateSerialization(self):
+        """ Test that a graph with a backdrop node can be saved as a template. """
+        g = Graph("Backdrop node template serialization")
+        backdrop = g.addNewNode("Backdrop")
+
+        # Save the graph as a template
+        templateFile = os.path.join(tempfile.mkdtemp(), "test_backdrop_template.mg")
+        g.save(templateFile, template=True)
+
+        # Reload the graph and check both nodes are present
+        g = loadGraph(templateFile)
+        assert g.node("Backdrop_1") is not None
+
+    def test_backdropNode_templateSerialization_customAttributes(self):
+        """ Test that a backdrop node with custom values is correctly saved as a template. """
+        g = Graph("Backdrop node template custom serialization")
+        backdrop = g.addNewNode("Backdrop")
+
+        # Set custom values
+        backdrop.internalAttribute("nodeWidth").value = 400
+        backdrop.internalAttribute("comment").value = "Template backdrop"
+
+        templateFile = os.path.join(tempfile.mkdtemp(), "test_backdrop_template_custom.mg")
+        g.save(templateFile, template=True)
+
+        # Reload and verify custom values are preserved
+        g = loadGraph(templateFile)
+        backdrop = g.node("Backdrop_1")
+        assert backdrop is not None
+        assert backdrop.nodeWidth == 400
+        assert backdrop.comment == "Template backdrop"
+
 
 class TestResourceLevels:
     """ Test that cpu, gpu, and ram descriptor attributes support both static Level values and callables. """


### PR DESCRIPTION
## Description

This PR fixes the template serialization of backdrop nodes.

Nodes are serialized differently when a project is saved as a template (as opposed to a "regular" project). In particular, a filtering is applied on the inputs attributes in order to only save those which have non-default values. In the case of `BackdropNodes`, the "inputs" (and "outputs") keys do not exist in their serialized data, as they do not have any. Attempting to filter them is thus useless and prior to this PR, an error would be raised when attempting to retrieve the data from these non-existing keys.

This PR addresses that issue by ensuring that non-existing keys are dealt with accordingly (using `get` and `pop` instead of direct access and `del`), rather than checking from the start whether the node is an instance of a `BackdropNode` and returning straight away.

Additionally, we add some unit tests on the template serialization of `BackdropNodes`.
