### PR TITLE
[ui/core] Add Validators paradigm

### DIFF
--- a/meshroom/common/PySignal.py
+++ b/meshroom/common/PySignal.py
@@ -158,6 +158,10 @@ class ClassSignal:
     """
     _map = {}
 
+    def __init__(self, *args, **kwargs):
+        self._args = args
+        self._kwargs = kwargs
+
     def __get__(self, instance, owner):
         if instance is None:
             # When we access ClassSignal element on the class object without any instance,

--- a/meshroom/core/attribute.py
+++ b/meshroom/core/attribute.py
@@ -12,6 +12,7 @@ import inspect
 from collections.abc import Iterable, Sequence
 from string import Template
 from meshroom.common import BaseObject, Property, Variant, Signal, ListModel, DictModel, Slot
+from meshroom.core.desc.validators import NotEmptyValidator
 from meshroom.core import desc, hashValue
 from meshroom.core.keyValues import KeyValues
 from meshroom.core.exception import InvalidEdgeError
@@ -84,6 +85,7 @@ class Attribute(BaseObject):
         self._enabled: bool = True
         self._depth: int = root.depth + 1 if root is not None else 0
         self._exposed: bool = root.exposed if root is not None else attributeDesc.exposed
+        self._description: str = attributeDesc.description
         self._invalidate = False if self._isOutput else attributeDesc.invalidate
         self._invalidationValue = ""  # invalidation value for output attributes
         self._value = None
@@ -234,6 +236,15 @@ class Attribute(BaseObject):
             # Internal attributes are set as inputs
             self.requestNodeUpdate()
         self.valueChanged.emit()
+
+    def _get_description(self):
+        return self._description
+
+    def _set_description(self, desc):
+        if self._description == desc:
+            return
+        self._description = desc
+        self.descriptionChanged.emit()
 
     def _getKeyValues(self):
         """
@@ -401,21 +412,6 @@ class Attribute(BaseObject):
         else:
             return self._getValue() == self.getDefaultValue()
 
-    def _isValid(self):
-        """
-        Check attribute description validValue:
-            - If it is a function, execute it and return the result
-            - Otherwise, simply return true
-        """
-        if callable(self._desc.validValue):
-            try:
-                return self._desc.validValue(self.node)
-            except Exception as exc:
-                if not self.node.isCompatibilityNode:
-                    logging.warning(f"Failed to evaluate 'isValid' (node lambda) for attribute '{self.fullName}': {exc}")
-                return True
-        return True
-
     def _is2dDisplayable(self) -> bool:
         """
         Return True if the current attribute is considered as a displayable 2D file.
@@ -486,6 +482,43 @@ class Attribute(BaseObject):
         """
         # Emit if the enable status has changed
         self._setEnabled(self._getEnabled())
+
+    def getErrorMessages(self) -> list[str]:
+        """ Execute the validators and aggregate the eventual error messages"""
+
+        result = []
+
+        for validator in self.desc.validators:
+            isValid, errorMessages = validator(self.node, self)
+
+            if isValid:
+                continue
+
+            for errorMessage in errorMessages:
+                result.append(errorMessage)
+
+        return result
+
+    def _isValid(self) -> bool:
+        """ Check the validation and return False if any validator return (False, erorrs)
+        """
+
+        for validator in self.desc.validators:
+            isValid, _ = validator(self.node, self)
+
+            if not isValid:
+                return False
+
+        return True
+
+    def _isMandatory(self) -> bool:
+        """ An attribute is considered as mandatory it contain a NotEmptyValidator """
+
+        for validator in self.desc.validators:
+            if isinstance(validator, NotEmptyValidator):
+                return True
+
+        return False
 
     def _getEnabled(self) -> bool:
         if callable(self._desc.enabled):
@@ -742,6 +775,9 @@ class Attribute(BaseObject):
 
     expressionApplied = Signal()
 
+    errorMessageChanged = Signal()
+    errorMessages = Property(Variant, lambda self: self.getErrorMessages(), notify=errorMessageChanged)
+    isMandatory = Property(bool, _isMandatory, constant=True )    
 
 def raiseIfLink(func):
     """

--- a/meshroom/core/attribute.py
+++ b/meshroom/core/attribute.py
@@ -85,7 +85,6 @@ class Attribute(BaseObject):
         self._enabled: bool = True
         self._depth: int = root.depth + 1 if root is not None else 0
         self._exposed: bool = root.exposed if root is not None else attributeDesc.exposed
-        self._description: str = attributeDesc.description
         self._invalidate = False if self._isOutput else attributeDesc.invalidate
         self._invalidationValue = ""  # invalidation value for output attributes
         self._value = None
@@ -236,15 +235,6 @@ class Attribute(BaseObject):
             # Internal attributes are set as inputs
             self.requestNodeUpdate()
         self.valueChanged.emit()
-
-    def _get_description(self):
-        return self._description
-
-    def _set_description(self, desc):
-        if self._description == desc:
-            return
-        self._description = desc
-        self.descriptionChanged.emit()
 
     def _getKeyValues(self):
         """

--- a/meshroom/core/attribute.py
+++ b/meshroom/core/attribute.py
@@ -484,8 +484,7 @@ class Attribute(BaseObject):
         self._setEnabled(self._getEnabled())
 
     def getErrorMessages(self) -> list[str]:
-        """ Execute the validators and aggregate the eventual error messages"""
-
+        """ Execute the validators and aggregate the error messages if there are any. """
         result = []
 
         for validator in self.desc.validators:
@@ -500,9 +499,7 @@ class Attribute(BaseObject):
         return result
 
     def _isValid(self) -> bool:
-        """ Check the validation and return False if any validator return (False, erorrs)
-        """
-
+        """ Check the validation and return False if any validator returns (False, errors). """
         for validator in self.desc.validators:
             isValid, _ = validator(self.node, self)
 
@@ -512,8 +509,7 @@ class Attribute(BaseObject):
         return True
 
     def _isMandatory(self) -> bool:
-        """ An attribute is considered as mandatory it contain a NotEmptyValidator """
-
+        """ An attribute is considered as mandatory if it contains a NotEmptyValidator. """
         for validator in self.desc.validators:
             if isinstance(validator, NotEmptyValidator):
                 return True

--- a/meshroom/core/desc/attribute.py
+++ b/meshroom/core/desc/attribute.py
@@ -6,6 +6,10 @@ from enum import auto, Enum
 
 from meshroom.common import BaseObject, JSValue, Property, Variant, VariantList, strtobool, deprecated
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from meshroom.core.desc.validators import AttributeValidator
 
 # Pre-compile regexes for better performance on repeated calls
 _ACRONYM_RE = re.compile(r'([A-Z]+)([A-Z][a-z])')
@@ -62,7 +66,7 @@ class Attribute(BaseObject):
 
     def __init__(self, name, label, description, value, advanced, semantic, commandLineGroup, enabled,
                  keyable=False, keyType=None, invalidate=True, uidIgnoreValue=None,
-                 validValue=True, errorMessage="", visible=True, exposed=False):
+                 validValue=True, errorMessage="", visible=True, exposed=False, validators:list["AttributeValidator"]=None):
         super(Attribute, self).__init__()
         self._name = name
         self._label = convertToLabel(name) if label is None else label
@@ -76,8 +80,6 @@ class Attribute(BaseObject):
         self._invalidate = invalidate
         self._semantic = semantic
         self._uidIgnoreValue = uidIgnoreValue
-        self._validValue = validValue
-        self._errorMessage = errorMessage
         self._visible = visible
         self._exposed = exposed
         self._isExpression = (isinstance(self._value, str) and "{" in self._value) \
@@ -85,6 +87,13 @@ class Attribute(BaseObject):
         self._isDynamicValue = (self._value is None)
         self._valueType = None
 
+        if validators is None:
+            self._validators = []
+        elif isinstance(validators, (list, tuple)):
+            self._validators = validators
+        else:
+            raise RuntimeError(f"Validators should be of type 'list[AttributeValidator]', the type '{type(validators)}' is not supported.")
+        
     def getInstanceType(self):
         """ Return the correct Attribute instance corresponding to the description. """
         # Import within the method to prevent cyclic dependencies
@@ -134,7 +143,11 @@ class Attribute(BaseObject):
         except ValueError:
             return False
         return True
-
+    
+    @property
+    def validators(self):
+        return self._validators
+    
     name = Property(str, lambda self: self._name, constant=True)
     label = Property(str, lambda self: self._label, constant=True)
     description = Property(str, lambda self: self._description, constant=True)
@@ -161,8 +174,6 @@ class Attribute(BaseObject):
     invalidate = Property(Variant, lambda self: self._invalidate, constant=True)
     semantic = Property(str, lambda self: self._semantic, constant=True)
     uidIgnoreValue = Property(Variant, lambda self: self._uidIgnoreValue, constant=True)
-    validValue = Property(Variant, lambda self: self._validValue, constant=True)
-    errorMessage = Property(str, lambda self: self._errorMessage, constant=True)
     # visible:
     #   The attribute is not displayed in the Graph Editor if False but still visible in the Node Editor.
     #   This property is useful to hide some attributes that are not relevant for the user.
