### PR TITLE
[GraphEditor] Node: Remove functions from `Component.onAction` handlers

### DIFF
--- a/meshroom/ui/qml/GraphEditor/Node.qml
+++ b/meshroom/ui/qml/GraphEditor/Node.qml
@@ -739,8 +739,8 @@ Item {
                                         }
 
                                         readOnly: Boolean(root.readOnly || modelData.isReadOnly)
-                                        Component.onCompleted: function(attribute, inPin) { attributePinCreated(attribute, inPin) }
-                                        Component.onDestruction: function(attribute, inPin) { attributePinDeleted(attribute, inPin) }
+                                        Component.onCompleted: attributePinCreated(attribute, inPin)
+                                        Component.onDestruction: attributePinDeleted(attribute, inPin)
 
                                         onPressed: function(mouse) {
                                             root.pressed(mouse)
@@ -849,8 +849,8 @@ Item {
                                             visible: (height == childrenRect.height)
 
                                             readOnly: Boolean(root.readOnly || modelData.isReadOnly)
-                                            Component.onCompleted: function(attribute, inParamsPin) { attributePinCreated(attribute, inParamsPin) }
-                                            Component.onDestruction: function(attribute, inParamsPin) { attributePinDeleted(attribute, inParamsPin) }
+                                            Component.onCompleted: attributePinCreated(attribute, inParamsPin)
+                                            Component.onDestruction: attributePinDeleted(attribute, inParamsPin)
 
                                             onPressed: function(mouse) {
                                                 root.pressed(mouse)


### PR DESCRIPTION
## Description

This PR reverts a code simplification applied in #3107 (commit 1adfa9f8f899f348a5f982b164d79ab57e6fd863) that led to some edges not being drawn in the Graph Editor. Using JS functions rather than injecting parameters in signal handlers should not be used for `Component.onAction` handlers, but only on "direct" signal handlers. 
