### PR TITLE
[buid] `setup.py`: Remove PySide6.QtCharts from modules to exclude

### DIFF
--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -109,7 +109,6 @@ jobs:
             *Qt6Designer*.so* \
             *Qt6Multimedia*.so* \
             *Qt6SpatialAudio*.so* \
-            *Qt6Charts*.so* \
             *Qt6DataVisualization*.so* \
             *Qt6Graphs*.so* \
             *Qt6Bluetooth*.so* \

--- a/setup.py
+++ b/setup.py
@@ -103,7 +103,6 @@ build_exe_options = {
         "PySide6.QtMultimedia",
         "PySide6.QtMultimediaWidgets",
         "PySide6.QtSpatialAudio",
-        "PySide6.QtCharts",
         "PySide6.QtDataVisualization",
         "PySide6.QtGraphs",
         "PySide6.QtGraphsWidgets",


### PR DESCRIPTION
## Description

This PR removes 'PySide6.QtCharts' from the modules that should not be packaged (used in csvData).
