### PR TITLE
[bug][graph] Fix issues in the dfs function

### DIFF
--- a/meshroom/core/graph.py
+++ b/meshroom/core/graph.py
@@ -1025,7 +1025,8 @@ class Graph(BaseObject):
 
         try:
             for node in nodes:
-                self.dfsVisit(node, visitor, colors, nodeChildren, longestPathFirst)
+                if colors.get(node, WHITE) == WHITE:
+                    self.dfsVisit(node, visitor, colors, nodeChildren, longestPathFirst)
         except StopGraphVisit:
             pass
 

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -17,98 +17,6 @@ def test_depth():
     assert tC.depth == 2
 
 
-def test_depth_diamond_graph():
-    graph = Graph("Tests tasks depth")
-
-    tA = graph.addNewNode("Ls", input="/tmp")
-    tB = graph.addNewNode("AppendText", inputText="echo B")
-    tC = graph.addNewNode("AppendText", inputText="echo C")
-    tD = graph.addNewNode("AppendFiles")
-
-    tA.output.connectTo(tB.input)
-    tA.output.connectTo(tC.input)
-    tB.output.connectTo(tD.input)
-    tC.output.connectTo(tD.input2)
-
-    assert tA.depth == 0
-    assert tB.depth == 1
-    assert tC.depth == 1
-    assert tD.depth == 2
-
-    nodes, edges = graph.dfsOnFinish()
-    assert len(nodes) == 4
-    assert nodes[0] == tA
-    assert nodes[-1] == tD
-    assert len(edges) == 4
-
-    nodes, edges = graph.dfsOnFinish(startNodes=[tD])
-    assert len(nodes) == 4
-    assert nodes[0] == tA
-    assert nodes[-1] == tD
-    assert len(edges) == 4
-
-    nodes, edges = graph.dfsOnFinish(startNodes=[tB])
-    assert len(nodes) == 2
-    assert nodes[0] == tA
-    assert nodes[-1] == tB
-    assert len(edges) == 1
-
-
-def test_depth_diamond_graph2():
-    graph = Graph("Tests tasks depth")
-
-    tA = graph.addNewNode("Ls", input="/tmp")
-    tB = graph.addNewNode("AppendText", inputText="echo B")
-    tC = graph.addNewNode("AppendText", inputText="echo C")
-    tD = graph.addNewNode("AppendText", inputText="echo D")
-    tE = graph.addNewNode("AppendFiles")
-    #         C
-    #       /   \
-    #  /---/---->\
-    # A -> B ---> E
-    #      \     /
-    #       \   /
-    #         D
-    tA.output.connectTo(tB.input)
-    tB.output.connectTo(tC.input)
-    tB.output.connectTo(tD.input)
-    tA.output.connectTo(tE.input)
-    tB.output.connectTo(tE.input2)
-    tC.output.connectTo(tE.input3)
-    tD.output.connectTo(tE.input4)
-
-    assert tA.depth == 0
-    assert tB.depth == 1
-    assert tC.depth == 2
-    assert tD.depth == 2
-    assert tE.depth == 3
-
-    nodes, edges = graph.dfsOnFinish()
-    assert len(nodes) == 5
-    assert nodes[0] == tA
-    assert nodes[-1] == tE
-    assert len(edges) == 7
-
-    nodes, edges = graph.dfsOnFinish(startNodes=[tE])
-    assert len(nodes) == 5
-    assert nodes[0] == tA
-    assert nodes[-1] == tE
-    assert len(edges) == 7
-
-    nodes, edges = graph.dfsOnFinish(startNodes=[tD])
-    assert len(nodes) == 3
-    assert nodes[0] == tA
-    assert nodes[1] == tB
-    assert nodes[2] == tD
-    assert len(edges) == 2
-
-    nodes, edges = graph.dfsOnFinish(startNodes=[tB])
-    assert len(nodes) == 2
-    assert nodes[0] == tA
-    assert nodes[-1] == tB
-    assert len(edges) == 1
-
-
 def test_transitive_reduction():
     graph = Graph("Tests tasks depth")
 
@@ -144,78 +52,6 @@ def test_transitive_reduction():
     assert len(graph._nodesMinMaxDepths) == len(graph.nodes)
     for node, (_, maxDepth) in graph._nodesMinMaxDepths.items():
         assert node.depth == maxDepth
