### PR TITLE
Fix illegal attempts to connect to `NodeChunks`

### DIFF
--- a/meshroom/core/taskManager.py
+++ b/meshroom/core/taskManager.py
@@ -2,7 +2,7 @@ import os
 import traceback
 import logging
 from threading import Thread
-from PySide6.QtCore import Qt, QThread, QEventLoop, QTimer
+from PySide6.QtCore import Qt, QMetaObject, QThread, QEventLoop, QTimer
 from enum import Enum
 from meshroom.common import strtobool
 
@@ -139,7 +139,9 @@ class TaskThread(QThread):
                             except ValueError:
                                 # Node already removed (for instance a global clear of _nodesToProcess)
                                 pass
-                            n.clearSubmittedChunks()
+                            # clearSubmittedChunks may create NodeChunk QObjects; those must be
+                            # created on the main thread so QML can safely connect to them.
+                            QMetaObject.invokeMethod(n, "clearSubmittedChunks", Qt.QueuedConnection)
             node.postprocess()
 
             if stopAndRestart:

--- a/meshroom/ui/graph.py
+++ b/meshroom/ui/graph.py
@@ -12,6 +12,7 @@ from collections.abc import Iterator
 from collections import OrderedDict
 
 from PySide6.QtCore import (
+    Qt,
     Slot,
     QJsonValue,
     QObject,
@@ -150,7 +151,7 @@ class NodeStatusMonitor(QObject):
         self.monitorableNodes = []
         self.monitoredFiles = {}  # Dict {filepath: node}
         self._filesTimePoller = FilesModTimePollerThread(parent=self)
-        self._filesTimePoller.timesAvailable.connect(self.compareFilesTimes)
+        self._filesTimePoller.timesAvailable.connect(self.compareFilesTimes, Qt.QueuedConnection)
         self._filesTimePoller.start()
         self.setMonitored([])
         self.filePollerRefreshChanged.connect(self._filesTimePoller.onFilePollerRefreshChanged)


### PR DESCRIPTION
## Description

This pull request addresses thread-safety and signal connection issues in the `meshroom` application, primarily by ensuring that certain operations involving Qt objects are executed on the main thread. This helps prevent crashes and undefined behavior when interacting with QML and Qt signals from background threads.

**Qt Thread-Safety and Signal Handling Improvements:**

* Ensured that `clearSubmittedChunks` is invoked on the main thread using `QMetaObject.invokeMethod` with `Qt.QueuedConnection` in `meshroom/core/taskManager.py`, to safely create `NodeChunk` QObjects for QML connections.
* Changed the connection of the `timesAvailable` signal to the `compareFilesTimes` slot in `meshroom/ui/graph.py` to use `Qt.QueuedConnection`, ensuring the slot is executed on the main thread.

