### PR TITLE
[submitters] Apply PEP8 linting

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,3 +1,5 @@
+# [submitters] Apply PEP8 linting
+c3151e0f97ce07dc752e6d63b7f6f7e5ab1c74e4
 # [components] Apply PEP8 linting
 9c86be7072d09dca8fce380fcc142c98f7e2fe6f
 # [localfarm] Apply PEP8 linting

--- a/meshroom/submitters/localFarm/localFarmSubmitter.py
+++ b/meshroom/submitters/localFarm/localFarmSubmitter.py
@@ -4,7 +4,6 @@ import os
 import re
 import shutil
 import logging
-from pathlib import Path
 from typing import Dict, List
 from collections import namedtuple
 
@@ -78,11 +77,12 @@ def getRequestPackages(packagesDelimiter="=="):
     return list(reqPackages)
 
 
-def rezWrapCommand(cmd: str, 
-                   useCurrentContext: bool=False, 
-                   otherRezPkg: List[str] = None, 
-                   additionalEnv: dict=None) -> str:
-    """Wrap command to be runned using rez.
+def rezWrapCommand(cmd: str,
+                   useCurrentContext: bool = False,
+                   otherRezPkg: List[str] = None,
+                   additionalEnv: dict = None) -> str:
+    """
+    Wrap command to be runned using rez.
 
     Args:
         cmd: command to run
@@ -261,7 +261,7 @@ class LocalFarmSubmitter(BaseSubmitter):
         metadata = dict()
         if orderedTask.node:
             metadata = {"nodeUid": orderedTask.node._uid}
-        
+
         if orderedTask.iteration >= 0:
             metadata["iteration"] = orderedTask.iteration
         elif orderedTask.taskType == OrderedTaskType.PREPROCESS:
@@ -271,9 +271,9 @@ class LocalFarmSubmitter(BaseSubmitter):
 
         if orderedTask.taskType == OrderedTaskType.PLACEHOLDER:
             return Task(name=orderedTask.node.name if orderedTask.node else "", command="", metadata=metadata)
-        
+
         cmdArgs = f"--node {orderedTask.node.name} \"{meshroomFile}\" --extern"
-        
+
         if orderedTask.taskType == OrderedTaskType.EXPANDING:
             cmd = self.getExpandWrappedCmd(cmdArgs, self.reqPackages)
             task = Task(name=orderedTask.node.name, command=cmd, metadata=metadata, env=self.jobEnv)
@@ -281,9 +281,9 @@ class LocalFarmSubmitter(BaseSubmitter):
             cmdBin = wrapMeshroomBin("meshroom_compute")
             cmd = f"{cmdBin} {cmdArgs}"
             if orderedTask.taskType == OrderedTaskType.PREPROCESS:
-                cmd += f" --preprocess"
+                cmd += " --preprocess"
             elif orderedTask.taskType == OrderedTaskType.POSTPROCESS:
-                cmd += f" --postprocess"
+                cmd += " --postprocess"
             elif orderedTask.taskType == OrderedTaskType.CHUNK:
                 cmd += f" --iteration {orderedTask.iteration}"
             if not self.disabled_rez:
@@ -315,7 +315,7 @@ class LocalFarmSubmitter(BaseSubmitter):
             deps = [createdTasks.get(t) for t in orderedTask.dependencies]
             for dependency in deps:
                 job.addTaskDependency(task, dependency)
-    
+
         # Submit job
         with LocalFarmClientContext(self.farmPath) as client:
             res = job.submit(client)


### PR DESCRIPTION
## Description

This PR applies PEP8 linting to the `submitters` module and fixes the following issues:
- F401: 'x' imported but unused.
- W291: trialing whitespace.
- E252: missing whitespace around parameter equals.
- W293: blank line contains whitespace.
- F541: f-string is missing placeholders.