### PR TITLE
Plugins: Use unique names

### DIFF
--- a/meshroom/core/__init__.py
+++ b/meshroom/core/__init__.py
@@ -43,7 +43,7 @@ def hashValue(value) -> str:
 
 
 @contextmanager
-def add_to_path(p):
+def add_to_path(p, packageName=None, pluginUid: str = None):
     import sys
     old_path = sys.path
     sys.path = sys.path[:]
@@ -52,9 +52,26 @@ def add_to_path(p):
         yield
     finally:
         sys.path = old_path
+        # Rename all meshroom plugins modules so that they all
+        # have a unique module name.
+        if packageName is not None:
+            for modName in list(sys.modules):
+                if modName == packageName or modName.startswith(packageName + "."):
+                    mod = sys.modules.pop(modName)
+                    uniqueModName = f"{pluginUid}_{modName}"
+                    mod.__name__ = uniqueModName
+                    sys.modules[uniqueModName] = mod
+                    # Update the spec name, required for module reloading
+                    mod.__spec__.name = uniqueModName
+                    # Update classes __module__ so that all functions using
+                    # __module__ string lookup resolve correctly.
+                    for attrName in dir(mod):
+                        attr = getattr(mod, attrName)
+                        if isinstance(attr, type) and attr.__module__ == modName:
+                            attr.__module__ = uniqueModName
 
 
-def loadClasses(folder: str, packageName: str, classType: type) -> list[type]:
+def loadClasses(folder: str, packageName: str, classType: type, pluginUid: str = None) -> list[type]:
     """
     Go over the Python module named "packageName" located in "folder" to find files
     that contain classes of type "classType" and return these classes in a list.
@@ -63,13 +80,14 @@ def loadClasses(folder: str, packageName: str, classType: type) -> list[type]:
         folder: the folder to load the module from.
         packageName: the name of the module to look for nodes in.
         classType: the class to look for in the files that are inspected.
+        pluginUid: (optional) A unique node for the plugin where will be the nodes.
     """
     classes = []
     errors = []
 
     resolvedFolder = str(Path(folder).resolve())
     # temporarily add folder to python path
-    with add_to_path(resolvedFolder):
+    with add_to_path(resolvedFolder, packageName, pluginUid):
         # import node package
 
         try:
@@ -107,7 +125,7 @@ def loadClasses(folder: str, packageName: str, classType: type) -> list[type]:
                         logging.debug(f"No class defined in plugin: {package.__name__}.{pluginName} ('{pluginMod.__file__}')")
 
                 for p in plugins:
-                    p.packageName = packageName
+                    p.packageName = f"{pluginUid}_{packageName}"
                     p.packagePath = packagePath
                     if classType == desc.BaseNode:
                         nodePlugin = NodePlugin(p)
@@ -142,7 +160,7 @@ def loadClasses(folder: str, packageName: str, classType: type) -> list[type]:
     return classes
 
 
-def loadClassesNodes(folder: str, packageName: str) -> list[NodePlugin]:
+def loadClassesNodes(folder: str, packageName: str, pluginUid: str) -> list[NodePlugin]:
     """
     Return the list of all the NodePlugins that were created following the search of the
     Python module named "packageName" located in the folder "folder".
@@ -152,12 +170,13 @@ def loadClassesNodes(folder: str, packageName: str) -> list[NodePlugin]:
     Args:
         folder: the folder to load the module from.
         packageName: the name of the module to look for nodes in.
+        pluginUid: A unique node for the plugin where will be the nodes.
 
     Returns:
         list[NodePlugin]: a list of all the NodePlugins that were created based on the
                           module's search. If none has been created, an empty list is returned.
     """
-    return loadClasses(folder, packageName, desc.BaseNode)
+    return loadClasses(folder, packageName, desc.BaseNode, pluginUid=pluginUid)
 
 
 def loadClassesSubmitters(folder: str, packageName: str) -> list[BaseSubmitter]:
@@ -324,12 +343,12 @@ def nodeVersion(nodeDesc: desc.Node, default=None):
     return moduleVersion(nodeDesc.__module__, default)
 
 
