### PR TITLE
New Custom Attributes

### DIFF
--- a/meshroom/common/core.py
+++ b/meshroom/common/core.py
@@ -27,6 +27,10 @@ class CoreDictModel:
         return self._objects.values()
 
     @property
+    def count(self):
+        return len(self._objects)
+
+    @property
     def objects(self):
         return self._objects
 
@@ -50,6 +54,18 @@ class CoreDictModel:
         assert key is not None
         assert key not in self._objects
         self._objects[key] = obj
+
+    def insert(self, i, obj):
+        """Insert obj at position i in the ordered dict.
+
+        Rebuilds the internal dict to place the new entry at the given index.
+        """
+        key = getattr(obj, self._keyAttrName, None)
+        assert key is not None
+        assert key not in self._objects
+        items = list(self._objects.items())
+        items.insert(i, (key, obj))
+        self._objects = dict(items)
 
     def rename(self, oldKey: str, newKey: str):
         """ Rename an element in the dict model

--- a/meshroom/common/core.py
+++ b/meshroom/common/core.py
@@ -83,6 +83,12 @@ class CoreDictModel:
         items = [(newKey if key == oldKey else key, value) for key, value in self._objects.items()]
         self._objects = dict(items)
 
+    def move(self, fromIndex: int, toIndex: int):
+        items = list(self._objects.items())
+        key, value = items.pop(fromIndex)
+        items.insert(toIndex, (key, value))
+        self._objects = dict(items)
+
     def pop(self, key):
         assert key in self._objects
         return self._objects.pop(key)

--- a/meshroom/common/core.py
+++ b/meshroom/common/core.py
@@ -80,8 +80,8 @@ class CoreDictModel:
         if newKey in self._objects.keys():
             raise KeyError(f"Key {newKey} is already in use in {self}")
         obj = self._objects[oldKey]
-        self._objects[newKey] = obj
-        del self._objects[oldKey]
+        items = [(newKey if key == oldKey else key, value) for key, value in self._objects.items()]
+        self._objects = dict(items)
 
     def pop(self, key):
         assert key in self._objects

--- a/meshroom/core/attribute.py
+++ b/meshroom/core/attribute.py
@@ -1867,6 +1867,18 @@ class AnySet(GroupAttribute):
             child.fullNameChanged.emit()
         self.flatStaticChildrenChanged.emit()
 
+    def moveAttribute(self, attribute: Attribute, toIndex: int) -> None:
+        if attribute not in self._value:
+            raise ValueError(f"Attribute '{attribute.fullName}' is not a child of '{self.fullName}'.")
+
+        fromIndex = list(self._value).index(attribute)
+        toIndex = max(0, min(toIndex, self._value.count - 1))
+        if fromIndex == toIndex:
+            return
+
+        self._value.move(fromIndex, toIndex)
+        self.flatStaticChildrenChanged.emit()
+
     def insertAttribute(self, serializedAttribute: dict, index: int) -> Attribute | None:
         """Restore a serialized child attribute at the requested position."""
         attributeDesc = attributeDescriptionFactory(serializedAttribute)
@@ -1905,16 +1917,19 @@ class AnySet(GroupAttribute):
         if duplicateIndex != -1:
             attributeDesc._label = indexPattern.format(name=attributeDesc._label, index=duplicateIndex)
 
-    def _setChildrenValues(self, values: dict):
-        """ Set individual children value from a dict
-        """
+    def _setChildrenValues(self, values: dict | list):
+        """Set individual children values from serialized AnySet data."""
 
-        for key, attrChildValue in values.items():
-            childAttr = self._value.get(key) if key in self._value.keys() else None
-            seriliazedValue = attrChildValue.get('value', None)
+        serializedChildren = values.values() if isinstance(values, dict) else values
+        for attrChildValue in serializedChildren:
+            if not isinstance(attrChildValue, dict):
+                continue
+
+            childName = attrChildValue.get('name', None)
+            childAttr = self._value.get(childName) if childName in self._value.keys() else None
+            serializedValue = attrChildValue.get('value', None)
 
             if not childAttr:
-                idx = self._value.count - 1
                 attrDescType = attrChildValue.get('type', None)
 
                 if not attrDescType:
@@ -1926,24 +1941,20 @@ class AnySet(GroupAttribute):
 
                 childAttr = attributeFactory(
                     description = attributeDescriptionFactory(attrChildValue),
-                    value = seriliazedValue,
+                    value = serializedValue,
                     isOutput = self.isOutput,
                     node = self.node,
                     root = self
                 )
 
-                self._value.insert(idx, childAttr)
+                self._value.insert(self._value.count, childAttr)
 
-            elif seriliazedValue:
-                childAttr.value = seriliazedValue
+            elif serializedValue:
+                childAttr.value = serializedValue
 
     # Override
     def getSerializedValue(self):
-        serializedValue = {}
-        for key, attr in self._value.objects.items():
-            serializedValue[key] = attr.asDict()
-
-        return serializedValue
+        return [attr.asDict() for attr in self._value]
 
     # Override
     def _getValue(self):
@@ -1956,7 +1967,7 @@ class AnySet(GroupAttribute):
             self._resetToNone()
             return
 
-        if not isinstance(exportedValue, dict):
+        if not isinstance(exportedValue, (dict, list)):
             raise AttributeError(f"Failed to set on CustomAttribute: {str(exportedValue)}")
 
         self._setChildrenValues(exportedValue)

--- a/meshroom/core/attribute.py
+++ b/meshroom/core/attribute.py
@@ -1917,10 +1917,17 @@ class AnySet(GroupAttribute):
         if duplicateIndex != -1:
             attributeDesc._label = indexPattern.format(name=attributeDesc._label, index=duplicateIndex)
 
+    def _serializedChildren(self, values: dict | list) -> list:
+        if isinstance(values, dict):
+            if isinstance(values.get("children"), list):
+                return values["children"]
+            return list(values.values())
+        return values
+
     def _setChildrenValues(self, values: dict | list):
         """Set individual children values from serialized AnySet data."""
 
-        serializedChildren = values.values() if isinstance(values, dict) else values
+        serializedChildren = self._serializedChildren(values)
         for attrChildValue in serializedChildren:
             if not isinstance(attrChildValue, dict):
                 continue
@@ -1954,7 +1961,10 @@ class AnySet(GroupAttribute):
 
     # Override
     def getSerializedValue(self):
-        return [attr.asDict() for attr in self._value]
+        return {
+            "expanded": self.expanded,
+            "children": [attr.asDict() for attr in self._value]
+        }
 
     # Override
     def _getValue(self):
@@ -1970,6 +1980,7 @@ class AnySet(GroupAttribute):
         if not isinstance(exportedValue, (dict, list)):
             raise AttributeError(f"Failed to set on CustomAttribute: {str(exportedValue)}")
 
+        self._restoreCollapseState(exportedValue)
         self._setChildrenValues(exportedValue)
 
 

--- a/meshroom/core/attribute.py
+++ b/meshroom/core/attribute.py
@@ -22,7 +22,7 @@ from meshroom.core.exception import InvalidEdgeError
 
 from typing import TYPE_CHECKING, Optional
 
-from meshroom.core.mixins import Collapsable
+from meshroom.core.mixins import Expandable
 
 if TYPE_CHECKING:
     from meshroom.core.graph import Edge
@@ -1226,7 +1226,7 @@ class ListAttribute(Attribute):
     hasAnyOutputLinks = Property(bool, _hasAnyOutputLinks, notify=Attribute.outputLinksChanged)
 
 
-class GroupAttribute(Attribute, Collapsable):
+class GroupAttribute(Attribute, Expandable):
 
     def __init__(self, node, attributeDesc: desc.GroupAttribute, isOutput: bool,
                  root=None, parent=None):
@@ -1980,7 +1980,7 @@ class AnySet(GroupAttribute):
         if not isinstance(exportedValue, (dict, list)):
             raise AttributeError(f"Failed to set on CustomAttribute: {str(exportedValue)}")
 
-        self._restoreCollapseState(exportedValue)
+        self._restoreExpandedState(exportedValue)
         self._setChildrenValues(exportedValue)
 
 

--- a/meshroom/core/attribute.py
+++ b/meshroom/core/attribute.py
@@ -749,16 +749,20 @@ class Attribute(BaseObject):
     node = Property(BaseObject, lambda self: self._node(), constant=True)
     # The attribute that contains this attribute.
     root = Property(BaseObject, lambda self: self._root() if self._root else None, constant=True)
+    # The attribute name or label changed. Dynamic AnySet children can be renamed from the UI.
+    nameChanged = Signal()
+    labelChanged = Signal()
+    fullNameChanged = Signal()
     # The attribute name following the path from the node to the attribute.
-    fullName = Property(str, _getFullName, constant=True)
+    fullName = Property(str, _getFullName, notify=fullNameChanged)
     # The attribute name following the path from the root attribute.
-    rootName = Property(str, _getRootName, constant=True)
+    rootName = Property(str, _getRootName, notify=fullNameChanged)
     # The description object of the attribute.
     desc = Property(desc.Attribute, lambda self: self._desc, constant=True)
     # The name of the attribute.
-    name = Property(str, lambda self: self._desc._name, constant=True)
+    name = Property(str, lambda self: self._desc._name, notify=nameChanged)
     # The human-readable label for the attribute.
-    label = Property(str, lambda self: self._desc.label, constant=True)
+    label = Property(str, lambda self: self._desc.label, notify=labelChanged)
     # The type of attribute as a string.
     type = Property(str, lambda self: self._desc.type, constant=True)
     # The type of the elements of the attribute as a string.
@@ -1805,6 +1809,8 @@ class ShapeListAttribute(ListAttribute):
 
 class AnySet(GroupAttribute):
 
+    _attributeNameRegex = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
     def duplicateAttribute(self, attribute: Attribute, isOutput: bool|None=None) -> Attribute:
         """ Create an attribute as child of the current, with the same description as the given one.
             Duplicated name's are handled by _renameAttributeDescriptionInPlace()
@@ -1832,6 +1838,34 @@ class AnySet(GroupAttribute):
         if attribute in self._value:
             self._value.remove(attribute)
             self.flatStaticChildrenChanged.emit()
+
+    def renameAttribute(self, attribute: Attribute, name: str, label: str) -> None:
+        if attribute not in self._value:
+            raise ValueError(f"Attribute '{attribute.fullName}' is not a child of '{self.fullName}'.")
+
+        name = name.strip()
+        label = label.strip()
+        if not self._attributeNameRegex.match(name):
+            raise ValueError(f"Invalid attribute name: '{name}'.")
+        if not label:
+            raise ValueError("Attribute label cannot be empty.")
+        if name != attribute.name and name in self._value.keys():
+            raise ValueError(f"Attribute name '{name}' already exists in '{self.fullName}'.")
+
+        oldName = attribute.name
+        if name != oldName:
+            self._value.rename(oldName, name)
+            attribute._desc._name = name
+            attribute.nameChanged.emit()
+
+        if label != attribute.label:
+            attribute._desc._label = label
+            attribute.labelChanged.emit()
+
+        attribute.fullNameChanged.emit()
+        for child in attribute.flatStaticChildren:
+            child.fullNameChanged.emit()
+        self.flatStaticChildrenChanged.emit()
 
     def insertAttribute(self, serializedAttribute: dict, index: int) -> Attribute | None:
         """Restore a serialized child attribute at the requested position."""

--- a/meshroom/core/attribute.py
+++ b/meshroom/core/attribute.py
@@ -1833,6 +1833,26 @@ class AnySet(GroupAttribute):
             self._value.remove(attribute)
             self.flatStaticChildrenChanged.emit()
 
+    def insertAttribute(self, serializedAttribute: dict, index: int) -> Attribute | None:
+        """Restore a serialized child attribute at the requested position."""
+        attributeDesc = attributeDescriptionFactory(serializedAttribute)
+        if attributeDesc is None:
+            return None
+
+        restoredAttribute = attributeFactory(
+            description=attributeDesc,
+            value=serializedAttribute.get("value", None),
+            isOutput=self.isOutput,
+            node=self.node,
+            root=self
+        )
+        if restoredAttribute.isOutput:
+            restoredAttribute._isOutput = True
+            restoredAttribute._desc._isDynamicValue = True
+        self._value.insert(index, restoredAttribute)
+        self.flatStaticChildrenChanged.emit()
+        return restoredAttribute
+
     def _renameAttributeDescriptionInPlace(self, attributeDesc: AttributeDescription, indexPattern:str="{name}_{index}"):
         """ If an attribute already exists with the same name,
             the attributeDescription name and label are indexed with a suffix using the givnen pattern "{name}_{index}" by default"

--- a/meshroom/core/attribute.py
+++ b/meshroom/core/attribute.py
@@ -14,10 +14,15 @@ from string import Template
 from meshroom.common import BaseObject, Property, Variant, Signal, ListModel, DictModel, Slot
 from meshroom.core.desc.validators import NotEmptyValidator
 from meshroom.core import desc, hashValue
+
+from meshroom.core.desc import Attribute as AttributeDescription
+
 from meshroom.core.keyValues import KeyValues
 from meshroom.core.exception import InvalidEdgeError
 
 from typing import TYPE_CHECKING, Optional
+
+from meshroom.core.mixins import Collapsable
 
 if TYPE_CHECKING:
     from meshroom.core.graph import Edge
@@ -40,8 +45,30 @@ def _captureExpressionTemplates(attr, value):
             except (KeyError, AttributeError):
                 logging.debug(f"Skipping expression template capture for {key} on {attr}.")
 
+def attributeDescriptionFactory(descType: dict) -> AttributeDescription:
+    """ Retrieve the corresponding Attribute Description from the given dictionary
+    """
+    attrClass = getattr(desc, descType.get('type', None))
+    if not attrClass:
+        return None
 
-def attributeFactory(description: str, value, isOutput: bool, node, root=None, parent=None):
+    name = descType.get('name')
+    label = descType.get('label')
+    description = descType.get('description')
+    elementDesc = descType.get('elementDesc')
+    items = descType.get('items')
+
+    attr = None
+    if items:
+        attr = attrClass(name=name, label=label, description=description, items=[attributeDescriptionFactory(item) for item in items])
+    elif elementDesc:
+        attr = attrClass(name=name, label=label, description=description, elementDesc=attributeDescriptionFactory(elementDesc))
+    else:
+        attr = attrClass(name=name, label=label, description=description)
+
+    return attr
+
+def attributeFactory(description: AttributeDescription, value, isOutput: bool, node, root=None, parent=None):
     """
     Create an Attribute based on description type.
 
@@ -169,7 +196,7 @@ class Attribute(BaseObject):
         params = inspect.signature(value).parameters
         if len(params) == 1 and list(params)[0] == "attr":
             return value(self)
-        
+
         return value(self.node)
 
     def _initValue(self):
@@ -380,6 +407,16 @@ class Attribute(BaseObject):
                 return self._expressionTemplate
             return self.getDefaultValue()
         return self.value
+
+    def asDict(self) -> dict:
+        serializedData = {
+            "name": self.name,
+            "label": self.label,
+            "type": self.desc.__class__.__name__,
+            "value": self.getSerializedValue()
+        }
+
+        return serializedData
 
     def getPrimitiveValue(self, exportDefault=True):
         return self._value
@@ -785,14 +822,16 @@ class Attribute(BaseObject):
     hasAnyInputLinks = Property(bool, _hasAnyInputLinks, notify=inputLinksChanged)
     # Whether the attribute or any of its elements is linked by another attribute.
     hasAnyOutputLinks = Property(bool, _hasAnyOutputLinks, notify=outputLinksChanged)
+
     # The list of attributes that refer to this one as their parent.
-    flatStaticChildren = Property(Variant, _getFlatStaticChildren, constant=True)
+    flatStaticChildrenChanged = Signal()  # AnySet's children list can change on runtime
+    flatStaticChildren = Property(Variant, _getFlatStaticChildren, notify=flatStaticChildrenChanged)
 
     expressionApplied = Signal()
 
     errorMessageChanged = Signal()
     errorMessages = Property(Variant, lambda self: self.getErrorMessages(), notify=errorMessageChanged)
