### PR TITLE
Add user-defined Menus

### DIFF
--- a/meshroom/common/__init__.py
+++ b/meshroom/common/__init__.py
@@ -13,6 +13,7 @@ class Backend(Enum):
     PYSIDE = 2
 
 
+CurrentBackend = None
 DictModel = None
 ListModel = None
 Slot = None
@@ -25,7 +26,8 @@ JSValue = None
 
 
 def init(backend):
-    global DictModel, ListModel, Slot, Signal, Property, BaseObject, Variant, VariantList, JSValue
+    global CurrentBackend, DictModel, ListModel, Slot, Signal, Property, BaseObject, Variant, VariantList, JSValue
+    CurrentBackend = backend
     if backend == Backend.PYSIDE:
         # PySide types
         from .qt import DictModel, ListModel, Slot, Signal, Property, BaseObject, Variant, VariantList, JSValue

--- a/meshroom/core/__init__.py
+++ b/meshroom/core/__init__.py
@@ -343,6 +343,32 @@ def nodeVersion(nodeDesc: desc.Node, default=None):
     return moduleVersion(nodeDesc.__module__, default)
 
 
+def loadPluginMenu(pluginMenuFile):
+    """
+    Registers a menu from a python script
+
+    Args:
+        folder: the folder where we search for the menu.
+    """
+    # Generate a custom module name to avoid collisions
+    moduleName = f"mrMenus.{uuid.uuid4().hex}"
+    try:
+        spec = importlib.util.spec_from_file_location(moduleName, pluginMenuFile)
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[moduleName] = module
+        spec.loader.exec_module(module)
+        logging.debug(f"Loaded menu registration from '{pluginMenuFile}'.")
+    except Exception as exc:
+        tb = traceback.extract_tb(exc.__traceback__)
+        last_call = tb[-1]
+        logging.warning(
+            f"  * Failed to load menu file '{pluginMenuFile}' ({type(exc).__name__}): {str(exc)}\n"
+            f"{last_call.filename}:{last_call.lineno} {last_call.name}\n"
+            f"{last_call.line}"
+            f"\n{traceback.format_exc()}\n\n"
+        )
+
+
 def loadNodes(folder, packageName, pluginUid) -> list[NodePlugin]:
     if not os.path.isdir(folder):
         logging.error(f"Node folder '{folder}' does not exist.")
@@ -376,6 +402,11 @@ def loadPluginFolder(folder, userPlugin: bool = False) -> list[Plugin]:
     if not mrFolder.exists():
         logging.info(f"Plugin folder '{folder}' does not contain a 'meshroom' folder.")
         return []
+
+    # Register any menu(s) declared by this plugin
+    pluginMenuFile = mrFolder / "menu.py"
+    if pluginMenuFile.exists():
+        loadPluginMenu(pluginMenuFile)
 
     plugins = loadAllNodes(folder=mrFolder)
     if plugins:

--- a/meshroom/core/__init__.py
+++ b/meshroom/core/__init__.py
@@ -1,6 +1,7 @@
 from contextlib import contextmanager
 import hashlib
 import importlib
+import importlib.util
 import inspect
 import logging
 import os
@@ -363,8 +364,11 @@ def loadPluginMenu(pluginMenuFile):
         last_call = tb[-1]
         logging.warning(
             f"  * Failed to load menu file '{pluginMenuFile}' ({type(exc).__name__}): {str(exc)}\n"
+            # filename:lineNumber functionName
             f"{last_call.filename}:{last_call.lineno} {last_call.name}\n"
+            # line of code with the error
             f"{last_call.line}"
+            # Full traceback
             f"\n{traceback.format_exc()}\n\n"
         )
 

--- a/meshroom/core/__init__.py
+++ b/meshroom/core/__init__.py
@@ -19,6 +19,7 @@ try:
 except Exception:
     pass
 
+from meshroom.common import CurrentBackend, Backend
 from meshroom.core.plugins import NodePlugin, NodePluginManager, Plugin, processEnvFactory, formatNodeDescriptionErrorMessage
 from meshroom.core.submitter import BaseSubmitter
 from meshroom.env import EnvVar, meshroomFolder
@@ -409,7 +410,7 @@ def loadPluginFolder(folder, userPlugin: bool = False) -> list[Plugin]:
 
     # Register any menu(s) declared by this plugin
     pluginMenuFile = mrFolder / "menu.py"
-    if pluginMenuFile.exists():
+    if CurrentBackend == Backend.PYSIDE and pluginMenuFile.exists():
         loadPluginMenu(pluginMenuFile)
 
     plugins = loadAllNodes(folder=mrFolder)

--- a/meshroom/ui/app.py
+++ b/meshroom/ui/app.py
@@ -31,6 +31,7 @@ from meshroom.ui.components.thumbnail import ThumbnailCache
 from meshroom.ui.components.messaging import MessageController
 from meshroom.ui.components.shapes import ShapeFilesHelper, ShapeViewerHelper
 from meshroom.ui.palette import PaletteManager
+from meshroom.ui.menu import MeshroomMenuManager
 from meshroom.ui.scene import Scene
 from meshroom.ui.utils import QmlInstantEngine
 from meshroom.ui import commands
@@ -287,6 +288,9 @@ class MeshroomApp(QApplication):
         pyside6QmlPath = os.path.join(os.path.dirname(QtCore.__file__), "Qt", "qml")
         if os.path.isdir(pyside6QmlPath):
             self.engine.addImportPath(pyside6QmlPath)
+
+        # Expose the menu manager
+        self.engine.rootContext().setContextProperty("MeshroomMenuManager", MeshroomMenuManager(parent=self))
 
         # expose available node types that can be instantiated
         self.engine.rootContext().setContextProperty("_nodeTypes", {n: {"category": pluginManager.getRegisteredNodePlugins()[n].nodeDescriptor.category} for n in sorted(pluginManager.getRegisteredNodePlugins().keys())})

--- a/meshroom/ui/menu.py
+++ b/meshroom/ui/menu.py
@@ -5,12 +5,11 @@ On top of the Meshroom menus that are set-up in the QML
 we can register additional menus that will trigger a callback if we click on the menu entry.
 
 Example :
-    class OpenSettingUi(MenuCallback):
-        def __call__(self, menu, app, **kwargs):
-            ...
+    def open_settings_ui(menu, app, **kwargs):
+        ...
 
     settings_menu = Menu("Settings")