-
-
-def test_graph_reverse_dfsOnDiscover():
-    graph = Graph("Test dfsOnDiscover(reverse=True)")
-
-    #    ------------\
-    #   /   ~ C - E - F
-    # A - B
-    #      ~ D
-
-    A = graph.addNewNode("Ls", input="/tmp")
-    B = graph.addNewNode("AppendText", inputText=A.output)
-    C = graph.addNewNode("AppendText", inputText=B.output)
-    D = graph.addNewNode("AppendText", inputText=B.output)
-    E = graph.addNewNode("Ls", input=C.output)
-    F = graph.addNewNode("AppendText", input=A.output, inputText=E.output)
-
-    # Get all nodes from A (use set, order not guaranteed)
-    nodes = graph.dfsOnDiscover(startNodes=[A], reverse=True)[0]
-    assert set(nodes) == {A, B, D, C, E, F}
-    # Get all nodes from B
-    nodes = graph.dfsOnDiscover(startNodes=[B], reverse=True)[0]
-    assert set(nodes) == {B, D, C, E, F}
-    # Get all nodes of type AppendText from B
-    nodes = graph.dfsOnDiscover(startNodes=[B], filterTypes=["AppendText"], reverse=True)[0]
-    assert set(nodes) == {B, D, C, F}
-    # Get all nodes from C (order guaranteed)
-    nodes = graph.dfsOnDiscover(startNodes=[C], reverse=True)[0]
-    assert nodes == [C, E, F]
-    # Get all nodes
-    nodes = graph.dfsOnDiscover(reverse=True)[0]
-    assert set(nodes) == {A, B, C, D, E, F}
-
-
-def test_graph_dfsOnDiscover():
-    graph = Graph("Test dfsOnDiscover(reverse=False)")
-
-    #    ------------\
-    #   /   ~ C - E - F
-    # A - B
-    #      ~ D
-    #    G
-
-    G = graph.addNewNode("Ls", input="/tmp")
-    A = graph.addNewNode("Ls", input="/tmp")
-    B = graph.addNewNode("AppendText", inputText=A.output)
-    C = graph.addNewNode("AppendText", inputText=B.output)
-    D = graph.addNewNode("AppendText", input=G.output, inputText=B.output)
-    E = graph.addNewNode("Ls", input=C.output)
-    F = graph.addNewNode("AppendText", input=A.output, inputText=E.output)
-
-    # Get all nodes from A (use set, order not guaranteed)
-    nodes = graph.dfsOnDiscover(startNodes=[A], reverse=False)[0]
-    assert set(nodes) == {A}
-    # Get all nodes from D
-    nodes = graph.dfsOnDiscover(startNodes=[D], reverse=False)[0]
-    assert set(nodes) == {A, B, D, G}
-    # Get all nodes from E
-    nodes = graph.dfsOnDiscover(startNodes=[E], reverse=False)[0]
-    assert set(nodes) == {A, B, C, E}
-    # Get all nodes from F
-    nodes = graph.dfsOnDiscover(startNodes=[F], reverse=False)[0]
-    assert set(nodes) == {A, B, C, E, F}
-    # Get all nodes of type AppendText from C
-    nodes = graph.dfsOnDiscover(startNodes=[C], filterTypes=["AppendText"], reverse=False)[0]
-    assert set(nodes) == {B, C}
-    # Get all nodes from D (order guaranteed)
-    nodes = graph.dfsOnDiscover(startNodes=[D], longestPathFirst=True, reverse=False)[0]
-    assert nodes == [D, B, A, G]
-    # Get all nodes
-    nodes = graph.dfsOnDiscover(reverse=False)[0]
-    assert set(nodes) == {A, B, C, D, E, F, G}
 
 
 def test_graph_nodes_sorting():
@@ -299,106 +135,266 @@ def test_rename_nodes():
     assert ls0.name == "nodels"
 
 
