### PR TITLE
[Controls] `TimelineSlider`: Improve slider's behaviour

### DIFF
--- a/meshroom/ui/qml/Controls/TimelineSlider.qml
+++ b/meshroom/ui/qml/Controls/TimelineSlider.qml
@@ -104,8 +104,8 @@ Slider {
 
                 Item {
                     readonly property int frameNum: root.from + index * ruler.majorInterval
-                    readonly property real xPos: ruler.range > 0
-                        ? (frameNum - root.from) / ruler.range * ruler.width
+                    readonly property real xPos: (root.to - root.from + 1) > 0
+                        ? (frameNum - root.from) / (root.to - root.from + 1) * ruler.width
                         : 0
 
                     x: xPos - width / 2

--- a/meshroom/ui/qml/Controls/TimelineSlider.qml
+++ b/meshroom/ui/qml/Controls/TimelineSlider.qml
@@ -20,7 +20,11 @@ Slider {
 
     implicitHeight: _rulerHeight + _trackHeight + topPadding + bottomPadding
 
-    // ── Playhead handle ──────────────────────────────────────────────────────
+    // The phantom-frame cell size: it will appear as available space on the right of the last frame,
+    // but will not be interactable (the handle will stop at the left edge of that cell when visualPosition=1.0).
+    rightPadding: (to > from) ? (width - leftPadding) / (to - from + 1) : 0
+
+    // Playhead handle
     handle: Item {
         // Center the playhead on the logical slider position
         x: root.leftPadding + root.visualPosition * root.availableWidth - width / 2
@@ -66,11 +70,12 @@ Slider {
         }
     }
 
-    // ── Background: ruler + track ────────────────────────────────────────────
+    // Background: ruler + track
     background: Item {
         x: root.leftPadding
         y: root.topPadding
-        width: root.availableWidth
+        // Extend to the full visual width (interactive zone + the phantom-frame cell)
+        width: root.availableWidth + root.rightPadding
         height: root.availableHeight
 
         // Ruler: tick marks and frame-number labels


### PR DESCRIPTION
## Description

Building up on top of #3059, this PR improves two elements of the Sequence Player's timeline slider:
- The slider's position could be misaligned with the frame number markers. For example, there could be a marker for frame n°5, the slider would be set for frame n°5, but the slider would not be visually aligned with the marker for that frame.
- The last position the slider could reach was the far-end of the timeline, which we do not want. Instead, we want this space to be reserved for a phantom-frame, and the slider to be physically blocked right before reaching this phantom-frame.