-    isMandatory = Property(bool, _isMandatory, constant=True )    
+    isMandatory = Property(bool, _isMandatory, constant=True )
 
 def raiseIfLink(func):
     """
@@ -1058,13 +1097,13 @@ class ListAttribute(Attribute):
         elif len(self._value) > 0:
             # Erase all items before reassigning
             self._value.removeAt(0, len(self._value))
-        
+
         # Effectively create the objects from the raw data
         if pendingValue:
             attrs = [attributeFactory(self._desc.elementDesc, v, self.isOutput, self.node, self)
                      for v in pendingValue]
             self._value.insert(0, attrs)
-        
+
         self.valueChanged.emit()
 
     # Override
@@ -1076,7 +1115,7 @@ class ListAttribute(Attribute):
                 if self._dynamicValue is None:
                     return []
                 return list(self._dynamicValue)
-        
+
         if exportDefault:
             return [attr.getPrimitiveValue(exportDefault=exportDefault) for attr in self._value]
         return [attr.getPrimitiveValue(exportDefault=exportDefault) for attr in self._value
@@ -1165,6 +1204,12 @@ class ListAttribute(Attribute):
         return super()._hasAnyOutputLinks() or \
                any(attribute.hasAnyOutputLinks for attribute in self._value if hasattr(attribute, 'hasAnyOutputLinks'))
 
+    # Override
+    def asDict(self):
+        serializedData = super().asDict()
+        serializedData['elementDesc'] = self.desc._elementDesc.asDict()
+        return serializedData
+
     # Override value property setter
     value = Property(Variant, Attribute._getValue, _setValue, notify=Attribute.valueChanged)
     isDefault = Property(bool, lambda self: self.value is None or len(self.value) == 0, notify=Attribute.valueChanged)
@@ -1177,7 +1222,7 @@ class ListAttribute(Attribute):
     hasAnyOutputLinks = Property(bool, _hasAnyOutputLinks, notify=Attribute.outputLinksChanged)
 
 
-class GroupAttribute(Attribute):
+class GroupAttribute(Attribute, Collapsable):
 
     def __init__(self, node, attributeDesc: desc.GroupAttribute, isOutput: bool,
                  root=None, parent=None):
@@ -1191,6 +1236,10 @@ class GroupAttribute(Attribute):
                 return self._value.get(key)
             except KeyError:
                 raise AttributeError(key)
+
+    def _resetToNone(self):
+        for child in self.flatStaticChildren:
+                child.value = None
 
     # Override
     def _initValue(self):
@@ -1208,6 +1257,11 @@ class GroupAttribute(Attribute):
 
     # Override
     def _setValue(self, exportedValue):
+
+        if exportedValue is None:
+            self._resetToNone()
+            return
+
         if self._handleLinkValue(exportedValue):
             return
 
@@ -1215,6 +1269,7 @@ class GroupAttribute(Attribute):
         if isinstance(value, dict):
             # set individual child attribute values
             for key, v in value.items():
+
                 self._value.get(key).value = v
         elif isinstance(value, (list, tuple)):
             if len(self._desc._items) != len(value):
@@ -1311,6 +1366,13 @@ class GroupAttribute(Attribute):
         for attr in self._value:
             attr.updateInternals()
 
+    #Override
+    def asDict(self) -> dict:
+        serialized = super().asDict()
+        serialized['items'] = [ item.asDict() for item in self.flatStaticChildren ]
+
+        return serialized
+
     # Override
     def _getFlatStaticChildren(self) -> list[Attribute]:
         attributes = []
@@ -1376,6 +1438,9 @@ class GroupAttribute(Attribute):
 
         for index, nestedAttribute in enumerate(list(self.value)):
             # If the attributes are already connected, do not connect them again
+            if index >= len(nestedDstAttributes):
+                continue
+
             if not nestedDstAttributes[index] in nestedAttribute.outputLinks:
                 connected, deleted = nestedAttribute.connectTo(nestedDstAttributes[index])
                 connectedEdges += connected
@@ -1408,7 +1473,7 @@ class GroupAttribute(Attribute):
         return super().matchText(text) or any(c.matchText(text) for c in self._value)
 
     # Override value property
-    value = Property(Variant, _getValue, _setValue, notify=Attribute.valueChanged)
+    value = Property(Variant, lambda self: self._getValue(), lambda self, value: self._setValue(value), notify=Attribute.valueChanged)
     # Override flatStaticChildren property
     flatStaticChildren = Property(Variant, _getFlatStaticChildren, constant=True)
     isDefault = Property(bool, lambda self: all(v.isDefault for v in self.value),
@@ -1736,6 +1801,121 @@ class ShapeListAttribute(ListAttribute):
     isVisible = Property(bool, _getVisible, _setVisible, notify=shapeListChanged)
     # Override hasDisplayableShape property.
     hasDisplayableShape = Property(bool, lambda self: True, constant=True)
+
+
+class AnySet(GroupAttribute):
+
+    def duplicateAttribute(self, attribute: Attribute, isOutput: bool|None=None) -> Attribute:
+        """ Create an attribute as child of the current, with the same description as the given one.
+            Duplicated name's are handled by _renameAttributeDescriptionInPlace()
+        """
+
+        newDesc = attribute.desc.clone()
+        self._renameAttributeDescriptionInPlace(newDesc)
+        newAttribute = attributeFactory(newDesc,
+                                        value=None,
+                                        isOutput=self.isOutput if isOutput is None else isOutput,
+                                        node=self.node,
+                                        root=self)
+
+        if newAttribute.isOutput:
+            newAttribute._isOutput = True
+            newAttribute._desc._isDynamicValue = True
+
+        lastIndex = self._value.count - 1
+        self._value.insert(lastIndex, newAttribute)
+        self.flatStaticChildrenChanged.emit()
+
+        return newAttribute
+
+    def removeAttribute(self, attribute: Attribute):
+        if attribute in self._value:
+            self._value.remove(attribute)
+            self.flatStaticChildrenChanged.emit()
+
+    def _renameAttributeDescriptionInPlace(self, attributeDesc: AttributeDescription, indexPattern:str="{name}_{index}"):
+        """ If an attribute already exists with the same name,
+            the attributeDescription name and label are indexed with a suffix using the givnen pattern "{name}_{index}" by default"
+        """
+
+        if indexPattern is None:
+            indexPattern = "{name}_{index}"
+
+        duplicateIndex = -1
+        newAttributeName = attributeDesc.name
+        while newAttributeName in self._value.keys():
+            duplicateIndex += 1
+            newAttributeName = indexPattern.format(name=attributeDesc.name, index=duplicateIndex)
+
+        attributeDesc._name = newAttributeName
+        if duplicateIndex != -1:
+            attributeDesc._label = indexPattern.format(name=attributeDesc._label, index=duplicateIndex)
+
+    def _setChildrenValues(self, values: dict):
+        """ Set individual children value from a dict
+        """
+
+        for key, attrChildValue in values.items():
+            childAttr = self._value.get(key) if key in self._value.keys() else None
+            seriliazedValue = attrChildValue.get('value', None)
+
+            if not childAttr:
+                idx = self._value.count - 1
+                attrDescType = attrChildValue.get('type', None)
+
+                if not attrDescType:
+                    continue
+
+                attributeClass = getattr(desc, attrDescType, None)
+                if attributeClass is None or not issubclass(attributeClass, AttributeDescription):
+                    continue
+
+                childAttr = attributeFactory(
+                    description = attributeDescriptionFactory(attrChildValue),
+                    value = seriliazedValue,
+                    isOutput = self.isOutput,
+                    node = self.node,
+                    root = self
+                )
+
+                self._value.insert(idx, childAttr)
+
+            elif seriliazedValue:
+                childAttr.value = seriliazedValue
+
+    # Override
+    def getSerializedValue(self):
+        serializedValue = {}
+        for key, attr in self._value.objects.items():
+            serializedValue[key] = attr.asDict()
+
+        return serializedValue
+
+    # Override
+    def _getValue(self):
+        return self._value
+
+    # Override
+    def _setValue(self, exportedValue):
+
+        if exportedValue is None:
+            self._resetToNone()
+            return
+
+        if not isinstance(exportedValue, dict):
+            raise AttributeError(f"Failed to set on CustomAttribute: {str(exportedValue)}")
+
+        self._setChildrenValues(exportedValue)
+
+
+    # Override
+    def _populateFromDynamicValue(self, exportedValue):
+        super()._setValue(exportedValue)  # Use the GroupAttribute usual setValue to restore values.json data
+
+    # Override
+    def _validateIncomingConnection(self, connectingAttribute: Attribute) -> bool:
+        """Accept connections of any type."""
+        return True
 
 
 class Flow(Attribute):

--- a/meshroom/core/desc/__init__.py
+++ b/meshroom/core/desc/__init__.py
@@ -26,6 +26,9 @@ from .shapeAttribute import (
     Rectangle,
     Circle
 )
+from .anySet import (
+    AnySet
+)
 from .computation import (
     DynamicNodeSize,
     Level,

--- a/meshroom/core/desc/anySet.py
+++ b/meshroom/core/desc/anySet.py
@@ -1,0 +1,38 @@
+from meshroom.core.desc import GroupAttribute, ValueTypeErrors
+from meshroom.common import Property, Variant
+
+
+class AnySet(GroupAttribute):
+
+    def __init__(self,
+                 name="Custom Attributes",
+                 label=None,
+                 description=None,
+                 commandLineGroup="allParams",
+                 advanced=False, semantic="",
+                 enabled=True,
+                 visible=True,
+                 exposed=False):
+
+        super().__init__(items = [],
+                         name=name,
+                         label=label,
+                         description=description,
+                         commandLineGroup=commandLineGroup,
+                         advanced=advanced,
+                         semantic=semantic,
+                         enabled=enabled,
+                         visible=visible,
+                         exposed=exposed)
+
+    def checkValueTypes(self):
+        return "", ValueTypeErrors.NONE
+
+    def getInstanceType(self):
+        from meshroom.core.attribute import AnySet
+        return AnySet
+
+    def validateValue(self, value):
+        return value
+
+    isCustomAttribute = Property(bool, lambda _: True, constant=True)

--- a/meshroom/core/desc/attribute.py
+++ b/meshroom/core/desc/attribute.py
@@ -6,13 +6,13 @@ from enum import auto, Enum
 from typing import Sequence
 
 from meshroom.common import (
-    BaseObject, 
-    ListModel, 
-    JSValue, 
-    Property, 
-    Variant, 
-    VariantList, 
-    strtobool, 
+    BaseObject,
+    ListModel,
+    JSValue,
+    Property,
+    Variant,
+    VariantList,
+    strtobool,
     deprecated
 )
 from meshroom.core.desc.validators import AttributeValidator
@@ -24,7 +24,7 @@ _SPLIT_RE = re.compile(r'[_\s]+')
 
 def convertToLabel(name: str) -> str:
     """Convert a camelCase or snake_case attribute name into a human-readable label.
-    
+
     Examples:
         >>> convertToLabel('camelCase')
         'Camel Case'
@@ -39,14 +39,14 @@ def convertToLabel(name: str) -> str:
     """
     if not name:
         return ''
-    
+
     # Handle consecutive uppercase letters (e.g. 'URL', 'HTTP')
     name = _ACRONYM_RE.sub(r'\1 \2', name)
     # Insert space between camelCase boundaries
     name = _CAMEL_CASE_RE.sub(r'\1 \2', name)
     # Split on underscores or spaces
     words = _SPLIT_RE.split(name)
-    
+
     # Preserve uppercase acronyms, capitalize others
     return ' '.join(
         word if word.isupper() else word.capitalize()
@@ -98,7 +98,7 @@ class Attribute(BaseObject):
             self._validators = validators
         else:
             raise RuntimeError(f"Validators should be of type 'Sequence[AttributeValidator]', the type '{type(validators)}' is not supported.")
-        
+
     def getInstanceType(self):
         """ Return the correct Attribute instance corresponding to the description. """
         # Import within the method to prevent cyclic dependencies
@@ -113,7 +113,7 @@ class Attribute(BaseObject):
         """
         raise NotImplementedError("Attribute.validateValue is an abstract function that should be "
                                   "implemented in the derived class.")
-    
+
     def checkUidIgnoreValue(self, testValue):
         """ Return true if the test value is the same as the `uidIgnoreValue` """
         return self._uidIgnoreValue == testValue
@@ -152,11 +152,43 @@ class Attribute(BaseObject):
         except ValueError:
             return False
         return True
-    
+
     @property
     def validators(self):
         return self._validators
-    
+
+    def clone(self):
+        return self.__class__(
+                name=self.name,
+                label=self.label,
+                description=self.description,
+                value=self.value,
+                advanced=self.advanced,
+                semantic=self.semantic,
+                commandLineGroup=self.commandLineGroup,
+                enabled=self.enabled,
+                invalidate=self.invalidate,
+                visible=self.visible,
+                exposed=self.exposed,
+                validators=self.validators
+            )
+
+    def asDict(self):
+        return {
+            'type': self.__class__.__name__,
+            'name':self.name,
+            'label':self.label,
+            'description':self.description,
+            'value':self.value,
+            'advanced': self.advanced,
+            'semantic': self.semantic,
+            'commandLineGroup': self.commandLineGroup,
+            'enabled': self.enabled,
+            'keyable':self.keyable,
+            'keyType':self.keyType,
+            'invalidate':self.invalidate
+        }
+
     name = Property(str, lambda self: self._name, constant=True)
     label = Property(str, lambda self: self._label, constant=True)
     description = Property(str, lambda self: self._description, constant=True)
@@ -199,8 +231,8 @@ class Attribute(BaseObject):
 class ListAttribute(Attribute):
     """ A list of Attributes """
     @deprecated.depreciateParam("group", "Param 'group' on {name} should not be used anymore. Please use 'commandLineGroup' instead")
