### PR TITLE
Add QML Actions callback system

### DIFF
--- a/meshroom/core/callbacks.py
+++ b/meshroom/core/callbacks.py
@@ -1,0 +1,125 @@
+"""
+Callback registry system for Meshroom.
+
+This module provides a mechanism to register, query, and trigger callbacks
+that can execute before certain actions (e.g., save, saveAs).
+
+Usage:
+    from meshroom.core.callbacks import registerCallback, getRegisteredCallback, triggerCallback
+
+    # Register a callback
+    def mySaveCallback(*args, **kwargs):
+        # ... do something ...
+        return result
+
+    registerCallback("save", mySaveCallback)
+
+    # Check if a callback is registered
+    cb = getRegisteredCallback("save")  # returns the callable or None
+
+    # Trigger the callback
+    result = triggerCallback("save", arg1, arg2)
+"""
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+# Internal registry: maps callback names to callables
+_callbacks = {}
+
+
+def registerCallback(name, callback):
+    """
+    Register a callback with the given name.
+
+    Args:
+        name (str): The name/key for the callback (e.g., "save").
+        callback (callable): The function to be called when the callback is triggered.
+
+    Raises:
+        ValueError: If `name` is empty or `callback` is not callable.
+    """
+    if not name:
+        raise ValueError("Callback name must not be empty.")
+    if not callable(callback):
+        raise ValueError(f"Callback for '{name}' must be callable.")
+    if name in _callbacks:
+        logger.warning(f"Overwriting existing callback for '{name}'.")
+    _callbacks[name] = callback
+    logger.debug(f"Callback registered: '{name}'")
+
+
+def unregisterCallback(name):
+    """
+    Unregister a callback by name.
+
+    Args:
+        name (str): The name of the callback to remove.
+
+    Returns:
+        bool: True if a callback was removed, False if none was found.
+    """
+    if name in _callbacks:
+        del _callbacks[name]
+        logger.debug(f"Callback unregistered: '{name}'")
+        return True
+    return False
+
+
+def getRegisteredCallback(name):
+    """
+    Get a registered callback by name.
+
+    Args:
+        name (str): The name of the callback to retrieve.
+
+    Returns:
+        callable or None: The registered callback, or None if not found.
+    """
+    return _callbacks.get(name, None)
+
+
+def triggerCallback(name, *args, **kwargs):
+    """
+    Trigger a registered callback by name.
+
+    Args:
+        name (str): The name of the callback to trigger.
+        *args: Positional arguments to pass to the callback.
+        **kwargs: Keyword arguments to pass to the callback.
+
+    Returns:
+        The result of the callback, or None if no callback is registered for `name`.
+    """
+    callback = _callbacks.get(name, None)
+    if callback is None:
+        logger.debug(f"No callback registered for '{name}', skipping.")
+        return None
+    logger.debug(f"Triggering callback '{name}' with args={args}, kwargs={kwargs}")
+    try:
+        return callback(*args, **kwargs)
+    except Exception as e:
+        logger.error(f"Error while executing callback '{name}': {e}")
+        raise
+
+
+def clearCallbacks():
+    """Clear all registered callbacks. Useful for testing."""
+    _callbacks.clear()
+
+
+# Convenience decorator-style function
+def REGISTER_CALLBACK(name):
+    """
+    Decorator to register a function as a callback.
+
+    Usage:
+        @REGISTER_CALLBACK(name="save")
+        def my_save_callback(*args, **kwargs):
+            ...
+    """
+    def decorator(func):
+        registerCallback(name, func)
+        return func
+    return decorator

--- a/meshroom/core/save_callback.py
+++ b/meshroom/core/save_callback.py
@@ -1,0 +1,43 @@
+"""
+Save callback for Meshroom.
+
+When the environment variable MR_ASK_TEMPLATE_BEFORE_SAVING is set to "1",
+this module registers a "save" callback that returns information about whether
+the user wants to save as a template or do a standard save.
+
+The callback returns a dictionary:
+    {"saveAsTemplate": True/False}
+
+This result is used by the QML save dialog to decide which save logic to execute.
+"""
+
+import os
+import logging
+
+from meshroom.core.callbacks import registerCallback
+
+logger = logging.getLogger(__name__)
+
+
+def _saveCallback(*args, **kwargs):
+    """
+    Save callback that signals the UI should ask the user whether to save
+    as a template or as a standard project file.
+
+    Returns:
+        dict: {"saveAsTemplate": True} to indicate the system should present
+              the template-or-save choice to the user.
+    """
+    return {"askTemplate": True}
+
+
+def registerSaveCallback():
+    """
+    Register the save callback if the environment variable
+    MR_ASK_TEMPLATE_BEFORE_SAVING is set to "1".
+    """
+    if os.environ.get("MR_ASK_TEMPLATE_BEFORE_SAVING", "0") == "1":
+        registerCallback("save", _saveCallback)
+        logger.info("Save callback registered (MR_ASK_TEMPLATE_BEFORE_SAVING=1).")
+    else:
+        logger.debug("Save callback not registered (MR_ASK_TEMPLATE_BEFORE_SAVING is not set to 1).")