@@ -181,7 +192,7 @@ class ListAttribute(Attribute):
     """ A list of Attributes """
     @deprecated.depreciateParam("group", "Param 'group' on {name} should not be used anymore. Please use 'commandLineGroup' instead")
     def __init__(self, elementDesc, name, label=None, description=None, group="allParams", commandLineGroup=_setParamSentinel, 
-                 advanced=False, semantic="", enabled=True, joinChar=" ", visible=True, exposed=False, value=None):
+                 advanced=False, semantic="", enabled=True, joinChar=" ", visible=True, exposed=False, value=None, validators=None):
         """
         :param elementDesc: the Attribute description of elements to store in that list
         :param value: default value. Use None to declare a dynamic output ListAttribute
@@ -193,7 +204,7 @@ class ListAttribute(Attribute):
         
         super(ListAttribute, self).__init__(name=name, label=label, description=description, value=value,
                                             invalidate=False, commandLineGroup=commandLineGroup, advanced=advanced, semantic=semantic,
-                                            enabled=enabled, visible=visible, exposed=exposed)
+                                            enabled=enabled, visible=visible, exposed=exposed, validators=validators)
 
     def getInstanceType(self):
         # Import within the method to prevent cyclic dependencies
@@ -239,7 +250,7 @@ class GroupAttribute(Attribute):
     @deprecated.depreciateParam("group", "Param 'group' on {name} should not be used anymore. Please use 'commandLineGroup' instead")
     def __init__(self, items, name, label=None, description=None, group="allParams", commandLineGroup=_setParamSentinel, 
                  advanced=False, semantic="",  enabled=True, joinChar=" ", brackets=None, visible=True,
-                 exposed=False):
+                 exposed=False, validators=None):
         """
         :param items: the description of the Attributes composing this group
         """
@@ -250,7 +261,7 @@ class GroupAttribute(Attribute):
 
         super(GroupAttribute, self).__init__(name=name, label=label, description=description, value={},
                                              commandLineGroup=commandLineGroup, advanced=advanced, invalidate=False, semantic=semantic,
-                                             enabled=enabled, visible=visible, exposed=exposed)
+                                             enabled=enabled, visible=visible, exposed=exposed, validators=validators)
 
     def getInstanceType(self):
         # Import within the method to prevent cyclic dependencies
@@ -350,26 +361,26 @@ class Param(Attribute):
     """
     def __init__(self, name, label, description, value, commandLineGroup, advanced, semantic, enabled,
                  keyable=False, keyType=None, invalidate=True, uidIgnoreValue=None,
-                 validValue=True, errorMessage="", visible=True, exposed=False):
+                 validValue=True, errorMessage="", visible=True, exposed=False, validators=None):
         super(Param, self).__init__(name=name, label=label, description=description, value=value,
                                     keyable=keyable, keyType=keyType, commandLineGroup=commandLineGroup, advanced=advanced,
                                     enabled=enabled, invalidate=invalidate, semantic=semantic,
                                     uidIgnoreValue=uidIgnoreValue, validValue=validValue,
-                                    errorMessage=errorMessage, visible=visible, exposed=exposed)
+                                    errorMessage=errorMessage, visible=visible, exposed=exposed, validators=validators)
 
 
 class File(Attribute):
     """
     """
     @deprecated.depreciateParam("group", "Param 'group' on {name} should not be used anymore. Please use 'commandLineGroup' instead")
-    def __init__(self, name, label=None, description=None, value=None, group="allParams", commandLineGroup=_setParamSentinel, 
-                 advanced=False, invalidate=True, semantic="", enabled=True, visible=True, exposed=True):
-        
+    def __init__(self, name, label=None, description=None, value=None, group="allParams", commandLineGroup=_setParamSentinel,
+                 advanced=False, invalidate=True, semantic="", enabled=True, visible=True, exposed=True, validators=None):
+
         commandLineGroup = commandLineGroup if commandLineGroup is not _setParamSentinel else group
 
-        super(File, self).__init__(name=name, label=label, description=description, value=value, 
-                                   commandLineGroup=commandLineGroup, advanced=advanced, enabled=enabled, 
-                                   invalidate=invalidate, semantic=semantic, visible=visible, exposed=exposed)
+        super(File, self).__init__(name=name, label=label, description=description, value=value,
+                                   commandLineGroup=commandLineGroup, advanced=advanced, enabled=enabled,
+                                   invalidate=invalidate, semantic=semantic, visible=visible, exposed=exposed, validators=validators)
         self._valueType = str
 
     def validateValue(self, value):
@@ -395,15 +406,15 @@ class BoolParam(Param):
     """
     @deprecated.depreciateParam("group", "Param 'group' on {name} should not be used anymore. Please use 'commandLineGroup' instead")
     def __init__(self, name, label=None, description=None, value=None, keyable=False, keyType=None,
-                 group="allParams", commandLineGroup=_setParamSentinel, advanced=False, 
-                 enabled=True, invalidate=True, semantic="", visible=True, exposed=False):
-        
+                 group="allParams", commandLineGroup=_setParamSentinel, advanced=False,
+                 enabled=True, invalidate=True, semantic="", visible=True, exposed=False, validators=None):
+
         commandLineGroup = commandLineGroup if commandLineGroup is not _setParamSentinel else group
 
         super(BoolParam, self).__init__(name=name, label=label, description=description, value=value,
-                                        keyable=keyable, keyType=keyType, commandLineGroup=commandLineGroup, 
-                                        advanced=advanced, enabled=enabled, invalidate=invalidate, 
-                                        semantic=semantic, visible=visible, exposed=exposed)
+                                        keyable=keyable, keyType=keyType, commandLineGroup=commandLineGroup,
+                                        advanced=advanced, enabled=enabled, invalidate=invalidate,
+                                        semantic=semantic, visible=visible, exposed=exposed, validators=validators)
         self._valueType = bool
 
     def validateValue(self, value):
@@ -430,17 +441,17 @@ class IntParam(Param):
     """
     @deprecated.depreciateParam("group", "Param 'group' on {name} should not be used anymore. Please use 'commandLineGroup' instead")
     def __init__(self, name, label=None, description=None, value=None, range=None, keyable=False, keyType=None,
-                 group="allParams", commandLineGroup=_setParamSentinel, advanced=False, enabled=True, 
-                 invalidate=True, semantic="", validValue=True, errorMessage="", visible=True, exposed=False):
+                 group="allParams", commandLineGroup=_setParamSentinel, advanced=False, enabled=True,
+                 invalidate=True, semantic="", validValue=True, errorMessage="", visible=True, exposed=False, validators=None):
         self._range = range
 
         commandLineGroup = commandLineGroup if commandLineGroup is not _setParamSentinel else group
 
         super(IntParam, self).__init__(name=name, label=label, description=description, value=value,
-                                       keyable=keyable, keyType=keyType, commandLineGroup=commandLineGroup, 
-                                       advanced=advanced, enabled=enabled, invalidate=invalidate, 
+                                       keyable=keyable, keyType=keyType, commandLineGroup=commandLineGroup,
+                                       advanced=advanced, enabled=enabled, invalidate=invalidate,
                                        semantic=semantic, validValue=validValue, errorMessage=errorMessage,
-                                       visible=visible, exposed=exposed)
+                                       visible=visible, exposed=exposed, validators=validators)
         self._valueType = int
 
     def validateValue(self, value):
@@ -470,16 +481,16 @@ class FloatParam(Param):
     """
     @deprecated.depreciateParam("group", "Param 'group' on {name} should not be used anymore. Please use 'commandLineGroup' instead")
     def __init__(self, name, label=None, description=None, value=None, range=None, keyable=False, keyType=None,
-                 group="allParams", commandLineGroup=_setParamSentinel, advanced=False, enabled=True, 
-                 invalidate=True, semantic="", validValue=True, errorMessage="", visible=True, exposed=False):
+                 group="allParams", commandLineGroup=_setParamSentinel, advanced=False, enabled=True,
+                 invalidate=True, semantic="", validValue=True, errorMessage="", visible=True, exposed=False, validators=None):
         self._range = range
         commandLineGroup = commandLineGroup if commandLineGroup is not _setParamSentinel else group
 
         super(FloatParam, self).__init__(name=name, label=label, description=description, value=value,
-                                         keyable=keyable, keyType=keyType, commandLineGroup=commandLineGroup, 
-                                         advanced=advanced, enabled=enabled, invalidate=invalidate, 
+                                         keyable=keyable, keyType=keyType, commandLineGroup=commandLineGroup,
+                                         advanced=advanced, enabled=enabled, invalidate=invalidate,
                                          semantic=semantic, validValue=validValue, errorMessage=errorMessage,
-                                         visible=visible, exposed=exposed)
+                                         visible=visible, exposed=exposed, validators=validators)
         self._valueType = float
 
     def validateValue(self, value):
@@ -507,15 +518,15 @@ class PushButtonParam(Param):
     """
     """
     @deprecated.depreciateParam("group", "Param 'group' on {name} should not be used anymore. Please use 'commandLineGroup' instead")
-    def __init__(self, name, label=None, description=None, group="allParams", commandLineGroup=_setParamSentinel, 
-                 advanced=False, enabled=True, invalidate=True, semantic="", visible=True, exposed=False):
-        
+    def __init__(self, name, label=None, description=None, group="allParams", commandLineGroup=_setParamSentinel,
+                 advanced=False, enabled=True, invalidate=True, semantic="", visible=True, exposed=False, validators=None):
+
         commandLineGroup = commandLineGroup if commandLineGroup is not _setParamSentinel else group
 
         super(PushButtonParam, self).__init__(name=name, label=label, description=description, value=None,
-                                              commandLineGroup=commandLineGroup, advanced=advanced, enabled=enabled, 
-                                              invalidate=invalidate, semantic=semantic, visible=visible, 
-                                              exposed=exposed)
+                                              commandLineGroup=commandLineGroup, advanced=advanced, enabled=enabled,
+                                              invalidate=invalidate, semantic=semantic, visible=visible,
+                                              exposed=exposed, validators=validators)
         self._valueType = None
 
     def getInstanceType(self):
@@ -550,15 +561,15 @@ class ChoiceParam(Param):
 
     @deprecated.depreciateParam("group", "Param 'group' on {name} should not be used anymore. Please use 'commandLineGroup' instead")
     def __init__(self, name: str, label=None, description=None, value=None, values=None, exclusive=True, saveValuesOverride=False,
-                 group="allParams", commandLineGroup=_setParamSentinel, joinChar=" ", advanced=False, enabled=True, 
-                 invalidate=True, semantic="", validValue=True, errorMessage="", visible=True, exposed=False):
+                 group="allParams", commandLineGroup=_setParamSentinel, joinChar=" ", advanced=False, enabled=True,
+                 invalidate=True, semantic="", validValue=True, errorMessage="", visible=True, exposed=False, validators=None):
 
         commandLineGroup = commandLineGroup if commandLineGroup is not _setParamSentinel else group
 
         super(ChoiceParam, self).__init__(name=name, label=label, description=description, value=value,
-                                          commandLineGroup=commandLineGroup, advanced=advanced, enabled=enabled, 
-                                          invalidate=invalidate, semantic=semantic, validValue=validValue, 
-                                          errorMessage=errorMessage, visible=visible, exposed=exposed)
+                                          commandLineGroup=commandLineGroup, advanced=advanced, enabled=enabled,
+                                          invalidate=invalidate, semantic=semantic, validValue=validValue,
+                                          errorMessage=errorMessage, visible=visible, exposed=exposed, validators=validators)
         self._values = values if values is not None else []
         self._saveValuesOverride = saveValuesOverride
         self._exclusive = exclusive
@@ -635,17 +646,17 @@ class StringParam(Param):
     """
     """
     @deprecated.depreciateParam("group", "Param 'group' on {name} should not be used anymore. Please use 'commandLineGroup' instead")
-    def __init__(self, name, label=None, description=None, value=None, group="allParams", commandLineGroup=_setParamSentinel, 
-                 advanced=False, enabled=True, invalidate=True, semantic="", uidIgnoreValue=None, validValue=True, 
-                 errorMessage="", visible=True, exposed=False):
+    def __init__(self, name, label=None, description=None, value=None, group="allParams", commandLineGroup=_setParamSentinel,
+                 advanced=False, enabled=True, invalidate=True, semantic="", uidIgnoreValue=None, validValue=True,
+                 errorMessage="", visible=True, exposed=False, validators=None):
 
         commandLineGroup = commandLineGroup if commandLineGroup is not _setParamSentinel else group
 
         super(StringParam, self).__init__(name=name, label=label, description=description, value=value,
-                                          commandLineGroup=commandLineGroup, advanced=advanced, enabled=enabled, 
-                                          invalidate=invalidate, semantic=semantic, uidIgnoreValue=uidIgnoreValue, 
-                                          validValue=validValue, errorMessage=errorMessage, visible=visible, 
-                                          exposed=exposed)
+                                          commandLineGroup=commandLineGroup, advanced=advanced, enabled=enabled,
+                                          invalidate=invalidate, semantic=semantic, uidIgnoreValue=uidIgnoreValue,
+                                          validValue=validValue, errorMessage=errorMessage, visible=visible,
+                                          exposed=exposed, validators=validators)
         self._valueType = str
 
     def validateValue(self, value):
@@ -668,14 +679,14 @@ class ColorParam(Param):
     """
     """
     @deprecated.depreciateParam("group", "Param 'group' on {name} should not be used anymore. Please use 'commandLineGroup' instead")
-    def __init__(self, name, label=None, description=None, value=None, group="allParams", commandLineGroup=_setParamSentinel, 
-                 advanced=False, enabled=True, invalidate=True, semantic="", visible=True, exposed=False):
-        
+    def __init__(self, name, label=None, description=None, value=None, group="allParams", commandLineGroup=_setParamSentinel,
+                 advanced=False, enabled=True, invalidate=True, semantic="", visible=True, exposed=False, validators=None):
+
         commandLineGroup = commandLineGroup if commandLineGroup is not _setParamSentinel else group
 
         super(ColorParam, self).__init__(name=name, label=label, description=description, value=value,
-                                         commandLineGroup=commandLineGroup, advanced=advanced, enabled=enabled, 
-                                         invalidate=invalidate, semantic=semantic, visible=visible, exposed=exposed)
+                                         commandLineGroup=commandLineGroup, advanced=advanced, enabled=enabled,
+                                         invalidate=invalidate, semantic=semantic, visible=visible, exposed=exposed, validators=validators)
         self._valueType = str
 
     def validateValue(self, value):

--- a/meshroom/core/desc/attribute.py
+++ b/meshroom/core/desc/attribute.py
@@ -65,8 +65,7 @@ class Attribute(BaseObject):
     """
 
     def __init__(self, name, label, description, value, advanced, semantic, commandLineGroup, enabled,
-                 keyable=False, keyType=None, invalidate=True, uidIgnoreValue=None,
-                 validValue=True, errorMessage="", visible=True, exposed=False, validators:list["AttributeValidator"]=None):
+                 keyable=False, keyType=None, invalidate=True, uidIgnoreValue=None, visible=True, exposed=False, validators:list["AttributeValidator"]=None):
         super(Attribute, self).__init__()
         self._name = name
         self._label = convertToLabel(name) if label is None else label