-    settings_menu.addButton("Open Settings", callback=OpenSettingUi)
+    settings_menu.addButton("Open Settings", callback=open_settings_ui)
     register_menu(menu=settings_menu)
 """
 
@@ -61,10 +60,10 @@ class MenuObject(BaseObject):
     """
 
     def __init__(self, parent: "Menu", callback: Optional[MenuCallback],
-                 type: MenuObjectType, **kwargs):
-        if type not in MenuObjectType:
+                 menuObjectType: MenuObjectType, **kwargs):
+        if menuObjectType not in MenuObjectType:
             raise ValueError(
-                f"Invalid MenuObject type: {type} (valid types are " +
+                f"Invalid MenuObject type: {menuObjectType} (valid types are " +
                 ", ".join(m.name for m in MenuObjectType) + ")"
             )
 
@@ -73,7 +72,7 @@ class MenuObject(BaseObject):
         self._uid: str = uuid.uuid4().hex
         self.parentMenu: "Menu" = parent
         self.callback: Callable = callback
-        self._type: MenuObjectType = type
+        self.menuObjectType: MenuObjectType = menuObjectType
 
         # General properties
         self._name: str = kwargs.get("name", "")
@@ -109,7 +108,7 @@ class MenuObject(BaseObject):
             return self.callback(self.parentMenu, app, **kwargs)
 
     uid = Property(str, lambda self: self._uid, constant=True)
-    type = Property(str, lambda self: self._type.value, constant=True)
+    objectType = Property(str, lambda self: self.menuObjectType.value, constant=True)
     label = Property(str, lambda self: self._label, constant=True)
     icon = Property(str, lambda self: self._icon, constant=True)
     tooltip = Property(str, lambda self: self._tooltip, constant=True)
@@ -138,11 +137,12 @@ class Menu(BaseObject):
         self.parentMenu: "Menu" = parent
         self.index: int = index
         self.menuObject = MenuObject(
-            parent=self, callback=None, type=MenuObjectType.MENU,
+            parent=self, callback=None, menuObjectType=MenuObjectType.MENU,
             # and kwargs :
             name=name, label=name, icon=icon, tooltip=tooltip, index=index
         )
         self._objects: ListModel = ListModel(parent=self)
+        self._initialized = False
 
     def __repr__(self):
         return f'<Menu name="{self._name}"|uid={self._uid}|size={len(self._objects)}>'
@@ -220,15 +220,28 @@ class MeshroomMenuManager(BaseObject):
 
     _menus: list[Menu] = []
     _objects: dict[str, MenuObject] = {}
+    
+    LIST_OBJ_TYPES = [
+        MenuObjectType.RADIOBUTTON.value
+    ]
 
     def __init__(self, parent=None):
         super().__init__(parent)
         self._menuModel: ListModel = ListModel(parent=self)
-        self._menuModel.extend(self._menus)
+        self._menuModel.setObjectList(self._menus)
         logging.info(f"Initialize MeshroomMenuManager with {len(self._menus)} menus.")
         for menu in self._menus:
-            logging.info(f"Adding user menu: {menu}")
+            if menu._initialized:
+                continue
+            logging.info(f"Initialize User Menu: {menu}")
             menu.onCreated()
+            menu._initialized = True
+
+    @classmethod  
+    def clear(cls):  
+        """Clear all registered menus and objects. Useful for testing and resetting state."""  
+        cls._menus.clear()  
+        cls._objects.clear()  
 
     @property
     def app(self):
@@ -241,7 +254,7 @@ class MeshroomMenuManager(BaseObject):
         cls._objects[menu.menuObject.uid] = menu.menuObject
         for obj in menu._objects:  # iterate CoreListModel/QObjectListModel directly
             cls._objects[obj.uid] = obj
-            if obj.type == MenuObjectType.MENU.value:
+            if obj.objectType == MenuObjectType.MENU.value:
                 cls._indexMenu(obj.submenu)
 
     @classmethod
@@ -274,9 +287,9 @@ class MeshroomMenuManager(BaseObject):
         self.trigger(uid, enabled=checked)
 
     @Slot(str, str)
-    def triggerRadioEntry(self, groupUid: str, entryName: str):
+    def triggerListEntry(self, groupUid: str, entryName: str):
         obj = self.getObject(groupUid)
-        if obj is None or obj.type != MenuObjectType.RADIOBUTTON.value:
+        if obj is None or obj.menuObjectType in self.LIST_OBJ_TYPES:
             return
         item = next((i for i in obj.items if i.name == entryName), None)
         if item is None:

--- a/meshroom/ui/menu.py
+++ b/meshroom/ui/menu.py
@@ -106,6 +106,7 @@ class MenuObject(BaseObject):
     def trigger(self, app, **kwargs):
         if self.callback is not None:
             return self.callback(self.parentMenu, app, **kwargs)
+        return None
 
     uid = Property(str, lambda self: self._uid, constant=True)
     objectType = Property(str, lambda self: self.menuObjectType.value, constant=True)

--- a/meshroom/ui/menu.py
+++ b/meshroom/ui/menu.py
@@ -15,10 +15,17 @@ Example :
 
 import logging
 import uuid
-from enum import Enum
 from typing import Optional, Callable
 
-from meshroom.common import BaseObject, Property, Signal, Slot, Variant, ListModel
+from PySide6.QtCore import QObject
+from meshroom.common.qt import (
+    Property,
+    Signal,
+    Slot,
+    Variant,
+    VariantList,
+    ListModel
+)
 
 
 class MenuCallback:
@@ -29,7 +36,7 @@ class MenuCallback:
         pass
 
 
-class MenuItem(BaseObject):
+class MenuItem(QObject):
     """A simple (name, label) pair, used for radio button entries."""
 
     def __init__(self, name, label=None, tooltip=None, shortcut=None, parent=None):
@@ -45,7 +52,7 @@ class MenuItem(BaseObject):
     shortcut = Property(str, lambda self: self._shortcut, constant=True)
 
 
-class MenuObject(BaseObject):
+class MenuObject(QObject):
     """Item registered as an entry in a menu.
     """
     def __init__(self, parent: "Menu", callback: Optional[MenuCallback], **kwargs):
@@ -135,10 +142,10 @@ class MenuTypeRadiobutton(MenuObject):
 
     selectedUidChanged = Signal()
     selectedUid = Property(str, lambda self: self._selectedUid, _setSelectedUid, notify=selectedUidChanged)
-    items = Property("QVariantList", lambda self: self._items, constant=True)
+    items = Property(VariantList, lambda self: self._items, constant=True)
 
 
-class Menu(BaseObject):
+class Menu(QObject):
     """Registerable menu (or submenu)."""
 
     def __init__(self, name: str, icon: str = None, tooltip: str = None,
@@ -249,7 +256,7 @@ class MenuExtension:
         )
 
 