--- a/meshroom/core/save_callback.py
+++ b/meshroom/core/save_callback.py
@@ -3,12 +3,13 @@ Save callback for Meshroom.
 
 When the environment variable MR_ASK_TEMPLATE_BEFORE_SAVING is set to "1",
 this module registers a "save" callback that returns information about whether
-the user wants to save as a template or do a standard save.
+the user should be asked to choose between saving as a template or a standard save.
 
 The callback returns a dictionary:
-    {"saveAsTemplate": True/False}
+    {"askTemplate": True}
 
-This result is used by the QML save dialog to decide which save logic to execute.
+This result is used by the QML save dialog to decide whether to present
+a choice dialog to the user.
 """
 
 import os
@@ -25,7 +26,7 @@ def _saveCallback(*args, **kwargs):
     as a template or as a standard project file.
 
     Returns:
-        dict: {"saveAsTemplate": True} to indicate the system should present
+        dict: {"askTemplate": True} to indicate the system should present
               the template-or-save choice to the user.
     """
     return {"askTemplate": True}

--- a/meshroom/ui/app.py
+++ b/meshroom/ui/app.py
@@ -15,6 +15,7 @@ from PySide6.QtWidgets import QApplication
 
 import meshroom
 from meshroom.core import pluginManager
+from meshroom.core.callbacks import getRegisteredCallback, triggerCallback
 from meshroom.core.submitter import BaseSubmitter
 from meshroom.core.taskManager import TaskManager
 from meshroom.common import Property, Variant, Signal, Slot
@@ -253,6 +254,10 @@ class MeshroomApp(QApplication):
         meshroom.core.initSubmitters()
         meshroom.core.initPlugins()
         meshroom.core.initNodes()
+
+        # Register callbacks (conditional on environment variables)
+        from meshroom.core.save_callback import registerSaveCallback
+        registerSaveCallback()
 
         # Initialize the list of recent project files
         self._recentProjectFiles = self._getRecentProjectFilesFromSettings()
@@ -771,6 +776,37 @@ class MeshroomApp(QApplication):
     def setDefaultSubmitter(self, name):
         logging.info(f"Submitter is now set to : {name}")
         self._defaultSubmitterName = name
+
+    @Slot(str, result=bool)
+    def hasRegisteredCallback(self, name):
+        """Check if a callback is registered with the given name."""
+        return getRegisteredCallback(name) is not None
+
+    @Slot(str, result="QVariant")
+    def getCallbackResult(self, name):
+        """
+        Trigger a registered callback by name (no arguments) and return the result.
+        Returns None (undefined in QML) if no callback is registered.
+        """
+        cb = getRegisteredCallback(name)
+        if cb is None:
+            return None
+        return triggerCallback(name)
+
+    @Slot(str, "QVariantList", result="QVariant")
+    def triggerCallbackWithArgs(self, name, args):
+        """
+        Trigger a registered callback by name with arguments and return the result.
+        Args:
+            name (str): The callback name.
+            args (list): List of arguments to pass to the callback.
+        Returns:
+            The result of the callback, or None if not registered.
+        """
+        cb = getRegisteredCallback(name)
+        if cb is None:
+            return None
+        return triggerCallback(name, *args)
 
     activeProjectChanged = Signal()
     activeProject = Property(Variant, lambda self: self._activeProject, notify=activeProjectChanged)

--- a/meshroom/ui/qml/Application.qml
+++ b/meshroom/ui/qml/Application.qml
@@ -148,10 +148,11 @@ Page {
         id: saveFileDialog
 
         property var _callback: undefined
+        property bool _saveAsTemplate: false
 
         signal closed(var result)
 
-        title: "Save File"
+        title: _saveAsTemplate ? "Save Template" : "Save File"
         nameFilters: ["Meshroom Graphs (*.mg)"]
         defaultSuffix: ".mg"
         fileMode: Platform.FileDialog.SaveFile
@@ -161,9 +162,15 @@ Page {
                 return;
             }
 
-            // Only save a valid file
-            _currentScene.saveAs(currentFile)
-            MeshroomApp.addRecentProjectFile(currentFile.toString())
+            if (_saveAsTemplate) {
+                // Save as template
+                _currentScene.saveAsTemplate(currentFile)
+                MeshroomApp.reloadTemplateList()
+            } else {
+                // Standard save
+                _currentScene.saveAs(currentFile)
+                MeshroomApp.addRecentProjectFile(currentFile.toString())
+            }
             closed(Platform.Dialog.Accepted)
             fireCallback(Platform.Dialog.Accepted)
         }