-def test_dfs_no_duplicates_start_node_is_ancestor_of_another():
-    """
-    Test that DFS does not visit the same node more than once when one startNode
-    is an ancestor (in the traversal direction) of another startNode.
+class TestDFS:
+    """ Tests for the graph DFS traversal methods. """
 
-    Graph:
-    A -> B -> C
+    def test_dfs_on_finish_depth_diamond_graph(self):
+        graph = Graph("Tests tasks depth (diamond graph)")
 
-    Starting DFS (reverse=False, toward roots) from both C and B: visiting C first
-    will traverse C -> B -> A. B should not be discovered or finished a second time
-    when it is encountered again as a startNode.
-    """
-    graph = Graph("")
+        tA = graph.addNewNode("Ls", input="/tmp")
+        tB = graph.addNewNode("AppendText", inputText="echo B")
+        tC = graph.addNewNode("AppendText", inputText="echo C")
+        tD = graph.addNewNode("AppendFiles")
 
-    A = graph.addNewNode("Ls", input="/tmp")
-    B = graph.addNewNode("AppendText", inputText=A.output)
-    C = graph.addNewNode("AppendText", inputText=B.output)
+        tA.output.connectTo(tB.input)
+        tA.output.connectTo(tC.input)
+        tB.output.connectTo(tD.input)
+        tC.output.connectTo(tD.input2)
 
-    nodes, _ = graph.dfsOnFinish(startNodes=[C, B])
+        assert tA.depth == 0
+        assert tB.depth == 1
+        assert tC.depth == 1
+        assert tD.depth == 2
 
-    # B must appear exactly once — it is visited when traversing from C, and
-    # must NOT be re-visited when it is encountered as a startNode.
-    assert len(nodes) == len(set(nodes)), "dfsOnFinish returned duplicate nodes"
-    assert len(nodes) == 3
-    assert set(nodes) == {A, B, C}
+        nodes, edges = graph.dfsOnFinish()
+        assert len(nodes) == 4
+        assert nodes[0] == tA
+        assert nodes[-1] == tD
+        assert len(edges) == 4
 
+        nodes, edges = graph.dfsOnFinish(startNodes=[tD])
+        assert len(nodes) == 4
+        assert nodes[0] == tA
+        assert nodes[-1] == tD
+        assert len(edges) == 4
 
-def test_dfs_no_duplicates_start_node_is_root_of_another():
-    """
-    Test that DFS does not visit the same node more than once when one startNode
-    is the root of the whole graph, and also appears in the traversal path of
-    another startNode in the list.
+        nodes, edges = graph.dfsOnFinish(startNodes=[tB])
+        assert len(nodes) == 2
+        assert nodes[0] == tA
+        assert nodes[-1] == tB
+        assert len(edges) == 1
 
-    Graph:
-    A -> B -> C
+    def test_dfs_on_finish_depth_diamond_graph2(self):
+        graph = Graph("Tests tasks depth (diamond graph 2)")
 
-    Starting DFS (reverse=False) from both C and A: visiting C will traverse
-    C -> B -> A. A should not be discovered or finished a second time when it is
-    encountered again as a startNode.
-    """
-    graph = Graph("")
+        tA = graph.addNewNode("Ls", input="/tmp")
+        tB = graph.addNewNode("AppendText", inputText="echo B")
+        tC = graph.addNewNode("AppendText", inputText="echo C")
+        tD = graph.addNewNode("AppendText", inputText="echo D")
+        tE = graph.addNewNode("AppendFiles")
+        #         C
+        #       /   \
+        #  /---/----->\
+        # A -> B ---> E
+        #      \     /
+        #       \   /
+        #         D
+        tA.output.connectTo(tB.input)
+        tB.output.connectTo(tC.input)
+        tB.output.connectTo(tD.input)
+        tA.output.connectTo(tE.input)
+        tB.output.connectTo(tE.input2)
+        tC.output.connectTo(tE.input3)
+        tD.output.connectTo(tE.input4)
 
-    A = graph.addNewNode("Ls", input="/tmp")
-    B = graph.addNewNode("AppendText", inputText=A.output)
-    C = graph.addNewNode("AppendText", inputText=B.output)
+        assert tA.depth == 0
+        assert tB.depth == 1
+        assert tC.depth == 2
+        assert tD.depth == 2
+        assert tE.depth == 3
 