-class MeshroomMenuManager(BaseObject):
+class MeshroomMenuManager(QObject):
     """
     Registry of all user menus and their objects.
     
@@ -370,4 +377,4 @@ class MeshroomMenuManager(BaseObject):
         self.trigger(groupUid, selected=item)
 
     menusChanged = Signal()
-    menus = Property(BaseObject, getMenus, notify=menusChanged)
+    menus = Property(QObject, getMenus, notify=menusChanged)

--- a/meshroom/ui/menu.py
+++ b/meshroom/ui/menu.py
@@ -10,7 +10,7 @@ Example :
 
     settings_menu = Menu("Settings")
     settings_menu.addButton("Open Settings", callback=open_settings_ui)
-    register_menu(menu=settings_menu)
+    MeshroomMenuManager.registerMenu(settings_menu)
 """
 
 import logging

--- a/meshroom/ui/menu.py
+++ b/meshroom/ui/menu.py
@@ -1,0 +1,288 @@
+#!/usr/bin/env python
+
+"""
+On top of the Meshroom menus that are set-up in the QML
+we can register additional menus that will trigger a callback if we click on the menu entry.
+
+Example :
+    class OpenSettingUi(MenuCallback):
+        def __call__(self, menu, app, **kwargs):
+            ...
+
+    settings_menu = Menu("Settings")
+    settings_menu.addButton("Open Settings", callback=OpenSettingUi)
+    register_menu(menu=settings_menu)
+"""
+
+import logging
+import uuid
+from enum import Enum
+from typing import Optional, Callable
+
+from meshroom.common import BaseObject, Property, Signal, Slot, Variant, ListModel
+
+
+class MenuCallback:
+    """ Override __call__ to react to menu interactions.
+    Can also be defined with a lamba or a function.
+    """
+    def __call__(self, menu, app, **kwargs):
+        pass
+
+
+class MenuObjectType(Enum):
+    MENU = "menu"
+    SEPARATOR = "separator"
+    BUTTON = "button"
+    CHECKBOX = "checkbox"
+    RADIOBUTTON = "radioButton"
+
+
+class MenuItem(BaseObject):
+    """A simple (name, label) pair, used for radio button entries."""
+
+    def __init__(self, name, label=None, tooltip=None, shortcut=None, parent=None):
+        super().__init__(parent)
+        self._name = name
+        self._label = label or name
+        self._tooltip = tooltip or ""
+        self._shortcut = shortcut or ""
+
+    name = Property(str, lambda self: self._name, constant=True)
+    label = Property(str, lambda self: self._label, constant=True)
+    tooltip = Property(str, lambda self: self._tooltip, constant=True)
+    shortcut = Property(str, lambda self: self._shortcut, constant=True)
+
+
+class MenuObject(BaseObject):
+    """
+    Item registered as an entry in a menu.
+    Can be either: a menu, a separator, a button, a checkbox, a radioButton.
+    """
+
+    def __init__(self, parent: "Menu", callback: Optional[MenuCallback],
+                 type: MenuObjectType, **kwargs):
+        if type not in MenuObjectType:
+            raise ValueError(
+                f"Invalid MenuObject type: {type} (valid types are " +
+                ", ".join(m.name for m in MenuObjectType) + ")"
+            )
+
+        super().__init__(parent)
+
+        self._uid: str = uuid.uuid4().hex
+        self.parentMenu: "Menu" = parent
+        self.callback: Callable = callback
+        self._type: MenuObjectType = type
+
+        # General properties
+        self._name: str = kwargs.get("name", "")
+        self._label: str = kwargs.get("label", self._name)
+        self._icon: str = kwargs.get("icon", "")
+        self._tooltip: str = kwargs.get("tooltip", "")
+        self._shortcut: str = kwargs.get("shortcut", "")
+        self.index: int = kwargs.get("index", -1)
+
+        # Menu
+        self._submenu: "Menu" = kwargs.get("submenu", None)
+        # Checkbox
+        self._checked: bool = kwargs.get("checked", False)
+        # Radio Button
+        self._items: list = kwargs.get("items") or []
+        self._selectedUid: str = kwargs.get("selectedUid", "")
+
+    def _setSubmenu(self, menu: "Menu"):
+        self._submenu = menu
+
+    def _setChecked(self, value):
+        if self._checked != value:
+            self._checked = value
+            self.checkedChanged.emit()
+
+    def _setSelectedUid(self, value):
+        if self._selectedUid != value:
+            self._selectedUid = value
+            self.selectedUidChanged.emit()
+
+    def trigger(self, app, **kwargs):
+        if self.callback is not None:
+            return self.callback(self.parentMenu, app, **kwargs)
+
+    uid = Property(str, lambda self: self._uid, constant=True)
+    type = Property(str, lambda self: self._type.value, constant=True)
+    label = Property(str, lambda self: self._label, constant=True)
+    icon = Property(str, lambda self: self._icon, constant=True)
+    tooltip = Property(str, lambda self: self._tooltip, constant=True)
+    shortcut = Property(str, lambda self: self._shortcut, constant=True)
+    # type: Menu
+    submenu = Property(Variant, lambda self: self._submenu, constant=True)
+    # type: Checkbox
+    checkedChanged = Signal()
+    checked = Property(bool, lambda self: self._checked, _setChecked, notify=checkedChanged)
+    # type: RadioButton
+    selectedUidChanged = Signal()
+    selectedUid = Property(str, lambda self: self._selectedUid, _setSelectedUid, notify=selectedUidChanged)
+    items = Property("QVariantList", lambda self: self._items, constant=True)
+
+
+class Menu(BaseObject):
+    """Registerable menu (or submenu)."""
+
+    def __init__(self, name: str, icon: str = None, tooltip: str = None,
+                 parent: "Menu" = None, index: int = -1):
+        super().__init__(parent)
+        self._uid: str = uuid.uuid4().hex
+        self._name: str = name
+        self._icon: str = icon or ""
+        self._tooltip: str = tooltip or ""
+        self.parentMenu: "Menu" = parent
+        self.index: int = index
+        self.menuObject = MenuObject(
+            parent=self, callback=None, type=MenuObjectType.MENU,
+            # and kwargs :
+            name=name, label=name, icon=icon, tooltip=tooltip, index=index
+        )
+        self._objects: ListModel = ListModel(parent=self)
+
+    def __repr__(self):
+        return f'<Menu name="{self._name}"|uid={self._uid}|size={len(self._objects)}>'
+    
+    def _addObject(self, obj: MenuObject):
+        self._objects.append(obj)
+        self.objectsChanged.emit()
+
+    def addSubmenu(self, name, icon=None, tooltip="", index=-1) -> "Menu":
+        submenu = Menu(name, icon=icon, tooltip=tooltip, parent=self, index=index)
+        submenu.menuObject._setSubmenu(submenu)
+        self._addObject(submenu.menuObject)
+        return submenu
+
+    def addSeparator(self, index=-1):
+        obj = MenuObject(self, None, MenuObjectType.SEPARATOR, index=index)
+        self._addObject(obj)
+        return obj
+
+    def addButton(self, name, callback: MenuCallback, label=None,
+                  icon=None, tooltip="", index=-1, shortcut=None):
+        obj = MenuObject(self, callback, MenuObjectType.BUTTON,
+                         name=name, label=label or name, icon=icon,
+                         tooltip=tooltip, index=index, shortcut=shortcut)
+        self._addObject(obj)
+        return obj
+
+    def addCheckbox(self, name, callback: MenuCallback, label=None, icon=None,
+                     tooltip="", index=-1, shortcut=None, checked=False):
+        obj = MenuObject(self, callback, MenuObjectType.CHECKBOX,
+                          name=name, label=label or name, icon=icon,
+                          tooltip=tooltip, index=index, shortcut=shortcut,
+                          checked=checked)
+        self._addObject(obj)
+        return obj
+
+    def addRadioButton(self, name, items: list[MenuItem], callback: MenuCallback,
+                        label=None, icon=None, tooltip="", index=-1):
+        """
+        Acts as a sub-menu: each entry in `items` becomes a selectable radio entry.
+        """
+        for item in items:
+            item.setParent(self)
+
+        group = MenuObject(self, callback, MenuObjectType.RADIOBUTTON,
+                           name=name, label=label or name, icon=icon,
+                           tooltip=tooltip, index=index, items=items)
+        if items:
+            group.selectedUid = items[0].name
+        self._addObject(group)
+        return group
+
+    def onCreated(self):
+        """Override to react once the menu has been registered (e.g. add entries)."""
+        pass
+
+    objectsChanged = Signal()
+    uid = Property(str, lambda self: self._uid, constant=True)
+    label = Property(str, lambda self: self._name, constant=True)
+    icon = Property(str, lambda self: self._icon, constant=True)
+    tooltip = Property(str, lambda self: self._tooltip, constant=True)
+    objects = Property(Variant, lambda self: self._objects, notify=objectsChanged)
+
+
+class MeshroomMenuManager(BaseObject):
+    """
+    Registry of all user menus and their objects.
+    
+    - _menus are the list of menus that are registered
+    - _objects is a dict to retrieve objects from their UID. The interface has access to the object
+      UID and therefore when we click on it, we retrieve the object throught the UID and we can
+      call the callback
+    - _menuModel is a ListModel built upon the _menus so that we can instanciate the QML objects
+    """
+
+    _menus: list[Menu] = []
+    _objects: dict[str, MenuObject] = {}
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self._menuModel: ListModel = ListModel(parent=self)
+        self._menuModel.extend(self._menus)
+        logging.info(f"Initialize MeshroomMenuManager with {len(self._menus)} menus.")
+        for menu in self._menus:
+            logging.info(f"Adding user menu: {menu}")
+            menu.onCreated()
+
+    @property
+    def app(self):
+        return self.parent()
+
+    @classmethod
+    def _indexMenu(cls, menu: Menu):
+        """ Build the _objects map
+        """
+        cls._objects[menu.menuObject.uid] = menu.menuObject
+        for obj in menu._objects:  # iterate CoreListModel/QObjectListModel directly
+            cls._objects[obj.uid] = obj
+            if obj.type == MenuObjectType.MENU.value:
+                cls._indexMenu(obj.submenu)
+
+    @classmethod
+    def registerMenu(cls, menu: Menu):
+        cls._menus.append(menu)
+        cls._indexMenu(menu)
+
+    def getMenus(self) -> ListModel:
+        return self._menuModel
+
+    def getObject(self, uid: str) -> Optional[MenuObject]:
+        return self._objects.get(uid)
+
+    def trigger(self, uid: str, **kwargs):
+        obj = self.getObject(uid)
+        if obj is None:
+            return None
+        return obj.trigger(self.app, **kwargs)
+
+    @Slot(str)
+    def triggerButton(self, uid: str):
+        self.trigger(uid)
+
+    @Slot(str, bool)
+    def triggerCheckbox(self, uid: str, checked: bool):
+        obj = self.getObject(uid)
+        if obj is None:
+            return
+        obj.checked = checked
+        self.trigger(uid, enabled=checked)
+
+    @Slot(str, str)
+    def triggerRadioEntry(self, groupUid: str, entryName: str):
+        obj = self.getObject(groupUid)
+        if obj is None or obj.type != MenuObjectType.RADIOBUTTON.value:
+            return
+        item = next((i for i in obj.items if i.name == entryName), None)
+        if item is None:
+            return
+        obj.selectedUid = entryName
+        self.trigger(groupUid, selected=item)
+
+    menusChanged = Signal()
+    menus = Property(BaseObject, getMenus, notify=menusChanged)