@@ -187,29 +194,91 @@ Page {
             _callback = callback
             open()
         }
+
+        function openForSave(asTemplate) {
+            _saveAsTemplate = asTemplate !== undefined ? asTemplate : false
+            initFileDialogFolder(saveFileDialog)
+            open()
+        }
+
+        function promptForSave(asTemplate, callback) {
+            _saveAsTemplate = asTemplate !== undefined ? asTemplate : false
+            _callback = callback
+            initFileDialogFolder(saveFileDialog)
+            open()
+        }
     }
 
-    Platform.FileDialog {
-        id: saveTemplateDialog
+    // Dialog to ask user whether to save as template or standard save
+    // Only shown when the "save" callback is registered (MR_ASK_TEMPLATE_BEFORE_SAVING=1)
+    Dialog {
+        id: saveChoiceDialog
 
-        signal closed(var result)
+        property var _pendingAction: undefined  // function to call after choice
 
-        title: "Save Template"
-        nameFilters: ["Meshroom Graphs (*.mg)"]
-        defaultSuffix: ".mg"
-        fileMode: Platform.FileDialog.SaveFile
-        onAccepted: {
-            if (!validateFilepathForSave(currentFile, saveTemplateDialog))
-            {
-                return;
+        anchors.centerIn: Overlay.overlay
+        parent: Overlay.overlay
+        modal: true
+        title: "Save Options"
+        standardButtons: Dialog.Cancel
+
+        width: 350
+
+        ColumnLayout {
+            anchors.fill: parent
+            spacing: 12
+
+            Label {
+                text: "How would you like to save?"
+                Layout.fillWidth: true
+                wrapMode: Text.WordWrap
             }
 
-            // Only save a valid template
-            _currentScene.saveAsTemplate(currentFile)
-            closed(Platform.Dialog.Accepted)
-            MeshroomApp.reloadTemplateList()
+            Button {
+                text: "Save as Project"
+                Layout.fillWidth: true
+                onClicked: {
+                    saveChoiceDialog.close()
+                    if (saveChoiceDialog._pendingAction)
+                        saveChoiceDialog._pendingAction(false)
+                    saveChoiceDialog._pendingAction = undefined
+                }
+            }
+
+            Button {
+                text: "Save as Template"
+                Layout.fillWidth: true
+                onClicked: {
+                    saveChoiceDialog.close()
+                    if (saveChoiceDialog._pendingAction)
+                        saveChoiceDialog._pendingAction(true)
+                    saveChoiceDialog._pendingAction = undefined
+                }
+            }
         }
-        onRejected: closed(Platform.Dialog.Rejected)
+
+        onRejected: {
+            _pendingAction = undefined
+        }
+
+        function ask(actionCallback) {
+            _pendingAction = actionCallback
+            open()
+        }
+    }
+
+    // Helper function: execute "save" callback and use result to decide save flow
+    function executeSaveWithCallback(actionCallback) {
+        if (MeshroomApp.hasRegisteredCallback("save")) {
+            var result = MeshroomApp.getCallbackResult("save")
+            if (result && result.askTemplate) {
+                // Show the choice dialog
+                saveChoiceDialog.ask(actionCallback)
+                return
+            }
+        }
+        // No callback or callback says no template question: proceed with standard save
+        actionCallback(false)
     }
 
     Platform.FileDialog {
@@ -796,19 +865,23 @@ Page {
                     shortcut: "Ctrl+S"
                     enabled: _currentScene ? (_currentScene.graph && !_currentScene.graph.filepath) || !_currentScene.undoStack.clean : false
                     onTriggered: {
-                        if (_currentScene.graph.filepath) {
-                            // Get current time date
-                            var date = _currentScene.graph.getFileDateVersionFromPath(_currentScene.graph.filepath)
+                        executeSaveWithCallback(function(asTemplate) {
+                            if (asTemplate) {
+                                // User chose to save as template
+                                saveFileDialog.openForSave(true)
+                            } else if (_currentScene.graph.filepath) {
+                                // Get current time date
+                                var date = _currentScene.graph.getFileDateVersionFromPath(_currentScene.graph.filepath)
 
-                            // Check if the file has been modified by another instance
-                            if (_currentScene.graph.fileDateVersion !== date) {
-                                fileModifiedDialog.open()
-                            } else
-                                _currentScene.save()
-                        } else {
-                            initFileDialogFolder(saveFileDialog)
-                            saveFileDialog.open()
-                        }
+                                // Check if the file has been modified by another instance
+                                if (_currentScene.graph.fileDateVersion !== date) {
+                                    fileModifiedDialog.open()
+                                } else
+                                    _currentScene.save()
+                            } else {
+                                saveFileDialog.openForSave(false)
+                            }
+                        })
                     }
                 }
                 Action {
@@ -816,8 +889,9 @@ Page {
                     text: "Save As..."
                     shortcut: "Ctrl+Shift+S"
                     onTriggered: {
-                        initFileDialogFolder(saveFileDialog)
-                        saveFileDialog.open()
+                        executeSaveWithCallback(function(asTemplate) {
+                            saveFileDialog.openForSave(asTemplate)
+                        })
                     }
                 }
                 Action {
@@ -867,8 +941,7 @@ Page {
                             onActivated: saveAsTemplateAction.triggered()
                         }
                         onTriggered: {
-                            initFileDialogFolder(saveTemplateDialog)
-                            saveTemplateDialog.open()
+                            saveFileDialog.openForSave(true)
                         }
                     }
 

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -1,0 +1,120 @@
+"""Tests for the callback registry system."""
+
+import pytest
+from meshroom.core.callbacks import (
+    registerCallback,
+    unregisterCallback,
+    getRegisteredCallback,
+    triggerCallback,
+    clearCallbacks,
+    REGISTER_CALLBACK,
+)
+
+
+@pytest.fixture(autouse=True)
+def clean_callbacks():
+    """Ensure callbacks are cleared before and after each test."""
+    clearCallbacks()
+    yield
+    clearCallbacks()
+
+
+def test_register_and_get_callback():
+    """Test that a callback can be registered and retrieved."""
+    def my_cb():
+        return "hello"
+
+    registerCallback("test", my_cb)
+    assert getRegisteredCallback("test") is my_cb
+
+
+def test_get_unregistered_callback():
+    """Test that getting an unregistered callback returns None."""
+    assert getRegisteredCallback("nonexistent") is None
+
+
+def test_trigger_callback():
+    """Test that a registered callback can be triggered."""
+    def my_cb(x, y):
+        return x + y
+
+    registerCallback("add", my_cb)
+    result = triggerCallback("add", 3, 4)
+    assert result == 7
+
+
+def test_trigger_unregistered_callback():
+    """Test that triggering an unregistered callback returns None."""
+    result = triggerCallback("nonexistent", 1, 2)
+    assert result is None
+
+
+def test_trigger_callback_with_kwargs():
+    """Test that kwargs are passed through to the callback."""
+    def my_cb(*args, **kwargs):
+        return {"args": args, "kwargs": kwargs}
+
+    registerCallback("kw", my_cb)
+    result = triggerCallback("kw", 1, key="value")
+    assert result == {"args": (1,), "kwargs": {"key": "value"}}
+
+
+def test_unregister_callback():
+    """Test that a callback can be unregistered."""
+    registerCallback("test", lambda: None)
+    assert unregisterCallback("test") is True
+    assert getRegisteredCallback("test") is None
+
+
+def test_unregister_nonexistent_callback():
+    """Test that unregistering a non-existent callback returns False."""
+    assert unregisterCallback("nonexistent") is False
+
+
+def test_overwrite_callback():
+    """Test that registering a callback with the same name overwrites the previous one."""
+    registerCallback("test", lambda: "first")
+    registerCallback("test", lambda: "second")
+    result = triggerCallback("test")
+    assert result == "second"
+
+
+def test_register_callback_empty_name_raises():
+    """Test that registering with an empty name raises ValueError."""
+    with pytest.raises(ValueError):
+        registerCallback("", lambda: None)
+
+
+def test_register_callback_non_callable_raises():
+    """Test that registering a non-callable raises ValueError."""
+    with pytest.raises(ValueError):
+        registerCallback("test", "not_callable")
+
+
+def test_trigger_callback_propagates_exceptions():
+    """Test that exceptions from the callback are propagated."""
+    def bad_cb():
+        raise RuntimeError("test error")
+
+    registerCallback("bad", bad_cb)
+    with pytest.raises(RuntimeError, match="test error"):
+        triggerCallback("bad")
+
+
+def test_register_callback_decorator():
+    """Test the REGISTER_CALLBACK decorator."""
+    @REGISTER_CALLBACK(name="decorated")
+    def my_decorated_cb(x):
+        return x * 2
+
+    assert getRegisteredCallback("decorated") is my_decorated_cb
+    assert triggerCallback("decorated", 5) == 10
+
+
+def test_clear_callbacks():
+    """Test that clearCallbacks removes all callbacks."""
+    registerCallback("a", lambda: "a")
+    registerCallback("b", lambda: "b")
+    clearCallbacks()
+    assert getRegisteredCallback("a") is None
+    assert getRegisteredCallback("b") is None


### PR DESCRIPTION
## Description

Propose a new system to add callbacks on specific actions.
For now we would add an optional callback to propose to save as template or save as project before saving.
This way this would avoid people saving templates as projects and therefore avoid compatibility node issues.