-    def __init__(self, elementDesc, name, label=None, description=None, group="allParams", commandLineGroup=_setParamSentinel, 
-                 advanced=False, semantic="", enabled=True, joinChar=" ", uidIgnoreValueIfEmpty=False, visible=True, exposed=False, 
+    def __init__(self, elementDesc, name, label=None, description=None, group="allParams", commandLineGroup=_setParamSentinel,
+                 advanced=False, semantic="", enabled=True, joinChar=" ", uidIgnoreValueIfEmpty=False, visible=True, exposed=False,
                  value=None, validators=None):
         """
         :param elementDesc: the Attribute description of elements to store in that list
@@ -210,7 +242,7 @@ class ListAttribute(Attribute):
         self._elementDesc = elementDesc
         self._joinChar = joinChar
         commandLineGroup = commandLineGroup if commandLineGroup is not _setParamSentinel else group
-        
+
         super(ListAttribute, self).__init__(name=name, label=label, description=description, value=value,
                                             invalidate=False, commandLineGroup=commandLineGroup, advanced=advanced, semantic=semantic,
                                             enabled=enabled, visible=visible, exposed=exposed, validators=validators)
@@ -239,7 +271,7 @@ class ListAttribute(Attribute):
         return value
 
     def checkUidIgnoreValue(self, testValue):
-        """ Don't affect Uid if _uidIgnoreValueIfEmpty is set to True 
+        """ Don't affect Uid if _uidIgnoreValueIfEmpty is set to True
         and if testValue is an empty list.
         """
         return self._uidIgnoreValueIfEmpty and len(testValue) == 0
@@ -256,6 +288,27 @@ class ListAttribute(Attribute):
             return self._elementDesc.matchDescription(value[0], strict)
         return True
 
+    def clone(self):
+        return self.__class__(elementDesc=self.elementDesc,
+                              name=self.name,
+                              label=self.label,
+                              description=self.description,
+                              commandLineGroup=self.commandLineGroup,
+                              advanced=self.advanced,
+                              semantic=self.semantic,
+                              enabled=self.enabled,
+                              joinChar=self.joinChar,
+                              visible=self.visible,
+                              exposed=self.exposed,
+                              value=self.value
+                              )
+
+    # Override
+    def asDict(self):
+        serializedData = super().asDict()
+        serializedData['elementDesc'] = self._elementDesc.asDict()
+        return serializedData
+
     elementDesc = Property(Attribute, lambda self: self._elementDesc, constant=True)
     invalidate = Property(Variant, lambda self: self.elementDesc.invalidate, constant=True)
     joinChar = Property(str, lambda self: self._joinChar, constant=True)
@@ -264,7 +317,7 @@ class ListAttribute(Attribute):
 class GroupAttribute(Attribute):
     """ A macro Attribute composed of several Attributes """
     @deprecated.depreciateParam("group", "Param 'group' on {name} should not be used anymore. Please use 'commandLineGroup' instead")
-    def __init__(self, items, name, label=None, description=None, group="allParams", commandLineGroup=_setParamSentinel, 
+    def __init__(self, items, name, label=None, description=None, group="allParams", commandLineGroup=_setParamSentinel,
                  advanced=False, semantic="",  enabled=True, joinChar=" ", brackets=None, visible=True,
                  exposed=False, validators=None):
         """
@@ -282,6 +335,7 @@ class GroupAttribute(Attribute):
     def getInstanceType(self):
         # Import within the method to prevent cyclic dependencies
         from meshroom.core.attribute import GroupAttribute
+
         return GroupAttribute
 
     def validateValue(self, value):
@@ -290,8 +344,7 @@ class GroupAttribute(Attribute):
             return value
         if JSValue is not None and isinstance(value, JSValue):
             # Note: we could use isArray(), property("length").toInt() to retrieve all values
-            raise ValueError("GroupAttribute.validateValue: cannot recognize QJSValue. "
-                             "Please, use JSON.stringify(value) in QML.")
+            raise ValueError("GroupAttribute.validateValue:cannot recognize QJSValue.\nPlease, use JSON.stringify(value) in QML.")
         if isinstance(value, str):
             # Alternative solution to set values from QML is to convert values to JSON string
             # In this case, it works with all data types
@@ -366,6 +419,20 @@ class GroupAttribute(Attribute):
             allInvalidations.append(desc.invalidate)
         return allInvalidations
 
+    def clone(self):
+        return self.__class__(items=[item.clone() for item in self._items],
+                              name=self.name,
+                              label=self.label,
+                              description=self.description,
+                              commandLineGroup=self.commandLineGroup,
+                              advanced=self.advanced,
+                              semantic=self.semantic,
+                              enabled=self.enabled,
+                              joinChar=self.joinChar,
+                              brackets=self.brackets,
+                              visible=self.visible,
+                              exposed=self.exposed)
+
     items = Property(Variant, lambda self: self._items, constant=True)
     invalidate = Property(Variant, retrieveChildrenInvalidations, constant=True)
     joinChar = Property(str, lambda self: self._joinChar, constant=True)
@@ -381,6 +448,25 @@ class Param(Attribute):
                                     keyable=keyable, keyType=keyType, commandLineGroup=commandLineGroup, advanced=advanced,
                                     enabled=enabled, invalidate=invalidate, semantic=semantic,
                                     uidIgnoreValue=uidIgnoreValue, visible=visible, exposed=exposed, validators=validators)
+
+    #Override
+    def clone(self):
+        return self.__class__(
+                name=self.name,
+                label=self.label,
+                description=self.description,
+                value=self.value,
+                advanced=self.advanced,
+                semantic=self.semantic,
+                commandLineGroup=self.commandLineGroup,
+                enabled=self.enabled,
+                keyable=self.keyable,
+                keyType=self.keyType,
+                invalidate=self.invalidate,
+                visible=self.visible,
+                exposed=self.exposed,
+                validators=self.validators
+            )
 
 
 class File(Attribute):
@@ -414,6 +500,8 @@ class File(Attribute):
             return self.name, ValueTypeErrors.TYPE
         return "", ValueTypeErrors.NONE
 
+    def clone(self):
+        return Attribute.clone(self)
 
 class BoolParam(Param):
     """
@@ -552,6 +640,20 @@ class PushButtonParam(Param):
     def checkValueTypes(self):
         return "", ValueTypeErrors.NONE
 
+    def clone(self):
+        return self.__class__(
+            name=self.name,
+            label=self.label,
+            description=self.description,
+            commandLineGroup=self.commandLineGroup,
+            advanced=self.advanced,
+            enabled=self.enabled,
+            invalidate=self.invalidate,
+            semantic=self.semantic,
+            visible=self.visible,
+            exposed=self.exposed,
+            validators=self.validators
+        )
 
 class ChoiceParam(Param):
     """
@@ -648,6 +750,9 @@ class ChoiceParam(Param):
 
         return "", ValueTypeErrors.NONE
 
+    def clone(self):
+        return Attribute.clone(self)
+
     values = Property(VariantList, lambda self: self._values, constant=True)
     exclusive = Property(bool, lambda self: self._exclusive, constant=True)
     joinChar = Property(str, lambda self: self._joinChar, constant=True)
@@ -683,6 +788,8 @@ class StringParam(Param):
             return self.name, ValueTypeErrors.TYPE
         return "", ValueTypeErrors.NONE
 
+    def clone(self):
+        return Attribute.clone(self)
 
 class ColorParam(Param):
     """
@@ -714,6 +821,8 @@ class ColorParam(Param):
             return self.name, ValueTypeErrors.TYPE
         return "", ValueTypeErrors.NONE
 
+    def clone(self):
+        return Attribute.clone(self)
 
 class Flow(Attribute):
     """

--- a/meshroom/core/desc/geometryAttribute.py
+++ b/meshroom/core/desc/geometryAttribute.py
@@ -21,6 +21,18 @@ class Geometry(GroupAttribute):
         from meshroom.core.attribute import GeometryAttribute
         return GeometryAttribute
 
+    def clone(self):
+        return self.__class__(items=[item.clone() for item in self._items],
+                              name=self.name,
+                              label=self.label,
+                              description=self.description,
+                              commandLineGroup=self.commandLineGroup,
+                              advanced=self.advanced,
+                              semantic=self.semantic,
+                              enabled=self.enabled,
+                              visible=self.visible,
+                              exposed=self.exposed
+                )
 
 class Size2d(Geometry):
     """
@@ -42,6 +54,25 @@ class Size2d(Geometry):
         super(Size2d, self).__init__(items, name, label, description, commandLineGroup=None, advanced=advanced,
                                      semantic=semantic, enabled=enabled, visible=visible, exposed=exposed)
 
+    def clone(self):
+        return self.__class__(
+             name=self.name,
+             label=self.label,
+             description=self.description,
+             width=self.items[0].value,
+             height=self.items[1].value,
+             widthRange=self.items[0].range,
+             heightRange=self.items[1].range,
+             keyable=self.items[0].keyable,
+             keyType=self.items[0].keyType,
+             commandLineGroup=self.commandLineGroup,
+             advanced=self.advanced,
+             semantic=self.semantic,
+             enabled=self.enabled,
+             visible=self.visible,
+             exposed=self.exposed
+        )
+
 class Vec2d(Geometry):
     """
     Vec2d is a Geometry attribute that allows to specify a 2d vector.
@@ -61,3 +92,22 @@ class Vec2d(Geometry):
         # GeometryAttribute constructor
         super(Vec2d, self).__init__(items, name, label, description, commandLineGroup=None, advanced=advanced,
                                      semantic=semantic, enabled=enabled, visible=visible, exposed=exposed)
+
+    def clone(self):
+        return self.__class__(
+             name=self.name,
+             label=self.label,
+             description=self.description,
+             x=self.items[0].value,
+             y=self.items[1].value,
+             xRange=self.items[0].range,
+             yRange=self.items[1].range,
+             keyable=self.items[0].keyable,
+             keyType=self.items[0].keyType,
+             commandLineGroup=self.commandLineGroup,
+             advanced=self.advanced,
+             semantic=self.semantic,
+             enabled=self.enabled,
+             visible=self.visible,
+             exposed=self.exposed
+        )

--- a/meshroom/core/desc/node.py
+++ b/meshroom/core/desc/node.py
@@ -14,6 +14,7 @@ import psutil
 
 from meshroom import _MESHROOM_ROOT
 from meshroom.core import cgroup
+from meshroom.core.desc.anySet import AnySet
 from meshroom.core.utils import VERBOSE_LEVEL
 
 from .computation import Level, StaticNodeSize
@@ -239,7 +240,7 @@ class BaseNode(object):
 
     def __init__(self):
         super(BaseNode, self).__init__()
-        self.hasDynamicOutputAttribute = any(output.isDynamicValue for output in self.outputs)
+        self.hasDynamicOutputAttribute = any(output.isDynamicValue or isinstance(output, AnySet) for output in self.outputs)
         self.sourceCodeFolder = Path(getfile(self.__class__)).parent.resolve().as_posix()
 
     def getMrNodeType(self):

--- a/meshroom/core/desc/shapeAttribute.py
+++ b/meshroom/core/desc/shapeAttribute.py
@@ -49,6 +49,18 @@ class ShapeList(ListAttribute):
         from meshroom.core.attribute import ShapeListAttribute
         return ShapeListAttribute
 
+    def clone(self):
+        return self.__class__(shape=self.elementDesc,
+                              name=self.name,
+                              label=self.label,
+                              description=self.description,
+                              commandLineGroup=self.commandLineGroup,
+                              advanced=self.advanced,
+                              semantic=self.semantic,
+                              enabled=self.enabled,
+                              visible=self.visible,
+                              exposed=self.exposed)
+
 class Point2d(Shape):
     """
     Point2d is a Shape attribute that allows to display and modify a 2d point.
@@ -67,6 +79,23 @@ class Point2d(Shape):
         super(Point2d, self).__init__(geometryItems, name, label, description, commandLineGroup=None, advanced=advanced,
                                       semantic=semantic, enabled=enabled, visible=visible, exposed=exposed)
 
+    def clone(self):
+        clone = self.__class__(
+             name=self.name,
+             label=self.label,
+             description=self.description,
+             keyable=self.items[0].keyable,
+             keyType=self.items[0].keyType,
+             commandLineGroup=self.commandLineGroup,
+             advanced=self.advanced,
+             semantic=self.semantic,
+             enabled=self.enabled,
+             visible=self.visible,
+             exposed=self.exposed
+        )
+        clone._items = [item.clone() for item in self._items]
+        return clone
+
 class Line2d(Shape):
     """
     Line2d is a Shape attribute that allows to display and modify a 2d line.
@@ -84,6 +113,23 @@ class Line2d(Shape):
         # ShapeAttribute constructor
         super(Line2d, self).__init__(geometryItems, name, label, description, commandLineGroup=None, advanced=advanced,
                                      semantic=semantic, enabled=enabled, visible=visible, exposed=exposed)
+
+    def clone(self):
+        cloned = self.__class__(
+             name=self.name,
+             label=self.label,
+             description=self.description,
+             keyable=self.items[0].keyable,
+             keyType=self.items[0].keyType,
+             commandLineGroup=self.commandLineGroup,
+             advanced=self.advanced,
+             semantic=self.semantic,
+             enabled=self.enabled,
+             visible=self.visible,
+             exposed=self.exposed
+        )
+        cloned._items = [item.clone() for item in self._items]
+        return cloned
 
 class Rectangle(Shape):
     """
@@ -105,6 +151,23 @@ class Rectangle(Shape):
         super(Rectangle, self).__init__(geometryItems, name, label, description, commandLineGroup=None, advanced=advanced,
                                         semantic=semantic, enabled=enabled, visible=visible, exposed=exposed)
 
+    def clone(self):
+        cloned = self.__class__(
+             name=self.name,
+             label=self.label,
+             description=self.description,
+             keyable=self.items[0].keyable,
+             keyType=self.items[0].keyType,
+             commandLineGroup=self.commandLineGroup,
+             advanced=self.advanced,
+             semantic=self.semantic,
+             enabled=self.enabled,
+             visible=self.visible,
+             exposed=self.exposed
+        )
+        cloned._items = [item.clone() for item in self._items]
+        return cloned
+
 class Circle(Shape):
     """
     Circle is a Shape attribute that allows to display and modify a circle.
@@ -124,3 +187,20 @@ class Circle(Shape):
         # ShapeAttribute constructor
         super(Circle, self).__init__(geometryItems, name, label, description, commandLineGroup=None, advanced=advanced,
                                      semantic=semantic, enabled=enabled, visible=visible, exposed=exposed)
+
+    def clone(self):
+        cloned = self.__class__(
+             name=self.name,
+             label=self.label,
+             description=self.description,
+             keyable=self.items[0].keyable,
+             keyType=self.items[0].keyType,
+             commandLineGroup=self.commandLineGroup,
+             advanced=self.advanced,
+             semantic=self.semantic,
+             enabled=self.enabled,
+             visible=self.visible,
+             exposed=self.exposed
+        )
+        cloned._items = [item.clone() for item in self._items]
+        return cloned

--- a/meshroom/core/graph.py
+++ b/meshroom/core/graph.py
@@ -16,7 +16,7 @@ import meshroom.core
 from meshroom.common import BaseObject, DictModel, Slot, Signal, Property
 from meshroom.core import Version
 from meshroom.core import submitters
-from meshroom.core.attribute import Attribute, ListAttribute, GroupAttribute
+from meshroom.core.attribute import Attribute, AnySet, ListAttribute, GroupAttribute
 from meshroom.core.exception import GraphCompatibilityError, InvalidEdgeError, StopGraphVisit, StopBranchVisit, CyclicDependencyError
 from meshroom.core.graphIO import GraphIO, GraphSerializer, TemplateGraphSerializer, PartialGraphSerializer
 from meshroom.core.node import BaseNode, Status, Node, CompatibilityNode
@@ -327,8 +327,8 @@ class Graph(BaseObject):
 
             # Create graph edges by resolving attributes expressions
             self._applyExpr()
-            
-        # Templates are specific: they contain only the minimal amount of 
+
+        # Templates are specific: they contain only the minimal amount of
         # serialized data to describe the graph structure.
         # They are not meant to be computed: therefore, we can early return here,
         # as uid conflict evaluation is only meaningful for nodes with computed data.
@@ -413,7 +413,7 @@ class Graph(BaseObject):
         """
         Compare the computed UIDs of all the nodes in the graph with the UIDs serialized in `graphContent`. If there
         are mismatches, the nodes with the unexpected UID are replaced with "UidConflict" compatibility nodes.
-  
+
         Args:
             graphContent: The serialized Graph content.
         """
@@ -439,7 +439,7 @@ class Graph(BaseObject):
 
         logging.warning("UID Compatibility issues found: recreating conflicting nodes as CompatibilityNodes.")
 
-        # A uid conflict is contagious: if a node has a uid conflict, all of its downstream nodes may be 
+        # A uid conflict is contagious: if a node has a uid conflict, all of its downstream nodes may be
         # impacted as well, as the uid flows through connections.
         # Therefore, we deal with conflicting uid nodes by depth: replacing a node with a CompatibilityNode restores
         # the serialized uid, which might solve "false-positives" downstream conflicts as well.
@@ -894,7 +894,7 @@ class Graph(BaseObject):
         if self.node(node).hasInternalAttribute(attribute):
             return self.node(node).internalAttribute(attribute)
         return None
-    
+
     @Slot(str, result=Attribute)
     def anyAttribute(self, fullName):
         # type: (str) -> Attribute
@@ -995,7 +995,7 @@ class Graph(BaseObject):
             raise InvalidEdgeError(srcAttr.fullName, dstAttr.fullName,
                                    "Attributes do not belong to this graph.")
 
-        if not dstAttr.validateIncomingConnection(srcAttr):
+        if not isinstance(srcAttr, AnySet) and not dstAttr.validateIncomingConnection(srcAttr):
             raise InvalidEdgeError(srcAttr.fullName, dstAttr.fullName,
                                    f"Attributes are not compatible (src base type: {srcAttr.baseType}; dst base type: {dstAttr.baseType}).")
 
@@ -1462,7 +1462,7 @@ class Graph(BaseObject):
             self._save(filepath=filepath, setupProjectFile=setupProjectFile, template=template)
         finally:
             self._saving = False
-    
+
     def _generateNextPath(self):
         """
         Generate the filename for the next version
@@ -1600,7 +1600,7 @@ class Graph(BaseObject):
         # Now, update each individual node
         for node in self.nodes:
             node.updateDuplicates(nodesPerUid)
-    
+
     def updateJobManagerWithNode(self, node):
         if node._uid in jobManager._nodeToJob.keys():
             return
@@ -1640,7 +1640,7 @@ class Graph(BaseObject):
             self.dirtyTopology = False
 
         self.updated.emit()
-    
+
     def updateMonitoredFiles(self):
         self.statusUpdated.emit()
 

--- a/meshroom/core/graphIO.py
+++ b/meshroom/core/graphIO.py
@@ -231,14 +231,15 @@ class PartialGraphSerializer(GraphSerializer):
             ]
 
         if isinstance(attribute, AnySet):
-            serializedData = {}
-            for name, child in attribute.value.items():
-                serializedData[name] = child.asDict()
+            serializedData = []
+            for child in attribute.value:
+                childData = child.asDict()
                 childLinkAttr = child.inputLink
 
                 # Remove connection if the sourceNode is not in the partialgraph nodes
                 if childLinkAttr and childLinkAttr.node not in self.nodes:
-                    serializedData[name]['value'] = child.getDefaultValue()
+                    childData['value'] = child.getDefaultValue()
+                serializedData.append(childData)
 
             return serializedData
 

--- a/meshroom/core/graphIO.py
+++ b/meshroom/core/graphIO.py
@@ -3,7 +3,7 @@ from typing import Any, TYPE_CHECKING, Union
 
 import meshroom
 from meshroom.core import Version
-from meshroom.core.attribute import Attribute, GroupAttribute, ListAttribute
+from meshroom.core.attribute import Attribute, AnySet, GroupAttribute, ListAttribute
 from meshroom.core.node import Node
 
 if TYPE_CHECKING:
@@ -97,7 +97,7 @@ class GraphSerializer:
         header[GraphIO.Keys.NodesVersions] = self._getNodeTypesVersions()
         if self._graph._hasExplicitCacheDir:
             # We store the absolute but also the relative cacheDir path (to the scene file)
-            # to make sure that if we move the scene+cacheDir we can still retrieve the cache 
+            # to make sure that if we move the scene+cacheDir we can still retrieve the cache
             header[GraphIO.Keys.CacheDir] = {
                 "absoluteCacheDir": self._graph._absoluteCacheDir,
                 "relativeCacheDir": self._graph._relativeCacheDir,
@@ -230,7 +230,20 @@ class PartialGraphSerializer(GraphSerializer):
                 if (exportValue := self._serializeAttribute(child)) is not None
             ]
 
-        if isinstance(attribute, GroupAttribute):
+        if isinstance(attribute, AnySet):
+            serializedData = {}
+            for name, child in attribute.value.items():
+                serializedData[name] = child.asDict()
+                childLinkAttr = child.inputLink
+
+                # Remove connection if the sourceNode is not in the partialgraph nodes
+                if childLinkAttr and childLinkAttr.node not in self.nodes:
+                    serializedData[name]['value'] = child.getDefaultValue()
+
+            return serializedData
+
+
+        elif isinstance(attribute, GroupAttribute):
             # Recursively serialize each child of the group attribute.
             return {name: self._serializeAttribute(child) for name, child in attribute.value.items()}
 

--- a/meshroom/core/graphIO.py
+++ b/meshroom/core/graphIO.py
@@ -231,7 +231,7 @@ class PartialGraphSerializer(GraphSerializer):
             ]
 
         if isinstance(attribute, AnySet):
-            serializedData = []
+            serializedChildren = []
             for child in attribute.value:
                 childData = child.asDict()
                 childLinkAttr = child.inputLink
@@ -239,9 +239,12 @@ class PartialGraphSerializer(GraphSerializer):
                 # Remove connection if the sourceNode is not in the partialgraph nodes
                 if childLinkAttr and childLinkAttr.node not in self.nodes:
                     childData['value'] = child.getDefaultValue()
-                serializedData.append(childData)
+                serializedChildren.append(childData)
 
-            return serializedData
+            return {
+                "expanded": attribute.expanded,
+                "children": serializedChildren
+            }
 
 
         elif isinstance(attribute, GroupAttribute):

--- a/meshroom/core/mixins.py
+++ b/meshroom/core/mixins.py
@@ -1,6 +1,6 @@
 from meshroom.common import Property, Signal
 
-class Collapsable(object):
+class Expandable(object):
 
     def __init__(self):
         super().__init__()
@@ -15,10 +15,10 @@ class Collapsable(object):
         self._expanded = value
         self.expandedChanged.emit()
 
-    def _restoreCollapseState(self, serializedValue):
+    def _restoreExpandedState(self, serializedValue):
         if isinstance(serializedValue, dict) and "expanded" in serializedValue:
             self.expanded = serializedValue["expanded"]
 
     expandedChanged = Signal()
-    isCollapsable = Property(bool, lambda self: True, constant=True)
+    isExpandable = Property(bool, lambda self: True, constant=True)
     expanded = Property(bool, _getExpanded, _setExpanded, notify=expandedChanged)

--- a/meshroom/core/mixins.py
+++ b/meshroom/core/mixins.py
@@ -1,0 +1,8 @@
+from meshroom.common import Property
+
+class Collapsable(object):
+
+    def __init__(self):
+        super().__init__()
+
+    isCollapsable = Property(bool, lambda self: True, constant=True)

--- a/meshroom/core/mixins.py
+++ b/meshroom/core/mixins.py
@@ -1,8 +1,24 @@
-from meshroom.common import Property
+from meshroom.common import Property, Signal
 
 class Collapsable(object):
 
     def __init__(self):
         super().__init__()
 
+    def _getExpanded(self) -> bool:
+        return getattr(self, "_expanded", False)
+
+    def _setExpanded(self, value: bool):
+        value = bool(value)
+        if self._getExpanded() == value:
+            return
+        self._expanded = value
+        self.expandedChanged.emit()
+
+    def _restoreCollapseState(self, serializedValue):
+        if isinstance(serializedValue, dict) and "expanded" in serializedValue:
+            self.expanded = serializedValue["expanded"]
+
+    expandedChanged = Signal()
     isCollapsable = Property(bool, lambda self: True, constant=True)
+    expanded = Property(bool, _getExpanded, _setExpanded, notify=expandedChanged)

--- a/meshroom/core/node.py
+++ b/meshroom/core/node.py
@@ -23,7 +23,7 @@ from meshroom.core.attribute import attributeFactory, ListAttribute, GroupAttrib
 from meshroom.core.desc.attribute import Attribute as AttributeDescription
 from meshroom.core.desc.anySet import AnySet as AnySetDescription
 from meshroom.core.exception import NodeUpgradeError, UnknownNodeTypeError
-from meshroom.core.mixins import Collapsable
+from meshroom.core.mixins import Expandable
 from meshroom.core.mtyping import PathLike
 
 
@@ -2496,7 +2496,7 @@ class Node(BaseNode):
                 continue
             internalInputs[k] = v.getSerializedValue()
         outputs = ({k: v.getSerializedValue() for k, v in self._attributes.objects.items()
-                    if v.isOutput and (not v.desc.isDynamicValue or isinstance(v, Collapsable))})
+                    if v.isOutput and (not v.desc.isDynamicValue or isinstance(v, Expandable))})
 
         return {
             'nodeType': self.nodeType,

--- a/meshroom/core/node.py
+++ b/meshroom/core/node.py
@@ -20,7 +20,10 @@ import meshroom
 from meshroom.common import Signal, Variant, Property, BaseObject, Slot, ListModel, DictModel
 from meshroom.core import desc, plugins, stats, hashValue, nodeVersion, Version, MrNodeType
 from meshroom.core.attribute import attributeFactory, ListAttribute, GroupAttribute, Attribute
+from meshroom.core.desc.attribute import Attribute as AttributeDescription
+from meshroom.core.desc.anySet import AnySet as AnySetDescription
 from meshroom.core.exception import NodeUpgradeError, UnknownNodeTypeError
+from meshroom.core.mixins import Collapsable
 from meshroom.core.mtyping import PathLike
 
 
@@ -40,6 +43,10 @@ def renameWritingToFinalPath(writingFilepath: str, filepath: str) -> str:
             except OSError:
                 pass
     os.rename(writingFilepath, filepath)
+
+
+def hasADynamicValue(attribute: AttributeDescription) ->bool:
+    return attribute.isDynamicValue or isinstance(attribute, AnySetDescription)
 
 class Status(Enum):
     """
@@ -72,18 +79,18 @@ class ChunkIndex(IntEnum):
 class ChunkIndexEnum(BaseObject):
     """
     Wrapper class to expose ChunkIndex enum to QML.
-    
+
     Usage in QML:
         import Node 1.0
-        
+
         if (chunkIndex === ChunkIndexEnum.PREPROCESS) {
             // Handle preprocess case
         }
     """
-    
+
     def __init__(self, parent=None):
         super().__init__(parent)
-    
+
     NONE = Property(int, lambda self: int(ChunkIndex.NONE), constant=True)
     PREPROCESS = Property(int, lambda self: int(ChunkIndex.PREPROCESS), constant=True)
     POSTPROCESS = Property(int, lambda self: int(ChunkIndex.POSTPROCESS), constant=True)
@@ -502,7 +509,7 @@ class NodeChunk(BaseObject):
 
     def __repr__(self):
         return f"<NodeChunk {self.name} ({self.getStatusName()}) {self.__uid}>"
-    
+
     def __del__(self):
         logging.debug(f"NodeChunk: delete chunk {self}")
 
@@ -513,7 +520,7 @@ class NodeChunk(BaseObject):
     @property
     def isPreprocess(self):
         return self.index == ChunkIndex.PREPROCESS
-    
+
     @property
     def isPostprocess(self):
         return self.index == ChunkIndex.POSTPROCESS
@@ -1805,7 +1812,7 @@ class BaseNode(BaseObject):
                 chunkPlaceholder._status.status = self._nodeStatus.status
                 self._chunkPlaceholder.setObjectList([chunkPlaceholder])
                 self.chunksChanged.emit()
-    
+
     def getChunkLogfileName(self, iteration: int):
         if iteration >= 0:
             stem = str(self.chunks[iteration].index)
@@ -1839,7 +1846,7 @@ class BaseNode(BaseObject):
 
     def postprocess(self, forceCompute=False, inCurrentEnv=False):
         """
-        Invoke the post process command on Client Node to execute after 
+        Invoke the post process command on Client Node to execute after
         the processing on the node is completed
         """
         if self.hasPostprocessChunk:
@@ -1908,14 +1915,14 @@ class BaseNode(BaseObject):
         # loop over all output attributes in the node description
         for output in self.nodeDesc.outputs:
             # Only consider dynamic values
-            if output.isDynamicValue:
+            if hasADynamicValue(output):
                 if self.hasAttribute(output.name) and output.name in data:
                     attr = self.attribute(output.name)
 
                     # Use _populateFromDynamicValue for compatible classes
                     # (E.g. for ListAttributes) to properly
                     # create QObject children on the main thread
-                    if hasattr(attr, '_populateFromDynamicValue'):
+                    if hasattr(attr, '_populateFromDynamicValue') and attr._populateFromDynamicValue is not None:
                         attr._populateFromDynamicValue(data[output.name])
                     else:
                         attr.value = data[output.name]
@@ -1932,9 +1939,10 @@ class BaseNode(BaseObject):
         """
         if not self.nodeDesc.hasDynamicOutputAttribute:
             return
+
         data = {}
         for output in self.nodeDesc.outputs:
-            if output.isDynamicValue:
+            if hasADynamicValue(output):
                 if self.hasAttribute(output.name):
                     # Store the primitive value and not the value itself
                     data[output.name] = self.attribute(output.name).getPrimitiveValue()
@@ -1981,7 +1989,7 @@ class BaseNode(BaseObject):
         anyOf = (Status.ERROR, Status.STOPPED, Status.KILLED,
                  Status.RUNNING, Status.SUBMITTED)
         allOf = (Status.SUCCESS,)
-        
+
         if self.isInitNode:
             return Status.INIT
         if not self._chunksCreated:
@@ -2394,6 +2402,7 @@ class Node(BaseNode):
 
         self.packageName = self.nodeDesc.packageName
 
+
         for attrDesc in self.nodeDesc.inputs:
             self._attributes.add(attributeFactory(attrDesc, kwargs.get(attrDesc.name, None),
                                                   isOutput=False, node=self))
@@ -2487,7 +2496,7 @@ class Node(BaseNode):
                 continue
             internalInputs[k] = v.getSerializedValue()
         outputs = ({k: v.getSerializedValue() for k, v in self._attributes.objects.items()
-                    if v.isOutput and not v.desc.isDynamicValue})
+                    if v.isOutput and (not v.desc.isDynamicValue or isinstance(v, Collapsable))})
 
         return {
             'nodeType': self.nodeType,
@@ -2500,7 +2509,7 @@ class Node(BaseNode):
             'uid': self._uid,
             'inputs': {k: v for k, v in inputs.items() if v is not None},  # filter empty values
             'internalInputs': {k: v for k, v in internalInputs.items() if v is not None},
-            'outputs': outputs,
+            'outputs': outputs
         }
 
     def _resetChunks(self):