@@ -360,13 +359,11 @@ class Param(Attribute):
     """
     """
     def __init__(self, name, label, description, value, commandLineGroup, advanced, semantic, enabled,
-                 keyable=False, keyType=None, invalidate=True, uidIgnoreValue=None,
-                 validValue=True, errorMessage="", visible=True, exposed=False, validators=None):
+                 keyable=False, keyType=None, invalidate=True, uidIgnoreValue=None, visible=True, exposed=False, validators=None):
         super(Param, self).__init__(name=name, label=label, description=description, value=value,
                                     keyable=keyable, keyType=keyType, commandLineGroup=commandLineGroup, advanced=advanced,
                                     enabled=enabled, invalidate=invalidate, semantic=semantic,
-                                    uidIgnoreValue=uidIgnoreValue, validValue=validValue,
-                                    errorMessage=errorMessage, visible=visible, exposed=exposed, validators=validators)
+                                    uidIgnoreValue=uidIgnoreValue, visible=visible, exposed=exposed, validators=validators)
 
 
 class File(Attribute):
@@ -442,7 +439,7 @@ class IntParam(Param):
     @deprecated.depreciateParam("group", "Param 'group' on {name} should not be used anymore. Please use 'commandLineGroup' instead")
     def __init__(self, name, label=None, description=None, value=None, range=None, keyable=False, keyType=None,
                  group="allParams", commandLineGroup=_setParamSentinel, advanced=False, enabled=True,
-                 invalidate=True, semantic="", validValue=True, errorMessage="", visible=True, exposed=False, validators=None):
+                 invalidate=True, semantic="", visible=True, exposed=False, validators=None):
         self._range = range
 
         commandLineGroup = commandLineGroup if commandLineGroup is not _setParamSentinel else group
@@ -450,8 +447,7 @@ class IntParam(Param):
         super(IntParam, self).__init__(name=name, label=label, description=description, value=value,
                                        keyable=keyable, keyType=keyType, commandLineGroup=commandLineGroup,
                                        advanced=advanced, enabled=enabled, invalidate=invalidate,
-                                       semantic=semantic, validValue=validValue, errorMessage=errorMessage,
-                                       visible=visible, exposed=exposed, validators=validators)
+                                       semantic=semantic, visible=visible, exposed=exposed, validators=validators)
         self._valueType = int
 
     def validateValue(self, value):
@@ -482,15 +478,14 @@ class FloatParam(Param):
     @deprecated.depreciateParam("group", "Param 'group' on {name} should not be used anymore. Please use 'commandLineGroup' instead")
     def __init__(self, name, label=None, description=None, value=None, range=None, keyable=False, keyType=None,
                  group="allParams", commandLineGroup=_setParamSentinel, advanced=False, enabled=True,
-                 invalidate=True, semantic="", validValue=True, errorMessage="", visible=True, exposed=False, validators=None):
+                 invalidate=True, semantic="", visible=True, exposed=False, validators=None):
         self._range = range
         commandLineGroup = commandLineGroup if commandLineGroup is not _setParamSentinel else group
 
         super(FloatParam, self).__init__(name=name, label=label, description=description, value=value,
                                          keyable=keyable, keyType=keyType, commandLineGroup=commandLineGroup,
                                          advanced=advanced, enabled=enabled, invalidate=invalidate,
-                                         semantic=semantic, validValue=validValue, errorMessage=errorMessage,
-                                         visible=visible, exposed=exposed, validators=validators)
+                                         semantic=semantic, visible=visible, exposed=exposed, validators=validators)
         self._valueType = float
 
     def validateValue(self, value):
@@ -562,14 +557,13 @@ class ChoiceParam(Param):
     @deprecated.depreciateParam("group", "Param 'group' on {name} should not be used anymore. Please use 'commandLineGroup' instead")
     def __init__(self, name: str, label=None, description=None, value=None, values=None, exclusive=True, saveValuesOverride=False,
                  group="allParams", commandLineGroup=_setParamSentinel, joinChar=" ", advanced=False, enabled=True,
-                 invalidate=True, semantic="", validValue=True, errorMessage="", visible=True, exposed=False, validators=None):
+                 invalidate=True, semantic="", visible=True, exposed=False, validators=None):
 
         commandLineGroup = commandLineGroup if commandLineGroup is not _setParamSentinel else group
 
         super(ChoiceParam, self).__init__(name=name, label=label, description=description, value=value,
                                           commandLineGroup=commandLineGroup, advanced=advanced, enabled=enabled,
-                                          invalidate=invalidate, semantic=semantic, validValue=validValue,
-                                          errorMessage=errorMessage, visible=visible, exposed=exposed, validators=validators)
+                                          invalidate=invalidate, semantic=semantic, visible=visible, exposed=exposed, validators=validators)
         self._values = values if values is not None else []
         self._saveValuesOverride = saveValuesOverride
         self._exclusive = exclusive
@@ -647,15 +641,13 @@ class StringParam(Param):
     """
     @deprecated.depreciateParam("group", "Param 'group' on {name} should not be used anymore. Please use 'commandLineGroup' instead")
     def __init__(self, name, label=None, description=None, value=None, group="allParams", commandLineGroup=_setParamSentinel,
-                 advanced=False, enabled=True, invalidate=True, semantic="", uidIgnoreValue=None, validValue=True,
-                 errorMessage="", visible=True, exposed=False, validators=None):
+                 advanced=False, enabled=True, invalidate=True, semantic="", uidIgnoreValue=None, visible=True, exposed=False, validators=None):
 
         commandLineGroup = commandLineGroup if commandLineGroup is not _setParamSentinel else group
 
         super(StringParam, self).__init__(name=name, label=label, description=description, value=value,
                                           commandLineGroup=commandLineGroup, advanced=advanced, enabled=enabled,
-                                          invalidate=invalidate, semantic=semantic, uidIgnoreValue=uidIgnoreValue,
-                                          validValue=validValue, errorMessage=errorMessage, visible=visible,
+                                          invalidate=invalidate, semantic=semantic, uidIgnoreValue=uidIgnoreValue, visible=visible,
                                           exposed=exposed, validators=validators)
         self._valueType = str
 

--- a/meshroom/core/desc/attribute.py
+++ b/meshroom/core/desc/attribute.py
@@ -6,10 +6,8 @@ from enum import auto, Enum
 
 from meshroom.common import BaseObject, JSValue, Property, Variant, VariantList, strtobool, deprecated
 
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from meshroom.core.desc.validators import AttributeValidator
+from typing import Sequence
+from meshroom.core.desc.validators import AttributeValidator
 
 # Pre-compile regexes for better performance on repeated calls
 _ACRONYM_RE = re.compile(r'([A-Z]+)([A-Z][a-z])')
@@ -65,7 +63,7 @@ class Attribute(BaseObject):
     """
 
     def __init__(self, name, label, description, value, advanced, semantic, commandLineGroup, enabled,
-                 keyable=False, keyType=None, invalidate=True, uidIgnoreValue=None, visible=True, exposed=False, validators:list["AttributeValidator"]=None):
+                 keyable=False, keyType=None, invalidate=True, uidIgnoreValue=None, visible=True, exposed=False, validators:Sequence["AttributeValidator"]=None):
         super(Attribute, self).__init__()
         self._name = name
         self._label = convertToLabel(name) if label is None else label
