### PR TITLE
[codecov] Add `meshroom/nodes` to ignored paths in coverage

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -52,3 +52,4 @@ ignore:
   - "bin/"
   - "localfarm/"  # For now ignore localfarm as it has no coverage yet
   - "meshroom/submitters/"
+  - "meshroom/nodes/"


### PR DESCRIPTION
## Description

This PR excludes the content of the `meshroom/nodes` folders, as the code they contain is neither meant to cover anything nor be covered.