--- a/meshroom/ui/menu.py
+++ b/meshroom/ui/menu.py
@@ -29,14 +29,6 @@ class MenuCallback:
         pass
 
 
-class MenuObjectType(Enum):
-    MENU = "menu"
-    SEPARATOR = "separator"
-    BUTTON = "button"
-    CHECKBOX = "checkbox"
-    RADIOBUTTON = "radioButton"
-
-
 class MenuItem(BaseObject):
     """A simple (name, label) pair, used for radio button entries."""
 
@@ -54,54 +46,28 @@ class MenuItem(BaseObject):
 
 
 class MenuObject(BaseObject):
+    """Item registered as an entry in a menu.
     """
-    Item registered as an entry in a menu.
-    Can be either: a menu, a separator, a button, a checkbox, a radioButton.
-    """
-
-    def __init__(self, parent: "Menu", callback: Optional[MenuCallback],
-                 menuObjectType: MenuObjectType, **kwargs):
-        if menuObjectType not in MenuObjectType:
-            raise ValueError(
-                f"Invalid MenuObject type: {menuObjectType} (valid types are " +
-                ", ".join(m.name for m in MenuObjectType) + ")"
-            )
-
+    def __init__(self, parent: "Menu", callback: Optional[MenuCallback], **kwargs):
         super().__init__(parent)
+
+        self.menuObjectType = None
 
         self._uid: str = uuid.uuid4().hex
         self.parentMenu: "Menu" = parent
         self.callback: Callable = callback
-        self.menuObjectType: MenuObjectType = menuObjectType
 
         # General properties
         self._name: str = kwargs.get("name", "")
         self._label: str = kwargs.get("label", self._name)
-        self._icon: str = kwargs.get("icon", "")
-        self._tooltip: str = kwargs.get("tooltip", "")
-        self._shortcut: str = kwargs.get("shortcut", "")
+        self._icon: str = kwargs.get("icon") or ""
+        self._tooltip: str = kwargs.get("tooltip") or ""
+        self._shortcut: str = kwargs.get("shortcut") or ""
         self.index: int = kwargs.get("index", -1)
 
-        # Menu
-        self._submenu: "Menu" = kwargs.get("submenu", None)
-        # Checkbox
-        self._checked: bool = kwargs.get("checked", False)
-        # Radio Button
-        self._items: list = kwargs.get("items") or []
-        self._selectedUid: str = kwargs.get("selectedUid", "")
-
-    def _setSubmenu(self, menu: "Menu"):
-        self._submenu = menu
-
-    def _setChecked(self, value):
-        if self._checked != value:
-            self._checked = value
-            self.checkedChanged.emit()
-
-    def _setSelectedUid(self, value):
-        if self._selectedUid != value:
-            self._selectedUid = value
-            self.selectedUidChanged.emit()
+    @classmethod
+    def allMenuTypes(cls):
+        return [t.menuObjectType for t in cls.__subclasses__()]
 
     def trigger(self, app, **kwargs):
         if self.callback is not None:
@@ -109,17 +75,64 @@ class MenuObject(BaseObject):
         return None
 
     uid = Property(str, lambda self: self._uid, constant=True)
-    objectType = Property(str, lambda self: self.menuObjectType.value, constant=True)
+    objectType = Property(str, lambda self: self.menuObjectType, constant=True)
     label = Property(str, lambda self: self._label, constant=True)
     icon = Property(str, lambda self: self._icon, constant=True)
     tooltip = Property(str, lambda self: self._tooltip, constant=True)
     shortcut = Property(str, lambda self: self._shortcut, constant=True)
-    # type: Menu
+
+
+class MenuTypeMenu(MenuObject):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.menuObjectType = "menu"
+        self._submenu: "Menu" = kwargs.get("submenu", None)
+
+    def _setSubmenu(self, menu: "Menu"):
+        self._submenu = menu
+
     submenu = Property(Variant, lambda self: self._submenu, constant=True)
-    # type: Checkbox
+
+
+class MenuTypeSeparator(MenuObject):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.menuObjectType = "separator"
+
+
+class MenuTypeButton(MenuObject):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.menuObjectType = "button"
+
+
+class MenuTypeCheckbox(MenuObject):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.menuObjectType = "checkbox"
+        self._checked: bool = kwargs.get("checked", False)
+
+    def _setChecked(self, value):
+        if self._checked != value:
+            self._checked = value
+            self.checkedChanged.emit()
+
     checkedChanged = Signal()
     checked = Property(bool, lambda self: self._checked, _setChecked, notify=checkedChanged)
-    # type: RadioButton
+
+
+class MenuTypeRadiobutton(MenuObject):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.menuObjectType = "radiobutton"
+        self._items: list = kwargs.get("items") or []
+        self._selectedUid: str = kwargs.get("selectedUid", "")
+
+    def _setSelectedUid(self, value):
+        if self._selectedUid != value:
+            self._selectedUid = value
+            self.selectedUidChanged.emit()
+
     selectedUidChanged = Signal()
     selectedUid = Property(str, lambda self: self._selectedUid, _setSelectedUid, notify=selectedUidChanged)
     items = Property("QVariantList", lambda self: self._items, constant=True)
@@ -137,10 +150,8 @@ class Menu(BaseObject):
         self._tooltip: str = tooltip or ""
         self.parentMenu: "Menu" = parent
         self.index: int = index
-        self.menuObject = MenuObject(
-            parent=self, callback=None, menuObjectType=MenuObjectType.MENU,
-            # and kwargs :
-            name=name, label=name, icon=icon, tooltip=tooltip, index=index
+        self.menuObject = MenuTypeMenu(
+            self, None, name=name, label=name, icon=icon, tooltip=tooltip, index=index
         )
         self._objects: ListModel = ListModel(parent=self)
         self._initialized = False
@@ -159,24 +170,21 @@ class Menu(BaseObject):
         return submenu
 
     def addSeparator(self, index=-1):
-        obj = MenuObject(self, None, MenuObjectType.SEPARATOR, index=index)
+        obj = MenuTypeSeparator(self, None, index=index)
         self._addObject(obj)
         return obj
 
     def addButton(self, name, callback: MenuCallback, label=None,
                   icon=None, tooltip="", index=-1, shortcut=None):
-        obj = MenuObject(self, callback, MenuObjectType.BUTTON,
-                         name=name, label=label or name, icon=icon,
-                         tooltip=tooltip, index=index, shortcut=shortcut)
+        obj = MenuTypeButton(self, callback, name=name, label=label or name, icon=icon, 
+                             tooltip=tooltip, index=index, shortcut=shortcut)
         self._addObject(obj)
         return obj
 
     def addCheckbox(self, name, callback: MenuCallback, label=None, icon=None,
                      tooltip="", index=-1, shortcut=None, checked=False):
-        obj = MenuObject(self, callback, MenuObjectType.CHECKBOX,
-                          name=name, label=label or name, icon=icon,
-                          tooltip=tooltip, index=index, shortcut=shortcut,
-                          checked=checked)
+        obj = MenuTypeCheckbox(self, callback, name=name, label=label or name, icon=icon, 
+                               tooltip=tooltip, index=index, shortcut=shortcut, checked=checked)
         self._addObject(obj)
         return obj
 
@@ -188,9 +196,9 @@ class Menu(BaseObject):
         for item in items:
             item.setParent(self)
 
-        group = MenuObject(self, callback, MenuObjectType.RADIOBUTTON,
-                           name=name, label=label or name, icon=icon,
-                           tooltip=tooltip, index=index, items=items)
+        group = MenuTypeRadiobutton(self, callback, name=name, label=label or name,
+                                    icon=icon, tooltip=tooltip, index=index, items=items)
+
         if items:
             group.selectedUid = items[0].name
         self._addObject(group)
@@ -259,9 +267,7 @@ class MeshroomMenuManager(BaseObject):
     # _menuExtensions can be attached to top-level menus
     _menuExtensions: dict[str, list["MenuExtension"]] = {}
     
-    LIST_OBJ_TYPES = [
-        MenuObjectType.RADIOBUTTON.value
-    ]
+    LIST_OBJ_TYPES = (MenuTypeRadiobutton,)
 
     def __init__(self, parent=None):
         self._indexMenuExtensions()
@@ -295,7 +301,7 @@ class MeshroomMenuManager(BaseObject):
         cls._objects[menu.menuObject.uid] = menu.menuObject
         for obj in menu._objects:  # iterate CoreListModel/QObjectListModel directly
             cls._objects[obj.uid] = obj
-            if obj.objectType == MenuObjectType.MENU.value:
+            if isinstance(obj, MenuTypeMenu):
                 cls._indexMenu(obj.submenu)
 
     @classmethod
@@ -355,7 +361,7 @@ class MeshroomMenuManager(BaseObject):
     @Slot(str, str)
     def triggerListEntry(self, groupUid: str, entryName: str):
         obj = self.getObject(groupUid)
-        if obj is None or obj.menuObjectType in self.LIST_OBJ_TYPES:
+        if not isinstance(obj, self.LIST_OBJ_TYPES):
             return
         item = next((i for i in obj.items if i.name == entryName), None)
         if item is None:

--- a/meshroom/ui/menu.py
+++ b/meshroom/ui/menu.py
@@ -208,6 +208,39 @@ class Menu(BaseObject):
     objects = Property(Variant, lambda self: self._objects, notify=objectsChanged)
 
 
+class MenuExtension:
+    """Object used to extend another existing menu.
+    You can use a MenuExtension and then use the `registerMenuExtension`
+    method of `MeshroomMenuManager` to add entries to a top-level menu.
+    """
+
+    parent: str = None
+
+    def __init__(self):
+        self.parentMenu: Optional[Menu] = None
+
+    def _bind(self, parentMenu: Menu):
+        self.parentMenu = parentMenu
+        self.register()
+
+    def register(self):
+        """ Populate the parent menu with new items. """
+        raise NotImplementedError(
+            f"{self.__class__.__name__} needs to override the 'register' method."
+        )
+
+    def __getattr__(self, name):
+        if not name.startswith("add"):
+            raise AttributeError(
+                f"attribute {name!r} should start with 'add'"
+            )
+        if hasattr(self.parentMenu, name):
+            return getattr(self.parentMenu, name)
+        raise AttributeError(
+            f"{type(self).__name__!r} object has no attribute {name!r}"
+        )
+
+
 class MeshroomMenuManager(BaseObject):
     """
     Registry of all user menus and their objects.
