### PR TITLE
[nodes] Fix executable access in `ComputeMeshroomScene`

### DIFF
--- a/meshroom/nodes/general/ComputeMeshroomScene.py
+++ b/meshroom/nodes/general/ComputeMeshroomScene.py
@@ -17,9 +17,10 @@ class ComputeMeshroomScene(desc.CommandLineNode):
     Compute or Submits a meshroom scene on the farm.
     """
 
+    pythonExecutable = "python"
     category = "Utils"
     commandLine = "{node.nodeDesc.pythonExecutable} " + str(_MESHROOM_BATCH) + " -p {node.scene.value} --save {node.scene.value}"
-    
+
     def __getSubmitters():
         from meshroom.core import submitters
         submitterNames = []


### PR DESCRIPTION
## Description 

Fix small issue on the `ComputeMeshroomScene` node.

The python executable was wrong because we don't have access to it from CommandLine Nodes