### PR TITLE
[core] node: Prevent using default output value if it is already defined

### DIFF
--- a/meshroom/core/node.py
+++ b/meshroom/core/node.py
@@ -1272,8 +1272,16 @@ class BaseNode(BaseObject):
                         logging.warning(f'Invalid lambda evaluation for "{self.name}.{attr.name}"')
                     if defaultValue is not None:
                         try:
-                            attr.value = defaultValue.format(**self._expVars)
+                            if attr.value and (attr.value != defaultValue and
+                                               attr.value != defaultValue.format(**self._expVars)):
+                                attr.value = attr.value.format(**self._expVars)
+                            else:
+                                attr.value = defaultValue.format(**self._expVars)
+
+                            # Always recompute from the template so _invalidationValue
+                            # reflects the current UID, regardless of attr.value state
                             attr._invalidationValue = defaultValue.format(**expVarsNoCache)
+
                         except KeyError as err:
                             logging.warning(f'Invalid expression with missing key on "{self.name}.{attr.name}" with '
                                             f'value "{defaultValue}".\nError: {str(err)}')

--- a/tests/test_compatibility.py
+++ b/tests/test_compatibility.py
@@ -167,6 +167,31 @@ class SampleInputNodeV2(desc.InputNode):
     ]
 
 
+class OutputTemplateNodeV1(desc.Node):
+    """Node with an output File attribute pointing to a specific file."""
+    inputs = [
+        desc.File(name="input", label="Input", description="", value=""),
+    ]
+    outputs = [
+        desc.File(name="output", label="Output", description="",
+                  value="{nodeCacheFolder}/file.abc"),
+    ]
+
+
+class OutputTemplateNodeV2(desc.Node):
+    """
+    Changes from OutputTemplateNodeV1:
+        * The output value template has changed from 'file.abc' to 'file.cba'.
+    """
+    inputs = [
+        desc.File(name="input", label="Input", description="", value=""),
+    ]
+    outputs = [
+        desc.File(name="output", label="Output", description="",
+                  value="{nodeCacheFolder}/file.cba"),
+    ]
+
+
 def replaceNodeTypeDesc(nodeType: str, nodeDesc: Type[desc.Node]):
     """Change the `nodeDesc` associated to `nodeType`."""
     pluginManager.getRegisteredNodePlugins()[nodeType] = NodePlugin(nodeDesc)
@@ -421,6 +446,49 @@ def test_conformUpgrade():
 
     unregisterNodeDesc(SampleNodeV5)
     unregisterNodeDesc(SampleNodeV6)
+
+
+def test_outputValueAfterDefaultOutputChange(tmp_path):
+    """
+    Test that when the default value of a node's output attribute is changed in the node
+    description, a saved graph that is reopened preserves the values saved on disk.
+
+    A new instance of that node is then created to check that the new default value is
+    properly applied to new nodes.
+    """
+    registerNodeDesc(OutputTemplateNodeV1)
+
+    g = Graph("")
+    n = g.addNewNode(OutputTemplateNodeV1.__name__)
+    nodeName = n.name
+
+    # Sanity-check: the output uses the V1 node description
+    assert n.output.value.endswith("/file.abc")
+
+    graphFile = os.path.join(tmp_path, "test_output_value_change.mg")
+    g.save(graphFile)
+
+    # Replace the registered description with V2 (only the output value changes)
+    replaceNodeTypeDesc(OutputTemplateNodeV1.__name__, OutputTemplateNodeV2)
+
+    # Reload the graph with the updated description
+    reloadedGraph = loadGraph(graphFile)
+    reloadedNode = reloadedGraph.node(nodeName)
+
+    # The reloaded node should not be a CompatibilityNode
+    assert not isinstance(reloadedNode, CompatibilityNode)
+
+    # The reloaded node should reflect the value saved on disk, not the new default value in the description
+    assert not reloadedNode.output.value.endswith("/file.cba")
+
+    # The internal folder (driven by inputs, not outputs) must be unchanged
+    assert reloadedNode.internalFolder == n.internalFolder
+
+    # A new instance of this node should reflect the new default value in the description
+    n = g.addNewNode(OutputTemplateNodeV1.__name__)
+    assert n.output.value.endswith("/file.cba")
+
+    unregisterNodeDesc(OutputTemplateNodeV1)
 
 
 class TestGraphLoadingWithStrictCompatibility:


### PR DESCRIPTION
## Description

This pull request enhances the handling and testing of output attribute value templates in node descriptions. The main focus is on ensuring that when a node's output value template changes, existing graphs preserve the saved values, while new nodes adopt the updated template. The changes include improvements to attribute value formatting logic and the addition of comprehensive tests to verify compatibility behavior.

**Testing and compatibility improvements:**

* Added `OutputTemplateNodeV1` and `OutputTemplateNodeV2` test node classes in `tests/test_compatibility.py` to simulate a node whose output value template changes from `file.abc` to `file.cba`.
* Introduced the `test_outputValueAfterDefaultOutputChange` test, which verifies that saved graphs retain old output values after a template change, while new nodes use the updated template. This ensures backward compatibility and correct application of new defaults.

**Core logic enhancement:**

* Updated `_buildAttributeExpVars` in `meshroom/core/node.py` to improve output attribute value formatting. The logic now always recomputes the invalidation value from the template, ensuring that the attribute's state reflects the current UID and the latest template, regardless of whether the value was previously set.
