### PR TITLE
[bug][ui] Fix undoImpl on RemoveEdgeCommand

### DIFF
--- a/meshroom/ui/commands.py
+++ b/meshroom/ui/commands.py
@@ -474,16 +474,24 @@ class RemoveEdgeCommand(GraphCommand):
         super().__init__(graph, parent)
         self.srcAttr = edge.src.fullName
         self.dstAttr = edge.dst.fullName
-        self.deletedEdges = []  # List of all the edges that have been deleted
+        self.deletedEdgeNames = []  # Store the names of deleted edges.
         self.setText(f"Disconnect '{self.srcAttr}' -> '{self.dstAttr}'")
 
     def redoImpl(self) -> bool:
-        self.deletedEdges = self.graph.attribute(self.dstAttr).disconnectEdge()
+        deletedEdges = self.graph.attribute(self.dstAttr).disconnectEdge()
+        # Store the fullNames instead of the actual attribute objects
+        self.deletedEdgeNames = [
+            (edge[0].fullName, edge[1].fullName) for edge in deletedEdges
+        ]
         return True
 
     def undoImpl(self) -> bool:
-        for edge in self.deletedEdges:
-            edge[0].connectTo(edge[1])
+        for srcName, dstName in self.deletedEdgeNames:
+            # Resolve the attributes from their names at undo time
+            # This way for ListAttribute we avoid getting a deleted object
+            srcAttr = self.graph.attribute(srcName)
+            dstAttr = self.graph.attribute(dstName)
+            srcAttr.connectTo(dstAttr)
         return True
 
 


### PR DESCRIPTION
# Description

Steps to reproduce the bug :
- create a connection to a ListAttribute
- delete the connection
- undo (ctrl+Z)

> The connection is not correctly restored and the edge is also not restored
<img width="865" height="406" alt="bug_a" src="https://github.com/user-attachments/assets/33f949ab-9d5d-45d4-bc83-c6a58de0fd56" />

### Why do we have the error

In the `deletedEdgeNames` list we stored reference to objects that are deleted on ListAttribute because the list is resize and therefore list items attributes are deleted.

### Proposed fix

Instead of storing objects we store the full names and retrieve them when we need to recreate the edge.
The list items are recreated at this point when we try to create the connection so we can retrieve everything correctly

> Connection and edge are correctly restored
<img width="865" height="406" alt="bug_b" src="https://github.com/user-attachments/assets/1dface13-3d2d-4c7e-82e0-c474d86fa510" />