-    nodes, _ = graph.dfsOnFinish(startNodes=[C, A])
+        nodes, edges = graph.dfsOnFinish()
+        assert len(nodes) == 5
+        assert nodes[0] == tA
+        assert nodes[-1] == tE
+        assert len(edges) == 7
 
-    # A must appear exactly once.
-    assert len(nodes) == len(set(nodes)), "dfsOnFinish returned duplicate nodes"
-    assert len(nodes) == 3
-    assert set(nodes) == {A, B, C}
+        nodes, edges = graph.dfsOnFinish(startNodes=[tE])
+        assert len(nodes) == 5
+        assert nodes[0] == tA
+        assert nodes[-1] == tE
+        assert len(edges) == 7
 
+        nodes, edges = graph.dfsOnFinish(startNodes=[tD])
+        assert len(nodes) == 3
+        assert nodes[0] == tA
+        assert nodes[1] == tB
+        assert nodes[2] == tD
+        assert len(edges) == 2
 
-def test_dfs_no_duplicates_reverse_start_node_is_descendant_of_another():
-    """
-    Test that reverse DFS does not visit the same node more than once when one
-    startNode is a descendant (in the reverse traversal direction, i.e. toward
-    leaves) of another startNode.
+        nodes, edges = graph.dfsOnFinish(startNodes=[tB])
+        assert len(nodes) == 2
+        assert nodes[0] == tA
+        assert nodes[-1] == tB
+        assert len(edges) == 1
 
-    Graph:
-    A -> B -> C
+    def test_reverse_dfs_on_discover(self):
+        graph = Graph("Test dfsOnDiscover(reverse=True)")
 
-    Starting reverse DFS from both A and B: visiting A first traverses A -> B -> C.
-    B and C should not be discovered a second time when B is encountered again as
-    a startNode.
-    """
-    graph = Graph("")
+        #    ------------\
+        #   /   ~ C - E - F
+        # A - B
+        #      ~ D
 
-    A = graph.addNewNode("Ls", input="/tmp")
-    B = graph.addNewNode("AppendText", inputText=A.output)
-    C = graph.addNewNode("AppendText", inputText=B.output)
+        A = graph.addNewNode("Ls", input="/tmp")
+        B = graph.addNewNode("AppendText", inputText=A.output)
+        C = graph.addNewNode("AppendText", inputText=B.output)
+        D = graph.addNewNode("AppendText", inputText=B.output)
+        E = graph.addNewNode("Ls", input=C.output)
+        F = graph.addNewNode("AppendText", input=A.output, inputText=E.output)
 
-    nodes, _ = graph.dfsOnDiscover(startNodes=[A, B], reverse=True)
+        # Get all nodes from A (use set, order not guaranteed)
+        nodes = graph.dfsOnDiscover(startNodes=[A], reverse=True)[0]
+        assert set(nodes) == {A, B, D, C, E, F}
+        # Get all nodes from B
+        nodes = graph.dfsOnDiscover(startNodes=[B], reverse=True)[0]
+        assert set(nodes) == {B, D, C, E, F}
+        # Get all nodes of type AppendText from B
+        nodes = graph.dfsOnDiscover(startNodes=[B], filterTypes=["AppendText"], reverse=True)[0]
+        assert set(nodes) == {B, D, C, F}
+        # Get all nodes from C (order guaranteed)
+        nodes = graph.dfsOnDiscover(startNodes=[C], reverse=True)[0]
+        assert nodes == [C, E, F]
+        # Get all nodes
+        nodes = graph.dfsOnDiscover(reverse=True)[0]
+        assert set(nodes) == {A, B, C, D, E, F}
 
-    # B must appear exactly once — it is visited when traversing forward from A,
-    # and must NOT be re-visited when encountered as a startNode.
-    assert len(nodes) == len(set(nodes)), "dfsOnDiscover(reverse=True) returned duplicate nodes"
-    assert set(nodes) == {A, B, C}
+    def test_dfs_on_discover(self):
+        graph = Graph("Test dfsOnDiscover(reverse=False)")
 
+        #    ------------\
+        #   /   ~ C - E - F
+        # A - B
+        #      ~ D
+        #    G
 
