### PR TITLE
Add usda and usdc file format for viewer3D

### DIFF
--- a/meshroom/core/attribute.py
+++ b/meshroom/core/attribute.py
@@ -53,7 +53,7 @@ class Attribute(BaseObject):
     """
     LINK_EXPRESSION_REGEX = re.compile(r'^\{[A-Za-z]+[A-Za-z0-9_.\[\]]*\}$')
     VALID_IMAGE_SEMANTICS = ["image", "imageList", "sequence"]
-    VALID_3D_EXTENSIONS = [".obj", ".stl", ".fbx", ".gltf", ".abc", ".ply"]
+    VALID_3D_EXTENSIONS = [".obj", ".stl", ".fbx", ".gltf", ".abc", ".ply", ".usdc", ".usda"]
     VALID_TEXT_EXTENSIONS = [".txt", ".json", ".log", ".csv", ".md"]
 
     @staticmethod

--- a/meshroom/ui/qml/Viewer3D/MediaLoader.qml
+++ b/meshroom/ui/qml/Viewer3D/MediaLoader.qml
@@ -57,6 +57,8 @@ import Utils 1.0
                     component = sceneLoaderEntityComponent
                 }
                 break
+            case ".usda":
+            case ".usdc":
             case ".abc": 
             case ".json":
             case ".sfm":

--- a/meshroom/ui/qml/Viewer3D/Viewer3DSettings.qml
+++ b/meshroom/ui/qml/Viewer3D/Viewer3DSettings.qml
@@ -17,6 +17,8 @@ Item {
     readonly property var supportedExtensions: {
         var exts = [".obj", ".stl", ".fbx", ".gltf", ".ply"];
         if (supportSfmData) {
+            exts.push(".usda")
+            exts.push(".usdc")
             exts.push(".abc")
             exts.push(".json")
             exts.push(".sfm")

--- a/tests/test_attributes.py
+++ b/tests/test_attributes.py
@@ -4,7 +4,7 @@ import pytest
 import logging
 logger = logging.getLogger('test')
 
-valid3DExtensionFiles = [(f'test.{ext}', True) for ext in ('obj', 'stl', 'fbx', 'gltf', 'abc', 'ply')]
+valid3DExtensionFiles = [(f'test.{ext}', True) for ext in ('obj', 'stl', 'fbx', 'gltf', 'abc', 'ply', 'usda', 'usdc')]
 invalid3DExtensionFiles = [(f'test.{ext}', False) for ext in ('', 'exe', 'jpg', 'png', 'py')]
 
 valid2DSemantics= [(semantic, True) for semantic in ('image', 'imageList', 'sequence')]


### PR DESCRIPTION
This pull request adds support for the `.usda` and `.usdc` 3D file formats throughout the codebase, ensuring they are recognized as valid 3D extensions in both the backend and the UI, and are covered by tests.

**3D File Format Support:**

* Added `.usda` and `.usdc` to the list of valid 3D file extensions in `Attribute` so they are recognized as supported formats.
* Updated the supported extensions in the 3D viewer settings (`Viewer3DSettings.qml`) to include `.usda` and `.usdc`, ensuring these formats appear as options in the UI.
* Modified the media loader (`MediaLoader.qml`) to handle `.usda` and `.usdc` files, allowing them to be loaded in the viewer.

**Testing:**

* Extended the test cases in `tests/test_attributes.py` to include `.usda` and `.usdc` as valid 3D extensions, ensuring the new formats are properly validated.