### PR TITLE
[ui] Fix some issues on the Sequence Player

### DIFF
--- a/meshroom/ui/graph.py
+++ b/meshroom/ui/graph.py
@@ -1461,6 +1461,7 @@ class UIGraph(QObject):
 
             # After every check we finally remove the attribute
             self.removeAttribute(image)
+        self.imageListChanged.emit()
 
     @Slot(list)
     def removeImages(self, images: list):
@@ -1468,16 +1469,19 @@ class UIGraph(QObject):
         if not images:
             return
         self.push(commands.RemoveSelectedImagesCommand(self._graph, self.cameraInit, images))
+        self.imageListChanged.emit()
 
     @Slot()
     def removeAllImages(self):
         with self.groupedGraphModification("Remove All Images"):
             self.push(commands.RemoveImagesCommand(self._graph, [self.cameraInit]))
+        self.imageListChanged.emit()
 
     @Slot()
     def removeImagesFromAllGroups(self):
         with self.groupedGraphModification("Remove Images From All CameraInit Nodes"):
             self.push(commands.RemoveImagesCommand(self._graph, list(self.cameraInits)))
+        self.imageListChanged.emit()
 
     @Slot(list)
     @Slot(list, int)
@@ -1656,6 +1660,8 @@ class UIGraph(QObject):
 
     sortedDFSChunks = Property(QObject, lambda self: self._sortedDFSChunks, constant=True)
     lockedChanged = Signal()
+    
+    imageListChanged = Signal()
 
     selectedNodeChanged = Signal()
     # Current main selected node

--- a/meshroom/ui/qml/Viewer/SequencePlayer.qml
+++ b/meshroom/ui/qml/Viewer/SequencePlayer.qml
@@ -31,6 +31,8 @@ FloatingPane {
     property alias frameId: m.frame
     property var frameRange: { "min" : 0, "max" : 0 }
 
+    property int nbViewpoints: _currentScene ? _currentScene.viewpoints.count : 0
+
     Settings {
         id: settings_SequencePlayer
         property int maxCacheMemory: viewer && viewer.ramInfo != undefined ? viewer.ramInfo.x / 4 : 0
@@ -80,9 +82,8 @@ FloatingPane {
         }
 
         onPlayingChanged: {
-            if (!playing) {
-                updateSceneView()
-            } else if (playing && (frame + 1 >= frameRange.max + 1)) {
+            updateSceneView()
+            if (playing && (frame + 1 >= frameRange.max + 1)) {
                 frame = frameRange.min
             }
             viewer.playback(playing)
@@ -99,6 +100,10 @@ FloatingPane {
                     m.frame = idx
                 }
             }
+        }
+
+        function onImageListChanged() {
+            nbViewpoints = Qt.binding(function() { return _currentScene ? _currentScene.viewpoints.count : 0 })
         }
     }
 
@@ -166,6 +171,7 @@ FloatingPane {
 
         MaterialToolButton {
             id: playButton
+            enabled: nbViewpoints > 0
 
             checkable: true
             checked: false
@@ -188,6 +194,7 @@ FloatingPane {
     
         TimelineSlider {
             id: frameSlider
+            enabled: nbViewpoints > 0
 
             Layout.fillWidth: true
 
@@ -200,7 +207,7 @@ FloatingPane {
             from: frameRange.min
             to: frameRange.max
 
-            cachedFrames: viewer ? viewer.cachedFrames : []
+            cachedFrames: viewer && nbViewpoints > 0 ? viewer.cachedFrames : []
 
             onValueChanged: {
                 m.frame = value
@@ -242,7 +249,6 @@ FloatingPane {
             text: MaterialIcons.subscriptions
             ToolTip.text: "Fetch"
             checkable: true
-            checked: loading
         }
 
         MaterialToolButton {


### PR DESCRIPTION
## Description

Several bugs in SequencePlayer.qml affecting the timeline slider behavior.

> [!NOTE]
> Issue linked : https://github.com/alicevision/Meshroom/issues/3095


**To Reproduce**
- Open blank scene
- [x] **Issue 1 (Solved) :** With no images loaded we can still move the slider <img width="634" height="131" alt="Image" src="https://github.com/user-attachments/assets/9ef1ca7b-dd29-4f34-90a3-08d845c0e9e7" />
- [x] **Issue 2 (Solved) :** Click on play and there is a QML warning
```
file:///.../meshroom/ui/qml/Viewer/Viewer2D.qml:1880:17: QML SequencePlayer: Binding loop detected for property "loading":
file:///.../meshroom/ui/qml/Viewer/SequencePlayer.qml:29:5
```
- Now load images
- [x] **Issue 3 (Solved) :** Even though the "Fetch" button is checked it doesn't fetch anything : you have to either press play or click somewhere on the timeline to start creating the image cache <img width="634" height="131" alt="Image" src="https://github.com/user-attachments/assets/cc577cea-f8b1-4671-b6e0-c27d82688234" />
- Play images so you fetch all images
- [ ] **Issue 4 :** Now remove all images from the Image Gallery. You can see the slider is not empty <img width="634" height="131" alt="Image" src="https://github.com/user-attachments/assets/7f946c3e-37b9-4dd4-b8a5-4f88ab42bc96" />
- Delete the CameraInit that holds images. The slider is empty now.
- [x] **Issue 5 (Solved) :** Click on play : it seems like there is an infinite timeline <img width="634" height="131" alt="Image" src="https://github.com/user-attachments/assets/3eaa52c6-e0eb-4a63-a3d0-c50ea1022480" />