-def test_dfs_no_duplicates_discover_start_node_is_ancestor_of_another():
-    """
-    Test that dfsOnDiscover does not return duplicate nodes when one startNode
-    is an ancestor (in the traversal direction) of another startNode.
+        G = graph.addNewNode("Ls", input="/tmp")
+        A = graph.addNewNode("Ls", input="/tmp")
+        B = graph.addNewNode("AppendText", inputText=A.output)
+        C = graph.addNewNode("AppendText", inputText=B.output)
+        D = graph.addNewNode("AppendText", input=G.output, inputText=B.output)
+        E = graph.addNewNode("Ls", input=C.output)
+        F = graph.addNewNode("AppendText", input=A.output, inputText=E.output)
 
-    Graph:
-    A -> B -> C
+        # Get all nodes from A (use set, order not guaranteed)
+        nodes = graph.dfsOnDiscover(startNodes=[A], reverse=False)[0]
+        assert set(nodes) == {A}
+        # Get all nodes from D
+        nodes = graph.dfsOnDiscover(startNodes=[D], reverse=False)[0]
+        assert set(nodes) == {A, B, D, G}
+        # Get all nodes from E
+        nodes = graph.dfsOnDiscover(startNodes=[E], reverse=False)[0]
+        assert set(nodes) == {A, B, C, E}
+        # Get all nodes from F
+        nodes = graph.dfsOnDiscover(startNodes=[F], reverse=False)[0]
+        assert set(nodes) == {A, B, C, E, F}
+        # Get all nodes of type AppendText from C
+        nodes = graph.dfsOnDiscover(startNodes=[C], filterTypes=["AppendText"], reverse=False)[0]
+        assert set(nodes) == {B, C}
+        # Get all nodes from D (order guaranteed)
+        nodes = graph.dfsOnDiscover(startNodes=[D], longestPathFirst=True, reverse=False)[0]
+        assert nodes == [D, B, A, G]
+        # Get all nodes
+        nodes = graph.dfsOnDiscover(reverse=False)[0]
+        assert set(nodes) == {A, B, C, D, E, F, G}
 
-    Starting dfsOnDiscover (reverse=False) from both C and B: visiting C first
-    traverses C -> B -> A. B should not be discovered a second time when it is
-    encountered again as a startNode.
-    """
-    graph = Graph("")
+    def test_no_duplicates_start_node_is_ancestor_of_another(self):
+        """
+        Test that DFS does not visit the same node more than once when one startNode
+        is an ancestor (in the traversal direction) of another startNode.
 
-    A = graph.addNewNode("Ls", input="/tmp")
-    B = graph.addNewNode("AppendText", inputText=A.output)
-    C = graph.addNewNode("AppendText", inputText=B.output)
+        Graph:
+        A -> B -> C
 
-    nodes, _ = graph.dfsOnDiscover(startNodes=[C, B])
+        Starting DFS (reverse=False, toward roots) from both C and B: visiting C first
+        will traverse C -> B -> A. B should not be discovered or finished a second time
+        when it is encountered again as a startNode.
+        """
+        graph = Graph("")
 