@@ -88,10 +86,12 @@ class Attribute(BaseObject):
 
         if validators is None:
             self._validators = []
-        elif isinstance(validators, (list, tuple)):
+        elif isinstance(validators, Sequence) and all(
+            isinstance(x, AttributeValidator) for x in validators
+        ):
             self._validators = validators
         else:
-            raise RuntimeError(f"Validators should be of type 'list[AttributeValidator]', the type '{type(validators)}' is not supported.")
+            raise RuntimeError(f"Validators should be of type 'Sequence[AttributeValidator]', the type '{type(validators)}' is not supported.")
         
     def getInstanceType(self):
         """ Return the correct Attribute instance corresponding to the description. """

--- a/meshroom/core/desc/attribute.py
+++ b/meshroom/core/desc/attribute.py
@@ -3,10 +3,9 @@ import os
 import re
 from collections.abc import Iterable
 from enum import auto, Enum
+from typing import Sequence
 
 from meshroom.common import BaseObject, JSValue, Property, Variant, VariantList, strtobool, deprecated
-
-from typing import Sequence
 from meshroom.core.desc.validators import AttributeValidator
 
 # Pre-compile regexes for better performance on repeated calls
@@ -63,7 +62,7 @@ class Attribute(BaseObject):
     """
 
     def __init__(self, name, label, description, value, advanced, semantic, commandLineGroup, enabled,
-                 keyable=False, keyType=None, invalidate=True, uidIgnoreValue=None, visible=True, exposed=False, validators:Sequence["AttributeValidator"]=None):
+                 keyable=False, keyType=None, invalidate=True, uidIgnoreValue=None, visible=True, exposed=False, validators: Sequence[AttributeValidator]=None):
         super(Attribute, self).__init__()
         self._name = name
         self._label = convertToLabel(name) if label is None else label
@@ -86,9 +85,7 @@ class Attribute(BaseObject):
 
         if validators is None:
             self._validators = []
-        elif isinstance(validators, Sequence) and all(
-            isinstance(x, AttributeValidator) for x in validators
-        ):
+        elif isinstance(validators, Sequence) and all(isinstance(x, AttributeValidator) for x in validators):
             self._validators = validators
         else:
             raise RuntimeError(f"Validators should be of type 'Sequence[AttributeValidator]', the type '{type(validators)}' is not supported.")

--- a/meshroom/core/desc/validators.py
+++ b/meshroom/core/desc/validators.py
@@ -13,55 +13,52 @@ def error(*messages: str) -> tuple[bool, list[str]]:
 
 @runtime_checkable
 class AttributeValidator(Protocol):
-    """ Interface for an attribute validation
-        You can inherit from this class and override the __call__ methods to implement your own attribute validation logic
+    """
+    Interface for an attribute validation.
+    This class can be inherited, and the __call__ methods overridden to implement any custom attribute validation logic.
 
-        Because it's a callable class, you can also create your own validators on the fly
+    Because it is a callable class, validators can also be created on the fly.
 
-        .. code-block: python
-
-            lambda node, attribute: success() if attribute.value and attribute.value != "" else error("attribute have no value")
+    .. code-block: python
+        lambda node, attribute: success() if attribute.value and attribute.value != "" else error("attribute have no value")
     """
 
     def __call__(self, node: "Node", attribute: "Attribute") -> tuple[bool, list[str]]:
         """
-            Override this method to implement your custom validation logic.
-            You can use the success() and error() helpers that encapsulate the returning response.
+        This method can be overridden to implement any custom attribute validation logic.
+        The `success()` and `error()` helpers can be used to encapsulate the returning responses.
 
-            :param node: The node that holds the attribute to validate
-            :param attribute: The atribute to validate
+        :param node: The node that holds the attribute to validate
+        :param attribute: The attribute to validate
 
-            :returns: The validtion response: (True, []) if it's valid, (False, [errorMessage1, errorMessage2, ...]) if error exists
-
+        :returns: The validation response: (True, []) if it is valid, (False, [errorMessage1, errorMessage2, ...]) otherwise.
         """
         raise NotImplementedError()
 
 
 class NotEmptyValidator(AttributeValidator):
-    """ The attribute value should not be empty
-        This class is used to determine if an attribute label should be considered as mandatory/required
+    """
+    Ensure that the attribute value is not empty.
+    This class is used to determine if an attribute value should be considered as mandatory/required.
     """
 
     def __call__(self, node: "Node", attribute: "Attribute") -> tuple[bool, list[str]]:
-
         if attribute.value is None or attribute.value == "":
-            return error("Empty value is not allowed")
-        
+            return error("An empty value is not allowed.")
+
         return success()
 
 
 class RangeValidator(AttributeValidator):
-    """ Check if the attribute value is in the given range
-    """
+    """ Check if the attribute value is in a given range. """
 
     def __init__(self, min, max):
         self._min = min
         self._max = max
 
-    def __call__(self, node:"Node", attribute: "Attribute") -> tuple[bool, list[str]]:
-
+    def __call__(self, node: "Node", attribute: "Attribute") -> tuple[bool, list[str]]:
         if attribute.value < self._min or attribute.value > self._max:
-            return error(f"Value should be greater than {self._min} and less than {self._max}", 
-                            f"({self._min} < {attribute.value} < {self._max})")
+            return error(f"Value should be greater than {self._min} and less than {self._max} ",
+                         f"({self._min} < {attribute.value} < {self._max}).")
 
         return success()

--- a/meshroom/core/desc/validators.py
+++ b/meshroom/core/desc/validators.py
@@ -1,0 +1,66 @@
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from meshroom.core.attribute import Attribute
+    from meshroom.core.node import Node
+
+
+def success() -> tuple[bool, list[str]]:
+    return (True, [])
+
+def error(*messages: str) -> tuple[bool, list[str]]:
+    return (False, list(messages))
+
+class AttributeValidator(object):
+    """ Interface for an attribute validation
+        You can inherit from this class and override the __call__ methods to implement your own attribute validation logic
+
+        Because it's a callable class, you can also create your own validators on the fly
+
+        .. code-block: python
+
+            lambda node, attribute: success() if attribute.value and attribute.value != "" else error("attribute have no value")
+    """
+
+    def __call__(self, node: "Node", attribute: "Attribute") -> tuple[bool, list[str]]:
+        """
+            Override this method to implement your custom validation logic.
+            You can use the success() and error() helpers that encapsulate the returning response.
+
+            :param node: The node that holds the attribute to validate
+            :param attribute: The atribute to validate
+
+            :returns: The validtion response: (True, []) if it's valid, (False, [errorMessage1, errorMessage2, ...]) if error exists
+
+        """
+        raise NotImplementedError()
+
+
+class NotEmptyValidator(AttributeValidator):
+    """ The attribute value should not be empty
+        This class is used to determine if an attribute label should be considered as mandatory/required
+    """
+
+    def __call__(self, node: "Node", attribute: "Attribute") -> tuple[bool, list[str]]:
+
+        if attribute.value is None or attribute.value == "":
+            return error("Empty value is not allowed")
+        
+        return success()
+
+
+class RangeValidator(AttributeValidator):
+    """ Check if the attribute value is in the given range
+    """
+
+    def __init__(self, min, max):
+        self._min = min
+        self._max = max
+
+    def __call__(self, node:"Node", attribute: "Attribute") -> tuple[bool, list[str]]:
+
+        if attribute.value < self._min or attribute.value > self._max:
+            return error(f"Value should be greater than {self._min} and less than {self._max}", 
+                            f"({self._min} < {attribute.value} < {self._max})")
+
+        return success()

--- a/meshroom/core/desc/validators.py
+++ b/meshroom/core/desc/validators.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
 if TYPE_CHECKING:
     from meshroom.core.attribute import Attribute
@@ -11,7 +11,8 @@ def success() -> tuple[bool, list[str]]:
 def error(*messages: str) -> tuple[bool, list[str]]:
     return (False, list(messages))
 
-class AttributeValidator(object):
+@runtime_checkable
+class AttributeValidator(Protocol):
     """ Interface for an attribute validation
         You can inherit from this class and override the __call__ methods to implement your own attribute validation logic
 

--- a/meshroom/core/graph.py
+++ b/meshroom/core/graph.py
@@ -1710,6 +1710,7 @@ class Graph(BaseObject):
     statusUpdated = Signal()
     canComputeLeavesChanged = Signal()
     canComputeLeaves = Property(bool, lambda self: self._canComputeLeaves, notify=canComputeLeavesChanged)
+    attributeValueChanged = Signal(Attribute)
 
 
 def loadGraph(filepath, strictCompatibility: bool = False) -> Graph:

--- a/meshroom/core/graph.py
+++ b/meshroom/core/graph.py
@@ -1710,7 +1710,6 @@ class Graph(BaseObject):
     statusUpdated = Signal()
     canComputeLeavesChanged = Signal()
     canComputeLeaves = Property(bool, lambda self: self._canComputeLeaves, notify=canComputeLeavesChanged)
-    attributeValueChanged = Signal(Attribute)
 
 
 def loadGraph(filepath, strictCompatibility: bool = False) -> Graph:

--- a/meshroom/core/node.py
+++ b/meshroom/core/node.py
@@ -1522,6 +1522,8 @@ class BaseNode(BaseObject):
         if callback:
             callback(self)
 
+        self.hasInvalidAttributeChanged.emit()
+
         if self.graph:
             # If we are in a graph, propagate the notification to the connected output attributes
             for edge in self.graph.outEdges(attr):
@@ -1792,7 +1794,7 @@ class BaseNode(BaseObject):
         # This does not apply to non dynamic output
         if not self.nodeDesc.hasDynamicOutputAttribute:
             return
-        
+
         # Check existence of values.json file
         valuesFile = self.valuesFile
         if not os.path.exists(valuesFile):
