### PR TITLE
chore: improve Meshroom maintenance path

### DIFF
--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -135,6 +135,14 @@ def test_rename_nodes():
     assert ls0.name == "nodels"
 
 
+def test_empty_graph():
+    """Test edge-case behavior on a graph with no nodes."""
+    graph = Graph("")
+    assert graph.nodes == []
+    assert graph.nodesOfType("Ls") == []
+    assert graph.flowEdges() == []
+
+
 class TestDFS:
     """ Tests for the graph DFS traversal methods. """
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -8,7 +8,7 @@ from meshroom.core.plugins import NodePlugin, NodePluginStatus
 import os
 
 @contextmanager
-def registeredNodeTypes(nodeTypes: list[desc.Node]):
+def registeredNodeTypes(nodeTypes: list[type[desc.Node]]):
     nodePluginsList = {}
     for nodeType in nodeTypes:
         nodePlugin = NodePlugin(nodeType)
@@ -22,7 +22,7 @@ def registeredNodeTypes(nodeTypes: list[desc.Node]):
 
 
 @contextmanager
-def overrideNodeTypeVersion(nodeType: desc.Node, version: str):
+def overrideNodeTypeVersion(nodeType: type[desc.Node], version: str):
     """ Helper context manager to override the version of a given node type. """
     unpatchedFunc = meshroom.core.nodeVersion
     with patch.object(
@@ -33,13 +33,13 @@ def overrideNodeTypeVersion(nodeType: desc.Node, version: str):
         yield
 
 
-def registerNodeDesc(nodeDesc: desc.Node):
+def registerNodeDesc(nodeDesc: type[desc.Node]):
     name = nodeDesc.__name__
     if not pluginManager.isRegistered(name):
         pluginManager._nodePlugins[name] = NodePlugin(nodeDesc)
 
 
-def unregisterNodeDesc(nodeDesc: desc.Node):
+def unregisterNodeDesc(nodeDesc: type[desc.Node]):
     name = nodeDesc.__name__
     if pluginManager.isRegistered(name):
         del pluginManager._nodePlugins[name]


### PR DESCRIPTION
Summary:
- Add or tighten focused edge-case tests or type assertions in tests/utils.py, tests/test_graph.py related to Python typing, tests, CLI ergonomics, observability; avoid docs-only changes and broad refactors.
- Keep the change narrow so it is straightforward to review.

Notes:
- I kept this scoped to the relevant implementation and tests.