### PR TITLE
[bug] Fix getAnyAttribute on ListAttributes

### DIFF
--- a/meshroom/core/node.py
+++ b/meshroom/core/node.py
@@ -1069,7 +1069,7 @@ class BaseNode(BaseObject):
                 elif n:
                     if att is None:
                         # Get root attribute
-                        att = attrList.getr(n)
+                        att = attrList.get(n)
                     else:
                         # GroupAttribute, the access should be done through the name
                         if not isinstance(att, GroupAttribute):


### PR DESCRIPTION
## Description

Fix a bug that prevent getting an attribute on a ListAttribute

## Cause

`getr` raised an error when we didn't want an error to be raised but simply `None` to be returned