### PR TITLE
[core] `ListAttributes`: Resolve expressions before emitting `valueChanged` on insertion

### DIFF
--- a/meshroom/core/attribute.py
+++ b/meshroom/core/attribute.py
@@ -872,8 +872,8 @@ class ListAttribute(Attribute):
         attrs = [attributeFactory(self._desc.elementDesc, v, self.isOutput, self.node, self)
                  for v in values]
         self._value.insert(index, attrs)
-        self.valueChanged.emit()
         self._applyExpr()
+        self.valueChanged.emit()
         if self.isInput:
             self.requestGraphUpdate()
 


### PR DESCRIPTION
## Description

This PR fixes an issue where `valueChanged` was emitted before link expressions were resolved when an element was inserted in the list, meaning that any callback reading the list's values would find the last inserted attribute still holding an unresolved link expression instead of the actual upstream value.

`valueChanged` is now only emitted to notify listeners once all link expressions have been resolved.