@@ -221,12 +254,17 @@ class MeshroomMenuManager(BaseObject):
 
     _menus: list[Menu] = []
     _objects: dict[str, MenuObject] = {}
+    # _menusByName contains only top-level menus
+    _menusByName: dict[str, Menu] = {}
+    # _menuExtensions can be attached to top-level menus
+    _menuExtensions: dict[str, list["MenuExtension"]] = {}
     
     LIST_OBJ_TYPES = [
         MenuObjectType.RADIOBUTTON.value
     ]
 
     def __init__(self, parent=None):
+        self._indexMenuExtensions()
         super().__init__(parent)
         self._menuModel: ListModel = ListModel(parent=self)
         self._menuModel.setObjectList(self._menus)
@@ -241,8 +279,10 @@ class MeshroomMenuManager(BaseObject):
     @classmethod  
     def clear(cls):  
         """Clear all registered menus and objects. Useful for testing and resetting state."""  
-        cls._menus.clear()  
-        cls._objects.clear()  
+        cls._menus.clear()
+        cls._objects.clear()
+        cls._menusByName.clear()
+        cls._menuExtensions.clear()
 
     @property
     def app(self):
@@ -259,9 +299,34 @@ class MeshroomMenuManager(BaseObject):
                 cls._indexMenu(obj.submenu)
 
     @classmethod