-    assert len(nodes) == len(set(nodes)), "dfsOnDiscover returned duplicate nodes"
-    assert set(nodes) == {A, B, C}
+        A = graph.addNewNode("Ls", input="/tmp")
+        B = graph.addNewNode("AppendText", inputText=A.output)
+        C = graph.addNewNode("AppendText", inputText=B.output)
+
+        nodes, _ = graph.dfsOnFinish(startNodes=[C, B])
+
+        # B must appear exactly once — it is visited when traversing from C, and
+        # must NOT be re-visited when it is encountered as a startNode.
+        assert len(nodes) == len(set(nodes)), "dfsOnFinish returned duplicate nodes"
+        assert len(nodes) == 3
+        assert set(nodes) == {A, B, C}
+
+    def test_no_duplicates_start_node_is_root_of_another(self):
+        """
+        Test that DFS does not visit the same node more than once when one startNode
+        is the root of the whole graph, and also appears in the traversal path of
+        another startNode in the list.
+
+        Graph:
+        A -> B -> C
+
+        Starting DFS (reverse=False) from both C and A: visiting C will traverse
+        C -> B -> A. A should not be discovered or finished a second time when it is
+        encountered again as a startNode.
+        """
+        graph = Graph("")
+
+        A = graph.addNewNode("Ls", input="/tmp")
+        B = graph.addNewNode("AppendText", inputText=A.output)
+        C = graph.addNewNode("AppendText", inputText=B.output)
+
+        nodes, _ = graph.dfsOnFinish(startNodes=[C, A])
+
+        # A must appear exactly once.
+        assert len(nodes) == len(set(nodes)), "dfsOnFinish returned duplicate nodes"
+        assert len(nodes) == 3
+        assert set(nodes) == {A, B, C}
+
+    def test_no_duplicates_reverse_start_node_is_descendant_of_another(self):
+        """
+        Test that reverse DFS does not visit the same node more than once when one
+        startNode is a descendant (in the reverse traversal direction, i.e. toward
+        leaves) of another startNode.
+
+        Graph:
+        A -> B -> C
+
+        Starting reverse DFS from both A and B: visiting A first traverses A -> B -> C.
+        B and C should not be discovered a second time when B is encountered again as
+        a startNode.
+        """
+        graph = Graph("")
+
+        A = graph.addNewNode("Ls", input="/tmp")
+        B = graph.addNewNode("AppendText", inputText=A.output)
+        C = graph.addNewNode("AppendText", inputText=B.output)
+
+        nodes, _ = graph.dfsOnDiscover(startNodes=[A, B], reverse=True)
+
+        # B must appear exactly once — it is visited when traversing forward from A,
+        # and must NOT be re-visited when encountered as a startNode.
+        assert len(nodes) == len(set(nodes)), "dfsOnDiscover(reverse=True) returned duplicate nodes"
+        assert set(nodes) == {A, B, C}
+
+    def test_no_duplicates_discover_start_node_is_ancestor_of_another(self):
+        """
+        Test that dfsOnDiscover does not return duplicate nodes when one startNode
+        is an ancestor (in the traversal direction) of another startNode.
+
+        Graph:
+        A -> B -> C
+
+        Starting dfsOnDiscover (reverse=False) from both C and B: visiting C first
+        traverses C -> B -> A. B should not be discovered a second time when it is
+        encountered again as a startNode.
+        """
+        graph = Graph("")
+
+        A = graph.addNewNode("Ls", input="/tmp")
+        B = graph.addNewNode("AppendText", inputText=A.output)
+        C = graph.addNewNode("AppendText", inputText=B.output)
+
+        nodes, _ = graph.dfsOnDiscover(startNodes=[C, B])
+
+        assert len(nodes) == len(set(nodes)), "dfsOnDiscover returned duplicate nodes"
+        assert set(nodes) == {A, B, C}

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -1,8 +1,6 @@
 from meshroom.core.exception import CyclicDependencyError
 from meshroom.core.graph import Graph
 
-import pytest
-
 
 def test_depth():
     graph = Graph("Tests tasks depth")
@@ -299,3 +297,108 @@ def test_rename_nodes():
     ls0.setLocked(True)
     graph.renameNode(ls0, "lockedLs")
     assert ls0.name == "nodels"