--- a/meshroom/core/nodeFactory.py
+++ b/meshroom/core/nodeFactory.py
@@ -4,6 +4,7 @@ from collections.abc import Iterable
 
 import meshroom.core
 from meshroom.core import Version, desc
+from meshroom.core.desc.anySet import AnySet
 from meshroom.core.node import BackdropNode, CompatibilityIssue, CompatibilityNode, Node, Position
 
 
@@ -37,6 +38,15 @@ def getNodeConstructor(nodeType: str, position: Optional[Position]=None, **kwarg
     constructor = constructors.get(nodeType, Node)
     return constructor(nodeType, position=position, **kwargs)
 
+
+def isCustomAttribute(attribute:Any) -> bool:
+    # Check if the given attribute is a AnySet instance or a child of a AnySet
+
+    if isinstance(attribute, AnySet):
+        return True
+    if hasattr(attribute, 'root') and isinstance(attribute.root, AnySet):
+        return True
+    return False
 
 class _NodeCreator:
 
@@ -130,13 +140,19 @@ class _NodeCreator:
         )
 
     def _checkAttributesAreCompatibleWithDescription(self) -> bool:
+
+        inputAnySet = [attribute.name for attribute in self.nodeDesc.inputs if isCustomAttribute(attribute)]
+        outputAnySet = [attribute.name for attribute in self.nodeDesc.outputs if isCustomAttribute(attribute)]
+        staticInputs = {k: v for k, v in self.inputs.items() if not k in inputAnySet }
+        staticOutputs = {k: v for k, v in self.outputs.items() if not k in outputAnySet }
+
         # Combine regular internal attributes with internal flow inputs for compatibility checking,
         # as internal flow inputs (when connected) appear in the 'internalInputs' section of the file.
         allInternalDescriptions = list(self.nodeDesc.internalInputs) + list(self.nodeDesc.internalFlowInputs)
         return (
-            self._checkAttributesCompatibility(self.nodeDesc.inputs, self.inputs)
+            self._checkAttributesCompatibility(self.nodeDesc.inputs, staticInputs)
             and self._checkAttributesCompatibility(allInternalDescriptions, self.internalInputs)
-            and self._checkAttributesCompatibility(self.nodeDesc.outputs, self.outputs)
+            and self._checkAttributesCompatibility(self.nodeDesc.outputs, staticOutputs)
         )
 
     def _checkInputAttributesNames(self) -> bool:

--- a/meshroom/ui/commands.py
+++ b/meshroom/ui/commands.py
@@ -5,7 +5,7 @@ from contextlib import contextmanager
 from PySide6.QtGui import QUndoCommand, QUndoStack
 from PySide6.QtCore import Property, Signal
 
-from meshroom.core.attribute import Attribute, Flow, ListAttribute
+from meshroom.core.attribute import Attribute, Flow, ListAttribute, AnySet
 from meshroom.core.exception import CyclicDependencyError,InvalidEdgeError
 from meshroom.core.graph import Graph, GraphModification
 from meshroom.core.node import Position, CompatibilityIssue
@@ -318,7 +318,7 @@ class SetAttributeCommand(GraphCommand):
         else:
             attribute = self.graph.internalAttribute(self.attrName)
 
-        attribute.value = self.value        
+        attribute.value = self.value
 
         return True
 
@@ -455,7 +455,7 @@ class AddEdgeCommand(GraphCommand):
         self.deletedEdges = []  # List of all the edges that have been deleted to create the new edge(s)
         self.setText(f"Connect '{self.srcAttr}' -> '{self.dstAttr}'")
 
-        if not dst.validateIncomingConnection(src):
+        if not isinstance(src, AnySet) and not dst.validateIncomingConnection(src):
             raise InvalidEdgeError(src.fullName, dst.fullName, "Attributes are not compatible.")
 
     def redoImpl(self) -> bool:
@@ -466,6 +466,7 @@ class AddEdgeCommand(GraphCommand):
             return False
         try:
             self.createdEdges, self.deletedEdges = srcAttribute.connectTo(dstAttribute)
+
         except CyclicDependencyError:
             self.graph.removeEdge(self.graph.attribute(self.dstAttr))
             return False
@@ -488,7 +489,7 @@ class RemoveEdgeCommand(GraphCommand):
         self.isFlow = isinstance(edge.dst, Flow)
         self.deletedEdgeNames = []  # Store the names of deleted edges.
         self.setText(f"Disconnect '{self.srcAttr}' -> '{self.dstAttr}'")
-    
+
     def getAttribute(self, attrName):
         if self.isFlow:
             return self.graph.internalAttribute(attrName)
@@ -526,7 +527,7 @@ class ListAttributeAppendCommand(GraphCommand):
         self.count = 1
         self.value = value if value else None
         self.setText(f"Append to {self.attrName}")
-    
+
     def getAttribute(self):
         if self.isFlowInputs:
             return self.graph.internalAttribute(self.attrName)
@@ -558,7 +559,7 @@ class ListAttributeRemoveCommand(GraphCommand):
         self.index = listAttribute.index(attribute)
         self.value = attribute.getSerializedValue()
         self.setText(f"Remove {attribute.fullName}")
-    
+
     def getAttribute(self):
         if self.isFlowInputs:
             return self.graph.internalAttribute(self.listAttrName)
@@ -704,6 +705,65 @@ class EnableGraphUpdateCommand(GraphCommand):
 
     def undoImpl(self):
         self.graph.updateEnabled = self.previousState
+
+
+class ConnectAnySetCommand(GraphCommand):
+    """
+    Create a new dynamic input attribute on a node by connecting a source attribute
+    to a AnySet.
+
+    When executed, a new attribute of the same type as the source is created on the
+    node (inserted before the AnySet) and the edge is established.
+    On undo, the edge is removed and the created attribute is deleted.
+    """
+
+    def __init__(self, graph, src, anySetAttribute, parent=None):
+        super().__init__(graph, parent)
+        self.srcAttrName = src.fullName
+        self.anySetAttribute = anySetAttribute.fullName
+        self.newAttrFullName = None
+        self.setText(f"Connect '{src.fullName}' to AnySet '{anySetAttribute.fullName}'")
+        self.newAttribute = None
+
+    def redoImpl(self) -> bool:
+
+        srcAttr = self.graph.attribute(self.srcAttrName)
+        anySetAttribute = self.graph.attribute(self.anySetAttribute)
+
+        # Create the new attribute on the node
+        newAttr = anySetAttribute.duplicateAttribute(srcAttr, isOutput=anySetAttribute.isOutput)
+        if newAttr is None:
+            return False
+
+        self.newAttrFullName = newAttr.fullName
+        self.newAttribute = newAttr
+
+        # Connect newly created attribute to the other one
+        try:
+            if anySetAttribute.isOutput:
+                self.graph.addEdge(newAttr, srcAttr)
+            else:
+                self.graph.addEdge(srcAttr, newAttr)
+        except Exception:
+            return False
+
+        return True
+
+    def undoImpl(self) -> bool:
+        if not self.newAttrFullName:
+            return True
+
+        newAttr = self.graph.attribute(self.newAttrFullName)
+        node = newAttr.node
+
+        # Disconnect the edge
+        newAttr.disconnectEdge()
+
+        anySetAttribute = self.graph.attribute(self.anySetAttribute)
+        anySetAttribute.removeAttribute(newAttr)
+
+        self.newAttrFullName = None
+        return True
 
 
 @contextmanager

--- a/meshroom/ui/commands.py
+++ b/meshroom/ui/commands.py
@@ -625,6 +625,38 @@ class RemoveAnySetAttributeCommand(GraphCommand):
         return True
 
 
+class RenameAnySetAttributeCommand(GraphCommand):
+    def __init__(self, graph, attribute, name, label, parent=None):
+        super().__init__(graph, parent)
+        anySetAttribute = attribute.root
+        assert isinstance(anySetAttribute, AnySet)
+        self.anySetAttrName = anySetAttribute.fullName
+        self.oldName = attribute.name
+        self.oldLabel = attribute.label
+        self.newName = name
+        self.newLabel = label
+        self.setText(f"Rename {attribute.fullName} to {name}")
+
+    def _attribute(self, name):
+        return self.graph.attribute(f"{self.anySetAttrName}.{name}")
+
+    def redoImpl(self):
+        anySetAttribute = self.graph.attribute(self.anySetAttrName)
+        attribute = self._attribute(self.oldName)
+        if anySetAttribute is None or attribute is None:
+            return False
+        anySetAttribute.renameAttribute(attribute, self.newName, self.newLabel)
+        return True
+
+    def undoImpl(self):
+        anySetAttribute = self.graph.attribute(self.anySetAttrName)
+        attribute = self._attribute(self.newName)
+        if anySetAttribute is None or attribute is None:
+            return False
+        anySetAttribute.renameAttribute(attribute, self.oldName, self.oldLabel)
+        return True
+
+
 class RemoveImagesCommand(GraphCommand):
     """
     Remove all the images from one or several CameraInit nodes as a single operation.

--- a/meshroom/ui/commands.py
+++ b/meshroom/ui/commands.py
@@ -576,6 +576,55 @@ class ListAttributeRemoveCommand(GraphCommand):
         listAttribute.insert(self.index, self.value)
 
 
+class RemoveAnySetAttributeCommand(GraphCommand):
+    def __init__(self, graph, attribute, parent=None):
+        super().__init__(graph, parent)
+        anySetAttribute = attribute.root
+        assert isinstance(anySetAttribute, AnySet)
+        self.anySetAttrName = anySetAttribute.fullName
+        self.index = list(anySetAttribute.value).index(attribute)
+        self.value = attribute.asDict()
+        self.edges = self._connectedEdgeNames(attribute)
+        self.setText(f"Remove {attribute.fullName}")
+
+    def _connectedEdgeNames(self, attribute):
+        attributes = [attribute] + attribute.flatStaticChildren
+        return [
+            (edge.src.fullName, edge.dst.fullName)
+            for edge in self.graph.edges.values()
+            if edge.src in attributes or edge.dst in attributes
+        ]
+
+    def redoImpl(self):
+        anySetAttribute = self.graph.attribute(self.anySetAttrName)
+        attribute = self.graph.attribute(f"{self.anySetAttrName}.{self.value['name']}")
+        if anySetAttribute is None or attribute is None:
+            return False
+
+        for _, dstName in self.edges:
+            dstAttr = self.graph.anyAttribute(dstName)
+            if dstAttr is not None:
+                self.graph.removeEdge(dstAttr)
+        anySetAttribute.removeAttribute(attribute)
+        return True
+
+    def undoImpl(self):
+        anySetAttribute = self.graph.attribute(self.anySetAttrName)
+        if anySetAttribute is None:
+            return False
+
+        restoredAttribute = anySetAttribute.insertAttribute(self.value, self.index)
+        if restoredAttribute is None:
+            return False
+
+        for srcName, dstName in self.edges:
+            srcAttr = self.graph.anyAttribute(srcName)
+            dstAttr = self.graph.anyAttribute(dstName)
+            if srcAttr is not None and dstAttr is not None:
+                self.graph.addEdge(srcAttr, dstAttr)
+        return True
+
+
 class RemoveImagesCommand(GraphCommand):
     """
     Remove all the images from one or several CameraInit nodes as a single operation.

--- a/meshroom/ui/commands.py
+++ b/meshroom/ui/commands.py
@@ -657,6 +657,45 @@ class RenameAnySetAttributeCommand(GraphCommand):
         return True
 
 
