### PR TITLE
[core] fileUtils: Never call `group()` on an empty match

### DIFF
--- a/meshroom/core/fileUtils.py
+++ b/meshroom/core/fileUtils.py
@@ -9,10 +9,11 @@ def getFileElements(inputFilePath: str):
 
     filename = os.path.basename(inputFilePath)
     match = compiled_pattern.fullmatch(filename)
-    frameId_str = match.group("FRAMEID_STR")
+    frameId_str = None
 
     fileElements = {}
     if match:
+        frameId_str = match.group("FRAMEID_STR")
         fileElements = {
             "<PATH>": inputFilePath,
             "<FILENAME>": filename,
@@ -20,6 +21,7 @@ def getFileElements(inputFilePath: str):
             "<FILESTEM_PREFIX>": match.group("FILESTEM_PREFIX"),
             "<EXTENSION>": match.group("EXTENSION"),
         }
+
     if frameId_str is not None:
         fileElements["<FRAMEID_STR>"] = frameId_str
         fileElements["<FILESTEM>"] += frameId_str


### PR DESCRIPTION
## Description

This PR addresses an issue when attempting to display images in the 2D viewer while there are several CameraInit nodes in the scene.

Ensuring `match` is not `None` before calling `group()` prevents an AttributeError that causes the display in the viewer of the selected image to fail:

```
frameId_str = match.group("FRAMEID_STR")
                  ^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'group'
```