+    def _indexMenuExtensions(cls):
+        for parentMenuName, extensions in cls._menuExtensions.items():
+            parentMenu = cls._menusByName.get(parentMenuName)
+            if parentMenu is None:
+                logging.error(
+                    f"Parent menu '{parentMenuName}' is not registered: "
+                    f"cannot add {len(extensions)} extension(s)"
+                    f" ({', '.join(e.__class__.__name__ for e in extensions)})."
+                )
+                continue
+            for extension in extensions:
+                extension._bind(parentMenu)
+                # re-index parent menus
+                cls._indexMenu(parentMenu)
+
+    @classmethod
     def registerMenu(cls, menu: Menu):
         cls._menus.append(menu)
+        cls._menusByName[menu._name] = menu
         cls._indexMenu(menu)
+
+    @classmethod
+    def registerMenuExtension(cls, extension: MenuExtension):
+        """Register a menu to append to another menu.
+        It's first added in the _menuExtensions dict and then indexed during the initialization
+        of MeshroomMenuManager.
+        """
+        cls._menuExtensions.setdefault(extension.parent, []).append(extension)
 
     def getMenus(self) -> ListModel:
         return self._menuModel

--- a/meshroom/ui/qml/Application.qml
+++ b/meshroom/ui/qml/Application.qml
@@ -690,6 +690,8 @@ Page {
             }
         }
         MenuBar {
+            id: menuBar
+
             palette.window: Qt.darker(activePalette.window, 1.15)
             Menu {
                 title: "File"
@@ -946,6 +948,7 @@ Page {
                     onTriggered: _window.close()
                 }
             }
+
             Menu {
                 title: "Edit"
                 MenuItem {
@@ -999,6 +1002,7 @@ Page {
                     }
                 }
             }
+
             Menu {
                 title: "View"
                 MenuItem {
@@ -1040,6 +1044,7 @@ Page {
                     onTriggered: _window.visibility == ApplicationWindow.FullScreen ? _window.showNormal() : showFullScreen()
                 }
             }
+
             Menu {
                 title: "Process"
                 Action {
@@ -1074,6 +1079,21 @@ Page {
                     }
                 }
             }
+
+            Instantiator {
+                model: MeshroomMenuManager.menus
+
+                delegate: UserMenu {
+                    // Required to have the index because UserMenu is not an Item/Component
+                    required property int index
+
+                    menuData: MeshroomMenuManager.menus.at(index)
+                }
+
+                onObjectAdded: (index, object) => menuBar.insertMenu(menuBar.count - 1, object)
+                onObjectRemoved: (index, object) => menuBar.removeMenu(object)
+            }
+
             Menu {
                 title: "Help"
                 Action {

--- a/meshroom/ui/qml/Controls/UserMenu.qml
+++ b/meshroom/ui/qml/Controls/UserMenu.qml
@@ -18,9 +18,9 @@ Menu {
             required property var itemData
 
             text: itemData.label
-            icon.source: itemData.icon
-            checkable: itemData.type === "checkbox"
-            checked: itemData.type === "checkbox" ? itemData.checked : false
+            icon.source: itemData.icon !== "" ? itemData.icon : undefined
+            checkable: itemData.objectType === "checkbox"
+            checked: itemData.objectType === "checkbox" ? itemData.checked : false
 
             ToolTip.visible: hovered && itemData.tooltip !== ""
             ToolTip.text: itemData.tooltip
@@ -34,7 +34,7 @@ Menu {
             onTriggered: trigger()
 
             function trigger() {
-                if (itemData.type === "checkbox")
+                if (itemData.objectType === "checkbox")
                     MeshroomMenuManager.triggerCheckbox(itemData.uid, checked)
                 else
                     MeshroomMenuManager.triggerButton(itemData.uid)
@@ -88,7 +88,7 @@ Menu {
         for (let i = 0; i < items.count; ++i) {
             const itemData = items.at(i)
 
-            switch (itemData.type) {
+            switch (itemData.objectType) {
                 case "separator": {
                     const sep = separatorComponent.createObject(null)
                     _createdItems.push(sep)

--- a/meshroom/ui/qml/Controls/UserMenu.qml
+++ b/meshroom/ui/qml/Controls/UserMenu.qml
@@ -28,6 +28,7 @@ Menu {
             Shortcut {
                 sequence: itemData.shortcut || ""
                 enabled: itemData.shortcut !== ""
+                context: Qt.ApplicationShortcut
                 onActivated: trigger()
             }
 

--- a/meshroom/ui/qml/Controls/UserMenu.qml
+++ b/meshroom/ui/qml/Controls/UserMenu.qml
@@ -95,7 +95,7 @@ Menu {
                     _createdItems.push(subMenu)
                     break
                 }
-                case "radioButton": {
+                case "radiobutton": {
                     const groupMenu = radioMenuComponent.createObject(null, {"itemData": itemData})
                     root.insertMenu(i, groupMenu)
                     _createdItems.push(groupMenu)

--- a/meshroom/ui/qml/Controls/UserMenu.qml
+++ b/meshroom/ui/qml/Controls/UserMenu.qml
@@ -1,0 +1,129 @@
+import QtQuick
+import QtQuick.Controls
+
+Menu {
+    id: root
+    required property var menuData
+
+    title: (menuData != undefined) ? menuData.label : ""
+
+    // HACK: Avoid issues created by the garbage collector
+    // Components are created in buildMenu and this means the
+    // GC can remove items.
+    property var _createdItems: []
+
+    Component {
+        id: menuItemComponent
+        MenuItem {
+            required property var itemData
+
+            text: itemData.label
+            icon.source: itemData.icon
+            checkable: itemData.type === "checkbox"
+            checked: itemData.type === "checkbox" ? itemData.checked : false
+
+            ToolTip.visible: hovered && itemData.tooltip !== ""
+            ToolTip.text: itemData.tooltip
+
+            Shortcut {
+                sequence: itemData.shortcut || ""
+                enabled: itemData.shortcut !== ""
+                onActivated: trigger()
+            }
+
+            onTriggered: trigger()
+
+            function trigger() {
+                if (itemData.type === "checkbox")
+                    MeshroomMenuManager.triggerCheckbox(itemData.uid, checked)
+                else
+                    MeshroomMenuManager.triggerButton(itemData.uid)
+            }
+        }
+    }
+
+    Component {
+        id: separatorComponent
+        MenuSeparator {}
+    }
+
+    Component {
+        id: radioMenuComponent
+        Menu {
+            required property var itemData
+            title: itemData.label
+        }
+    }
+
+    Component {
+        id: radioMenuItemComponent
+        MenuItem {
+            required property var groupData
+            required property var entryData
+
+            text: entryData.label
+            checkable: true
+            autoExclusive: true
+            checked: groupData.selectedUid === entryData.name
+
+            ToolTip.visible: hovered && entryData.tooltip !== ""
+            ToolTip.text: entryData.tooltip
+
+            onTriggered: MeshroomMenuManager.triggerRadioEntry(groupData.uid, entryData.name)
+        }
+    }
+
+    Component.onCompleted: {
+        if (menuData !== undefined)
+            buildMenu()
+    }
+
+    function buildMenu() {
+        if (menuData == undefined)
+            return
+
+        const items = menuData.objects
+        _createdItems = []  // reset
+
+        for (let i = 0; i < items.count; ++i) {
+            const itemData = items.at(i)
+
+            switch (itemData.type) {
+                case "separator": {
+                    const sep = separatorComponent.createObject(null)
+                    _createdItems.push(sep)
+                    root.insertItem(i, sep)
+                    break
+                }
+                case "menu": {
+                    const subMenuComponent = Qt.createComponent(Qt.resolvedUrl("UserMenu.qml"))
+                    const subMenu = subMenuComponent.createObject(null, {"menuData": itemData.submenu})
+                    _createdItems.push(subMenu)
+                    root.insertMenu(i, subMenu)
+                    break
+                }
+                case "radioButton": {
+                    const groupMenu = radioMenuComponent.createObject(null, {"itemData": itemData})
+                    const entries = itemData.items || []
+                    for (let j = 0; j < entries.length; ++j) {
+                        const entry = radioMenuItemComponent.createObject(null, {
+                            "groupData": itemData,
+                            "entryData": entries[j]
+                        })
+                        groupMenu.insertItem(j, entry)
+                        _createdItems.push(entry)
+                    }
+                    root.insertMenu(i, groupMenu)
+                    _createdItems.push(groupMenu)
+                    break
+                }
+                default: {
+                    const item = menuItemComponent.createObject(null, {"itemData": itemData})
+                    _createdItems.push(item)
+                    root.insertItem(i, item)
+                    break
+                }
+            }
+        }
+    }
+}

--- a/meshroom/ui/qml/Controls/UserMenu.qml
+++ b/meshroom/ui/qml/Controls/UserMenu.qml
@@ -52,24 +52,16 @@ Menu {
         Menu {
             required property var itemData
             title: itemData.label
-        }
-    }
 
-    Component {
-        id: radioMenuItemComponent
-        MenuItem {
-            required property var groupData
-            required property var entryData
-
-            text: entryData.label
-            checkable: true
-            autoExclusive: true
-            checked: groupData.selectedUid === entryData.name
-
-            ToolTip.visible: hovered && entryData.tooltip !== ""
-            ToolTip.text: entryData.tooltip
-
-            onTriggered: MeshroomMenuManager.triggerRadioEntry(groupData.uid, entryData.name)
+            Repeater {
+                model: itemData.items
+                RadioButton {
+                    required property var modelData
+                    text: modelData.label
+                    checked: itemData.selectedUid === modelData.name
+                    onClicked: MeshroomMenuManager.triggerListEntry(itemData.uid, modelData.name)
+                }
+            }
         }
     }
 
@@ -91,36 +83,27 @@ Menu {
             switch (itemData.objectType) {
                 case "separator": {
                     const sep = separatorComponent.createObject(null)
-                    _createdItems.push(sep)
                     root.insertItem(i, sep)
+                    _createdItems.push(sep)
                     break
                 }
                 case "menu": {
                     const subMenuComponent = Qt.createComponent(Qt.resolvedUrl("UserMenu.qml"))
                     const subMenu = subMenuComponent.createObject(null, {"menuData": itemData.submenu})
-                    _createdItems.push(subMenu)
                     root.insertMenu(i, subMenu)
+                    _createdItems.push(subMenu)
                     break
                 }
                 case "radioButton": {
                     const groupMenu = radioMenuComponent.createObject(null, {"itemData": itemData})
-                    const entries = itemData.items || []
-                    for (let j = 0; j < entries.length; ++j) {
-                        const entry = radioMenuItemComponent.createObject(null, {
-                            "groupData": itemData,
-                            "entryData": entries[j]
-                        })
-                        groupMenu.insertItem(j, entry)
-                        _createdItems.push(entry)
-                    }
                     root.insertMenu(i, groupMenu)
                     _createdItems.push(groupMenu)
                     break
                 }
                 default: {
                     const item = menuItemComponent.createObject(null, {"itemData": itemData})
-                    _createdItems.push(item)
                     root.insertItem(i, item)
+                    _createdItems.push(item)
                     break
                 }
             }

--- a/meshroom/ui/qml/Controls/qmldir
+++ b/meshroom/ui/qml/Controls/qmldir
@@ -1,5 +1,6 @@
 module Controls
 
+UserMenu 1.0 UserMenu.qml
 ColorChart 1.0 ColorChart.qml
 ColorSelector 1.0 ColorSelector.qml
 ExpandableGroup 1.0 ExpandableGroup.qml


### PR DESCRIPTION
## Description

New feature to add user-defined menus.
<img width="442" height="203" alt="image" src="https://github.com/user-attachments/assets/c0b298cf-94d2-4cb8-9487-06c9b9cd769b" />


### Features

- Create Menu
- Add different items inside :
  - A sub-menu
  - A button
  - A checkbox
  - A radio button (choose option in a list of checkbox)
- Attach callbacks on clickable items
- Callbacks are either callable object or a function with specific params 
- Callbacks have access to the `MeshroomApp` instance so that we can access the node graph
- Callbacks have access to the menu object : for radio buttons, it enables having access to menu items, ...
- We also pass kwargs which change depending on the context (checked status for checkbox, selected item for radio button, etc)
- Each menu entry can have these properties :
  - `name` : name
  - `label` : display label (`name` by default)
  - `icon` : for menu entry and buttons
  - `tooltip` : display detailed message about the entry
  - `shortcut` : shortcut to call the entry
  - `index` : insert index (by default last one)
- Meshroom looks for a `menu.py` script in the `meshroom` folder of plugins to load menus.

### How the API looks

```bash
import logging
from meshroom.api import register_menu, Menu, MenuItem, MenuCallback

# === Callbacks ===

def say_hello(menu, app, **kwargs):
    logging.info("[MenuTest] Hello from the 'Say Hello' button!")
    app.showMessage("Hello from the Menu Test plugin!", duration=3000)


class ToggleVerboseLogging(MenuCallback):
    def __call__(self, menu, app, **kwargs):
        enabled = kwargs.get("enabled", False)
        level = "debug" if enabled else "info"
        logging.getLogger().setLevel(level.upper())
        logging.info(f"[MenuTest] Verbose logging {'enabled' if enabled else 'disabled'}.")


# === Create the Menu ===

user_menu = Menu("Settings")

user_menu.addButton(
    "sayHello",
    label="Say Hello",
    callback=say_hello,
    tooltip="Show a status bar message",
    icon="testMenu/meshroom/agitant-la-main.png", 
    shortcut="Ctrl+Alt+H",
)

user_menu.addSeparator()

user_menu.addCheckbox(
    "verboseLogging",
    label="Verbose Logging",
    callback=ToggleVerboseLogging(),
    tooltip="Toggle debug-level logging",
    checked=False,
)


# === Register the Menu ===

register_menu(user_menu)
```

Another example with a radio button :
```python
from meshroom.api import register_menu, Menu, MenuItem


def radioButtonCallback(menu, app, **kwargs):
    selected: MenuItem = kwargs["selected"]
    print(f"[MenuTest] Radiobutton selected: {selected.label}")
    app.showMessage(f"Radiobutton selected: {selected.label}", duration=2000)


menu_test = Menu("Test")

menu_test.addRadioButton(
    "testRadioButton",
    items=[
        MenuItem("a", label="A"),
        MenuItem("b", label="B"),
        MenuItem("c", label="C"),
    ],
    callback=radioButtonCallback,
)

register_menu(menu_test)
```

### Details

Here's how the code is organized. I ordered every file by logical order so you can review from the first to last file here :
- `core/`
  - `core/menu.py` : Define the Menu, MenuItem, MeshroomMenuManager, etc. All the objects used in the rest of the code, specific to a menu. Also build the list model for the QML part.
  - `core.__init__.py` : Add a `loadPluginMenu` function to find menus on plugins when launching Meshroom.
- `api/`
  - `api/menu.py` gives a top-level access to a register function. This is what should be used in plugins
  - `api/__init__.py` creates redirections to every useful class/function to create menus in plugins. That way every import should be :
  ```python
  from meshroom.api import Menu, register_menu, ...
  ```
- `ui/`
  - `ui/app.py` : set the menu manager as a context property to access it in QML
  - `ui/qml/Controls/userMenu.qml` : define the menu and components for every instanciable widget
    - `ui/qml/Application.qml` : Add Instantiator using the menu model.