+class MoveAnySetAttributeCommand(GraphCommand):
+    def __init__(self, graph, attribute, offset, parent=None):
+        super().__init__(graph, parent)
+
+        anySetAttribute = attribute.root
+        assert isinstance(anySetAttribute, AnySet)
+
+        self.anySetAttrName = anySetAttribute.fullName
+        self.attrName = attribute.name
+        self.oldIndex = list(anySetAttribute.value).index(attribute)
+        self.newIndex = max(0, min(self.oldIndex + offset, anySetAttribute.value.count - 1))
+        self.setText(f"Move {attribute.fullName}")
+
+    def _getAttribute(self):
+        return self.graph.attribute(f"{self.anySetAttrName}.{self.attrName}")
+
+    def redoImpl(self):
+        anySetAttribute = self.graph.attribute(self.anySetAttrName)
+        attribute = self._getAttribute()
+
+        if anySetAttribute is None or attribute is None or self.oldIndex == self.newIndex:
+            return False
+
+        anySetAttribute.moveAttribute(attribute, self.newIndex)
+
+        return True
+
+    def undoImpl(self):
+        anySetAttribute = self.graph.attribute(self.anySetAttrName)
+        attribute = self._getAttribute()
+
+        if anySetAttribute is None or attribute is None:
+            return False
+
+        anySetAttribute.moveAttribute(attribute, self.oldIndex)
+
+        return True
+
+
 class RemoveImagesCommand(GraphCommand):
     """
     Remove all the images from one or several CameraInit nodes as a single operation.

--- a/meshroom/ui/graph.py
+++ b/meshroom/ui/graph.py
@@ -1453,6 +1453,12 @@ class UIGraph(QObject):
             return
         self.push(commands.RenameAnySetAttributeCommand(self._graph, attribute, name, label))
 
+    @Slot(Attribute, int)
+    def moveAnySetAttribute(self, attribute, offset):
+        if not isinstance(attribute.root, AnySet):
+            return
+        self.push(commands.MoveAnySetAttributeCommand(self._graph, attribute, offset))
+
     @Slot(Attribute)
     def removeImage(self, image):
         if image is None:

--- a/meshroom/ui/graph.py
+++ b/meshroom/ui/graph.py
@@ -1447,6 +1447,12 @@ class UIGraph(QObject):
             return
         self.push(commands.RemoveAnySetAttributeCommand(self._graph, attribute))
 
+    @Slot(Attribute, str, str)
+    def renameAnySetAttribute(self, attribute, name, label):
+        if not isinstance(attribute.root, AnySet):
+            return
+        self.push(commands.RenameAnySetAttributeCommand(self._graph, attribute, name, label))
+
     @Slot(Attribute)
     def removeImage(self, image):
         if image is None:

--- a/meshroom/ui/graph.py
+++ b/meshroom/ui/graph.py
@@ -1442,6 +1442,12 @@ class UIGraph(QObject):
         self.push(commands.ListAttributeRemoveCommand(self._graph, attribute))
 
     @Slot(Attribute)
+    def removeAnySetAttribute(self, attribute):
+        if not isinstance(attribute.root, AnySet):
+            return
+        self.push(commands.RemoveAnySetAttributeCommand(self._graph, attribute))
+
+    @Slot(Attribute)
     def removeImage(self, image):
         if image is None:
             return

--- a/meshroom/ui/graph.py
+++ b/meshroom/ui/graph.py
@@ -26,7 +26,7 @@ from PySide6.QtCore import (
 
 from meshroom.core import sessionUid
 from meshroom.common.qt import QObjectListModel
-from meshroom.core.attribute import Attribute, ListAttribute, ShapeAttribute
+from meshroom.core.attribute import Attribute, AnySet, ListAttribute, ShapeAttribute
 from meshroom.core.graph import Graph, Edge, generateTempProjectFilepath
 from meshroom.core.graphIO import GraphIO
 
@@ -1300,7 +1300,11 @@ class UIGraph(QObject):
 
     @Slot(Attribute, Attribute)
     def addEdge(self, src, dst):
-        if isinstance(src, ListAttribute) and not isinstance(dst, ListAttribute):
+        if isinstance(src, AnySet):
+            self.push(commands.ConnectAnySetCommand(self._graph, src=dst, anySetAttribute=src))
+        elif isinstance(dst, AnySet):
+            self.push(commands.ConnectAnySetCommand(self._graph, src=src, anySetAttribute=dst))
+        elif isinstance(src, ListAttribute) and not isinstance(dst, ListAttribute):
             self._addEdge(src.at(0), dst)
         elif isinstance(dst, ListAttribute) and not isinstance(src, ListAttribute):
             with self.groupedGraphModification(f"Insert and Add Edge on {dst.fullName}"):
@@ -1660,7 +1664,7 @@ class UIGraph(QObject):
 
     sortedDFSChunks = Property(QObject, lambda self: self._sortedDFSChunks, constant=True)
     lockedChanged = Signal()
-    
+
     imageListChanged = Signal()
 
     selectedNodeChanged = Signal()

--- a/meshroom/ui/qml/GraphEditor/AnySetUtils.js
+++ b/meshroom/ui/qml/GraphEditor/AnySetUtils.js
@@ -1,0 +1,30 @@
+.pragma library
+
+function childIndex(attribute) {
+    if (!attribute || !attribute.root || attribute.root.type !== "AnySet") {
+        return -1
+    }
+
+    const anySetValue = attribute.root.value
+    for (let i = 0; i < anySetValue.count; i++) {
+        if (anySetValue.at(i) === attribute) {
+            return i
+        }
+    }
+    return -1
+}
+
+function childCount(attribute) {
+    if (!attribute || !attribute.root || attribute.root.type !== "AnySet") {
+        return 0
+    }
+    return attribute.root.value.count
+}
+
+function canMoveBy(attribute, offset) {
+    const index = childIndex(attribute)
+    if (index < 0) {
+        return false
+    }
+    return index + offset >= 0 && index + offset < childCount(attribute)
+}

--- a/meshroom/ui/qml/GraphEditor/AttributeItemDelegate.qml
+++ b/meshroom/ui/qml/GraphEditor/AttributeItemDelegate.qml
@@ -175,7 +175,7 @@ RowLayout {
                             onClicked: Qt.openUrlExternally(Filepath.stringToUrl(attribute.evalValue))
                         }
 
-                        MenuItem { 
+                        MenuItem {
                             visible: attribute.isOutput && (attribute.is2dDisplayable || attribute.is3dDisplayable || attribute.isTextDisplayable)
                             height: visible ? implicitHeight : 0
                             text: {
@@ -299,6 +299,8 @@ RowLayout {
                 case "ListAttribute":
                     return listAttributeComponent
                 case "GroupAttribute":
+                    return groupAttributeComponent
+                case "AnySet":
                     return groupAttributeComponent
                 case "StringParam":
                     if (attribute.desc.semantic.includes('multiline'))

--- a/meshroom/ui/qml/GraphEditor/AttributeItemDelegate.qml
+++ b/meshroom/ui/qml/GraphEditor/AttributeItemDelegate.qml
@@ -25,6 +25,7 @@ RowLayout {
 
     readonly property bool editable: !attribute.isOutput && !attribute.isLink &&
                                      !readOnly && !(attribute.keyable && _currentScene.selectedViewId === "-1")
+    readonly property bool isAnySetChild: !!attribute && !!attribute.root && attribute.root.type === "AnySet"
     property var errorMessages: attribute.errorMessages
 
     signal doubleClicked(var mouse, var attr)
@@ -36,6 +37,17 @@ RowLayout {
         target: attribute
         function onValueChanged() {
             root.errorMessages = attribute.errorMessages
+        }
+    }
+
+    Component {
+        id: removeAnySetAttributeMenuComp
+        Menu {
+            MenuItem {
+                text: "Remove Attribute"
+                enabled: root.isAnySetChild
+                onTriggered: _currentScene.removeAnySetAttribute(attribute)
+            }
         }
     }
 
@@ -186,6 +198,18 @@ RowLayout {
                                 return "Show in 3D Viewer"
                             }
                             onClicked: root.showInViewer(attribute)
+                        }
+
+                        MenuSeparator {
+                            visible: root.isAnySetChild
+                            height: visible ? implicitHeight : 0
+                        }
+
+                        MenuItem {
+                            visible: root.isAnySetChild
+                            height: visible ? implicitHeight : 0
+                            text: "Remove Attribute"
+                            onTriggered: _currentScene.removeAnySetAttribute(attribute)
                         }
 
                     }
@@ -873,8 +897,17 @@ RowLayout {
                         MouseArea {
                             id: labelMA
                             anchors.fill: parent
+                            acceptedButtons: Qt.LeftButton | Qt.RightButton
                             hoverEnabled: true
-                            onClicked: groupItem.expanded = !groupItem.expanded
+                            onClicked: function(mouse) {
+                                if (mouse.button == Qt.RightButton && root.isAnySetChild) {
+                                    var menu = removeAnySetAttributeMenuComp.createObject(labelMA)
+                                    menu.parent = labelMA
+                                    menu.popup()
+                                    return
+                                }
+                                groupItem.expanded = !groupItem.expanded
+                            }
                             onDoubleClicked: function(mouse) { root.doubleClicked(mouse, root.attribute) }
                         }
                     }

--- a/meshroom/ui/qml/GraphEditor/AttributeItemDelegate.qml
+++ b/meshroom/ui/qml/GraphEditor/AttributeItemDelegate.qml
@@ -7,6 +7,7 @@ import MaterialIcons 2.2
 import Utils 1.0
 import Controls 1.0
 import "AttributeControls" as AttributeControls
+import "AnySetUtils.js" as AnySetUtils
 
 /**
  * Instantiate a control to visualize and edit an Attribute based on its type.
@@ -48,6 +49,17 @@ RowLayout {
             property real preferredX: 0
             property real preferredY: 0
 
+            MenuItem {
+                text: "Move Up"
+                enabled: AnySetUtils.canMoveBy(attribute, -1)
+                onTriggered: _currentScene.moveAnySetAttribute(attribute, -1)
+            }
+            MenuItem {
+                text: "Move Down"
+                enabled: AnySetUtils.canMoveBy(attribute, 1)
+                onTriggered: _currentScene.moveAnySetAttribute(attribute, 1)
+            }
+            MenuSeparator {}
             MenuItem {
                 text: "Rename Attribute"
                 enabled: root.isAnySetChild
@@ -285,6 +297,27 @@ RowLayout {
                                 return "Show in 3D Viewer"
                             }
                             onClicked: root.showInViewer(attribute)
+                        }
+
+                        MenuSeparator {
+                            visible: root.isAnySetChild
+                            height: visible ? implicitHeight : 0
+                        }
+
+                        MenuItem {
+                            visible: root.isAnySetChild
+                            height: visible ? implicitHeight : 0
+                            text: "Move Up"
+                            enabled: AnySetUtils.canMoveBy(attribute, -1)
+                            onTriggered: _currentScene.moveAnySetAttribute(attribute, -1)
+                        }
+
+                        MenuItem {
+                            visible: root.isAnySetChild
+                            height: visible ? implicitHeight : 0
+                            text: "Move Down"
+                            enabled: AnySetUtils.canMoveBy(attribute, 1)
+                            onTriggered: _currentScene.moveAnySetAttribute(attribute, 1)
                         }
 
                         MenuSeparator {

--- a/meshroom/ui/qml/GraphEditor/AttributeItemDelegate.qml
+++ b/meshroom/ui/qml/GraphEditor/AttributeItemDelegate.qml
@@ -43,11 +43,96 @@ RowLayout {
     Component {
         id: removeAnySetAttributeMenuComp
         Menu {
+            id: anySetMenu
+
+            property real preferredX: 0
+            property real preferredY: 0
+
+            MenuItem {
+                text: "Rename Attribute"
+                enabled: root.isAnySetChild
+                onTriggered: {
+                    var dialog = renameAnySetAttributeDialogComp.createObject(Overlay.overlay, {
+                        "targetAttribute": attribute,
+                        "preferredX": anySetMenu.preferredX,
+                        "preferredY": anySetMenu.preferredY
+                    })
+                    dialog.open()
+                }
+            }
             MenuItem {
                 text: "Remove Attribute"
                 enabled: root.isAnySetChild
                 onTriggered: _currentScene.removeAnySetAttribute(attribute)
             }
+        }
+    }
+
+    Component {
+        id: renameAnySetAttributeDialogComp
+        Dialog {
+            id: renameDialog
+
+            property var targetAttribute: null
+            property real preferredX: 0
+            property real preferredY: 0
+
+            title: "Rename Attribute"
+            modal: true
+            parent: Overlay.overlay
+            contentWidth: 280
+            x: parent ? Math.max(0, Math.min(preferredX, parent.width - width)) : 0
+            y: parent ? Math.max(0, Math.min(preferredY, parent.height - height)) : 0
+            standardButtons: Dialog.Ok | Dialog.Cancel
+            closePolicy: Popup.CloseOnEscape
+
+            GridLayout {
+                columns: 2
+                columnSpacing: 8
+                rowSpacing: 8
+                width: renameDialog.contentWidth
+
+                Label {
+                    text: "Name"
+                    Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
+                }
+                TextField {
+                    id: nameField
+                    Layout.fillWidth: true
+                    Layout.minimumWidth: 0
+                    text: renameDialog.targetAttribute ? renameDialog.targetAttribute.name : ""
+                    selectByMouse: true
+                    validator: RegularExpressionValidator { regularExpression: /^[A-Za-z_][A-Za-z0-9_]*$/ }
+                    onAccepted: renameDialog.accept()
+                }
+
+                Label {
+                    text: "Label"
+                    Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
+                }
+                TextField {
+                    id: labelField
+                    Layout.fillWidth: true
+                    Layout.minimumWidth: 0
+                    text: renameDialog.targetAttribute ? renameDialog.targetAttribute.label : ""
+                    selectByMouse: true
+                    onAccepted: renameDialog.accept()
+                }
+            }
+
+            onOpened: {
+                nameField.forceActiveFocus()
+                nameField.selectAll()
+            }
+
+            onAccepted: {
+                if (targetAttribute && nameField.acceptableInput && labelField.text.trim() !== "") {
+                    _currentScene.renameAnySetAttribute(targetAttribute, nameField.text.trim(), labelField.text.trim())
+                }
+                destroy()
+            }
+
+            onRejected: destroy()
         }
     }
 
@@ -141,6 +226,8 @@ RowLayout {
                     property Component menuComp: Menu {
                         id: paramMenu
 
+                        property real preferredX: 0
+                        property real preferredY: 0
                         property bool isFileAttribute: attribute.type === "File"
                         property bool isFilepath: isFileAttribute && Filepath.isFile(attribute.evalValue)
 
@@ -208,6 +295,20 @@ RowLayout {
                         MenuItem {
                             visible: root.isAnySetChild
                             height: visible ? implicitHeight : 0
+                            text: "Rename Attribute"
+                            onTriggered: {
+                                var dialog = renameAnySetAttributeDialogComp.createObject(Overlay.overlay, {
+                                    "targetAttribute": attribute,
+                                    "preferredX": paramMenu.preferredX,
+                                    "preferredY": paramMenu.preferredY
+                                })
+                                dialog.open()
+                            }
+                        }
+
+                        MenuItem {
+                            visible: root.isAnySetChild
+                            height: visible ? implicitHeight : 0
                             text: "Remove Attribute"
                             onTriggered: _currentScene.removeAnySetAttribute(attribute)
                         }
@@ -218,6 +319,9 @@ RowLayout {
                         forceActiveFocus()
                         if (mouse.button == Qt.RightButton) {
                             var menu = menuComp.createObject(parameterLabel)
+                            var position = parameterMA.mapToItem(Overlay.overlay, mouse.x, mouse.y)
+                            menu.preferredX = position.x
+                            menu.preferredY = position.y
                             menu.parent = parameterLabel
                             menu.popup()
                         }
@@ -902,6 +1006,9 @@ RowLayout {
                             onClicked: function(mouse) {
                                 if (mouse.button == Qt.RightButton && root.isAnySetChild) {
                                     var menu = removeAnySetAttributeMenuComp.createObject(labelMA)
+                                    var position = labelMA.mapToItem(Overlay.overlay, mouse.x, mouse.y)
+                                    menu.preferredX = position.x
+                                    menu.preferredY = position.y
                                     menu.parent = labelMA
                                     menu.popup()
                                     return

--- a/meshroom/ui/qml/GraphEditor/AttributePin.qml
+++ b/meshroom/ui/qml/GraphEditor/AttributePin.qml
@@ -30,7 +30,8 @@ RowLayout {
                                                       outputAnchor.y + outputAnchor.height / 2)
 
     readonly property bool isList: attribute && attribute.type === "ListAttribute"
-    readonly property bool isGroup: attribute && attribute.type === "GroupAttribute"
+    readonly property bool isCollapsable: attribute && attribute.isCollapsable === true
+    readonly property bool isDynamic: !!attribute.desc && !!attribute.desc.isCustomAttribute
     readonly property bool isConnected: attribute.hasAnyInputLinks || attribute.hasAnyOutputLinks
 
     signal childPinCreated(var childAttribute, var pin)
@@ -44,6 +45,16 @@ RowLayout {
     layoutDirection: Qt.LeftToRight
     spacing: 3
     height: attribute && attribute.isOutput ? outputAnchor.height : inputAnchor.height
+
+    function getCurrentAttributePinColor(hasChildrenConnected) {
+        if (root.isDynamic) {
+            return "transparent"
+        }
+        if (hasChildrenConnected) {
+            return Colors.sysPalette.iconText
+        }
+        return Colors.sysPalette.mid
+    }
 
     ToolTip {
         text: attribute.fullName + ": " + attribute.type
@@ -81,18 +92,14 @@ RowLayout {
             radius: root.isList ? 0 : width / 2
             Layout.alignment: Qt.AlignVCenter
 
-            border.color: {
-                if (innerInputAnchor.hasConnectedChildren)
-                    return Colors.sysPalette.text
-                return Colors.sysPalette.mid
-            }
+            border.color: getCurrentAttributePinColor(innerInputAnchor.hasConnectedChildren)
             color: Colors.sysPalette.base
 
             Rectangle {
                 id: innerInputAnchor
                 property bool linkEnabled: true
                 property bool hasConnectedChildren: {
-                    if (!root.isGroup || root.isConnected || !attribute)
+                    if (!isCollapsable || root.isConnected || !attribute)
                         return false
                     for (var i = 0; i < attribute.flatStaticChildren.length; ++i) {
                         if (attribute.flatStaticChildren[i].hasAnyInputLinks) {
@@ -102,6 +109,7 @@ RowLayout {
                     return false
                 }
                 visible: inputConnectMA.containsMouse || childrenRepeater.count > 0 || hasConnectedChildren ||
+                        root.isDynamic ||
                         (root.attribute && root.attribute.isLink && linkEnabled) || inputConnectMA.drag.active || inputDropArea.containsDrag
                 radius: root.isList ? 0 : 2
                 anchors.fill: parent
@@ -111,6 +119,8 @@ RowLayout {
                         return Colors.sysPalette.highlight
                     if (hasConnectedChildren)
                         return Colors.sysPalette.mid
+                    if (root.isDynamic)
+                        return "transparent"
                     return Colors.sysPalette.text
                 }
             }
@@ -128,7 +138,7 @@ RowLayout {
 
                 keys: [inputDragTarget.objectName]
                 onEntered: function(drag) {
-                    var validIncomingConnection = drag.source.attribute.validateIncomingConnection(inputDragTarget.attribute)
+                    var validIncomingConnection = inputDragTarget.attribute.validateIncomingConnection(drag.source.attribute)
                     // Check if attributes are compatible to create a valid connection
                     if (root.readOnly                                            // Cannot connect on a read-only attribute
                         || drag.source.objectName != inputDragTarget.objectName  // Not an edge connector
@@ -167,7 +177,7 @@ RowLayout {
                 readonly property alias nodeItem: root.nodeItem
                 readonly property bool isOutput: Boolean(attribute.isOutput)
                 readonly property alias isList: root.isList
-                readonly property alias isGroup: root.isGroup
+                readonly property alias isCollapsable: root.isCollapsable
                 property bool dragAccepted: false
                 anchors.verticalCenter: parent.verticalCenter
                 anchors.horizontalCenter: parent.horizontalCenter
@@ -291,10 +301,11 @@ RowLayout {
             label.horizontalAlignment: root.attribute && root.attribute.isOutput ? Text.AlignRight : Text.AlignLeft
             label.verticalAlignment: Text.AlignVCenter
             label.visible: true
+            label.font.italic: root.isDynamic || (!!attribute.root && !!attribute.root.desc && !!attribute.root.desc.isCustomAttribute)
 
             // Icon
             iconText: {
-                if (root.isGroup) {
+                if (root.isCollapsable) {
                     return root.expanded ? MaterialIcons.expand_more : MaterialIcons.chevron_right
                 }
                 return ""
@@ -320,18 +331,14 @@ RowLayout {
 
         Layout.alignment: Qt.AlignVCenter
 
-        border.color: {
-            if (innerOutputAnchor.hasConnectedChildren)
-                return Colors.sysPalette.text
-            return Colors.sysPalette.mid
-        }
+        border.color: getCurrentAttributePinColor(innerOutputAnchor.hasConnectedChildren)
         color: Colors.sysPalette.base
 
         Rectangle {
             id: innerOutputAnchor
             property bool linkEnabled: true
             property bool hasConnectedChildren: {
-                if (!root.isGroup || root.isConnected)
+                if (!root.isCollapsable || root.isConnected)
                     return false
                 for (var i = 0; i < attribute.flatStaticChildren.length; ++i) {
                     if (attribute.flatStaticChildren[i].hasAnyOutputLinks) {
@@ -402,7 +409,7 @@ RowLayout {
             readonly property alias nodeItem: root.nodeItem
             readonly property bool isOutput: Boolean(attribute.isOutput)
             readonly property alias isList: root.isList
-            readonly property alias isGroup: root.isGroup
+            readonly property alias isCollapsable: root.isCollapsable
             property bool dropAccepted: false
             anchors.horizontalCenter: parent.horizontalCenter
             anchors.verticalCenter: parent.verticalCenter

--- a/meshroom/ui/qml/GraphEditor/AttributePin.qml
+++ b/meshroom/ui/qml/GraphEditor/AttributePin.qml
@@ -4,6 +4,7 @@ import QtQuick.Layouts
 
 import Utils 1.0
 import MaterialIcons 2.2
+import "AnySetUtils.js" as AnySetUtils
 
 /**
  * The representation of an Attribute on a Node.
@@ -50,6 +51,17 @@ RowLayout {
             property real preferredX: 0
             property real preferredY: 0
 
+            MenuItem {
+                text: "Move Up"
+                enabled: AnySetUtils.canMoveBy(attribute, -1)
+                onTriggered: _currentScene.moveAnySetAttribute(attribute, -1)
+            }
+            MenuItem {
+                text: "Move Down"
+                enabled: AnySetUtils.canMoveBy(attribute, 1)
+                onTriggered: _currentScene.moveAnySetAttribute(attribute, 1)
+            }
+            MenuSeparator {}
             MenuItem {
                 text: "Rename Attribute"
                 enabled: root.isAnySetChild

--- a/meshroom/ui/qml/GraphEditor/AttributePin.qml
+++ b/meshroom/ui/qml/GraphEditor/AttributePin.qml
@@ -45,11 +45,96 @@ RowLayout {
     Component {
         id: removeAnySetAttributeMenuComp
         Menu {
+            id: anySetMenu
+
+            property real preferredX: 0
+            property real preferredY: 0
+
+            MenuItem {
+                text: "Rename Attribute"
+                enabled: root.isAnySetChild
+                onTriggered: {
+                    var dialog = renameAnySetAttributeDialogComp.createObject(Overlay.overlay, {
+                        "targetAttribute": attribute,
+                        "preferredX": anySetMenu.preferredX,
+                        "preferredY": anySetMenu.preferredY
+                    })
+                    dialog.open()
+                }
+            }
             MenuItem {
                 text: "Remove Attribute"
                 enabled: root.isAnySetChild
                 onTriggered: _currentScene.removeAnySetAttribute(attribute)
             }
+        }
+    }
+
+    Component {
+        id: renameAnySetAttributeDialogComp
+        Dialog {
+            id: renameDialog
+
+            property var targetAttribute: null
+            property real preferredX: 0
+            property real preferredY: 0
+
+            title: "Rename Attribute"
+            modal: true
+            parent: Overlay.overlay
+            contentWidth: 280
+            x: parent ? Math.max(0, Math.min(preferredX, parent.width - width)) : 0
+            y: parent ? Math.max(0, Math.min(preferredY, parent.height - height)) : 0
+            standardButtons: Dialog.Ok | Dialog.Cancel
+            closePolicy: Popup.CloseOnEscape
+
+            GridLayout {
+                columns: 2
+                columnSpacing: 8
+                rowSpacing: 8
+                width: renameDialog.contentWidth
+
+                Label {
+                    text: "Name"
+                    Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
+                }
+                TextField {
+                    id: nameField
+                    Layout.fillWidth: true
+                    Layout.minimumWidth: 0
+                    text: renameDialog.targetAttribute ? renameDialog.targetAttribute.name : ""
+                    selectByMouse: true
+                    validator: RegularExpressionValidator { regularExpression: /^[A-Za-z_][A-Za-z0-9_]*$/ }
+                    onAccepted: renameDialog.accept()
+                }
+
+                Label {
+                    text: "Label"
+                    Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
+                }
+                TextField {
+                    id: labelField
+                    Layout.fillWidth: true
+                    Layout.minimumWidth: 0
+                    text: renameDialog.targetAttribute ? renameDialog.targetAttribute.label : ""
+                    selectByMouse: true
+                    onAccepted: renameDialog.accept()
+                }
+            }
+
+            onOpened: {
+                nameField.forceActiveFocus()
+                nameField.selectAll()
+            }
+
+            onAccepted: {
+                if (targetAttribute && nameField.acceptableInput && labelField.text.trim() !== "") {
+                    _currentScene.renameAnySetAttribute(targetAttribute, nameField.text.trim(), labelField.text.trim())
+                }
+                destroy()
+            }
+
+            onRejected: destroy()
         }
     }
 
@@ -338,6 +423,9 @@ RowLayout {
             acceptedButtons: Qt.RightButton
             onClicked: function(mouse) {
                 var menu = removeAnySetAttributeMenuComp.createObject(nameContainer)
+                var position = mapToItem(Overlay.overlay, mouse.x, mouse.y)
+                menu.preferredX = position.x
+                menu.preferredY = position.y
                 menu.parent = nameContainer
                 menu.popup()
             }

--- a/meshroom/ui/qml/GraphEditor/AttributePin.qml
+++ b/meshroom/ui/qml/GraphEditor/AttributePin.qml
@@ -31,7 +31,7 @@ RowLayout {
                                                       outputAnchor.y + outputAnchor.height / 2)
 
     readonly property bool isList: attribute && attribute.type === "ListAttribute"
-    readonly property bool isCollapsable: attribute && attribute.isCollapsable === true
+    readonly property bool isExpandable: attribute && attribute.isExpandable === true
     readonly property bool isDynamic: !!attribute.desc && !!attribute.desc.isCustomAttribute
     readonly property bool isAnySetChild: !!attribute && !!attribute.root && attribute.root.type === "AnySet"
     readonly property bool isConnected: attribute.hasAnyInputLinks || attribute.hasAnyOutputLinks
@@ -208,7 +208,7 @@ RowLayout {
                 id: innerInputAnchor
                 property bool linkEnabled: true
                 property bool hasConnectedChildren: {
-                    if (!isCollapsable || root.isConnected || !attribute)
+                    if (!isExpandable || root.isConnected || !attribute)
                         return false
                     for (var i = 0; i < attribute.flatStaticChildren.length; ++i) {
                         if (attribute.flatStaticChildren[i].hasAnyInputLinks) {
@@ -286,7 +286,7 @@ RowLayout {
                 readonly property alias nodeItem: root.nodeItem
                 readonly property bool isOutput: Boolean(attribute.isOutput)
                 readonly property alias isList: root.isList
-                readonly property alias isCollapsable: root.isCollapsable
+                readonly property alias isExpandable: root.isExpandable
                 property bool dragAccepted: false
                 anchors.verticalCenter: parent.verticalCenter
                 anchors.horizontalCenter: parent.horizontalCenter
@@ -414,7 +414,7 @@ RowLayout {
 
             // Icon
             iconText: {
-                if (root.isCollapsable) {
+                if (root.isExpandable) {
                     return root.expanded ? MaterialIcons.expand_more : MaterialIcons.chevron_right
                 }
                 return ""
@@ -461,7 +461,7 @@ RowLayout {
             id: innerOutputAnchor
             property bool linkEnabled: true
             property bool hasConnectedChildren: {
-                if (!root.isCollapsable || root.isConnected)
+                if (!root.isExpandable || root.isConnected)
                     return false
                 for (var i = 0; i < attribute.flatStaticChildren.length; ++i) {
                     if (attribute.flatStaticChildren[i].hasAnyOutputLinks) {
@@ -532,7 +532,7 @@ RowLayout {
             readonly property alias nodeItem: root.nodeItem
             readonly property bool isOutput: Boolean(attribute.isOutput)
             readonly property alias isList: root.isList
-            readonly property alias isCollapsable: root.isCollapsable
+            readonly property alias isExpandable: root.isExpandable
             property bool dropAccepted: false
             anchors.horizontalCenter: parent.horizontalCenter
             anchors.verticalCenter: parent.verticalCenter

--- a/meshroom/ui/qml/GraphEditor/AttributePin.qml
+++ b/meshroom/ui/qml/GraphEditor/AttributePin.qml
@@ -32,6 +32,7 @@ RowLayout {
     readonly property bool isList: attribute && attribute.type === "ListAttribute"
     readonly property bool isCollapsable: attribute && attribute.isCollapsable === true
     readonly property bool isDynamic: !!attribute.desc && !!attribute.desc.isCustomAttribute
+    readonly property bool isAnySetChild: !!attribute && !!attribute.root && attribute.root.type === "AnySet"
     readonly property bool isConnected: attribute.hasAnyInputLinks || attribute.hasAnyOutputLinks
 
     signal childPinCreated(var childAttribute, var pin)
@@ -40,6 +41,17 @@ RowLayout {
     signal pressed(var mouse)
     signal edgeAboutToBeRemoved(var input)
     signal clicked()
+
+    Component {
+        id: removeAnySetAttributeMenuComp
+        Menu {
+            MenuItem {
+                text: "Remove Attribute"
+                enabled: root.isAnySetChild
+                onTriggered: _currentScene.removeAnySetAttribute(attribute)
+            }
+        }
+    }
 
     objectName: attribute ? attribute.name + "." : ""
     layoutDirection: Qt.LeftToRight
@@ -318,6 +330,17 @@ RowLayout {
             property int groupPaddingWidth: root.attribute.depth * 10
             icon.leftPadding: root.attribute.isOutput ? 0 : groupPaddingWidth
             icon.rightPadding: root.attribute.isOutput ? groupPaddingWidth : 0
+        }
+
+        MouseArea {
+            anchors.fill: parent
+            enabled: root.isAnySetChild
+            acceptedButtons: Qt.RightButton
+            onClicked: function(mouse) {
+                var menu = removeAnySetAttributeMenuComp.createObject(nameContainer)
+                menu.parent = nameContainer
+                menu.popup()
+            }
         }
     }
 

--- a/meshroom/ui/qml/GraphEditor/GraphEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/GraphEditor.qml
@@ -18,7 +18,6 @@ Item {
     property variant nodeTypesModel: null  /// The list of node types that can be instantiated
     property real maxZoom: 2.0
     property real minZoom: 0.1
-
     property var edgeAboutToBeRemoved: undefined
 
     property var _attributeToDelegate: ({})
@@ -209,7 +208,7 @@ Item {
             root.forceActiveFocus()
             workspaceClicked()
         }
-        
+
         onPositionChanged: {
             if (drag.active)
                 workspaceMoved()
@@ -423,7 +422,7 @@ Item {
                             }
                         }
 
-                        // We add 1 to the index because of human readable index (starting at 1) 
+                        // We add 1 to the index because of human readable index (starting at 1)
                         value: listAttr ? listAttr.value.indexOf(edgeMenu.currentEdge.src) + 1 : 0
                         range: { "min": 1, "max": listAttr ? listAttr.value.count : 0 }
 
@@ -497,9 +496,14 @@ Item {
                 model: nodeRepeater.loaded && root.graph ? root.graph.edges : undefined
 
                 delegate: Edge {
-                    function getAttributePin(attribute) {
+                    function getAttributePin(attribute, attributeToDelegate) {
+                        if (!attribute) {
+                            return null
+                        }
+
                         // Get the first visible parent of "attribute"
-                        let dstAttributeDelegate = root._attributeToDelegate[attribute]
+                        let dstAttributeDelegate = attributeToDelegate[attribute.fullName]
+
                         if (dstAttributeDelegate && dstAttributeDelegate.visible) {
                             return dstAttributeDelegate
                         }
@@ -517,24 +521,28 @@ Item {
                             groupAttribute = groupAttribute ? groupAttribute.root : null
 
                             if (groupAttribute) {
-                                groupAttributeDelegate = root._attributeToDelegate[groupAttribute]
+                                groupAttributeDelegate = attributeToDelegate[groupAttribute.fullName]
                             }
                         }
 
-                        if (groupAttributeDelegate) {
+                        if (groupAttributeDelegate && groupAttributeDelegate.visible) {
                             return groupAttributeDelegate
                         }
 
                         return dstAttributeDelegate
                     }
 
-                    property var src: getAttributePin(edge.src)
-                    property var dst: getAttributePin(edge.dst)
-                    property bool isValidEdge: src !== null && dst !== null
+                    property var src: {
+                        return getAttributePin(edge.src, root._attributeToDelegate)
+                        }
+                    property var dst: {
+                        return getAttributePin(edge.dst, root._attributeToDelegate)
+                        }
+                    property bool isValidEdge: src != null && dst != null
                     visible: isValidEdge && src.visible && dst.visible
 
                     property bool forLoop: {
-                        if (src !== null && dst !== null) {
+                        if (src != null && dst != null) {
                             return src.attribute.type === "ListAttribute" && dst.attribute.type != "ListAttribute"
                         }
                         return false
@@ -545,6 +553,7 @@ Item {
                     edge: object
                     isForLoop: forLoop
                     loopSize: forLoop ? edge.src.root.value.count : 0
+
                     iteration: forLoop ? edge.src.root.value.indexOf(edge.src) : 0
                     color: edge.dst === root.edgeAboutToBeRemoved ? "red" : inFocus ? activePalette.highlight : activePalette.text
                     thickness: {
@@ -609,7 +618,7 @@ Item {
                 id: nodeMenuComponent
                 Menu {
                     id: nodeMenu
-                    
+
                     property var currentNode: nodeMenuLoader.currentNode
 
                     // Cache computatibility/submitability status of each selected node.
@@ -699,7 +708,7 @@ Item {
                         onTriggered: {
                             if (nodeMenu.isSelectionFullyComputed) {
                                 nodeMenuLoader.showDataDeletionDialog(
-                                    false, 
+                                    false,
                                     function(request, uigraph) {
                                         request(uigraph.getSelectedNodes())
                                     }.bind(null, computeRequest, uigraph)
@@ -720,7 +729,7 @@ Item {
                         onTriggered: {
                             if (nodeMenu.isSelectionFullyComputed) {
                                 nodeMenuLoader.showDataDeletionDialog(
-                                    false, 
+                                    false,
                                     function(request, uigraph) {
                                         request(uigraph.getSelectedNodes())
                                     }.bind(null, submitRequest, uigraph)
@@ -1477,7 +1486,7 @@ Item {
             // Search nodes in the graph
             SearchBar {
                 id: graphSearchBar
-  
+
                 toggle: true // enable toggling the actual text field by the search button
                 Layout.minimumWidth: graphSearchBar.width
                 maxWidth: 150
@@ -1568,11 +1577,17 @@ Item {
     }
 
     function registerAttributePin(attribute, pin) {
-        root._attributeToDelegate[attribute] = pin
+        const attributeToDelegate = Object.assign({}, root._attributeToDelegate)
+        attributeToDelegate[attribute.fullName] = pin
+        root._attributeToDelegate = attributeToDelegate
     }
 
     function unregisterAttributePin(attribute, pin) {
-        delete root._attributeToDelegate[attribute]
+        const attributeToDelegate = Object.assign({}, root._attributeToDelegate)
+        if (attributeToDelegate[attribute.fullName] === pin) {
+            delete attributeToDelegate[attribute.fullName]
+            root._attributeToDelegate = attributeToDelegate
+        }
     }
 
     function boundingBox() {
@@ -1596,7 +1611,7 @@ Item {
     function selectionBoundingBox() {
         /**
          * Returns the bounding box considering the nodes which are selected.
-         * The returned bounding box starts from the Minumum x,y position to the 
+         * The returned bounding box starts from the Minumum x,y position to the
          * Maximum x,y postion of the selected nodes.
          */
         var firstIdx = uigraph.nodeSelection.selectedIndexes[0]

--- a/meshroom/ui/qml/GraphEditor/GraphEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/GraphEditor.qml
@@ -503,6 +503,14 @@ Item {
 
                         // Get the first visible parent of "attribute"
                         let dstAttributeDelegate = attributeToDelegate[attribute.fullName]
+                        if (!dstAttributeDelegate) {
+                            for (const key in attributeToDelegate) {
+                                if (attributeToDelegate[key].attribute === attribute) {
+                                    dstAttributeDelegate = attributeToDelegate[key]
+                                    break
+                                }
+                            }
+                        }
 
                         if (dstAttributeDelegate && dstAttributeDelegate.visible) {
                             return dstAttributeDelegate
@@ -1583,8 +1591,14 @@ Item {
 
     function unregisterAttributePin(attribute, pin) {
         const attributeToDelegate = Object.assign({}, root._attributeToDelegate)
-        if (attributeToDelegate[attribute.fullName] === pin) {
-            delete attributeToDelegate[attribute.fullName]
+        let updated = false
+        for (const key in attributeToDelegate) {
+            if (attributeToDelegate[key] === pin) {
+                delete attributeToDelegate[key]
+                updated = true
+            }
+        }
+        if (updated) {
             root._attributeToDelegate = attributeToDelegate
         }
     }

--- a/meshroom/ui/qml/GraphEditor/GraphEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/GraphEditor.qml
@@ -520,7 +520,6 @@ Item {
                             return null
                         }
 
-                        let index = Array.from(attribute.root.value).indexOf(attribute)
                         let groupAttributeDelegate = null
                         let groupAttribute = attribute
 

--- a/meshroom/ui/qml/GraphEditor/GraphEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/GraphEditor.qml
@@ -541,20 +541,19 @@ Item {
                     property bool isValidEdge: src != null && dst != null
                     visible: isValidEdge && src.visible && dst.visible
 
-                    property bool forLoop: {
-                        if (src != null && dst != null) {
-                            return src.attribute.type === "ListAttribute" && dst.attribute.type != "ListAttribute"
-                        }
-                        return false
-                    }
+                    property var loopSource: edge.src && edge.src.root && edge.src.root.value ? edge.src.root : null
+                    property bool forLoop: src != null && dst != null &&
+                                           loopSource != null &&
+                                           src.attribute.type === "ListAttribute" &&
+                                           dst.attribute.type != "ListAttribute"
 
                     property bool inFocus: containsMouse || (edgeMenu.opened && edgeMenu.currentEdge === edge)
 
                     edge: object
                     isForLoop: forLoop
-                    loopSize: forLoop ? edge.src.root.value.count : 0
+                    loopSize: forLoop ? loopSource.value.count : 0
 
-                    iteration: forLoop ? edge.src.root.value.indexOf(edge.src) : 0
+                    iteration: forLoop ? loopSource.value.indexOf(edge.src) : 0
                     color: edge.dst === root.edgeAboutToBeRemoved ? "red" : inFocus ? activePalette.highlight : activePalette.text
                     thickness: {
                         if (forLoop) {

--- a/meshroom/ui/qml/GraphEditor/Node.qml
+++ b/meshroom/ui/qml/GraphEditor/Node.qml
@@ -35,7 +35,7 @@ Item {
     /// Shake Relevance
     readonly property double maxAmplitude: 500.0;
     readonly property int shakeThreshold: 5;
-    
+
     property int shakeCounter: 0;
     property bool shaking: false;
     property int shakeDetectionInterval: 1000;  // 1 Second to complete the shake else the counter is reset
@@ -147,7 +147,7 @@ Item {
          * Detects a shake if a the node has been moved across the originally captured x and y positions
          * back and forth a given number of times specified by the amplitude.
          */
-        
+
         if (!root.shaking) {
             return;
         }
@@ -252,10 +252,11 @@ Item {
         if (Boolean(attribute.enabled)) {
             // If the parent is a GroupAttribute, use the status of the parent's pin to determine visibility
             // UNLESS the child attribute is already connected with a visible edge
-            if (attribute.root && attribute.root.baseType === "GroupAttribute") {
-                var visible = Boolean(parentPins.get(attribute.root.name))
-                if (!visible && parentPins.has(attribute.name) && parentPins.get(attribute.name) === true) {
-                    parentPins.set(attribute.name, false)
+            if (attribute.root && attribute.root.isCollapsable) {
+
+                var visible = Boolean(parentPins.get(attribute.root.fullName))
+                if (!visible && parentPins.has(attribute.fullName) && parentPins.get(attribute.fullName) === true) {
+                    parentPins.set(attribute.fullName, false)
                     pin.expanded = false
                 }
                 return visible
@@ -276,17 +277,17 @@ Item {
             if (attr.isOutput == isOutput) {
                 // Add the attribute to the model
                 attributes.push(attr)
-                if (attr.baseType === "GroupAttribute") {
-                    // If it is a GroupAttribute, initialize its pin status
-                    parentPins.set(attr.name, false)
+                if (attr.isCollapsable) {
+                    // initialize its pin status
+                    parentPins.set(attr.fullName, false)
                 }
 
                 // Check and add any child this attribute might have
                 attr.flatStaticChildren.forEach((child) =>
                     {
                         attributes.push(child)
-                        if (child.baseType === "GroupAttribute") {
-                            parentPins.set(child.name, false)
+                        if (child.isCollapsable && !parentPins.has(child.fullName)) {
+                            parentPins.set(child.fullName, false)
                         }
                     }
                 )
@@ -344,7 +345,7 @@ Item {
             }
             border.color: {
                 if (hasWarnings === true)
-                    return Colors.warning                    
+                    return Colors.warning
                 if (root.mainSelected)
                     return activePalette.highlight
                 if (root.selected)
@@ -698,8 +699,8 @@ Item {
                                     active: Boolean(modelData.isOutput && modelData.desc.visible)
                                     visible: {
                                         if (Boolean(modelData.enabled || modelData.hasAnyOutputLinks || modelData.hasAnyInputLinks)) {
-                                            if (modelData.root && modelData.root.baseType === "GroupAttribute") {
-                                                return Boolean(outputs.parentPins.get(modelData.root.name) ||
+                                            if (modelData.root && modelData.root.isCollapsable) {
+                                                return Boolean(outputs.parentPins.get(modelData.root.fullName) ||
                                                                modelData.hasAnyOutputLinks ||
                                                                modelData.hasAnyInputLinks)
                                             }
@@ -737,8 +738,8 @@ Item {
 
                                         onClicked: function() {
                                             expanded = !expanded
-                                            if (outputs.parentPins.has(modelData.name)) {
-                                                outputs.parentPins.set(modelData.name, expanded)
+                                            if (outputs.parentPins.has(modelData.fullName)) {
+                                                outputs.parentPins.set(modelData.fullName, expanded)
                                                 outputs.parentPinsUpdated()
                                             }
                                         }
@@ -773,8 +774,8 @@ Item {
                                     active: !modelData.isOutput && modelData.exposed && modelData.desc.visible
                                     visible: {
                                         if (Boolean(modelData.enabled)) {
-                                            if (modelData.root && modelData.root.baseType === "GroupAttribute") {
-                                                return Boolean(inputs.parentPins.get(modelData.root.name) ||
+                                            if (modelData.root && (modelData.root.isCollapsable) ) {
+                                                return Boolean(inputs.parentPins.get(modelData.root.fullName) ||
                                                                modelData.hasAnyOutputLinks ||
                                                                modelData.hasAnyInputLinks)
                                             }
@@ -815,8 +816,8 @@ Item {
 
                                         onClicked: function() {
                                             expanded = !expanded
-                                            if (inputs.parentPins.has(modelData.name)) {
-                                                inputs.parentPins.set(modelData.name, expanded)
+                                            if (inputs.parentPins.has(modelData.fullName)) {
+                                                inputs.parentPins.set(modelData.fullName, expanded)
                                                 inputs.parentPinsUpdated()
                                             }
                                         }
@@ -877,7 +878,7 @@ Item {
                                         visible: {
                                             if (Boolean(modelData.enabled || modelData.hasAnyOutputLinks || modelData.hasAnyInputLinks)) {
                                                 if (modelData.root && modelData.root.baseType === "GroupAttribute") {
-                                                    return Boolean(inputParams.parentPins.get(modelData.root.name) ||
+                                                    return Boolean(inputParams.parentPins.get(modelData.root.fullName) ||
                                                                    modelData.hasAnyOutputLinks ||
                                                                    modelData.hasAnyInputLinks)
                                                 }
@@ -925,8 +926,8 @@ Item {
 
                                             onClicked: function() {
                                                 expanded = !expanded
-                                                if (inputParams.parentPins.has(modelData.name)) {
-                                                    inputParams.parentPins.set(modelData.name, expanded)
+                                                if (inputParams.parentPins.has(modelData.fullName)) {
+                                                    inputParams.parentPins.set(modelData.fullName, expanded)
                                                     inputParams.parentPinsUpdated()
                                                 }
                                             }

--- a/meshroom/ui/qml/GraphEditor/Node.qml
+++ b/meshroom/ui/qml/GraphEditor/Node.qml
@@ -257,7 +257,7 @@ Item {
                 var visible = Boolean(parentPins.get(attribute.root.fullName))
                 if (!visible && parentPins.has(attribute.fullName) && parentPins.get(attribute.fullName) === true) {
                     parentPins.set(attribute.fullName, false)
-                    pin.expanded = false
+                    attribute.expanded = false
                 }
                 return visible
             }
@@ -279,7 +279,7 @@ Item {
                 attributes.push(attr)
                 if (attr.isCollapsable) {
                     // initialize its pin status
-                    parentPins.set(attr.fullName, false)
+                    parentPins.set(attr.fullName, attr.expanded)
                 }
 
                 // Check and add any child this attribute might have
@@ -287,7 +287,7 @@ Item {
                     {
                         attributes.push(child)
                         if (child.isCollapsable && !parentPins.has(child.fullName)) {
-                            parentPins.set(child.fullName, false)
+                            parentPins.set(child.fullName, child.expanded)
                         }
                     }
                 )
@@ -724,6 +724,7 @@ Item {
                                         id: outPin
                                         nodeItem: root
                                         attribute: modelData
+                                        expanded: Boolean(modelData.expanded)
 
                                         property real globalX: root.x + nodeAttributes.x + outputs.x + outputLoader.x + outPin.x
                                         property real globalY: root.y + nodeAttributes.y + outputs.y + outputLoader.y + outPin.y
@@ -737,9 +738,9 @@ Item {
                                         }
 
                                         onClicked: function() {
-                                            expanded = !expanded
                                             if (outputs.parentPins.has(modelData.fullName)) {
-                                                outputs.parentPins.set(modelData.fullName, expanded)
+                                                modelData.expanded = !modelData.expanded
+                                                outputs.parentPins.set(modelData.fullName, modelData.expanded)
                                                 outputs.parentPinsUpdated()
                                             }
                                         }
@@ -798,6 +799,7 @@ Item {
                                         id: inPin
                                         nodeItem: root
                                         attribute: modelData
+                                        expanded: Boolean(modelData.expanded)
 
                                         property real globalX: root.x + nodeAttributes.x + inputs.x + inputLoader.x + inPin.x
                                         property real globalY: root.y + nodeAttributes.y + inputs.y + inputLoader.y + inPin.y
@@ -815,9 +817,9 @@ Item {
                                         }
 
                                         onClicked: function() {
-                                            expanded = !expanded
                                             if (inputs.parentPins.has(modelData.fullName)) {
-                                                inputs.parentPins.set(modelData.fullName, expanded)
+                                                modelData.expanded = !modelData.expanded
+                                                inputs.parentPins.set(modelData.fullName, modelData.expanded)
                                                 inputs.parentPinsUpdated()
                                             }
                                         }
@@ -877,7 +879,7 @@ Item {
                                         active: !modelData.isOutput && !modelData.exposed && modelData.desc.visible
                                         visible: {
                                             if (Boolean(modelData.enabled || modelData.hasAnyOutputLinks || modelData.hasAnyInputLinks)) {
-                                                if (modelData.root && modelData.root.baseType === "GroupAttribute") {
+                                                if (modelData.root && modelData.root.isCollapsable) {
                                                     return Boolean(inputParams.parentPins.get(modelData.root.fullName) ||
                                                                    modelData.hasAnyOutputLinks ||
                                                                    modelData.hasAnyInputLinks)
@@ -904,6 +906,7 @@ Item {
                                             id: inParamsPin
                                             nodeItem: root
                                             attribute: modelData
+                                            expanded: Boolean(modelData.expanded)
 
                                             property real globalX: root.x + nodeAttributes.x + inputParamsRect.x + paramLoader.x + inParamsPin.x
                                             property real globalY: root.y + nodeAttributes.y + inputParamsRect.y + paramLoader.y + inParamsPin.y
@@ -925,9 +928,9 @@ Item {
                                             }
 
                                             onClicked: function() {
-                                                expanded = !expanded
                                                 if (inputParams.parentPins.has(modelData.fullName)) {
-                                                    inputParams.parentPins.set(modelData.fullName, expanded)
+                                                    modelData.expanded = !modelData.expanded
+                                                    inputParams.parentPins.set(modelData.fullName, modelData.expanded)
                                                     inputParams.parentPinsUpdated()
                                                 }
                                             }

--- a/meshroom/ui/qml/GraphEditor/Node.qml
+++ b/meshroom/ui/qml/GraphEditor/Node.qml
@@ -252,7 +252,7 @@ Item {
         if (Boolean(attribute.enabled)) {
             // If the parent is a GroupAttribute, use the status of the parent's pin to determine visibility
             // UNLESS the child attribute is already connected with a visible edge
-            if (attribute.root && attribute.root.isCollapsable) {
+            if (attribute.root && attribute.root.isExpandable) {
 
                 var visible = Boolean(parentPins.get(attribute.root.fullName))
                 if (!visible && parentPins.has(attribute.fullName) && parentPins.get(attribute.fullName) === true) {
@@ -277,7 +277,7 @@ Item {
             if (attr.isOutput == isOutput) {
                 // Add the attribute to the model
                 attributes.push(attr)
-                if (attr.isCollapsable) {
+                if (attr.isExpandable) {
                     // initialize its pin status
                     parentPins.set(attr.fullName, attr.expanded)
                 }
@@ -286,7 +286,7 @@ Item {
                 attr.flatStaticChildren.forEach((child) =>
                     {
                         attributes.push(child)
-                        if (child.isCollapsable && !parentPins.has(child.fullName)) {
+                        if (child.isExpandable && !parentPins.has(child.fullName)) {
                             parentPins.set(child.fullName, child.expanded)
                         }
                     }
@@ -699,7 +699,7 @@ Item {
                                     active: Boolean(modelData.isOutput && modelData.desc.visible)
                                     visible: {
                                         if (Boolean(modelData.enabled || modelData.hasAnyOutputLinks || modelData.hasAnyInputLinks)) {
-                                            if (modelData.root && modelData.root.isCollapsable) {
+                                            if (modelData.root && modelData.root.isExpandable) {
                                                 return Boolean(outputs.parentPins.get(modelData.root.fullName) ||
                                                                modelData.hasAnyOutputLinks ||
                                                                modelData.hasAnyInputLinks)
@@ -775,7 +775,7 @@ Item {
                                     active: !modelData.isOutput && modelData.exposed && modelData.desc.visible
                                     visible: {
                                         if (Boolean(modelData.enabled)) {
-                                            if (modelData.root && (modelData.root.isCollapsable) ) {
+                                            if (modelData.root && (modelData.root.isExpandable) ) {
                                                 return Boolean(inputs.parentPins.get(modelData.root.fullName) ||
                                                                modelData.hasAnyOutputLinks ||
                                                                modelData.hasAnyInputLinks)
@@ -879,7 +879,7 @@ Item {
                                         active: !modelData.isOutput && !modelData.exposed && modelData.desc.visible
                                         visible: {
                                             if (Boolean(modelData.enabled || modelData.hasAnyOutputLinks || modelData.hasAnyInputLinks)) {
-                                                if (modelData.root && modelData.root.isCollapsable) {
+                                                if (modelData.root && modelData.root.isExpandable) {
                                                     return Boolean(inputParams.parentPins.get(modelData.root.fullName) ||
                                                                    modelData.hasAnyOutputLinks ||
                                                                    modelData.hasAnyInputLinks)

--- a/tests/nodes/test/AllAttributesNodes.py
+++ b/tests/nodes/test/AllAttributesNodes.py
@@ -1,0 +1,290 @@
+from meshroom.core import desc
+from meshroom.core.desc import Level
+
+
+class AllAttributesNode(desc.Node):
+    """
+    Reference node showcasing every available Meshroom attribute type.
+    Both in inputs and outputs.
+    Useful as a development reference or a template.
+    """
+
+    cpu = Level.NORMAL
+    ram = Level.NORMAL
+    gpu = Level.NONE
+
+    inputs = [
+
+        # -----------------------------------------------------------------------
+        # Basic Parameters
+        # -----------------------------------------------------------------------
+        desc.BoolParam(
+            name="boolParam",
+            label="Boolean",
+            description="A simple boolean toggle.",
+            value=False,
+        ),
+        desc.IntParam(
+            name="intParam",
+            label="Integer",
+            description="An integer with a range constraint.",
+            value=10,
+            range=(0, 100, 1),
+        ),
+        desc.FloatParam(
+            name="floatParam",
+            label="Float",
+            description="A floating-point value with a range constraint.",
+            value=3.14,
+            range=(0.0, 10.0, 0.01),
+        ),
+        desc.StringParam(
+            name="stringParam",
+            label="String",
+            description="A free-form string.",
+            value="default",
+        ),
+        desc.File(
+            name="fileParam",
+            label="File",
+            description="A file or directory path.",
+            value="",
+        ),
+        desc.ChoiceParam(
+            name="exclusiveChoice",
+            label="Exclusive Choice",
+            description="A single-selection dropdown.",
+            value="optionA",
+            values=["optionA", "optionB", "optionC"],
+            exclusive=True,
+        ),
+        desc.ChoiceParam(
+            name="multiChoice",
+            label="Multi Choice",
+            description="A multiple-selection list.",
+            value=["optionA"],
+            values=["optionA", "optionB", "optionC"],
+            exclusive=False,
+        ),
+        desc.PushButtonParam(
+            name="buttonParam",
+            label="Action Button",
+            description="A UI-only action button. No stored value.",
+        ),
+
+        # -----------------------------------------------------------------------
+        # Advanced Parameters (hidden by default in UI)
+        # -----------------------------------------------------------------------
+        desc.IntParam(
+            name="advancedInt",
+            label="Advanced Integer",
+            description="An advanced parameter hidden by default.",
+            value=42,
+            range=(0, 1000, 1),
+            advanced=True,
+        ),
+        desc.FloatParam(
+            name="advancedFloat",
+            label="Advanced Float",
+            description="An advanced float hidden by default.",
+            value=0.5,
+            range=(0.0, 1.0, 0.01),
+            advanced=True,
+        ),
+
+        # -----------------------------------------------------------------------
+        # Enabled conditionally (dynamic enable via lambda)
+        # -----------------------------------------------------------------------
+        desc.FloatParam(
+            name="conditionalParam",
+            label="Conditional Float",
+            description="Only active when boolParam is True.",
+            value=1.0,
+            range=(0.0, 10.0, 0.1),
+            enabled=lambda node: node.boolParam.value,
+        ),
+
+        # -----------------------------------------------------------------------
+        # Compound Containers
+        # -----------------------------------------------------------------------
+        desc.ListAttribute(
+            name="fileList",
+            label="File List",
+            description="A homogeneous list of file paths.",
+            elementDesc=desc.File(
+                name="file",
+                label="File",
+                description="A single file entry.",
+                value="",
+            ),
+            joinChar=" ",
+        ),
+        desc.ListAttribute(
+            name="intList",
+            label="Integer List",
+            description="A homogeneous list of integers.",
+            elementDesc=desc.IntParam(
+                name="item",
+                label="Item",
+                description="",
+                value=0,
+                range=(0, 1000, 1),
+            ),
+            joinChar=",",
+        ),
+        desc.GroupAttribute(
+            name="paramGroup",
+            label="Parameter Group",
+            description="A fixed collection of heterogeneous attributes.",
+            items=[
+                desc.BoolParam(
+                    name="groupBool",
+                    label="Group Bool",
+                    description="",
+                    value=True,
+                ),
+                desc.IntParam(
+                    name="groupInt",
+                    label="Group Int",
+                    description="",
+                    value=5,
+                    range=(0, 50, 1),
+                ),
+                desc.FloatParam(
+                    name="groupFloat",
+                    label="Group Float",
+                    description="",
+                    value=0.1,
+                    range=(0.0, 1.0, 0.01),
+                ),
+                desc.StringParam(
+                    name="groupString",
+                    label="Group String",
+                    description="",
+                    value="group_default",
+                ),
+                desc.File(
+                    name="groupFile",
+                    label="Group File",
+                    description="",
+                    value="",
+                ),
+            ],
+        ),
+
+        # -----------------------------------------------------------------------
+        # Geometry Helpers
+        # -----------------------------------------------------------------------
+        desc.Size2d(
+            name="size2d",
+            label="Size 2D",
+            description="A 2D size (width x height).",
+            width=1920.0,
+            height=1080.0,
+        ),
+        desc.Vec2d(
+            name="vec2d",
+            label="Vector 2D",
+            description="A 2D vector (x, y).",
+            x=0.0,
+            y=0.0,
+        ),
+
+        # -----------------------------------------------------------------------
+        # Shape Parameters (UI overlays, support keyable per-view values)
+        # -----------------------------------------------------------------------
+        desc.Point2d(
+            name="point2d",
+            label="Point 2D",
+            description="A single 2D point overlay.",
+        ),
+        desc.Line2d(
+            name="line2d",
+            label="Line 2D",
+            description="A 2D line defined by two points.",
+        ),
+        desc.Rectangle(
+            name="rectangle",
+            label="Rectangle",
+            description="An axis-aligned 2D rectangle.",
+        ),
+        desc.Circle(
+            name="circle",
+            label="Circle",
+            description="A circle defined by center and radius.",
+        ),
+        desc.ShapeList(
+            name="pointList",
+            label="Point List",
+            description="A list of 2D points.",
+            shape=desc.Point2d(name="pt", label="Point", description=""),
+        ),
+
+        # -----------------------------------------------------------------------
+        # Keyable Attribute (per-view value)
+        # -----------------------------------------------------------------------
+        desc.FloatParam(
+            name="keyableFloat",
+            label="Keyable Float",
+            description="A float that supports per-key (per-view) values.",
+            value=1.0,
+            range=(0.0, 2.0, 0.01),
+            keyable=True,
+        ),
+    ]
+
+    outputs = [
+
+        # -----------------------------------------------------------------------
+        # Static File Output (path expression)
+        # -----------------------------------------------------------------------
+        desc.File(
+            name="outputFile",
+            label="Output File",
+            description="A statically defined output file path (expression-based).",
+            value="{nodeCacheFolder}/output.txt",
+        ),
+        desc.File(
+            name="outputDir",
+            label="Output Directory",
+            description="A statically defined output directory.",
+            value="{nodeCacheFolder}/",
+        ),
+
+        # -----------------------------------------------------------------------
+        # Dynamic Outputs (value computed at runtime)
+        # -----------------------------------------------------------------------
+        desc.IntParam(
+            name="outputInt",
+            label="Output Integer",
+            description="Dynamically computed integer output.",
+            value=None,
+        ),
+        desc.FloatParam(
+            name="outputFloat",
+            label="Output Float",
+            description="Dynamically computed float output.",
+            value=None,
+        ),
+        desc.BoolParam(
+            name="outputBool",
+            label="Output Bool",
+            description="Dynamically computed boolean output.",
+            value=None,
+        ),
+        desc.StringParam(
+            name="outputString",
+            label="Output String",
+            description="Dynamically computed string output.",
+            value=None,
+        ),
+        desc.ColorParam(
+            name="outputColor",
+            label="Output Color",
+            description="Dynamically computed color output.",
+            value=None,
+        ),
+    ]
+
+    def process(self, node):
+        pass

--- a/tests/nodes/test/DynamicNode.py
+++ b/tests/nodes/test/DynamicNode.py
@@ -1,0 +1,31 @@
+from meshroom.core import desc
+
+
+class DynamicNode(desc.Node):
+    inputs = [
+        desc.StringParam(
+            name="code",
+            label="Python Code",
+            value="Python Code",
+            exposed=True,
+            semantic="multiline"
+        ),
+        desc.AnySet(
+            name="ins",
+            label="Custom Inputs",
+            description="Custom Inputs",
+            exposed=True
+        )
+    ]
+
+    outputs = [
+        desc.AnySet(
+            name="outs",
+            label="Custom Outputs",
+            description="Custom Outputs",
+            exposed=True
+        )
+    ]
+
+    def process(self, node):
+        exec(node.code.value)

--- a/tests/test_anySet_attribute.py
+++ b/tests/test_anySet_attribute.py
@@ -5,6 +5,10 @@ from meshroom.core.desc import AnySet as AnySetDesc
 from meshroom.core.graph import Graph
 
 
+def anyset_child(serializedAnySet, name):
+    return next(attribute for attribute in serializedAnySet if attribute.get("name") == name)
+
+
 def initGraphAndNode():
     graph = Graph("test")
     node = graph.addNewNode("DynamicNode")
@@ -159,6 +163,26 @@ def test_rename_anyset_attribute_rejects_duplicate_name():
         raise AssertionError("Renaming an AnySet child to an existing name should fail.")
 
 
+def test_move_anyset_attribute_updates_order():
+    graph, dynamicNode = initGraphAndNode()
+    srcNode = graph.addNewNode("Ls", input="/fakeDirectory")
+
+    dynamicNode.ins.duplicateAttribute(srcNode.input, isOutput=False)
+    dynamicNode.ins.duplicateAttribute(srcNode.input, isOutput=False)
+    dynamicNode.ins.duplicateAttribute(srcNode.input, isOutput=False)
+
+    initialOrder = [attribute.name for attribute in dynamicNode.ins.value]
+    attributeToMove = list(dynamicNode.ins.value)[-1]
+
+    dynamicNode.ins.moveAttribute(attributeToMove, 0)
+
+    assert [attribute.name for attribute in dynamicNode.ins.value] == [initialOrder[-1], *initialOrder[:-1]]
+
+    dynamicNode.ins.moveAttribute(attributeToMove, 99)
+
+    assert [attribute.name for attribute in dynamicNode.ins.value] == initialOrder
+
+
 # ---------------------------------------------------------------------------
 # Serialization / deserialization tests
 # ---------------------------------------------------------------------------
@@ -185,17 +209,19 @@ def test_dynamic_inputs_serialized_in_todict():
     nodeDict = dynamicNode.toDict()
     dynInputs = nodeDict.get('inputs', {}).get('ins')
 
-    assert dynInputs.get('input').get('name') == 'input'
-    assert dynInputs.get('input').get('label') == 'Input'
-    assert dynInputs.get('input').get('type') == 'File'
-    assert dynInputs.get('input').get('value') == '/somePath'
+    inputAttribute = anyset_child(dynInputs, "input")
+    assert inputAttribute.get('name') == 'input'
+    assert inputAttribute.get('label') == 'Input'
+    assert inputAttribute.get('type') == 'File'
+    assert inputAttribute.get('value') == '/somePath'
 
     dynOutputs = nodeDict.get('outputs', {}).get('outs')
 
-    assert dynOutputs.get('input').get('name') == 'input'
-    assert dynOutputs.get('input').get('label') == 'Input'
-    assert dynOutputs.get('input').get('type') == 'File'
-    assert dynOutputs.get('input').get('value') == ''
+    outputAttribute = anyset_child(dynOutputs, "input")
+    assert outputAttribute.get('name') == 'input'
+    assert outputAttribute.get('label') == 'Input'
+    assert outputAttribute.get('type') == 'File'
+    assert outputAttribute.get('value') == ''
 
     assert lsNode3.toDict().get('inputs').get('input') == '{DynamicNode_1.outs.input}'  # Check for connection
 
@@ -228,6 +254,62 @@ def test_dynamic_inputs_restored_after_load(tmp_path):
     assert loadedDstNode.ins.input.value == "/somePath"
     assert loadedDstNode.outs.input is not None
     assert lsNode3.input.isLink, "Dynamic output should still be connected after load"
+
+
+def test_moved_anyset_attribute_order_restored_after_load(tmp_path):
+    from meshroom.core.graph import loadGraph
+
+    graph, dynamicNode = initGraphAndNode()
+    srcNode = graph.addNewNode("Ls", input="/fakeDirectory")
+
+    dynamicNode.ins.duplicateAttribute(srcNode.input, isOutput=False)
+    dynamicNode.ins.duplicateAttribute(srcNode.input, isOutput=False)
+    dynamicNode.ins.duplicateAttribute(srcNode.input, isOutput=False)
+
+    initialOrder = [attribute.name for attribute in dynamicNode.ins.value]
+    attributeToMove = list(dynamicNode.ins.value)[-1]
+    dynamicNode.ins.moveAttribute(attributeToMove, 0)
+    movedOrder = [attribute.name for attribute in dynamicNode.ins.value]
+
+    assert movedOrder == [initialOrder[-1], *initialOrder[:-1]]
+
+    graphFile = str(tmp_path / "graph.mg")
+    graph.save(graphFile)
+
+    serializedIns = graph.serialize()["graph"][dynamicNode.name]["inputs"]["ins"]
+    assert [attribute["name"] for attribute in serializedIns] == movedOrder
+
+    loadedGraph = loadGraph(graphFile)
+    loadedDynamicNode = loadedGraph.node(dynamicNode.name)
+
+    assert [attribute.name for attribute in loadedDynamicNode.ins.value] == movedOrder
+
+
+def test_legacy_dict_anyset_serialization_still_loads(tmp_path):
+    import json
+    from meshroom.core.graph import loadGraph
+
+    graph, dynamicNode = initGraphAndNode()
+    srcNode = graph.addNewNode("Ls", input="/fakeDirectory")
+
+    dynamicNode.ins.duplicateAttribute(srcNode.input, isOutput=False)
+    dynamicNode.ins.duplicateAttribute(srcNode.input, isOutput=False)
+
+    graphData = graph.serialize()
+    serializedIns = graphData["graph"][dynamicNode.name]["inputs"]["ins"]
+    graphData["graph"][dynamicNode.name]["inputs"]["ins"] = {
+        attribute["name"]: attribute for attribute in serializedIns
+    }
+
+    graphFile = tmp_path / "legacy_dict_anyset.mg"
+    graphFile.write_text(json.dumps(graphData), encoding="utf-8")
+
+    loadedGraph = loadGraph(str(graphFile))
+    loadedDynamicNode = loadedGraph.node(dynamicNode.name)
+
+    assert [attribute.name for attribute in loadedDynamicNode.ins.value] == [
+        attribute["name"] for attribute in serializedIns
+    ]
 
 def test_clone_attributes():
     graph = Graph("test")

--- a/tests/test_anySet_attribute.py
+++ b/tests/test_anySet_attribute.py
@@ -6,7 +6,13 @@ from meshroom.core.graph import Graph
 
 
 def anyset_child(serializedAnySet, name):
-    return next(attribute for attribute in serializedAnySet if attribute.get("name") == name)
+    return next(attribute for attribute in anyset_children(serializedAnySet) if attribute.get("name") == name)
+
+
+def anyset_children(serializedAnySet):
+    if isinstance(serializedAnySet, dict):
+        return serializedAnySet["children"]
+    return serializedAnySet
 
 
 def initGraphAndNode():
@@ -277,12 +283,33 @@ def test_moved_anyset_attribute_order_restored_after_load(tmp_path):
     graph.save(graphFile)
 
     serializedIns = graph.serialize()["graph"][dynamicNode.name]["inputs"]["ins"]
-    assert [attribute["name"] for attribute in serializedIns] == movedOrder
+    assert [attribute["name"] for attribute in anyset_children(serializedIns)] == movedOrder
 
     loadedGraph = loadGraph(graphFile)
     loadedDynamicNode = loadedGraph.node(dynamicNode.name)
 
     assert [attribute.name for attribute in loadedDynamicNode.ins.value] == movedOrder
+
+
+def test_anyset_expanded_state_restored_after_load(tmp_path):
+    from meshroom.core.graph import loadGraph
+
+    graph, dynamicNode = initGraphAndNode()
+    dynamicNode.ins.expanded = True
+    dynamicNode.outs.expanded = False
+
+    graphFile = str(tmp_path / "graph.mg")
+    graph.save(graphFile)
+
+    serializedNode = graph.serialize()["graph"][dynamicNode.name]
+    assert serializedNode["inputs"]["ins"]["expanded"] is True
+    assert serializedNode["outputs"]["outs"]["expanded"] is False
+
+    loadedGraph = loadGraph(graphFile)
+    loadedDynamicNode = loadedGraph.node(dynamicNode.name)
+
+    assert loadedDynamicNode.ins.expanded is True
+    assert loadedDynamicNode.outs.expanded is False
 
 
 def test_legacy_dict_anyset_serialization_still_loads(tmp_path):
@@ -298,7 +325,7 @@ def test_legacy_dict_anyset_serialization_still_loads(tmp_path):
     graphData = graph.serialize()
     serializedIns = graphData["graph"][dynamicNode.name]["inputs"]["ins"]
     graphData["graph"][dynamicNode.name]["inputs"]["ins"] = {
-        attribute["name"]: attribute for attribute in serializedIns
+        attribute["name"]: attribute for attribute in anyset_children(serializedIns)
     }
 
     graphFile = tmp_path / "legacy_dict_anyset.mg"
@@ -308,7 +335,32 @@ def test_legacy_dict_anyset_serialization_still_loads(tmp_path):
     loadedDynamicNode = loadedGraph.node(dynamicNode.name)
 
     assert [attribute.name for attribute in loadedDynamicNode.ins.value] == [
-        attribute["name"] for attribute in serializedIns
+        attribute["name"] for attribute in anyset_children(serializedIns)
+    ]
+
+
+def test_legacy_list_anyset_serialization_still_loads(tmp_path):
+    import json
+    from meshroom.core.graph import loadGraph
+
+    graph, dynamicNode = initGraphAndNode()
+    srcNode = graph.addNewNode("Ls", input="/fakeDirectory")
+
+    dynamicNode.ins.duplicateAttribute(srcNode.input, isOutput=False)
+    dynamicNode.ins.duplicateAttribute(srcNode.input, isOutput=False)
+
+    graphData = graph.serialize()
+    serializedIns = graphData["graph"][dynamicNode.name]["inputs"]["ins"]
+    graphData["graph"][dynamicNode.name]["inputs"]["ins"] = anyset_children(serializedIns)
+
+    graphFile = tmp_path / "legacy_list_anyset.mg"
+    graphFile.write_text(json.dumps(graphData), encoding="utf-8")
+
+    loadedGraph = loadGraph(str(graphFile))
+    loadedDynamicNode = loadedGraph.node(dynamicNode.name)
+
+    assert [attribute.name for attribute in loadedDynamicNode.ins.value] == [
+        attribute["name"] for attribute in anyset_children(serializedIns)
     ]
 
 def test_clone_attributes():

--- a/tests/test_anySet_attribute.py
+++ b/tests/test_anySet_attribute.py
@@ -126,6 +126,39 @@ def test_anyset_attribute_can_be_restored_with_edges():
     assert dynamicNode.ins.input.inputLink is srcNode.input
 
 
+def test_rename_anyset_attribute_updates_name_label_and_keeps_edges():
+    graph, dynamicNode = initGraphAndNode()
+    srcNode = graph.addNewNode("Ls", input="/fakeDirectory")
+
+    dynamicNode.ins.duplicateAttribute(srcNode.input, isOutput=False)
+    srcNode.input.connectTo(dynamicNode.ins.input)
+
+    dynamicNode.ins.renameAttribute(dynamicNode.ins.input, "customInput", "Custom Input")
+
+    assert dynamicNode.ins.input is None
+    assert isinstance(dynamicNode.ins.customInput, Attribute)
+    assert dynamicNode.ins.customInput.name == "customInput"
+    assert dynamicNode.ins.customInput.label == "Custom Input"
+    assert dynamicNode.ins.customInput.isLink
+    assert dynamicNode.ins.customInput.inputLink is srcNode.input
+    assert graph.attribute(f"{dynamicNode.ins.fullName}.customInput") is dynamicNode.ins.customInput
+
+
+def test_rename_anyset_attribute_rejects_duplicate_name():
+    graph, dynamicNode = initGraphAndNode()
+    srcNode = graph.addNewNode("Ls", input="/fakeDirectory")
+
+    dynamicNode.ins.duplicateAttribute(srcNode.input, isOutput=False)
+    dynamicNode.ins.duplicateAttribute(srcNode.input, isOutput=False)
+
+    try:
+        dynamicNode.ins.renameAttribute(dynamicNode.ins.input_0, "input", "Input")
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("Renaming an AnySet child to an existing name should fail.")
+
+
 # ---------------------------------------------------------------------------
 # Serialization / deserialization tests
 # ---------------------------------------------------------------------------

--- a/tests/test_anySet_attribute.py
+++ b/tests/test_anySet_attribute.py
@@ -1,0 +1,178 @@
+"""Tests for the AnySet feature."""
+
+from meshroom.core.attribute import AnySet, Attribute
+from meshroom.core.desc import AnySet as AnySetDesc
+from meshroom.core.graph import Graph
+
+
+def initGraphAndNode():
+    graph = Graph("test")
+    node = graph.addNewNode("DynamicNode")
+    return graph, node
+
+# ---------------------------------------------------------------------------
+# Descriptor tests
+# ---------------------------------------------------------------------------
+
+def test_dynamic_attribute_desc_type():
+    """descriptor has the correct type string."""
+    d = AnySetDesc(name="customInputs")
+    assert d.type == "AnySet"
+
+
+def test_dynamic_attribute_desc_instance_type():
+    """descriptor returns the correct instance class."""
+    d = AnySetDesc(name="customInputs")
+    assert d.instanceType is AnySet
+
+
+# ---------------------------------------------------------------------------
+# Node / attribute creation tests
+# ---------------------------------------------------------------------------
+
+def test_dynamic_attribute_present_on_node():
+    """A node that declares a DynamicAttribute exposes it as an attribute."""
+    graph, node = initGraphAndNode()
+    assert node.hasAttribute("ins")
+    customInputsAttrs = node.attribute("ins")
+    assert isinstance(customInputsAttrs, AnySet)
+
+    assert node.hasAttribute("outs")
+    customOuputsAttrs = node.attribute("outs")
+    assert isinstance(customOuputsAttrs, AnySet)
+
+
+def test_dynamic_attribute_validates_any_connection():
+    """DynamicAttribute.validateIncomingConnection returns True for any type."""
+    graph, node = initGraphAndNode()
+    dynAttr = node.attribute("ins")
+
+    # Build a fake source attribute of type File
+    srcNode = graph.addNewNode("Ls", input="/fakeDirectory")
+    assert dynAttr.validateIncomingConnection(srcNode.output)
+
+
+# ---------------------------------------------------------------------------
+# Dynamic input creation tests (via Node.addDynamicInput / removeDynamicInput)
+# ---------------------------------------------------------------------------
+
+def test_add_dynamic_input_creates_sibling_attribute():
+    """Adding a dynamic input inserts a new attribute before the DynamicAttribute."""
+    graph, dstNode = initGraphAndNode()
+
+    srcNode = graph.addNewNode("Ls", input="/fakeDirectory")
+    dynAttr = dstNode.attribute("ins")
+
+    attributeSrc = srcNode.attribute("input")
+    assert(isinstance(attributeSrc, Attribute))
+
+    newAttr = dynAttr.duplicateAttribute(attributeSrc, isOutput=False)
+    assert(newAttr is not None)
+    assert(dstNode.ins.input is not None)
+    assert(isinstance(dstNode.ins.input, Attribute))
+
+    # Check renaming auto when concurrent naming
+    input_0 = dynAttr.duplicateAttribute(attributeSrc, isOutput=False)
+    assert(input_0 is not None)
+    assert(dstNode.ins.input_0 is not None)
+    assert(isinstance(dstNode.ins.input_0, Attribute))
+
+    input_1 = dynAttr.duplicateAttribute(attributeSrc, isOutput=False)
+    assert(input_1 is not None)
+    assert(dstNode.ins.input_1 is not None)
+    assert(isinstance(dstNode.ins.input_1, Attribute))
+
+def test_remove_dynamic_input():
+    """Removing a dynamic input deletes the attribute from the node."""
+
+    graph, dynamicNode = initGraphAndNode()
+    srcNode = graph.addNewNode("Ls", input="/fakeDirectory")
+
+    dynamicNode.ins.duplicateAttribute(srcNode.input, isOutput=False)
+
+    assert(dynamicNode.ins.input is not None)
+    assert(isinstance(dynamicNode.ins.input, Attribute))
+
+    # When
+    dynamicNode.ins.removeAttribute(dynamicNode.ins.input)
+
+    # Then
+    assert(dynamicNode.ins.input is None)
+
+
+# ---------------------------------------------------------------------------
+# Serialization / deserialization tests
+# ---------------------------------------------------------------------------
+
+def test_dynamic_inputs_serialized_in_todict():
+    """Dynamic inputs are included in the node's serialized form."""
+
+    graph, dynamicNode = initGraphAndNode()
+
+    lsNode = graph.addNewNode("Ls", input="/fakeDirectory")
+    lsNode2 = graph.addNewNode("Ls", input="/fakeDirectory2")
+    lsNode3 = graph.addNewNode("Ls", input="/fakeDirectory3")
+    colorNode = graph.addNewNode("Color")
+
+    dynamicNode.ins.duplicateAttribute(lsNode.input)
+    dynamicNode.ins.duplicateAttribute(colorNode.rgb)
+    dynamicNode.outs.duplicateAttribute(lsNode2.input, isOutput=True)
+
+    dynamicNode.ins.input.value = "/somePath"
+
+    assert isinstance(dynamicNode.outs.input, Attribute)
+    dynamicNode.outs.input.connectTo(lsNode3.input)
+
+    nodeDict = dynamicNode.toDict()
+    dynInputs = nodeDict.get('inputs', {}).get('ins')
+
+    assert dynInputs.get('input').get('name') == 'input'
+    assert dynInputs.get('input').get('label') == 'Input'
+    assert dynInputs.get('input').get('type') == 'File'
+    assert dynInputs.get('input').get('value') == '/somePath'
+
+    dynOutputs = nodeDict.get('outputs', {}).get('outs')
+
+    assert dynOutputs.get('input').get('name') == 'input'
+    assert dynOutputs.get('input').get('label') == 'Input'
+    assert dynOutputs.get('input').get('type') == 'File'
+    assert dynOutputs.get('input').get('value') == ''
+
+    assert lsNode3.toDict().get('inputs').get('input') == '{DynamicNode_1.outs.input}'  # Check for connection
+
+def test_dynamic_inputs_restored_after_load(tmp_path):
+    """Dynamic inputs survive a graph save/load cycle."""
+
+    from meshroom.core.graph import loadGraph
+
+    graph, dynamicNode = initGraphAndNode()
+
+    lsNode = graph.addNewNode("Ls", input="/fakeDirectory")
+    lsNode2 = graph.addNewNode("Ls", input="/fakeDirectory2")
+    lsNode3 = graph.addNewNode("Ls", input="/fakeDirectory3")
+    colorNode = graph.addNewNode("Color")
+
+    dynamicNode.ins.duplicateAttribute(lsNode.input)
+    dynamicNode.ins.duplicateAttribute(colorNode.rgb)
+    dynamicNode.outs.duplicateAttribute(lsNode2.input, isOutput=True)
+    dynamicNode.outs.input.connectTo(lsNode3.input)
+
+    dynamicNode.ins.input.value = "/somePath"
+
+    graphFile = str(tmp_path / "graph.mg")
+    graph.save(graphFile)
+
+    # Reload
+    loadedGraph = loadGraph(graphFile)
+    loadedDstNode = loadedGraph.node(dynamicNode.name)
+
+    assert loadedDstNode.ins.input.value == "/somePath"
+    assert loadedDstNode.outs.input is not None
+    assert lsNode3.input.isLink, "Dynamic output should still be connected after load"
+
+def test_clone_attributes():
+    graph = Graph("test")
+    node = graph.addNewNode("AllAttributesNode")
+
+    for attribute in node.attributes:
+        assert(attribute.desc.clone() is not None)  # Check clone doesn't raise

