### PR TITLE
Fix `CompatibilityNodes` status handling and improve display

### DIFF
--- a/meshroom/core/node.py
+++ b/meshroom/core/node.py
@@ -1370,6 +1370,10 @@ class BaseNode(BaseObject):
     def hasStatus(self, status: Status):
         if self.isInputNode:
             return status == Status.INPUT
+        if self.isCompatibilityNode:
+            # CompatibilityNodes have no chunks but may still have a status
+            # Use it instead of defaulting to checking with Status.NONE
+            return status == self._nodeStatus.status
         if not self._chunks or not self._chunksCreated:
             return status == Status.NONE
         for chunk in self.getAllChunks():

--- a/meshroom/ui/qml/GraphEditor/CompatibilityBadge.qml
+++ b/meshroom/ui/qml/GraphEditor/CompatibilityBadge.qml
@@ -33,7 +33,9 @@ Loader {
             MouseArea {
                 anchors.fill: parent
                 hoverEnabled: true
-                onPressed: mouse.accepted = false
+                onPressed: function(mouse) {
+                    mouse.accepted = false
+                }
                 ToolTip.text: issueDetails
                 ToolTip.visible: containsMouse
             }

--- a/meshroom/ui/qml/GraphEditor/Node.qml
+++ b/meshroom/ui/qml/GraphEditor/Node.qml
@@ -635,11 +635,23 @@ Item {
                     implicitHeight: 3
                     width: parent.width
 
+                    ListModel {
+                        id: compatibilityModel
+                    }
+
                     model: {
-                        if (node && node.chunksCreated)
+                        if (!node)
+                            return undefined
+
+                        if (node.chunksCreated)
                             return node.chunks
-                        else if (node && !node.chunksCreated)
+                        else if (!node.chunksCreated && !node.isCompatibilityNode)
                             return node.chunkPlaceholder
+                        else if (node.isCompatibilityNode && !["NONE"].includes(node.globalStatus)) {
+                            compatibilityModel.clear()
+                            compatibilityModel.append({ "object": { "statusName": node.globalStatus } })
+                            return compatibilityModel
+                        }
 
                         return undefined
                     }


### PR DESCRIPTION
## Description

This PR fixes an issue in the evaluation of the status for compatibility nodes. 

When evaluating whether a node can be computed, we check if it is topologically computable, meaning:
- it is not a compatibility node
- it does not have a non-computed compatibility node in its chain of dependencies.
 
However, checking whether a compatibility node was computed always evaluated to false, as it fell into a check relying on the  chunks (which are not available in the case of compatibility nodes). 

Additionally and for clarity, we now correctly display the status of compatibility nodes in the Graph Editor if they have been computed. This removes the need to select the compatibility node and check its "Status" tab to determine whether or not it had been computed.