### PR TITLE
[core] Output attributes: Keep saved template value instead of node description

### DIFF
--- a/meshroom/core/attribute.py
+++ b/meshroom/core/attribute.py
@@ -23,6 +23,24 @@ if TYPE_CHECKING:
     from meshroom.core.graph import Edge
 
 
+def _captureExpressionTemplates(attr, value):
+    """
+    Recursively set _expressionTemplate on output expression attributes from their loaded values.
+    Preserves the serialized expression template so that description changes on the node type
+    only affect new nodes, not existing ones loaded from a project file.
+    """
+    if attr.desc.isExpression and isinstance(value, str):
+        attr._expressionTemplate = value
+    elif isinstance(attr, GroupAttribute) and isinstance(value, dict):
+        for key, childValue in value.items():
+            try:
+                childAttr = attr._value.get(key)
+                if childAttr is not None:
+                    _captureExpressionTemplates(childAttr, childValue)
+            except (KeyError, AttributeError):
+                logging.debug(f"Skipping expression template capture for {key} on {attr}.")
+
+
 def attributeFactory(description: str, value, isOutput: bool, node, root=None, parent=None):
     """
     Create an Attribute based on description type.
@@ -39,6 +57,10 @@ def attributeFactory(description: str, value, isOutput: bool, node, root=None, p
     attr: Attribute = description.instanceType(node, description, isOutput, root, parent)
     if value is not None:
         attr._setValue(value)
+        # For output expression attributes loaded from a file, store the expression template
+        # so that description changes on the node type only affect new nodes.
+        if isOutput:
+            _captureExpressionTemplates(attr, value)
     else:
         attr.resetToDefaultValue()
     # Only connect slot that reacts to value change once initial value has been set.
@@ -90,6 +112,10 @@ class Attribute(BaseObject):
         self._value = None
         self._keyValues = None  # list of pairs (key, value) for keyable attribute
         self._linkExpression: Optional[str] = None
+        # Expression template stored when loading from a saved project file.
+        # When set, this overrides the descriptor's expression for this node instance,
+        # so that description changes on the node type only affect new nodes.
+        self._expressionTemplate: Optional[str] = None
         self._initValue()
 
     def _getFullName(self) -> str:
@@ -350,6 +376,8 @@ class Attribute(BaseObject):
         if self.keyable:
             return self._keyValues.getSerializedValues()
         if self.isOutput and self._desc.isExpression:
+            if self._expressionTemplate is not None:
+                return self._expressionTemplate
             return self.getDefaultValue()
         return self.value
 

--- a/meshroom/core/node.py
+++ b/meshroom/core/node.py
@@ -1265,7 +1265,10 @@ class BaseNode(BaseObject):
                 # (the expression may refer to other attributes that are not defined)
                 if attr.enabled:
                     try:
-                        defaultValue = attr.getDefaultValue()
+                        # Use the expression template stored when loading from a file (if any),
+                        # so that description changes on the node type only affect new nodes.
+                        defaultValue = attr._expressionTemplate if attr._expressionTemplate is not None \
+                            else attr.getDefaultValue()
                     except AttributeError:
                         # If we load an old scene, the lambda associated to the 'value' could try to
                         # access other params that could not exist yet

--- a/tests/test_compatibility.py
+++ b/tests/test_compatibility.py
@@ -155,7 +155,8 @@ class SampleInputNodeV1(desc.InputNode):
 
 
 class SampleInputNodeV2(desc.InputNode):
-    """ Changes from V1:
+    """
+    Changes from V1:
         * 'path' has been renamed to 'in'
     """
     inputs = [
@@ -167,8 +168,33 @@ class SampleInputNodeV2(desc.InputNode):
     ]
 
 
+class OutputTemplateNodeV1(desc.Node):
+    """ Node with an output File attribute pointing to a specific file. """
+    inputs = [
+        desc.File(name="input", label="Input", description="", value=""),
+    ]
+    outputs = [
+        desc.File(name="output", label="Output", description="",
+                  value="{nodeCacheFolder}/file.abc"),
+    ]
+
+
+class OutputTemplateNodeV2(desc.Node):
+    """
+    Changes from OutputTemplateNodeV1:
+        * The output value template has changed from 'file.abc' to 'file.cba'.
+    """
+    inputs = [
+        desc.File(name="input", label="Input", description="", value=""),
+    ]
+    outputs = [
+        desc.File(name="output", label="Output", description="",
+                  value="{nodeCacheFolder}/file.cba"),
+    ]
+
+
 def replaceNodeTypeDesc(nodeType: str, nodeDesc: Type[desc.Node]):