-def loadNodes(folder, packageName) -> list[NodePlugin]:
+def loadNodes(folder, packageName, pluginUid) -> list[NodePlugin]:
     if not os.path.isdir(folder):
         logging.error(f"Node folder '{folder}' does not exist.")
         return []
 
-    nodes = loadClassesNodes(folder, packageName)
+    nodes = loadClassesNodes(folder, packageName, pluginUid)
     return nodes
 
 
@@ -338,7 +357,7 @@ def loadAllNodes(folder) -> list[Plugin]:
     for _, package, ispkg in pkgutil.iter_modules([folder]):
         if ispkg:
             plugin = Plugin(package, folder)
-            nodePlugins = loadNodes(folder, package)
+            nodePlugins = loadNodes(folder, package, plugin._uid)
             if nodePlugins:
                 for node in nodePlugins:
                     plugin.addNodePlugin(node)

--- a/meshroom/core/__init__.py
+++ b/meshroom/core/__init__.py
@@ -357,7 +357,7 @@ def loadAllNodes(folder) -> list[Plugin]:
     for _, package, ispkg in pkgutil.iter_modules([folder]):
         if ispkg:
             plugin = Plugin(package, folder)
-            nodePlugins = loadNodes(folder, package, plugin._uid)
+            nodePlugins = loadNodes(folder, package, plugin.uid)
             if nodePlugins:
                 for node in nodePlugins:
                     plugin.addNodePlugin(node)

--- a/meshroom/core/plugins.py
+++ b/meshroom/core/plugins.py
@@ -293,10 +293,14 @@ class Plugin(BaseObject):
         configFullEnv: the static merge of os.environ and configEnv, with os.environ taking precedence
         processEnv: the environment required for the nodes' processes to be correctly executed
     """
+    
+    _pluginLastUid = 0
 
     def __init__(self, name: str, path: str):
         super().__init__()
 
+        Plugin._pluginLastUid += 1
+        self._uid: str = f"{Plugin._pluginLastUid:04d}"
         self._name: str = name
         self._path: str = path
 
@@ -309,10 +313,18 @@ class Plugin(BaseObject):
         self.loadTemplates()
         self.loadConfig()
 
+    def __repr__(self):
+        return f"<Plugin {self._name} (uid={self._uid})>"
+
     @property
     def name(self):
         """ Return the name of the plugin. """
         return self._name
+    
+    @property
+    def uname(self):
+        """ Return the unique name of the plugin. """
+        return f"{self._uid}_{self._name}"
 
     @property
     def path(self):
@@ -634,18 +646,28 @@ class NodePluginManager(BaseObject):
         """
         return self._plugins
 
-    def getPlugin(self, name: str) -> Plugin:
+    def getPlugin(self, name: str, uname: bool = True) -> Plugin:
         """
-        Return the loaded Plugin object named "name".
+        Return the loaded Plugin object with "name".
 
         Args:
-            name: the name of the Plugin, used upon its loading.
+            name: the unique name of the Plugin, used upon its loading.
+            uname: the name passed as argument is the unique name of the plugin.
+                   if set to False, we will search for any plugin with this name
+                   but this means there can be a collision. To avoid any confusion
+                   use this function with the unique name as much as possible.
 
         Returns:
             Plugin | None: the loaded Plugin object if it exists, None otherwise.
         """
-        if name in self._plugins:
-            return self._plugins[name]
+        if uname:
+            # Find plugin with unique name
+            if name in self._plugins:
+                return self._plugins[name]
+        else:
+            for plugin in self._plugins.values():
+                if plugin.name == name:
+                    return plugin
         return None
 
     def addPlugin(self, plugin: Plugin, registerNodePlugins: bool = True):
@@ -658,11 +680,14 @@ class NodePluginManager(BaseObject):
                                  at the same time the plugin is being loaded. Otherwise, the
                                  NodePlugins will have to be registered at a later occasion.
         """
-        if not self.getPlugin(plugin.name):
-            self._plugins[plugin.name] = plugin
-            if registerNodePlugins:
-                for node in plugin.nodes:
-                    self.registerNode(plugin.nodes[node])
+        pluginUName = plugin.uname
+        if self.getPlugin(pluginUName):
+            logging.warning(f"Plugin {pluginUName} is already registered.")
+            return
+        self._plugins[pluginUName] = plugin
+        if registerNodePlugins:
+            for node in plugin.nodes:
+                self.registerNode(plugin.nodes[node])
 
     def removePlugin(self, plugin: Plugin, unregisterNodePlugins: bool = True):
         """
