### PR TITLE
[ui] Fix NodeChunk offset issue

### DIFF
--- a/meshroom/ui/qml/GraphEditor/NodeChunks.qml
+++ b/meshroom/ui/qml/GraphEditor/NodeChunks.qml
@@ -39,6 +39,7 @@ ListView {
     header: Loader {
         active: root.hasHeader
         visible: active
+        width: active ? root.chunkWidth : 0
         
         sourceComponent: Rectangle {
             height: root.chunkHeight
@@ -78,6 +79,7 @@ ListView {
     footer: Loader {
         active: root.hasFooter
         visible: active
+        width: active ? root.chunkWidth : 0
         
         sourceComponent: Rectangle {
             height: root.chunkHeight


### PR DESCRIPTION
## Description

Fix UI issues :
<img width="609" height="298" alt="image" src="https://github.com/user-attachments/assets/6e46064a-3d9a-42a4-93ad-89a6e34a8c9f" />
Sometimes an offset is caused a remaining component.
If we create a preprocess chunk and then remove it we will have this offset added before the NodeChunks.

## Changes

To fix this I simply forced a width reset on the header and footer when they are not supposed to be active.