@@ -2160,6 +2162,12 @@ class BaseNode(BaseObject):
         """
         return next((attr for attr in self._attributes if attr.enabled and attr.isOutput and attr.isTextDisplayable), None) is not None
 
+    def _hasInvalidAttribute(self):
+        for attribute in self._attributes:
+            if len(attribute.errorMessages) > 0:
+                return True
+        return False
+
     def _hasDisplayableShape(self):
         """
         Return True if at least one attribute is a ShapeAttribute, a ShapeListAttribute or a shape File.
@@ -2239,6 +2247,9 @@ class BaseNode(BaseObject):
     hasTextOutput = Property(bool, hasTextOutputAttribute, notify=outputAttrChanged)
     # Whether the node contains a ShapeAttribute, a ShapeListAttribute or a shape File.
     hasDisplayableShape = Property(bool, _hasDisplayableShape, constant=True)
+
+    hasInvalidAttributeChanged = Signal()
+    hasInvalidAttribute = Property(bool, _hasInvalidAttribute, notify=hasInvalidAttributeChanged)
 
 
 class Node(BaseNode):

--- a/meshroom/ui/commands.py
+++ b/meshroom/ui/commands.py
@@ -314,16 +314,21 @@ class SetAttributeCommand(GraphCommand):
         if self.value == self.oldValue:
             return False
         if self.graph.attribute(self.attrName) is not None:
-            self.graph.attribute(self.attrName).value = self.value
+            attribute = self.graph.attribute(self.attrName)
         else:
-            self.graph.internalAttribute(self.attrName).value = self.value
+            attribute = self.graph.internalAttribute(self.attrName)
+
+        attribute.value = self.value        
+
         return True
 
     def undoImpl(self):
         if self.graph.attribute(self.attrName) is not None:
-            self.graph.attribute(self.attrName).value = self.oldValue
+            attribute = self.graph.attribute(self.attrName)
         else:
-            self.graph.internalAttribute(self.attrName).value = self.oldValue
+            attribute = self.graph.internalAttribute(self.attrName)
+
+        attribute.value = self.oldValue
 
 class AddAttributeKeyValueCommand(GraphCommand):
     def __init__(self, graph, attribute, key, value, parent=None):