@@ -675,11 +700,11 @@ class NodePluginManager(BaseObject):
                                    the registered NodePlugins will remain while the Plugin itself will
                                    be unloaded.
         """
-        if self.getPlugin(plugin.name):
+        if self.getPlugin(plugin.uname):
             if unregisterNodePlugins:
                 for node in plugin.nodes.values():
                     self.unregisterNode(node)
-            del self._plugins[plugin.name]
+            del self._plugins[plugin.uname]
 
     def getRegisteredNodePlugins(self) -> dict[str: NodePlugin]:
         """

--- a/meshroom/core/plugins.py
+++ b/meshroom/core/plugins.py
@@ -317,6 +317,10 @@ class Plugin(BaseObject):
         return f"<Plugin {self._name} (uid={self._uid})>"
 
     @property
+    def uid(self):
+        return self._uid
+
+    @property
     def name(self):
         """ Return the name of the plugin. """
         return self._name

--- a/meshroom/core/plugins.py
+++ b/meshroom/core/plugins.py
@@ -294,13 +294,13 @@ class Plugin(BaseObject):
         processEnv: the environment required for the nodes' processes to be correctly executed
     """
     
-    _pluginLastUid = 0
+    _instancesCount = 0
 
     def __init__(self, name: str, path: str):
         super().__init__()
 
-        Plugin._pluginLastUid += 1
-        self._uid: str = f"{Plugin._pluginLastUid:04d}"
+        Plugin._instancesCount += 1
+        self._uid: str = f"{Plugin._instancesCount:04d}"
         self._name: str = name
         self._path: str = path
 

--- a/tests/test_compute.py
+++ b/tests/test_compute.py
@@ -248,7 +248,7 @@ class TestLockUpdates:
         folder = os.path.join(os.path.dirname(__file__), "plugins", "meshroom")
         package = "pluginA"
         cls.plugin = Plugin(package, folder)
-        nodes = loadClassesNodes(folder, package, pluginUid=cls.plugin._uid)
+        nodes = loadClassesNodes(folder, package, pluginUid=cls.plugin.uid)
         for node in nodes:
             cls.plugin.addNodePlugin(node)
         pluginManager.addPlugin(cls.plugin)

--- a/tests/test_compute.py
+++ b/tests/test_compute.py
@@ -248,7 +248,7 @@ class TestLockUpdates:
         folder = os.path.join(os.path.dirname(__file__), "plugins", "meshroom")
         package = "pluginA"
         cls.plugin = Plugin(package, folder)
-        nodes = loadClassesNodes(folder, package)
+        nodes = loadClassesNodes(folder, package, pluginUid=cls.plugin._uid)
         for node in nodes:
             cls.plugin.addNodePlugin(node)
         pluginManager.addPlugin(cls.plugin)

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -26,7 +26,7 @@ class TestNodeInfo:
         cls.folder = os.path.join(os.path.dirname(__file__), "plugins", "meshroom")
         package = "pluginC"
         cls.plugin = Plugin(package, cls.folder)
-        nodes = loadClassesNodes(cls.folder, package, pluginUid=cls.plugin._uid)
+        nodes = loadClassesNodes(cls.folder, package, pluginUid=cls.plugin.uid)
         for node in nodes:
             cls.plugin.addNodePlugin(node)
         pluginManager.addPlugin(cls.plugin)
@@ -71,7 +71,7 @@ class TestNodeVariables:
         folder = os.path.join(os.path.dirname(__file__), "plugins", "meshroom")
         package = "pluginA"
         cls.plugin = Plugin(package, folder)
-        nodes = loadClassesNodes(folder, package, pluginUid=cls.plugin._uid)
+        nodes = loadClassesNodes(folder, package, pluginUid=cls.plugin.uid)
         for node in nodes:
             cls.plugin.addNodePlugin(node)
         pluginManager.addPlugin(cls.plugin)
@@ -126,7 +126,7 @@ class TestInitNode:
         folder = os.path.join(os.path.dirname(__file__), "plugins", "meshroom")
         package = "pluginA"
         cls.plugin = Plugin(package, folder)
-        nodes = loadClassesNodes(folder, package, pluginUid=cls.plugin._uid)
+        nodes = loadClassesNodes(folder, package, pluginUid=cls.plugin.uid)
         for node in nodes:
             cls.plugin.addNodePlugin(node)
         pluginManager.addPlugin(cls.plugin)

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -26,7 +26,7 @@ class TestNodeInfo:
         cls.folder = os.path.join(os.path.dirname(__file__), "plugins", "meshroom")
         package = "pluginC"
         cls.plugin = Plugin(package, cls.folder)
-        nodes = loadClassesNodes(cls.folder, package)
+        nodes = loadClassesNodes(cls.folder, package, pluginUid=cls.plugin._uid)
         for node in nodes:
             cls.plugin.addNodePlugin(node)
         pluginManager.addPlugin(cls.plugin)
@@ -40,7 +40,9 @@ class TestNodeInfo:
 
     def test_loadedPlugin(self):
         assert len(pluginManager.getPlugins()) >= 1
-        plugin = pluginManager.getPlugin("pluginC")
+        plugin = pluginManager.getPlugin("pluginC", uname=False)
+        pluginUName = plugin.uname
+        assert pluginUName.endswith("pluginC")
         assert plugin == self.plugin
         node = plugin.nodes["PluginCNodeA"]
         nodeType = node.nodeDescriptor
@@ -52,7 +54,7 @@ class TestNodeInfo:
         nodeDocumentation = node.getDocumentation()
         assert nodeDocumentation == "PluginCNodeA"
         nodeInfo = {item["key"]: item["value"] for item in node.getNodeInfo()}
-        assert nodeInfo["module"] == "pluginC.PluginCNodeA"
+        assert nodeInfo["module"].endswith("pluginC.PluginCNodeA")
         pluginPath = os.path.join(self.folder, "pluginC", "PluginCNodeA.py")
         assert nodeInfo["modulePath"] == Path(pluginPath).as_posix()  # modulePath seems to follow Linux convention
         assert nodeInfo["author"] == "testAuthor"
@@ -69,7 +71,7 @@ class TestNodeVariables:
         folder = os.path.join(os.path.dirname(__file__), "plugins", "meshroom")
         package = "pluginA"
         cls.plugin = Plugin(package, folder)
-        nodes = loadClassesNodes(folder, package)
+        nodes = loadClassesNodes(folder, package, pluginUid=cls.plugin._uid)
         for node in nodes:
             cls.plugin.addNodePlugin(node)
         pluginManager.addPlugin(cls.plugin)
@@ -124,7 +126,7 @@ class TestInitNode:
         folder = os.path.join(os.path.dirname(__file__), "plugins", "meshroom")
         package = "pluginA"
         cls.plugin = Plugin(package, folder)
-        nodes = loadClassesNodes(folder, package)
+        nodes = loadClassesNodes(folder, package, pluginUid=cls.plugin._uid)
         for node in nodes:
             cls.plugin.addNodePlugin(node)
         pluginManager.addPlugin(cls.plugin)

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -17,7 +17,7 @@ class TestPluginWithValidNodesOnly:
         folder = os.path.join(os.path.dirname(__file__), "plugins", "meshroom")
         package = "pluginA"
         cls.plugin = Plugin(package, folder)
-        nodes = loadClassesNodes(folder, package, pluginUid=cls.plugin._uid)
+        nodes = loadClassesNodes(folder, package, pluginUid=cls.plugin.uid)
         for node in nodes:
             cls.plugin.addNodePlugin(node)
         pluginManager.addPlugin(cls.plugin)
@@ -28,7 +28,7 @@ class TestPluginWithValidNodesOnly:
             pluginManager.unregisterNode(node)
         pluginManager.removePlugin(cls.plugin)
         cls.plugin = None
-    
+
     def test_getPlugin(self):
         # Assert that there are loaded plugins, and that "pluginA" is one of them
         assert len(pluginManager.getPlugins()) >= 1
@@ -37,7 +37,7 @@ class TestPluginWithValidNodesOnly:
         assert plugin == self.plugin
         # Get with unique name
         pluginUName = self.plugin.uname
-        assert pluginUName == f"{self.plugin._uid}_pluginA"
+        assert pluginUName == f"{self.plugin.uid}_pluginA"
         plugin = pluginManager.getPlugin(pluginUName, uname=True)
         assert plugin == self.plugin
         # Check path too
@@ -135,7 +135,7 @@ class TestPluginWithInvalidNodes:
         folder = os.path.join(os.path.dirname(__file__), "plugins", "meshroom")
         package = "pluginB"
         cls.plugin = Plugin(package, folder)
-        nodes = loadClassesNodes(folder, package, pluginUid=cls.plugin._uid)
+        nodes = loadClassesNodes(folder, package, pluginUid=cls.plugin.uid)
         for node in nodes:
             cls.plugin.addNodePlugin(node)
         pluginManager.addPlugin(cls.plugin)

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -17,7 +17,7 @@ class TestPluginWithValidNodesOnly:
         folder = os.path.join(os.path.dirname(__file__), "plugins", "meshroom")
         package = "pluginA"
         cls.plugin = Plugin(package, folder)
-        nodes = loadClassesNodes(folder, package)
+        nodes = loadClassesNodes(folder, package, pluginUid=cls.plugin._uid)
         for node in nodes:
             cls.plugin.addNodePlugin(node)
         pluginManager.addPlugin(cls.plugin)
@@ -28,14 +28,24 @@ class TestPluginWithValidNodesOnly:
             pluginManager.unregisterNode(node)
         pluginManager.removePlugin(cls.plugin)
         cls.plugin = None
+    
+    def test_getPlugin(self):
+        # Assert that there are loaded plugins, and that "pluginA" is one of them
+        assert len(pluginManager.getPlugins()) >= 1
+        # Get with name
+        plugin = pluginManager.getPlugin("pluginA", uname=False)
+        assert plugin == self.plugin
+        # Get with unique name
+        pluginUName = self.plugin.uname
+        assert pluginUName == f"{self.plugin._uid}_pluginA"
+        plugin = pluginManager.getPlugin(pluginUName, uname=True)
+        assert plugin == self.plugin
+        # Check path too
+        assert str(plugin.path) == os.path.join(os.path.dirname(__file__), "plugins", "meshroom")
 
     def test_loadedPlugin(self):
         # Assert that there are loaded plugins, and that "pluginA" is one of them
-        assert len(pluginManager.getPlugins()) >= 1
-        plugin = pluginManager.getPlugin("pluginA")
-        assert plugin == self.plugin
-        assert str(plugin.path) == os.path.join(os.path.dirname(__file__), "plugins", "meshroom")
-
+        plugin = pluginManager.getPlugin("pluginA", uname=False)
         # Assert that the nodes of pluginA have been successfully registered
         assert len(pluginManager.getRegisteredNodePlugins()) >= 2
         for nodeName, nodePlugin in plugin.nodes.items():
@@ -49,14 +59,14 @@ class TestPluginWithValidNodesOnly:
         assert plugin.templates[name] == os.path.join(str(plugin.path), "sharedTemplate.mg")
 
     def test_unloadPlugin(self):
-        plugin = pluginManager.getPlugin("pluginA")
+        plugin = pluginManager.getPlugin("pluginA", uname=False)
         assert plugin == self.plugin
 
         # Unload the plugin without unregistering the nodes
         pluginManager.removePlugin(plugin, unregisterNodePlugins=False)
 
         # Assert the plugin is not loaded anymore
-        assert pluginManager.getPlugin(plugin.name) is None
+        assert pluginManager.getPlugin(plugin.name, uname=False) is None
 
         # Assert the nodes are still registered and belong to an unloaded plugin
         for nodeName, nodePlugin in plugin.nodes.items():
@@ -66,13 +76,13 @@ class TestPluginWithValidNodesOnly:
 
         # Re-add the plugin
         pluginManager.addPlugin(plugin, registerNodePlugins=False)
-        assert pluginManager.getPlugin(plugin.name)
+        assert pluginManager.getPlugin(plugin.name, uname=False)
 
         # Unload the plugin with a full unregistration of the nodes
         pluginManager.removePlugin(plugin)
 
         # Assert the plugin is not loaded anymore
-        assert pluginManager.getPlugin(plugin.name) is None
+        assert pluginManager.getPlugin(plugin.name, uname=False) is None
 
         # Assert the nodes have been successfully unregistered
         for nodeName, nodePlugin in plugin.nodes.items():
@@ -81,14 +91,14 @@ class TestPluginWithValidNodesOnly:
 
         # Re-add the plugin and re-register the nodes
         pluginManager.addPlugin(plugin)
-        assert pluginManager.getPlugin(plugin.name)
+        assert pluginManager.getPlugin(plugin.name, uname=False)
         for nodeName, nodePlugin in plugin.nodes.items():
             assert nodePlugin.status == NodePluginStatus.LOADED
             assert pluginManager.isRegistered(nodeName)
 
     def test_updateRegisteredNodes(self):
         nbRegisteredNodes = len(pluginManager.getRegisteredNodePlugins())
-        plugin = pluginManager.getPlugin("pluginA")
+        plugin = pluginManager.getPlugin("pluginA", uname=False)
         assert plugin == self.plugin
         nodeA = pluginManager.getRegisteredNodePlugin("PluginANodeA")
         nodeAName = nodeA.nodeDescriptor.__name__
@@ -125,7 +135,7 @@ class TestPluginWithInvalidNodes:
         folder = os.path.join(os.path.dirname(__file__), "plugins", "meshroom")
         package = "pluginB"
         cls.plugin = Plugin(package, folder)
-        nodes = loadClassesNodes(folder, package)
+        nodes = loadClassesNodes(folder, package, pluginUid=cls.plugin._uid)
         for node in nodes:
             cls.plugin.addNodePlugin(node)
         pluginManager.addPlugin(cls.plugin)
@@ -140,7 +150,7 @@ class TestPluginWithInvalidNodes:
     def test_loadedPlugin(self):
         # Assert that there are loaded plugins, and that "pluginB" is one of them
         assert len(pluginManager.getPlugins()) >= 1
-        plugin = pluginManager.getPlugin("pluginB")
+        plugin = pluginManager.getPlugin("pluginB", uname=False)
         assert plugin == self.plugin
         assert str(plugin.path) == os.path.join(os.path.dirname(__file__), "plugins", "meshroom")
 
@@ -161,7 +171,7 @@ class TestPluginWithInvalidNodes:
         assert plugin.templates[name] == os.path.join(str(plugin.path), "sharedTemplate.mg")
 
     def test_reloadNodePluginInvalidDescrpition(self):
-        plugin = pluginManager.getPlugin("pluginB")
+        plugin = pluginManager.getPlugin("pluginB", uname=False)
         assert plugin == self.plugin
         node = plugin.nodes["PluginBNodeB"]
         nodeName = node.nodeDescriptor.__name__
@@ -220,7 +230,7 @@ class TestPluginWithInvalidNodes:
         assert not pluginManager.isRegistered(nodeName)
 
     def test_reloadNodePluginSyntaxError(self):
-        plugin = pluginManager.getPlugin("pluginB")
+        plugin = pluginManager.getPlugin("pluginB", uname=False)
         assert plugin == self.plugin
         node = plugin.nodes["PluginBNodeA"]
         nodeName = node.nodeDescriptor.__name__
@@ -265,7 +275,7 @@ class TestPluginsConfiguration:
         # correctly loaded
         folder = os.path.join(os.path.dirname(__file__), "plugins")
         with registeredPlugins(folder):
-            plugin = pluginManager.getPlugin("pluginA")
+            plugin = pluginManager.getPlugin("pluginA", uname=False)
             assert plugin
 
             # Check that the config file has been properly loaded
@@ -303,7 +313,7 @@ class TestPluginsConfiguration:
 
         folder = os.path.join(os.path.dirname(__file__), "plugins")
         with (overrideOsEnvironmentVariables(environment), registeredPlugins(folder)):
-            plugin = pluginManager.getPlugin("pluginA")
+            plugin = pluginManager.getPlugin("pluginA", uname=False)
             assert plugin
 
             # Check that the config file has been properly loaded and read
@@ -340,7 +350,7 @@ class TestPluginsConfiguration:
 
         folder = os.path.join(os.path.dirname(__file__), "plugins")
         with (overrideOsEnvironmentVariables(environment), registeredPlugins(folder)):
-            plugin = pluginManager.getPlugin("pluginA")
+            plugin = pluginManager.getPlugin("pluginA", uname=False)
             assert plugin
 
             # Check that the config file has been properly loaded and read

--- a/tests/test_submit.py
+++ b/tests/test_submit.py
@@ -50,7 +50,7 @@ def checkTask(task, taskType, nbDependencies):
     assert len(task.dependencies) == nbDependencies
 
 
-def waitForNodeCompletion(job: LocalFarmJob, node: Node, timeout=10):
+def waitForNodeCompletion(job: LocalFarmJob, node: Node, timeout=15):
     """
     Wait for a node to complete processing
     """
@@ -136,7 +136,7 @@ class TestNodeSubmit:
         cls.folder = os.path.join(os.path.dirname(__file__), "plugins", "meshroom")
         package = "pluginSubmitter"
         cls.plugin = Plugin(package, cls.folder)
-        nodes = loadClassesNodes(cls.folder, package)
+        nodes = loadClassesNodes(cls.folder, package, pluginUid=cls.plugin._uid)
         for node in nodes:
             cls.plugin.addNodePlugin(node)
         pluginManager.addPlugin(cls.plugin)
@@ -149,7 +149,7 @@ class TestNodeSubmit:
         cls.plugin = None
 
     def registerNode(self, name):
-        plugin = pluginManager.getPlugin("pluginSubmitter")
+        plugin = pluginManager.getPlugin("pluginSubmitter", uname=False)
         node = plugin.nodes[name]
         nodeType = node.nodeDescriptor
         registerNodeDesc(nodeType)

--- a/tests/test_submit.py
+++ b/tests/test_submit.py
@@ -136,7 +136,7 @@ class TestNodeSubmit:
         cls.folder = os.path.join(os.path.dirname(__file__), "plugins", "meshroom")
         package = "pluginSubmitter"
         cls.plugin = Plugin(package, cls.folder)
-        nodes = loadClassesNodes(cls.folder, package, pluginUid=cls.plugin._uid)
+        nodes = loadClassesNodes(cls.folder, package, pluginUid=cls.plugin.uid)
         for node in nodes:
             cls.plugin.addNodePlugin(node)
         pluginManager.addPlugin(cls.plugin)


### PR DESCRIPTION
## Description

This feature addresses a current limitation about node plugins.
Before this, if we had 2 plugins :
```
/pluginA
    meshroom/
        nodes/
            __init__.py
            pluginANodes.py

/pluginB
    meshroom/
        nodes/
            __init__.py
            pluginBNodes.py
```
Then as the module name is the same for both plugins ("nodes"), then we would have one of the plugins that would not load.

## Details

The way I addressed this issue is :
- declare a unique ID on the plugins. When we create an instance of a plugin, it generates a new UID.
- use the unique name in the plugin manager dictionary
- updating the `add_to_path` function so that it will modify the loaded modules to use the plugin UID. Modules will be named `pluginUID_moduleName` instead of `moduleName`. This way another plugin will always have a different prefix.


## Features

- we can also have in 2 plugins a node script with the same name as in another plugin and it will still work
- nothing breaks : moving a node from a plugin to another is still automatically resolved, reloading plugins still work etc


## Limitations / drawbacks

- In the UI documentation tab we can see the UID prefix in the module name, it can be a bit confusing (but at the same time it enables identifying modules in a unique way)
- it only works for node plugins, not for submitter plugins, because they don't really declare a plugin. So if we have 2 submitters with the same module name it will have the same behavior as before. This is not a huge issue in this case because on [mrSubmitters](https://github.com/meshroomHub/mrSubmitters/tree/master/meshroom) for example we would use the submitter name as the module folder
