### PR TITLE
[ui] Homepage: Highlight the pipeline or project that is being loaded

### DIFF
--- a/meshroom/ui/qml/Homepage.qml
+++ b/meshroom/ui/qml/Homepage.qml
@@ -29,6 +29,8 @@ Page {
         if (visible) {
             logo.playing = true
             isLoading = false
+            homepageGridView.loadingIndex = -1
+            pipelinesListView.loadingIndex = -1
         }
     }
 
@@ -258,6 +260,8 @@ Page {
                     id: pipelinesListView
                     visible: tabPanel.currentTab === 0
 
+                    property int loadingIndex: -1
+
                     anchors.fill: parent
                     anchors.margins: 10
 
@@ -267,6 +271,7 @@ Page {
                         id: pipelineDelegate
                         padding: 10
                         width: pipelinesListView.width
+                        enabled: !root.isLoading || index === pipelinesListView.loadingIndex
 
                         contentItem: Label {
                             id: pipeline
@@ -279,6 +284,7 @@ Page {
                             target: pipelineDelegate
                             function onClicked() {
                                 root.isLoading = true
+                                pipelinesListView.loadingIndex = index
                                 let path = modelData["path"]
                                 root.executeAfterFrameRendered(function() {
                                     mainStack.push("Application.qml")
@@ -294,6 +300,8 @@ Page {
                     visible: tabPanel.currentTab === 1
                     anchors.fill: parent
                     anchors.topMargin: cellHeight * 0.1
+
+                    property int loadingIndex: -1
 
                     cellWidth: 195
                     cellHeight: cellWidth
@@ -425,6 +433,7 @@ Page {
                                     
                                     else {
                                         root.isLoading = true
+                                        homepageGridView.loadingIndex = index
                                         let path = modelData["path"]
                                         root.executeAfterFrameRendered(function() {
                                             mainStack.push("Application.qml")
@@ -432,6 +441,7 @@ Page {
                                                 MeshroomApp.addRecentProjectFile(path)
                                             } else {
                                                 root.isLoading = false
+                                                homepageGridView.loadingIndex = -1
                                             }
                                         })
                                     }
@@ -446,6 +456,7 @@ Page {
                                     text: "Open"
                                     onTriggered: {
                                         root.isLoading = true
+                                        homepageGridView.loadingIndex = index
                                         let path = modelData["path"]
                                         root.executeAfterFrameRendered(function() {
                                             mainStack.push("Application.qml")
@@ -453,6 +464,7 @@ Page {
                                                 MeshroomApp.addRecentProjectFile(path)
                                             } else {
                                                 root.isLoading = false
+                                                homepageGridView.loadingIndex = -1
                                             }
                                         })
                                     }

--- a/meshroom/ui/qml/Homepage.qml
+++ b/meshroom/ui/qml/Homepage.qml
@@ -290,6 +290,15 @@ Page {
                             }
                         }
 
+                        // Highlight overlay shown when this pipeline is being loaded
+                        Rectangle {
+                            anchors.fill: parent
+                            color: "transparent"
+                            border.color: palette.highlight
+                            border.width: 2
+                            visible: root.isLoading && index === pipelinesListView.loadingIndex
+                        }
+
                         Connections {
                             target: pipelineDelegate
                             function onClicked() {
@@ -519,6 +528,15 @@ Page {
                                 anchors.centerIn: parent
                                 running: (homepageGridView.visible && projectContent.thumbnailBusy) || (root.isLoading && index === homepageGridView.loadingIndex)
                                 visible: running
+                            }
+
+                            // Highlight overlay shown when this project is being loaded
+                            Rectangle {
+                                anchors.fill: parent
+                                color: "transparent"
+                                border.color: palette.highlight
+                                border.width: 2
+                                visible: root.isLoading && index === homepageGridView.loadingIndex
                             }
                         }
                         Label {

--- a/meshroom/ui/qml/Homepage.qml
+++ b/meshroom/ui/qml/Homepage.qml
@@ -279,6 +279,7 @@ Page {
                             verticalAlignment: Text.AlignVCenter
                             text: modelData["name"]
                         }
+                        opacity: (!root.isLoading || index === pipelinesListView.loadingIndex) ? 1.0 : 0.4
 
                         Connections {
                             target: pipelineDelegate
@@ -338,6 +339,7 @@ Page {
 
                         width: homepageGridView.cellWidth
                         height: homepageGridView.cellHeight
+                        opacity: (!root.isLoading || index === homepageGridView.loadingIndex) ? 1.0 : 0.4
 
                         property var source: modelData["thumbnail"] ? Filepath.stringToUrl(modelData["thumbnail"]) : ""
                         property int retryCount: 0

--- a/meshroom/ui/qml/Homepage.qml
+++ b/meshroom/ui/qml/Homepage.qml
@@ -16,10 +16,13 @@ Page {
     // the UI thread is blocked by a heavy synchronous operation.
     // Uses _window (the ApplicationWindow id from main.qml) since root.window
     // is not reliably available for Page items inside a StackView.
-    function executeAfterFrameRendered(action) {
+    function executeAfterFrameRendered(action, params = undefined) {
         function onFrame() {
             _window.frameSwapped.disconnect(onFrame)
-            action()
+            if (params === undefined)
+                action()
+            else
+                action(params)
         }
         _window.frameSwapped.connect(onFrame)
     }

--- a/meshroom/ui/qml/Homepage.qml
+++ b/meshroom/ui/qml/Homepage.qml
@@ -9,10 +9,26 @@ import Controls 1.0
 Page {
     id: root
 
+    property bool isLoading: false
+
+    // Schedule an action to run after the current frame has been rendered and
+    // displayed, so that visual feedback (highlight, spinner) is visible before
+    // the UI thread is blocked by a heavy synchronous operation.
+    // Uses _window (the ApplicationWindow id from main.qml) since root.window
+    // is not reliably available for Page items inside a StackView.
+    function executeAfterFrameRendered(action) {
+        function onFrame() {
+            _window.frameSwapped.disconnect(onFrame)
+            action()
+        }
+        _window.frameSwapped.connect(onFrame)
+    }
+
     onVisibleChanged: {
         logo.playing = false
         if (visible) {
             logo.playing = true
+            isLoading = false
         }
     }
 
@@ -262,9 +278,12 @@ Page {
                         Connections {
                             target: pipelineDelegate
                             function onClicked() {
-                                // Open pipeline
-                                mainStack.push("Application.qml")
-                                _currentScene.new(modelData["path"])
+                                root.isLoading = true
+                                let path = modelData["path"]
+                                root.executeAfterFrameRendered(function() {
+                                    mainStack.push("Application.qml")
+                                    _currentScene.new(path)
+                                })
                             }
                         }
                     }
@@ -387,6 +406,8 @@ Page {
 
                                 onClicked: function(mouse) {
 
+                                    if (root.isLoading) return
+
                                     if (mouse.button === Qt.RightButton) {
 
                                         if (!modelData["path"]) { return }
@@ -403,11 +424,16 @@ Page {
                                     } 
                                     
                                     else {
-                                        // Open project
-                                        mainStack.push("Application.qml")
-                                        if (_currentScene.load(modelData["path"])) {
-                                            MeshroomApp.addRecentProjectFile(modelData["path"])
-                                        }
+                                        root.isLoading = true
+                                        let path = modelData["path"]
+                                        root.executeAfterFrameRendered(function() {
+                                            mainStack.push("Application.qml")
+                                            if (_currentScene.load(path)) {
+                                                MeshroomApp.addRecentProjectFile(path)
+                                            } else {
+                                                root.isLoading = false
+                                            }
+                                        })
                                     }
                                 }
                             }
@@ -416,13 +442,19 @@ Page {
                                 id: projectContextMenu
 
                                 MenuItem {
-                                    enabled: projectDelegate.fileExists
+                                    enabled: projectDelegate.fileExists && !root.isLoading
                                     text: "Open"
-                                    onTriggered: {                                        
-                                        if (_currentScene.load(modelData["path"])) {
+                                    onTriggered: {
+                                        root.isLoading = true
+                                        let path = modelData["path"]
+                                        root.executeAfterFrameRendered(function() {
                                             mainStack.push("Application.qml")
-                                            MeshroomApp.addRecentProjectFile(modelData["path"])
-                                        }
+                                            if (_currentScene.load(path)) {
+                                                MeshroomApp.addRecentProjectFile(path)
+                                            } else {
+                                                root.isLoading = false
+                                            }
+                                        })
                                     }
                                 }
 

--- a/meshroom/ui/qml/Homepage.qml
+++ b/meshroom/ui/qml/Homepage.qml
@@ -27,6 +27,16 @@ Page {
         _window.frameSwapped.connect(onFrame)
     }
 
+    function openProject(path) {
+        mainStack.push("Application.qml")
+        if (_currentScene.load(path)) {
+            MeshroomApp.addRecentProjectFile(path)
+        } else {
+            root.isLoading = false
+            homepageGridView.loadingIndex = -1
+        }
+    }
+
     onVisibleChanged: {
         logo.playing = false
         if (visible) {
@@ -458,15 +468,7 @@ Page {
                                         root.isLoading = true
                                         homepageGridView.loadingIndex = index
                                         let path = modelData["path"]
-                                        root.executeAfterFrameRendered(function() {
-                                            mainStack.push("Application.qml")
-                                            if (_currentScene.load(path)) {
-                                                MeshroomApp.addRecentProjectFile(path)
-                                            } else {
-                                                root.isLoading = false
-                                                homepageGridView.loadingIndex = -1
-                                            }
-                                        })
+                                        root.executeAfterFrameRendered(openProject, path)
                                     }
                                 }
                             }
@@ -481,15 +483,7 @@ Page {
                                         root.isLoading = true
                                         homepageGridView.loadingIndex = index
                                         let path = modelData["path"]
-                                        root.executeAfterFrameRendered(function() {
-                                            mainStack.push("Application.qml")
-                                            if (_currentScene.load(path)) {
-                                                MeshroomApp.addRecentProjectFile(path)
-                                            } else {
-                                                root.isLoading = false
-                                                homepageGridView.loadingIndex = -1
-                                            }
-                                        })
+                                        root.executeAfterFrameRendered(openProject, path)
                                     }
                                 }
 

--- a/meshroom/ui/qml/Homepage.qml
+++ b/meshroom/ui/qml/Homepage.qml
@@ -272,14 +272,23 @@ Page {
                         padding: 10
                         width: pipelinesListView.width
                         enabled: !root.isLoading || index === pipelinesListView.loadingIndex
-
-                        contentItem: Label {
-                            id: pipeline
-                            horizontalAlignment: Text.AlignLeft
-                            verticalAlignment: Text.AlignVCenter
-                            text: modelData["name"]
-                        }
                         opacity: (!root.isLoading || index === pipelinesListView.loadingIndex) ? 1.0 : 0.4
+
+                        contentItem: RowLayout {
+                            Label {
+                                id: pipeline
+                                Layout.fillWidth: true
+                                horizontalAlignment: Text.AlignLeft
+                                verticalAlignment: Text.AlignVCenter
+                                text: modelData["name"]
+                            }
+                            BusyIndicator {
+                                Layout.preferredWidth: 24
+                                Layout.preferredHeight: 24
+                                running: index === pipelinesListView.loadingIndex && root.isLoading
+                                visible: running
+                            }
+                        }
 
                         Connections {
                             target: pipelineDelegate
@@ -508,8 +517,8 @@ Page {
 
                             BusyIndicator {
                                 anchors.centerIn: parent
-                                running: homepageGridView.visible && projectContent.thumbnailBusy
-                                visible: homepageGridView.visible && projectContent.thumbnailBusy
+                                running: (homepageGridView.visible && projectContent.thumbnailBusy) || (root.isLoading && index === homepageGridView.loadingIndex)
+                                visible: running
                             }
                         }
                         Label {


### PR DESCRIPTION
## Description

This PR highlights the pipeline or project that is clicked on (and then loaded in the application) on the Homepage. In particular, it pushes a graphical update right before the loading process is started, ensuring the Homepage will display the loading state. 

The selected project or pipeline will be highlighted with a colored border and a busy indicator, while the non-selected projects/pipelines will have their opacity dimmed.

## Implementation remarks

The `executeAfterFrameRendered` function  has been added to ensure that a graphical update is pushed before processing the load of the selected project/pipeline, which then blocks the UI.

Closes https://github.com/alicevision/Meshroom/issues/2812.