--- a/tests/test_anySet_attribute.py
+++ b/tests/test_anySet_attribute.py
@@ -100,6 +100,32 @@ def test_remove_dynamic_input():
     assert(dynamicNode.ins.input is None)
 
 
+def test_anyset_attribute_can_be_restored_with_edges():
+    graph, dynamicNode = initGraphAndNode()
+    srcNode = graph.addNewNode("Ls", input="/fakeDirectory")
+
+    dynamicNode.ins.duplicateAttribute(srcNode.input, isOutput=False)
+    srcNode.input.connectTo(dynamicNode.ins.input)
+
+    serializedAttribute = dynamicNode.ins.input.asDict()
+    index = list(dynamicNode.ins.value).index(dynamicNode.ins.input)
+    edgeNames = [(edge.src.fullName, edge.dst.fullName) for edge in graph.edges.values()]
+
+    graph.removeEdge(dynamicNode.ins.input)
+    dynamicNode.ins.removeAttribute(dynamicNode.ins.input)
+
+    assert dynamicNode.ins.input is None
+    assert not graph.edges
+
+    dynamicNode.ins.insertAttribute(serializedAttribute, index)
+    for srcName, dstName in edgeNames:
+        graph.addEdge(graph.anyAttribute(srcName), graph.anyAttribute(dstName))
+
+    assert isinstance(dynamicNode.ins.input, Attribute)
+    assert dynamicNode.ins.input.isLink
+    assert dynamicNode.ins.input.inputLink is srcNode.input
+
+
 # ---------------------------------------------------------------------------
 # Serialization / deserialization tests
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description

