### PR TITLE
[localfarm] Apply PEP8 linting

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,3 +1,5 @@
+# [localfarm] Apply PEP8 linting
+d68979f891abb87622e0b8d221a969ffad63d04b
 # Linting: Harmonize docstrings and comments
 039e0620ad05d673a2ef9aa501e9a509219671c9
 # Linting: Remove all trailing whitespaces

--- a/localfarm/localFarmBackend.py
+++ b/localfarm/localFarmBackend.py
@@ -9,7 +9,6 @@ import sys
 import random
 import argparse
 import json
-import shlex
 import time
 import signal
 import logging
@@ -66,7 +65,7 @@ class Task:
         self.returnCode = None
         self.process = None
         self.logFile: Path = self.taskDir / f"{tid}.log"
-    
+
     @property
     def duration_string(self):
         end_time = self.finished_at or datetime.now()
@@ -91,7 +90,7 @@ class Task:
 
 
 class Job:
-    def __init__(self, jid: str, label: str, farmRoot: PathLike, maxParallel: int=4):
+    def __init__(self, jid: str, label: str, farmRoot: PathLike, maxParallel: int = 4):
         self.jid: str = jid
         self.label: str = label
         self.submitted: bool = False
@@ -259,7 +258,7 @@ class LocalFarmEngine:
 
     def start(self):
         """ Start the server. """
-        logger.info(f"Starting the server...")
+        logger.info("Starting the server...")
         # Start the server to listen to queries
         self.running = True
         handler = lambda *args: LocalFarmRequestHandler(self, *args)
@@ -366,14 +365,13 @@ class LocalFarmEngine:
                 log.write(f"# ========== Starting task {task.tid} at {task.started_at.isoformat()}"
                           f" (command=\"{task.command}\") ==========\n")
                 log.write(f"# metadata: {task.metadata}\n")
-                log.write(f"# process_env:\n")
-                log.write(f"# Additional env variables:\n")
+                log.write("# process_env:\n")
+                log.write("# Additional env variables:\n")
                 for _k, _v in additional_env.items():
                     log.write(f"# - {str(_k)}={str(_v)}\n")
-                log.write(f"\n")
+                log.write("\n")
                 task.process = subprocess.Popen(
                     task.command,
-                    # shlex.split(task.command),
                     stdout=log,
                     stderr=log,
                     cwd=task.taskDir,
@@ -621,7 +619,7 @@ class LocalFarmRequestHandler(BaseRequestHandler):
             except Exception as e:
                 logger.error(f"Error handling request: {e}", exc_info=True)
                 return
-    
+
     def __read_and_answer_request(self):
         """ Read request, get response and send response """
         data = b""

--- a/localfarm/localFarmClient.py
+++ b/localfarm/localFarmClient.py
@@ -68,6 +68,7 @@ class LocalFarmClient:
             "method": method,
             "params": params
         }
+
         def get_response(sock):
             response_data = b""
             while True:
@@ -111,8 +112,8 @@ class LocalFarmClient:
                     raise RuntimeError(f"Parent task {parentTask.name} not created yet")
                 deps.append(tasksCreated[parentTask])
             createdTask = self._call("create_task",
-                jid=jid, name=task.name, command=task.command,
-                metadata=task.metadata, dependencies=deps, env=task.env)
+                                     jid=jid, name=task.name, command=task.command,
+                                     metadata=task.metadata, dependencies=deps, env=task.env)
             tasksCreated[task] = createdTask["tid"]
         # Submit the job
         self._call("submit_job", jid=jid)
@@ -121,8 +122,8 @@ class LocalFarmClient:
     def create_additional_task(self, jid, tid, task):
         """ Create new task in an existing job. """
         createdTask = self._call("expand_task",
-            jid=jid, name=task.name, command=task.command,
-            metadata=task.metadata, parentTid=tid, env=task.env)
+                                 jid=jid, name=task.name, command=task.command,
+                                 metadata=task.metadata, parentTid=tid, env=task.env)
         return {"tid": createdTask["tid"]}
 
     def get_job_info(self, jid):
@@ -191,7 +192,7 @@ class LocalFarmClientContext(LocalFarmClient):
     def __enter__(self):
         self.connect()
         return self
-    
+
     def __exit__(self, *args):
         self.disconnect()
 
@@ -280,6 +281,7 @@ class Job:
         Tasks closer to roots appear first.
         """
         taskLevels = {}
+
         def exploreTask(task: str, currentLevel=0):
             if task in taskLevels:
                 if currentLevel > taskLevels[task]:
@@ -288,6 +290,7 @@ class Job:
                 taskLevels[task] = currentLevel
             for child in self.reverseDependencies[task]:
                 exploreTask(child, currentLevel + 1)
+
         # Start from root and explore down
         for task in self.getRootTasks():
             exploreTask(task.uid)

--- a/localfarm/test.py
+++ b/localfarm/test.py
@@ -49,7 +49,7 @@ class TestLocalFarm:
         task2 = self.createTask(job, 2, sleepTime=2, dependencies=[task1])
         task3 = self.createTask(job, 3, sleepTime=2, dependencies=[task1])
         task4 = self.createTask(job, 4, sleepTime=2, dependencies=[task2, task3])
-        task5 = self.createTask(job, 5, sleepTime=2, dependencies=[task4])
+        self.createTask(job, 5, sleepTime=2, dependencies=[task4])
         # Submit job
         res = job.submit()
         jid = res['jid']


### PR DESCRIPTION
## Description

This PR applies PEP8 linting to the `localfarm` module and fixes the following issues:
- F401: module imported but not used.
- W293: blank line contains whitespaces.
- E252: missing whitespace around parameter 'equals'.
- F541: f-string missing placeholders.
- E306: expected 1 blank line before a nested definition.
- E128: continuation line under-indented for visual indent.
- F841: local variable name is assigned but never used.

No functional change is applied.