--- a/meshroom/ui/qml/Application.qml
+++ b/meshroom/ui/qml/Application.qml
@@ -137,7 +137,7 @@ Page {
 
     function getAllNodes() {
         const nodes = []
-        for(let i=0; i<graphEditor.graph.nodes.count; i++) {
+        for (let i = 0; i < graphEditor.graph.nodes.count; i++) {
             nodes.push(graphEditor.graph.nodes.at(i))
         }
         return nodes
@@ -278,17 +278,17 @@ Page {
             }
             else {
                 try {
-                    if(nodes == null) {
+                    if (nodes == null) {
                         nodes = getAllNodes()
                     }
-                    if ( nodes && nodes.find(node => node.hasInvalidAttribute) ) {
+                    if (nodes && nodes.find(node => node.hasInvalidAttribute)) {
                         submitWithWarningDialog.nodes = nodes
                         submitWithWarningDialog.open()
                     } else {
                         _currentScene.submit(nodes)
                     }
                 }
-                 catch (error) {
+                catch (error) {
                     const data = ErrorHandler.analyseError(error)
                     if (data.context === "SUBMITTING") {
                         computeSubmitErrorDialog.openError(data.type, data.msg, nodes)
@@ -425,9 +425,9 @@ Page {
             icon.text: MaterialIcons.warning
             parent: Overlay.overlay
             preset: "Warning"
-            title: "Nodes Containing Warnings"
-            text: "Some nodes contain warnings. Are you sure you want to submit?"
-            helperText: "Submit even if some nodes have warnings"
+            title: "Nodes With Warnings"
+            text: "Some nodes have warnings. Are you sure you want to submit them?"
+            helperText: "Submit nodes even if some of them have warnings."
             standardButtons: Dialog.Cancel | Dialog.Yes
 
             property var nodes: []

--- a/meshroom/ui/qml/Application.qml
+++ b/meshroom/ui/qml/Application.qml
@@ -39,7 +39,7 @@ Page {
         property alias showImageGallery: imageGalleryVisibilityCB.checked
         property alias showTextViewer: textViewerVisibilityCB.checked
     }
-    
+
     Settings {
         id: nodeActionsSettings
         category: "NodeActions"
@@ -133,6 +133,14 @@ Page {
 
         // Everything is valid
         return true;
+    }
+
+    function getAllNodes() {
+        const nodes = []
+        for(let i=0; i<graphEditor.graph.nodes.count; i++) {
+            nodes.push(graphEditor.graph.nodes.at(i))
+        }
+        return nodes
     }
 
     // File dialogs
@@ -267,14 +275,24 @@ Page {
         function submit(nodes) {
             if (!canSubmit) {
                 unsavedSubmitDialog.open()
-            } else {
+            }
+            else {
                 try {
-                    _currentScene.submit(nodes)
+                    if(nodes == null) {
+                        nodes = getAllNodes()
+                    }
+                    if ( nodes && nodes.find(node => node.hasInvalidAttribute) ) {
+                        submitWithWarningDialog.nodes = nodes
+                        submitWithWarningDialog.open()
+                    } else {
+                        _currentScene.submit(nodes)
+                    }
                 }
-                catch (error) {
+                 catch (error) {
                     const data = ErrorHandler.analyseError(error)
-                    if (data.context === "SUBMITTING")
+                    if (data.context === "SUBMITTING") {
                         computeSubmitErrorDialog.openError(data.type, data.msg, nodes)
+                    }
                 }
             }
         }
@@ -398,6 +416,26 @@ Page {
 
             onDiscarded: close()
             onAccepted: saveAsAction.trigger()
+        }
+
+        MessageDialog {
+            id: submitWithWarningDialog
+
+            canCopy: false
+            icon.text: MaterialIcons.warning
+            parent: Overlay.overlay
+            preset: "Warning"
+            title: "Nodes Containing Warnings"
+            text: "Some nodes contain warnings. Are you sure you want to submit?"
+            helperText: "Submit even if some nodes have warnings"
+            standardButtons: Dialog.Cancel | Dialog.Yes
+
+            property var nodes: []
+
+            onDiscarded: close()
+            onAccepted: {
+                _currentScene.submit(nodes)
+            }
         }
 
         MessageDialog {
@@ -733,7 +771,7 @@ Page {
                         model: MeshroomApp.recentProjectFiles
                         MenuItem {
                             enabled: modelData["status"] != 0
-                            
+
                             onTriggered: ensureSaved(function() {
                                 openRecentMenu.dismiss()
                                 if (_currentScene.load(modelData["path"])) {
@@ -887,7 +925,7 @@ Page {
                         id: nodeActionsSettingsMenu
                         title: "NodeActions Settings"
                         implicitWidth: 250
-                        
+
                         MenuItem {
                             id: nodeActionsConfirmDelete
                             checkable: true
@@ -1504,7 +1542,7 @@ Page {
                     SplitView.minimumWidth: 350
 
                     node: _currentScene ? _currentScene.selectedNode : null
-                    property bool computing: _currentScene ? _currentScene.computing : false       
+                    property bool computing: _currentScene ? _currentScene.computing : false
                     property var currentAttributes: []
 
                     // Make NodeEditor readOnly when computing

--- a/meshroom/ui/qml/GraphEditor/AttributeItemDelegate.qml
+++ b/meshroom/ui/qml/GraphEditor/AttributeItemDelegate.qml
@@ -37,7 +37,6 @@ RowLayout {
         function onValueChanged() {
             root.errorMessages = attribute.errorMessages
         }
-
     }
 
     spacing: 2
@@ -108,7 +107,7 @@ RowLayout {
                     y: parameterMA.mouseY + 10
 
                     text: {
-                        return `<b>${object.desc.name} :</b> ${attribute.type}  <br> ${Format.plainToHtml(object.desc.description)}`
+                        return `<b>${object.desc.name}:</b> ${attribute.type}<br>${Format.plainToHtml(object.desc.description)}`
                     }
                     visible: parameterMA.containsMouse
                     delay: 800
@@ -409,15 +408,15 @@ RowLayout {
                         }
                     }
                     onPressed: (event) => {
-                        if(event.button == Qt.RightButton) {
+                        if (event.button == Qt.RightButton) {
                             // Keep selection persistent while context menu is open to
                             // visualize what is being copied or what will be replaced on paste.
-                            persistentSelection = true;
-                            const menu = textFieldMenuComponent.createObject(textField);
-                            menu.popup();
+                            persistentSelection = true
+                            const menu = textFieldMenuComponent.createObject(textField)
+                            menu.popup()
 
-                            if(selectedText === "") {
-                                cursorPosition = positionAt(event.x, event.y);
+                            if (selectedText === "") {
+                                cursorPosition = positionAt(event.x, event.y)
                             }
                         }
                     }
@@ -427,26 +426,26 @@ RowLayout {
                         Menu {
                             onOpened: {
                                 // Keep cursor visible to see where pasting would happen.
-                                textField.cursorVisible = true;
+                                textField.cursorVisible = true
                             }
                             onClosed: {
                                 // Disable selection persistency behavior once menu is closed and
                                 // give focus back to the parent TextField.
-                                textField.persistentSelection = false;
-                                textField.forceActiveFocus();
-                                destroy();
+                                textField.persistentSelection = false
+                                textField.forceActiveFocus()
+                                destroy()
                             }
                             MenuItem {
                                 text: "Copy"
                                 enabled: attribute.value != ""
                                 onTriggered: {
-                                    const hasSelection = textField.selectionStart !== textField.selectionEnd;
-                                    if(hasSelection) {
+                                    const hasSelection = textField.selectionStart !== textField.selectionEnd
+                                    if (hasSelection) {
                                         // Use `TextField.copy` to copy only the current selection.
-                                        textField.copy();
+                                        textField.copy()
                                     }
                                     else {
-                                        Clipboard.setText(attribute.value);
+                                        Clipboard.setText(attribute.value)
                                     }
                                 }
                             }
@@ -454,24 +453,22 @@ RowLayout {
                                 text: "Paste"
                                 enabled: !readOnly
                                 onTriggered: {
-                                    const clipboardText = Clipboard.getText();
+                                    const clipboardText = Clipboard.getText()
                                     if (clipboardText.length === 0) {
-                                        return;
+                                        return
                                     }
-                                    const before = textField.text.substr(0, textField.selectionStart);
-                                    const after = textField.text.substr(textField.selectionEnd, textField.text.length);
-                                    const updatedValue = before + clipboardText + after;
-                                    setTextFieldAttribute(updatedValue);
+                                    const before = textField.text.substr(0, textField.selectionStart)
+                                    const after = textField.text.substr(textField.selectionEnd, textField.text.length)
+                                    const updatedValue = before + clipboardText + after
+                                    setTextFieldAttribute(updatedValue)
                                     // Set the cursor at the end of the added text
-                                    textField.cursorPosition = before.length + clipboardText.length;
+                                    textField.cursorPosition = before.length + clipboardText.length
                                 }
                             }
                         }
                     }
+                }
             }
-
-            }
-
         }
 
         Component {
@@ -714,7 +711,7 @@ RowLayout {
 
                         onPressedChanged: {
                             if (!pressed) {
-                                if(attribute.keyable)
+                                if (attribute.keyable)
                                     _currentScene.addAttributeKeyValue(attribute, _currentScene.selectedViewId, formattedValue)
                                 else
                                     _currentScene.setAttribute(attribute, formattedValue)

--- a/meshroom/ui/qml/GraphEditor/AttributeItemDelegate.qml
+++ b/meshroom/ui/qml/GraphEditor/AttributeItemDelegate.qml
@@ -23,34 +23,30 @@ RowLayout {
     property alias label: parameterLabel  // Accessor to the internal Label (attribute's name)
     property int labelWidth               // Shortcut to set the fixed size of the Label
 
-    readonly property bool editable: !attribute.isOutput && !attribute.isLink &&   
+    readonly property bool editable: !attribute.isOutput && !attribute.isLink &&
                                      !readOnly && !(attribute.keyable && _currentScene.selectedViewId === "-1")
+    property var errorMessages: attribute.errorMessages
 
     signal doubleClicked(var mouse, var attr)
     signal inAttributeClicked(var srcItem, var mouse, var inAttributes)
     signal outAttributeClicked(var srcItem, var mouse, var outAttributes)
     signal showInViewer(var attr)
 
-    spacing: 2
-
-    function updateAttributeLabel() {
-        background.color = attribute.isValid ?  Qt.darker(palette.window, 1.1) : Qt.darker(Colors.red, 1.5)
-
-        if (attribute.desc) {
-            var tooltip = ""
-            if (!attribute.isValid && attribute.desc.errorMessage !== "")
-                tooltip += "<i><b>Error: </b>" + Format.plainToHtml(attribute.desc.errorMessage) + "</i><br><br>"
-            tooltip += "<b> " + attribute.desc.name + ":</b> " + attribute.type + "<br>" + Format.plainToHtml(attribute.desc.description)
-
-            parameterTooltip.text = tooltip
+    Connections {
+        target: attribute
+        function onValueChanged() {
+            root.errorMessages = attribute.errorMessages
         }
+
     }
+
+    spacing: 2
 
     Pane {
         visible: attribute.type !== "GroupAttribute"
         background: Rectangle {
             id: background
-            color: object != undefined && object.isValid ? Qt.darker(parent.palette.window, 1.1) : Qt.darker(Colors.red, 1.5)
+            color: Qt.darker(parent.palette.window, 1.1)
         }
         padding: 0
         Layout.preferredWidth: labelWidth || implicitWidth
@@ -95,7 +91,7 @@ RowLayout {
                 padding: 5
                 wrapMode: Label.WrapAtWordBoundaryOrAnywhere
 
-                text: object.label
+                text: attribute.isMandatory && attribute.isDefault ? `\* ${object.label}` : object.label
 
                 color: {
                     if (object != undefined && (object.hasAnyOutputLinks || object.isLink) && !object.enabled)
@@ -112,11 +108,7 @@ RowLayout {
                     y: parameterMA.mouseY + 10
 
                     text: {
-                        var tooltip = ""
-                        if (!object.isValid && object.desc.errorMessage !== "")
-                            tooltip += "<i><b>Error: </b>" + Format.plainToHtml(object.desc.errorMessage) + "</i><br><br>"
-                        tooltip += "<b>" + object.desc.name + ":</b> " + attribute.type + "<br>" + Format.plainToHtml(object.desc.description)
-                        return tooltip
+                        return `<b>${object.desc.name} :</b> ${attribute.type}  <br> ${Format.plainToHtml(object.desc.description)}`
                     }
                     visible: parameterMA.containsMouse
                     delay: 800
@@ -146,7 +138,6 @@ RowLayout {
                             enabled: root.editable && !attribute.isDefault
                             onTriggered: {
                                 _currentScene.resetAttribute(attribute)
-                                updateAttributeLabel()
                             }
                         }
                         MenuItem {
@@ -274,21 +265,20 @@ RowLayout {
                     _currentScene.addAttributeKeyValue(root.attribute, _currentScene.selectedViewId, Number(value))
                 else
                     _currentScene.setAttribute(root.attribute, Number(value))
-                updateAttributeLabel()
                 break
             case "File":
                 _currentScene.setAttribute(root.attribute, value)
                 break
             default:
                 _currentScene.setAttribute(root.attribute, value.trim())
-                updateAttributeLabel()
                 break
         }
     }
 
+
     Loader {
-        id: attributeLoader
         Layout.fillWidth: true
+        id: inputField
 
         sourceComponent: {
             // PushButtonParam always has value == undefined, so it needs to be excluded from this check
@@ -352,117 +342,136 @@ RowLayout {
 
         Component {
             id: textFieldComponent
-            TextField {
-                id: textField
-                readOnly: !root.editable
-                text: attribute.value
 
-                // Don't disable the component to keep interactive features (text selection, context menu...).
-                // Only override the look by using the Disabled palette.
-                SystemPalette { 
-                    id: disabledPalette
-                    colorGroup: SystemPalette.Disabled
-                }
+            RowLayout {
+                anchors.fill: parent
 
-                states: [
-                    State {
-                        when: readOnly
-                        PropertyChanges {
-                            target: textField
-                            color: disabledPalette.text
-                        }
+                TextField {
+                    id: textField
+                    Layout.fillWidth: true
+
+                    readOnly: !root.editable
+                    text: attribute.value
+                    placeholderText: attribute.isMandatory ? "This field is required" : ""
+                    placeholderTextColor: "gray"
+                    // Don't disable the component to keep interactive features (text selection, context menu...).
+                    // Only override the look by using the Disabled palette.
+                    SystemPalette {
+                        id: disabledPalette
+                        colorGroup: SystemPalette.Disabled
                     }
-                ]
 
-                selectByMouse: true
-                onEditingFinished: setTextFieldAttribute(text)
-                persistentSelection: false
+                    background: Rectangle {
+                        border.color: errorMessages.length ? "orange" : "transparent"
+                        color:  Qt.darker(palette.window, 1.2)
+                        radius: 2
+                    }
 
-                onAccepted: {
-                    setTextFieldAttribute(text)
-                    parameterLabel.forceActiveFocus()
-                }
-                Keys.onPressed: function(event) {
-                    if ((event.key == Qt.Key_Escape)) {
-                        event.accepted = true
+                    states: [
+                        State {
+                            when: readOnly
+                            PropertyChanges {
+                                target: textField
+                                color: disabledPalette.text
+                            }
+                        }
+                    ]
+
+                    selectByMouse: true
+                    persistentSelection: false
+
+                    onEditingFinished: {
+                        setTextFieldAttribute(text)
+                    }
+
+                    onAccepted: {
+                        setTextFieldAttribute(text)
                         parameterLabel.forceActiveFocus()
                     }
-                }
-                Component.onDestruction: {
-                    if (activeFocus)
-                        setTextFieldAttribute(text)
-                }
-                DropArea {
-                    enabled: root.editable
-                    anchors.fill: parent
-                    onDropped: function(drop) {
-                        if (drop.hasUrls)
-                            setTextFieldAttribute(Filepath.urlToString(drop.urls[0]))
-                        else if (drop.hasText && drop.text != '')
-                            setTextFieldAttribute(drop.text)
-                    }
-                }
-                onPressed: (event) => {
-                    if(event.button == Qt.RightButton) {
-                        // Keep selection persistent while context menu is open to 
-                        // visualize what is being copied or what will be replaced on paste.
-                        persistentSelection = true;
-                        const menu = textFieldMenuComponent.createObject(textField);
-                        menu.popup();
-
-                        if(selectedText === "") {
-                            cursorPosition = positionAt(event.x, event.y);
+                    Keys.onPressed: function(event) {
+                        if ((event.key == Qt.Key_Escape)) {
+                            event.accepted = true
+                            parameterLabel.forceActiveFocus()
                         }
                     }
-                }
+                    Component.onDestruction: {
+                        if (activeFocus)
+                            setTextFieldAttribute(text)
+                    }
+                    DropArea {
+                        enabled: root.editable
+                        anchors.fill: parent
+                        onDropped: function(drop) {
+                            if (drop.hasUrls)
+                                setTextFieldAttribute(Filepath.urlToString(drop.urls[0]))
+                            else if (drop.hasText && drop.text != '')
+                                setTextFieldAttribute(drop.text)
+                        }
+                    }
+                    onPressed: (event) => {
+                        if(event.button == Qt.RightButton) {
+                            // Keep selection persistent while context menu is open to
+                            // visualize what is being copied or what will be replaced on paste.
+                            persistentSelection = true;
+                            const menu = textFieldMenuComponent.createObject(textField);
+                            menu.popup();
 
-                Component {
-                    id: textFieldMenuComponent
-                    Menu {
-                        onOpened: {
-                            // Keep cursor visible to see where pasting would happen.
-                            textField.cursorVisible = true;
+                            if(selectedText === "") {
+                                cursorPosition = positionAt(event.x, event.y);
+                            }
                         }
-                        onClosed: {
-                            // Disable selection persistency behavior once menu is closed and
-                            // give focus back to the parent TextField.
-                            textField.persistentSelection = false;
-                            textField.forceActiveFocus();
-                            destroy();
-                        }
-                        MenuItem {
-                            text: "Copy"
-                            enabled: attribute.value != ""
-                            onTriggered: {
-                                const hasSelection = textField.selectionStart !== textField.selectionEnd;
-                                if(hasSelection) {
-                                    // Use `TextField.copy` to copy only the current selection.
-                                    textField.copy();
+                    }
+
+                    Component {
+                        id: textFieldMenuComponent
+                        Menu {
+                            onOpened: {
+                                // Keep cursor visible to see where pasting would happen.
+                                textField.cursorVisible = true;
+                            }
+                            onClosed: {
+                                // Disable selection persistency behavior once menu is closed and
+                                // give focus back to the parent TextField.
+                                textField.persistentSelection = false;
+                                textField.forceActiveFocus();
+                                destroy();
+                            }
+                            MenuItem {
+                                text: "Copy"
+                                enabled: attribute.value != ""
+                                onTriggered: {
+                                    const hasSelection = textField.selectionStart !== textField.selectionEnd;
+                                    if(hasSelection) {
+                                        // Use `TextField.copy` to copy only the current selection.
+                                        textField.copy();
+                                    }
+                                    else {
+                                        Clipboard.setText(attribute.value);
+                                    }
                                 }
-                                else {
-                                    Clipboard.setText(attribute.value);
+                            }
+                            MenuItem {
+                                text: "Paste"
+                                enabled: !readOnly
+                                onTriggered: {
+                                    const clipboardText = Clipboard.getText();
+                                    if (clipboardText.length === 0) {
+                                        return;
+                                    }
+                                    const before = textField.text.substr(0, textField.selectionStart);
+                                    const after = textField.text.substr(textField.selectionEnd, textField.text.length);
+                                    const updatedValue = before + clipboardText + after;
+                                    setTextFieldAttribute(updatedValue);
+                                    // Set the cursor at the end of the added text
+                                    textField.cursorPosition = before.length + clipboardText.length;
                                 }
                             }
                         }
-                        MenuItem {
-                            text: "Paste"
-                            enabled: !readOnly
-                            onTriggered: {
-                                const clipboardText = Clipboard.getText();
-                                if (clipboardText.length === 0) {
-                                    return;
-                                }
-                                const before = textField.text.substr(0, textField.selectionStart);
-                                const after = textField.text.substr(textField.selectionEnd, textField.text.length);
-                                const updatedValue = before + clipboardText + after;
-                                setTextFieldAttribute(updatedValue);
-                                // Set the cursor at the end of the added text
-                                textField.cursorPosition = before.length + clipboardText.length;
-                            }
-                        }
-                    } 
-                }
+                    }
             }
+
+            }
+
         }
 
         Component {
@@ -492,6 +501,14 @@ RowLayout {
                         onEditingFinished: setTextFieldAttribute(text)
                         text: attribute.value
                         selectByMouse: true
+
+                        background: Rectangle {
+                            visible: errorMessages.length
+                            border.color: "orange"
+                            color: "transparent"
+                            radius: 2
+                        }
+
                         onPressed: {
                             root.forceActiveFocus()
                         }
@@ -611,6 +628,7 @@ RowLayout {
                 values: root.attribute.values
                 enabled: root.editable
                 customValueColor: Colors.orange
+
                 onToggled: (value, checked) => {
                     var currentValue = root.attribute.value;
                     if (!checked) {
@@ -627,13 +645,13 @@ RowLayout {
             id: sliderComponent
             RowLayout {
                 ExpressionTextField {
-                    id: expressionTextField 
+                    id: expressionTextField
                     implicitWidth: 100
                     Layout.fillWidth: !slider.active
                     enabled: root.editable
                     // Cast value to string to avoid intrusive scientific notations on numbers
-                    property string displayValue: String(slider.active && slider.item.pressed ? slider.item.formattedValue : 
-                                                        attribute.keyable ? attribute.keyValues.getValueAtKeyOrDefault(_currentScene.selectedViewId) : 
+                    property string displayValue: String(slider.active && slider.item.pressed ? slider.item.formattedValue :
+                                                        attribute.keyable ? attribute.keyValues.getValueAtKeyOrDefault(_currentScene.selectedViewId) :
                                                         attribute.value)
                     text: displayValue
                     selectByMouse: true
@@ -642,7 +660,6 @@ RowLayout {
                     // of the number. When we are editing (item is in focus), the content should follow the editing.
                     autoScroll: activeFocus
                     isInt: attribute.type === "FloatParam" ? false : true
-                    
                     onEditingFinished: {
                         if (!hasExprError) {
                             setTextFieldAttribute(expressionTextField.evaluatedValue)
@@ -650,6 +667,13 @@ RowLayout {
                             expressionTextField.text = Qt.binding(function() { return String(expressionTextField.displayValue); })
                         }
                     }
+
+                    background: Rectangle {
+                            border.color: errorMessages.length ? "orange" : "transparent"
+                            color: Qt.darker(palette.window, 1.2)
+                            radius: 2
+                        }
+
                     onAccepted: {
                         if (!hasExprError) {
                             setTextFieldAttribute(expressionTextField.evaluatedValue)
@@ -660,7 +684,7 @@ RowLayout {
                         // (with the most important values and cut the floating point details)
                         ensureVisible(0)
                     }
-                    
+
                     Component.onDestruction: {
                         if (activeFocus) {
                             if (!hasExprError)
@@ -694,7 +718,6 @@ RowLayout {
                                     _currentScene.addAttributeKeyValue(attribute, _currentScene.selectedViewId, formattedValue)
                                 else
                                     _currentScene.setAttribute(attribute, formattedValue)
-                                updateAttributeLabel()
                             }
                         }
                     }
@@ -709,12 +732,12 @@ RowLayout {
                     enabled: root.editable
                     checked: attribute.keyable ? attribute.keyValues.getValueAtKeyOrDefault(_currentScene.selectedViewId) : attribute.value
                     onToggled: {
-                        if(attribute.keyable) 
+                        if(attribute.keyable)
                         {
                             const value = attribute.keyValues.getValueAtKeyOrDefault(_currentScene.selectedViewId)
                             _currentScene.addAttributeKeyValue(attribute, _currentScene.selectedViewId, !value)
                         }
-                        else 
+                        else
                         {
                             _currentScene.setAttribute(attribute, !attribute.value)
                         }
@@ -938,6 +961,13 @@ RowLayout {
                 }
             }
         }
+    }
+
+    MaterialLabel {
+        visible: !attribute.isOutput && root.errorMessages.length
+        text: MaterialIcons.fmd_bad
+        ToolTip.text: root.errorMessages.join("\n")
+        color: "orange"
     }
 
     // Add or remove key button for keyable attribute

--- a/meshroom/ui/qml/GraphEditor/GraphEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/GraphEditor.qml
@@ -941,9 +941,9 @@ Item {
                             node: object
                             width: uigraph.layout.nodeWidth
 
-                    mainSelected: uigraph.selectedNode === node
-                    hovered: uigraph.hoveredNode === node
-                    hasWarnings: node.hasInvalidAttribute
+                            mainSelected: uigraph.selectedNode === node
+                            hovered: uigraph.hoveredNode === node
+                            hasWarnings: node.hasInvalidAttribute
 
                             // ItemSelectionModel.hasSelection triggers updates anytime the selectionChanged() signal is emitted.
                             selected: uigraph.nodeSelection.hasSelection ? uigraph.nodeSelection.isRowSelected(index) : false
@@ -1219,7 +1219,6 @@ Item {
                     onLoaded: {
                         nodeLoader.z = Qt.binding(function() { return nodeLoader.item ? nodeLoader.item.z : 0 })
                     }
-
                 }
             }
         }

--- a/meshroom/ui/qml/GraphEditor/GraphEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/GraphEditor.qml
@@ -941,8 +941,9 @@ Item {
                             node: object
                             width: uigraph.layout.nodeWidth
 
-                            mainSelected: uigraph.selectedNode === node
-                            hovered: uigraph.hoveredNode === node
+                    mainSelected: uigraph.selectedNode === node
+                    hovered: uigraph.hoveredNode === node
+                    hasWarnings: node.hasInvalidAttribute
 
                             // ItemSelectionModel.hasSelection triggers updates anytime the selectionChanged() signal is emitted.
                             selected: uigraph.nodeSelection.hasSelection ? uigraph.nodeSelection.isRowSelected(index) : false
@@ -1218,6 +1219,7 @@ Item {
                     onLoaded: {
                         nodeLoader.z = Qt.binding(function() { return nodeLoader.item ? nodeLoader.item.z : 0 })
                     }
+
                 }
             }
         }
@@ -1329,11 +1331,11 @@ Item {
         draggable: draggable
         nodeRepeater: nodeRepeater
         anchors.fill: parent
-        
+
         onComputeRequest: function(node) {
             root.computeRequest([node])
         }
-        
+
         onStopComputeRequest: function(node) {
             if (node.canBeStopped()) {
                 uigraph.stopNodeComputation(node)
@@ -1358,7 +1360,7 @@ Item {
                 uigraph.clearSelectedNodesData()
             }
         }
-        
+
         onSubmitRequest: function(node) {
             root.submitRequest([node])
         }
@@ -1373,7 +1375,7 @@ Item {
             uigraph.restartJobErrorTasks(node)
         }
     }
-    
+
     MessageDialog {
         id: errorDialog
 

--- a/meshroom/ui/qml/GraphEditor/Node.qml
+++ b/meshroom/ui/qml/GraphEditor/Node.qml
@@ -343,14 +343,11 @@ Item {
                 return 2
             }
             border.color: {
-
-                if(hasWarnings === true) {
+                if (hasWarnings === true)
                     return Colors.warning                    
-                }
-                
-                if(root.mainSelected)
+                if (root.mainSelected)
                     return activePalette.highlight
-                if(root.selected)
+                if (root.selected)
                     return Qt.darker(activePalette.highlight, 1.2)
                 return Qt.lighter(activePalette.base, 3)
             }
@@ -480,7 +477,7 @@ Item {
                                 padding: 2
                                 font.pointSize: 7
                                 palette.text: Colors.sysPalette.text
-                                ToolTip.text: "Some attribute validations are failing"
+                                ToolTip.text: "Some attribute validations are failing for this node."
                             }
 
                             // Submitted externally indicator

--- a/meshroom/ui/qml/GraphEditor/Node.qml
+++ b/meshroom/ui/qml/GraphEditor/Node.qml
@@ -47,6 +47,7 @@ Item {
     property int directionY: 0;
 
     property point mousePosition: Qt.point(mouseArea.mouseX, mouseArea.mouseY)
+    property bool hasWarnings: false
 
     Item {
         id: m
@@ -342,6 +343,11 @@ Item {
                 return 2
             }
             border.color: {
+
+                if(hasWarnings === true) {
+                    return Colors.warning                    
+                }
+                
                 if(root.mainSelected)
                     return activePalette.highlight
                 if(root.selected)
@@ -464,6 +470,17 @@ Item {
                                     repeat: false
                                     onTriggered: parent.toolTipText = visible ? parent.baseText : ""
                                 }
+                            }
+
+                            // Attribute warnings
+                            MaterialLabel {
+                                visible: hasWarnings
+                                text: MaterialIcons.fmd_bad
+                                color: Colors.warning
+                                padding: 2
+                                font.pointSize: 7
+                                palette.text: Colors.sysPalette.text
+                                ToolTip.text: "Some attribute validations are failing"
                             }
 
                             // Submitted externally indicator

--- a/meshroom/ui/qml/Utils/Colors.qml
+++ b/meshroom/ui/qml/Utils/Colors.qml
@@ -22,6 +22,7 @@ QtObject {
     readonly property color lime: "#CDDC39"
     readonly property color grey: "#555555"
     readonly property color lightgrey: "#999999"
+    readonly property color warning: "#FF9800"
     readonly property color darkpurple: "#5c4885"
 
     readonly property var statusColors: {
@@ -66,7 +67,7 @@ QtObject {
         console.warn("Unknown status : " + chunk.status)
         return "magenta"
     }
-    
+
     function getNodeColor(node, overrides) {
         if (node === undefined)
             return "transparent"

--- a/meshroom/ui/qml/Utils/format.js
+++ b/meshroom/ui/qml/Utils/format.js
@@ -9,6 +9,7 @@ function intToString(v) {
 
 // Convert a plain text to an html escaped string.
 function plainToHtml(t) {
+    if (!t) { return t }
     var escaped = t.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')  // Escape text
     return escaped.replace(/\n/g, '<br>')  // Replace line breaks
 }

--- a/tests/nodes/test/nodeValidators.py
+++ b/tests/nodes/test/nodeValidators.py
@@ -6,27 +6,27 @@ class NodeWithValidators(desc.CommandLineNode):
 
     inputs = [
         desc.StringParam(
-            name='mandatory',
-            label='Mandatory input',
-            description='''''',
-            value='',
+            name="mandatory",
+            label="Mandatory Input",
+            description="",
+            value="",
             validators= [
                 NotEmptyValidator()
             ]
         ),
         desc.FloatParam(
-            name='floatRange',
-            label='range input',
-            description='''''',
+            name="floatRange",
+            label="Range Input",
+            description="",
             value=0.0,
             validators=[
                 RangeValidator(min=0.0, max=1.0)
             ]
         ),
         desc.IntParam(
-            name='intRange',
-            label='range input',
-            description='''''',
+            name="intRange",
+            label="Range Input",
+            description="",
             value=0,
             validators=[lambda node, attr: success() if 0 <= attr.value < 5 else error("Value should be in range 0-5")]
         ),
@@ -35,10 +35,9 @@ class NodeWithValidators(desc.CommandLineNode):
 
     outputs = [
         desc.File(
-            name='output',
-            label='Output',
-            description='''''',
-            value='{nodeCacheFolder}/appendText.txt',
+            name="output",
+            label="Output",
+            description="",
+            value="{nodeCacheFolder}/appendText.txt",
         )
     ]
-

--- a/tests/nodes/test/nodeValidators.py
+++ b/tests/nodes/test/nodeValidators.py
@@ -1,0 +1,43 @@
+from meshroom.core import desc
+from meshroom.core.desc.validators import NotEmptyValidator, RangeValidator
+
+
+class NodeWithValidators(desc.CommandLineNode):
+
+    inputs = [
+        desc.StringParam(
+            name='mandatory',
+            label='Mandatory input',
+            description='''''',
+            value='',
+            validators= [
+                NotEmptyValidator()
+            ]
+        ),
+        desc.FloatParam(
+            name='floatRange',
+            label='range input',
+            description='''''',
+            value=0.0,
+            validators=[
+                RangeValidator(min=0.0, max=1.0)
+            ]
+        ),
+        desc.IntParam(
+            name='intRange',
+            label='range input',
+            description='''''',
+            value=0,
+        ),
+
+    ]
+
+    outputs = [
+        desc.File(
+            name='output',
+            label='Output',
+            description='''''',
+            value='{nodeCacheFolder}/appendText.txt',
+        )
+    ]
+

--- a/tests/nodes/test/nodeValidators.py
+++ b/tests/nodes/test/nodeValidators.py
@@ -1,5 +1,5 @@
 from meshroom.core import desc
-from meshroom.core.desc.validators import NotEmptyValidator, RangeValidator
+from meshroom.core.desc.validators import NotEmptyValidator, RangeValidator, success, error
 
 
 class NodeWithValidators(desc.CommandLineNode):
@@ -28,6 +28,7 @@ class NodeWithValidators(desc.CommandLineNode):
             label='range input',
             description='''''',
             value=0,
+            validators=[lambda node, attr: success() if 0 <= attr.value < 5 else error("Value should be in range 0-5")]
         ),
 
     ]

--- a/tests/test_attributes.py
+++ b/tests/test_attributes.py
@@ -1,4 +1,7 @@
 from meshroom.core.graph import Graph
+from tests.utils import registerNodeDesc
+from tests.nodes.test.nodeValidators import NodeWithValidators
+
 import pytest
 
 import logging
@@ -10,6 +13,7 @@ invalid3DExtensionFiles = [(f'test.{ext}', False) for ext in ('', 'exe', 'jpg', 
 valid2DSemantics= [(semantic, True) for semantic in ('image', 'imageList', 'sequence')]
 invalid2DSemantics = [(semantic, False) for semantic in ('3d', '', 'multiline', 'color/hue')]
 
+registerNodeDesc(NodeWithValidators)
 validTextExtensionFiles = [(f'test{ext}', True) for ext in ('.txt', '.json', '.log', '.csv', '.md')]
 invalidTextExtensionFiles = [(f'test{ext}', False) for ext in ('', '.exe', '.jpg', '.obj', '.py')]
 
@@ -69,7 +73,6 @@ def test_attribute_is3D_file_extensions(givenFile, expected):
     # Then
     assert n0.input.is3dDisplayable == expected
 
-
 def test_attribute_i3D_by_description_semantic():
     """ """
 
@@ -104,6 +107,54 @@ def test_attribute_is2D_file_semantic(givenSemantic, expected):
 
     # Then
     assert n0.input.is2dDisplayable == expected
+    
+
+def test_attribute_notEmpty_validation():
+
+    # Given
+    g = Graph('')
+    node = g.addNewNode('NodeWithValidators')
+
+    # When
+    node.mandatory.value = ''
+
+    # Then
+    assert not node.mandatory.isValid
+    assert len(node.mandatory.getErrorMessages()) == 1
+    assert node.mandatory.isMandatory is True
+    assert node.hasInvalidAttribute
+
+    # When
+    node.mandatory.value = 'test'
+
+    # Then
+    assert node.mandatory.isValid
+    assert len(node.mandatory.getErrorMessages()) == 0
+    assert not node.hasInvalidAttribute
+
+def test_attribute_range_validation():
+
+    # Given
+    g = Graph('')
+    node = g.addNewNode('NodeWithValidators')
+    node.mandatory.value = 'test'
+
+    # When
+    node.floatRange.value = 2.0
+
+    # Then
+    assert not node.floatRange.isValid
+    assert len(node.floatRange.getErrorMessages()) == 2
+    assert node.mandatory.isMandatory is True
+    assert node.hasInvalidAttribute
+
+    # When
+    node.floatRange.value = 0.25
+
+    # Then
+    assert node.floatRange.isValid
+    assert len(node.floatRange.getErrorMessages()) == 0
+    assert not node.hasInvalidAttribute
 
 
 @pytest.mark.parametrize("givenFile,expected", validTextExtensionFiles + invalidTextExtensionFiles)


### PR DESCRIPTION
<!-- Checklist before submission:

 - I have read the [contribution guidelines](../CONTRIBUTING.md).
 - I have updated the documentation, if applicable.
 - I have ensured that the change is tested somewhere.
 - I have followed the prevailing code style (for history readability and limit conflicts for maintainance).

-->
## Description

[Alicevision related PR](https://github.com/alicevision/AliceVision/pull/1875)

Add a standard way to validate the attribute value.
It add a way to apply validators to an attribute description and to represent in the UI when these attributes are not valid.

![Screenshot_2025-05-23_17-35-17](https://github.com/user-attachments/assets/10c548dd-7dc3-4204-ae06-8fae6b111aba)

![image](https://github.com/user-attachments/assets/9a7f4ba2-ddb4-43ae-ae10-f98368ff23e1)

#### Validators
```python
class AttributeValidator(object):

    def __call__(self, node: "Node", attribute: "Attribute") -> tuple[bool, list[str]]: raise NotImplementedError()


class NotEmptyValidator(AttributeValidator):

    def __call__(self, node: "Node", attribute: "Attribute") -> tuple[bool, list[str]]:

        if attribute.value is None or attribute.value == "":
            return error("Empty value are not allowed")
        
        return success()
```

#### Validators usage (can be a lambda)

```python
desc.StringParam(
            name="input",
            label="Test input",
            description="",
            value="",
            validators=[
                NotEmptyValidator(),
                lambda node, attribute: success() if attribute == "test" else error("Attribute value should be 'test'")
                ]
        ),
```

## Features list
- [X] Add the notion of reusable validators
- [X] Validator embed the error messages
- [X] Validator can be a lambda
- [X] An icon with error message appear when an attribute value is invalid (at least one validator return error messages)
- [X] A node containing an invalid attribute is tagged with an orange icon and the selection rectangle is orange
- [X] Attribute value is checked every time the attribute value is set (in the Command) 
- [X] A Warning Dialog is displayed before trying to submit a graph where a node is in warning state

<!--
- [ ] Feature one. Fix #XXX
- [ ] Improve something else
- [ ] Connect to #3 (to declare link to issues without closing it when the PR is merged).
- [X] Add "X" when it is done.
-->


<!--
Explain main implementation choices.
It is also the right place to ask for feedback and help when you hesitate on the implementation.
-->