-    """Change the `nodeDesc` associated to `nodeType`."""
+    """ Change the `nodeDesc` associated to `nodeType`. """
     pluginManager.getRegisteredNodePlugins()[nodeType] = NodePlugin(nodeDesc)
 
 
@@ -421,6 +447,47 @@ def test_conformUpgrade():
 
     unregisterNodeDesc(SampleNodeV5)
     unregisterNodeDesc(SampleNodeV6)
+
+
+def test_outputValueAfterDefaultOutputChange(tmp_path):
+    """
+    Test that when the default value of a node's output attribute is changed in the node
+    description, a saved graph that is reopened preserves the values saved on disk.
+
+    A new instance of that node is then created to check that the new default value is
+    properly applied to new nodes.
+    """
+    registerNodeDesc(OutputTemplateNodeV1)
+
+    g = Graph("")
+    n = g.addNewNode(OutputTemplateNodeV1.__name__)
+    nodeName = n.name
+    assert n.output.value.endswith("/file.abc")
+
+    graphFile = os.path.join(tmp_path, "test_output_value_change.mg")
+    g.save(graphFile)
+
+    # Replace the registered description with V2 (only the output value changes)
+    replaceNodeTypeDesc(OutputTemplateNodeV1.__name__, OutputTemplateNodeV2)
+
+    # Reload the graph with the updated description
+    reloadedGraph = loadGraph(graphFile)
+    reloadedNode = reloadedGraph.node(nodeName)
+
+    # The reloaded node should not be a CompatibilityNode
+    assert not isinstance(reloadedNode, CompatibilityNode)
+
+    # The reloaded node should reflect the value saved on disk, not the new default value in the description
+    assert not reloadedNode.output.value.endswith("/file.cba")
+
+    # The internal folder (driven by inputs, not outputs) must be unchanged
+    assert reloadedNode.internalFolder == n.internalFolder
+
+    # A new instance of this node should reflect the new default value in the description
+    n = g.addNewNode(OutputTemplateNodeV1.__name__)
+    assert n.output.value.endswith("/file.cba")
+
+    unregisterNodeDesc(OutputTemplateNodeV1)
 
 
 class TestGraphLoadingWithStrictCompatibility:


### PR DESCRIPTION
## Description 

This pull request introduces logic to preserve output expression attribute templates when loading saved projects, ensuring that changes to node descriptions only affect new nodes and not existing ones. It also adds comprehensive tests to verify this behavior.

**Attribute expression template handling:**

* Added the `_expressionTemplate` field to the `Attribute` class to store the original expression template when loading from a project file, ensuring that output expression attributes retain their saved template even if the node description changes later (`meshroom/core/attribute.py`).
* Implemented the `_captureExpressionTemplates` function to recursively set `_expressionTemplate` on output expression attributes during loading, and integrated this logic into `attributeFactory` (`meshroom/core/attribute.py`). [[1]](diffhunk://#diff-346bf2284498d029adfca15a85216268454d6143e70541993cd79f5ea9c8076eR26-R43) [[2]](diffhunk://#diff-346bf2284498d029adfca15a85216268454d6143e70541993cd79f5ea9c8076eR60-R63)
* Modified `getSerializedValue` to prioritize returning the stored `_expressionTemplate` for output expression attributes, preserving user data on reload (`meshroom/core/attribute.py`).
* Updated `_buildAttributeExpVars` to use the stored `_expressionTemplate` if present, ensuring correct default value resolution for expressions after node description changes (`meshroom/core/node.py`).

**Testing and compatibility:**

* Added new test nodes (`OutputTemplateNodeV1`, `OutputTemplateNodeV2`) and a test (`test_outputValueAfterDefaultOutputChange`) to verify that reloading a graph after changing an output attribute's default value in the node description preserves the original value for existing nodes and applies the new value only to new nodes (`tests/test_compatibility.py`). [[1]](diffhunk://#diff-159252527e667164280c08edbd3c6ab4c3c5e9c43f866ac2456f54adcb971b03R170-R194) [[2]](diffhunk://#diff-159252527e667164280c08edbd3c6ab4c3c5e9c43f866ac2456f54adcb971b03R451-R493)