### PR TITLE
[GraphEditor] Dynamically adjust `Backdrop`'s z-level based on its size

### DIFF
--- a/meshroom/ui/qml/GraphEditor/Backdrop.qml
+++ b/meshroom/ui/qml/GraphEditor/Backdrop.qml
@@ -77,8 +77,9 @@ Item {
     x: root.node ? root.node.x : undefined
     y: root.node ? root.node.y : undefined
 
-    // The backdrop node always needs to be at the back
-    z: -1
+    // The backdrop node always needs to be at the back (below nodes which default to z=0).
+    // Among backdrops, smaller area gets a higher (less negative) z so it renders on top.
+    z: -(width * height)
 
     width: root.node ? root.node.nodeWidth : 300
     height: root.node ? root.node.nodeHeight : 200

--- a/meshroom/ui/qml/GraphEditor/GraphEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/GraphEditor.qml
@@ -1216,7 +1216,7 @@ Item {
                     sourceComponent: object.isBackdropNode ? backdropComponent : nodeComponent
 
                     onLoaded: {
-                        nodeLoader.z = nodeLoader.item.z
+                        nodeLoader.z = Qt.binding(function() { return nodeLoader.item ? nodeLoader.item.z : 0 })
                     }
                 }
             }


### PR DESCRIPTION
## Description

When backdrops are overlapping, their superposition depends on which was created first. However, we would rather have the larger backdrop only below the smaller one, and have the z-levels updated dynamically when backdrops are resized.

This PR adjusts the z-level of the backdrop based on its size, which allows to dynamically re-order the backdrops. Nodes always remain on top.
<img width="1213" height="576" alt="backdrops" src="https://github.com/user-attachments/assets/4943a62b-e343-425f-adee-ecc0a6805c79" />