<img width="1238" height="274" alt="Peek 2026-06-15 10-45" src="https://github.com/user-attachments/assets/2fd02144-ff2b-4f99-a828-a0816369e85a" />

<p align="center">
<img width="45%" height="224" alt="image" src="https://github.com/user-attachments/assets/065840f6-42ab-4b51-a47e-88b9da18edea" />
<img width="45%" height="158" alt="image" src="https://github.com/user-attachments/assets/5dfe69cf-3538-497b-a510-0abc75db1831" />
</p>

`CustomAttributes` concept:
It's a container of custom attributes. It can be input/output as usual attribute.
When an attribute is connected to it's slot, a clone of the attribute connected is added to the container, and both attributes a re connected by default.

## Features list
- [ X ] Add the CustomAttributes concept: A connection on it duplicate the connected attribute as a child of the CustomAttributes.
- [ X ] Add a contextMenu in graphEditor and AttributeEditor to remove a Any Attribute
- [ X ] Rename (name/label)  attribute in GraphEditor and AttributeEditor
- [ X ] Attribute can be reordered (Move Up / Down)


## Known Limitations:

- Group is collapsed when an attribute is created, need a store of the collapsed/expanded state

## Implementation remarks

- To avoid concepts conflict, the parameter is called CustomAttributes, and no more DynamicAttributes.
The Dynamic attribute/value already exists for output attributes that have a value of None.

- In this version **there is no way to rename/delete an attribute** created by the user using the UI.
It would be added in an other PR

- Add the Collapsable class as a mixin to indicate in qml if the attribute should have the `Collapsable` behavior.
The idea is to add some internal properties later to store the expanded state, ... 

- A `forceEdgesVisualUpdate` has been added in the GraphEditor.qml to force the edge evaluation when an attribute is added at runtime.

- A refacto of the AttributePin.qml/AttributeItemDelegate.qml  should be done to help writing of new attributes display.
It should be decomposed in smaller parts

- At serialization, the CustomAttributes serialize it's children atttribute with the necessary information to recreate the same attributes at deserialization time.
-> name, label, type, value
<img width="402" height="185" alt="image" src="https://github.com/user-attachments/assets/7602012b-d136-4d5c-b35f-82f92b24e345" />




