### PR TITLE
[bug][ui] Fix typo in ChunkIndexEnum items

### DIFF
--- a/meshroom/ui/qml/GraphEditor/ChunksListView.qml
+++ b/meshroom/ui/qml/GraphEditor/ChunksListView.qml
@@ -17,7 +17,7 @@ ColumnLayout {
     property int currentIndex: 0
 
     function getCurrentChunkIndex() {
-        if ( currentIndex == undefined || !chunks || chunks.length === 0 || currentIndex == ChunkIndexEnum.NULL ) {
+        if ( currentIndex == undefined || !chunks || chunks.length === 0 || currentIndex == ChunkIndexEnum.NONE ) {
             return -1
         }
         let hasPreprocess  = chunks[0].chunkNode.hasPreprocessChunk
@@ -41,7 +41,7 @@ ColumnLayout {
     onChunksChanged: {
         // When the list changes, ensure the current index is in the new range
         if (!chunks)
-            currentIndex = ChunkIndexEnum.NULL
+            currentIndex = ChunkIndexEnum.NONE
         else if (currentIndex >= chunks.length)
             currentIndex = chunks.length-1
     }
@@ -83,7 +83,7 @@ ColumnLayout {
                     checked = summaryEnabled
                 }
                 onClicked: {
-                    root.currentIndex = ChunkIndexEnum.NULL
+                    root.currentIndex = ChunkIndexEnum.NONE
                     checked = true
                 }
             }


### PR DESCRIPTION
## Description

QML warning raised by a typo from 9508dea46b4fc11d09f9c0f78f5c37d5891bb33d :
- `ChunkIndexEnum.NULL` was replaced by `ChunkIndexEnum.NONE`