+
+
+def test_dfs_no_duplicates_start_node_is_ancestor_of_another():
+    """
+    Test that DFS does not visit the same node more than once when one startNode
+    is an ancestor (in the traversal direction) of another startNode.
+
+    Graph:
+    A -> B -> C
+
+    Starting DFS (reverse=False, toward roots) from both C and B: visiting C first
+    will traverse C -> B -> A. B should not be discovered or finished a second time
+    when it is encountered again as a startNode.
+    """
+    graph = Graph("")
+
+    A = graph.addNewNode("Ls", input="/tmp")
+    B = graph.addNewNode("AppendText", inputText=A.output)
+    C = graph.addNewNode("AppendText", inputText=B.output)
+
+    nodes, _ = graph.dfsOnFinish(startNodes=[C, B])
+
+    # B must appear exactly once — it is visited when traversing from C, and
+    # must NOT be re-visited when it is encountered as a startNode.
+    assert len(nodes) == len(set(nodes)), "dfsOnFinish returned duplicate nodes"
+    assert len(nodes) == 3
+    assert set(nodes) == {A, B, C}
+
+
+def test_dfs_no_duplicates_start_node_is_root_of_another():
+    """
+    Test that DFS does not visit the same node more than once when one startNode
+    is the root of the whole graph, and also appears in the traversal path of
+    another startNode in the list.
+
+    Graph:
+    A -> B -> C
+
+    Starting DFS (reverse=False) from both C and A: visiting C will traverse
+    C -> B -> A. A should not be discovered or finished a second time when it is
+    encountered again as a startNode.
+    """
+    graph = Graph("")
+
+    A = graph.addNewNode("Ls", input="/tmp")
+    B = graph.addNewNode("AppendText", inputText=A.output)
+    C = graph.addNewNode("AppendText", inputText=B.output)
+
+    nodes, _ = graph.dfsOnFinish(startNodes=[C, A])
+
+    # A must appear exactly once.
+    assert len(nodes) == len(set(nodes)), "dfsOnFinish returned duplicate nodes"
+    assert len(nodes) == 3
+    assert set(nodes) == {A, B, C}
+
+
+def test_dfs_no_duplicates_reverse_start_node_is_descendant_of_another():
+    """
+    Test that reverse DFS does not visit the same node more than once when one
+    startNode is a descendant (in the reverse traversal direction, i.e. toward
+    leaves) of another startNode.
+
+    Graph:
+    A -> B -> C
+
+    Starting reverse DFS from both A and B: visiting A first traverses A -> B -> C.
+    B and C should not be discovered a second time when B is encountered again as
+    a startNode.
+    """
+    graph = Graph("")
+
+    A = graph.addNewNode("Ls", input="/tmp")
+    B = graph.addNewNode("AppendText", inputText=A.output)
+    C = graph.addNewNode("AppendText", inputText=B.output)
+
+    nodes, _ = graph.dfsOnDiscover(startNodes=[A, B], reverse=True)
+
+    # B must appear exactly once — it is visited when traversing forward from A,
+    # and must NOT be re-visited when encountered as a startNode.
+    assert len(nodes) == len(set(nodes)), "dfsOnDiscover(reverse=True) returned duplicate nodes"
+    assert set(nodes) == {A, B, C}
+
+
+def test_dfs_no_duplicates_discover_start_node_is_ancestor_of_another():
+    """
+    Test that dfsOnDiscover does not return duplicate nodes when one startNode
+    is an ancestor (in the traversal direction) of another startNode.
+
+    Graph:
+    A -> B -> C
+
+    Starting dfsOnDiscover (reverse=False) from both C and B: visiting C first
+    traverses C -> B -> A. B should not be discovered a second time when it is
+    encountered again as a startNode.
+    """
+    graph = Graph("")
+
+    A = graph.addNewNode("Ls", input="/tmp")
+    B = graph.addNewNode("AppendText", inputText=A.output)
+    C = graph.addNewNode("AppendText", inputText=B.output)
+
+    nodes, _ = graph.dfsOnDiscover(startNodes=[C, B])
+
+    assert len(nodes) == len(set(nodes)), "dfsOnDiscover returned duplicate nodes"
+    assert set(nodes) == {A, B, C}


### PR DESCRIPTION
## Description

In several cases we get duplicated nodes from the dfs process.

## What happens

After investigation I saw what happened :
- when we submit the whole graph, we list the nodes
- then we call `dfsToProcess`
- it calls `dfs`
- we iterate over all nodes and calling `dfsVisit` on them
- in the `dfsVisit` we list children and if a child have not been visited we call `dfsVisit` on it

In the end if we have this kind of graph :
```
     .- B
A -'
     `- C
```
Then when we submit the graph 
- we call : `dfsToProcess(startNodes=[all nodes in he scene])`
- the list can be `[B, C, A]` in some cases (it is not ordered by depth)
- `dfsVisit` on B : 
  - children are : [A]
  - `dfsVisit` on A : 
    - no children
    - finish : adding A to the node list
  - finish : adding B to the node list
- `dfsVisit` on C :
  - children are : [A]
  - A has already been visited : we skip
  - finish : adding C to the list
- `dfsVisit` on A
  - no children
  - finish : adding A to the list
- in the end the node list is : [A, B, C, A]

## Proposed fix

On the iteration over nodes on the initial `dfs` call before exploring a node we check it's color first and only explore it if we didn't reached it before.