### PR TITLE
[bin] Add a meshroom_info command

### DIFF
--- a/bin/meshroom_info
+++ b/bin/meshroom_info
@@ -1,0 +1,170 @@
+#!/usr/bin/env python
+
+import argparse
+import os
+import sys
+import logging
+import json
+
+import meshroom
+
+
+parser = argparse.ArgumentParser(description="Query infos on meshroom.")
+
+parser.add_argument("-v", "--verbose",
+                    help="Set the verbosity level for logging:\n"
+                            "  - fatal: Show only critical errors.\n"
+                            "  - error: Show errors only.\n"
+                            "  - warning: Show warnings and errors.\n"
+                            "  - info: Show standard informational messages.\n"
+                            "  - debug: Show detailed debug information.\n"
+                            "  - trace: Show all messages, including trace-level details.",
+                    default=os.environ.get("MESHROOM_VERBOSE", "error"),
+                    choices=["fatal", "error", "warning", "info", "debug", "trace"])
+
+subparsers = parser.add_subparsers(dest="command")
+
+# Version subparser
+version_mode_parser = subparsers.add_parser(
+    "version", help="Display Meshroom version.")
+version_mode_parser.add_argument("-p", "--path", action="store_true")
+
+# Node info subparser
+nodes_mode_parser = subparsers.add_parser(
+    "nodeinfo", help="Display nodes info.")
+nodes_mode_parser.add_argument("-n", "--name", type=str, help="Get infos for a specific node.")
+nodes_mode_parser.add_argument("--default_value", action="store_true", help="Display input default value.")
+
+# Pipeline info subparser
+pipeline_mode_parser = subparsers.add_parser(
+    "pipelines", help="Display pipelines info.")
+pipeline_mode_parser.add_argument("-n", "--name", type=str, help="Get infos for a specific pipeline.")
+
+
+# ===== VERSION =====
+def get_version(args):
+    print(f"Meshroom version is {meshroom.__version__}")
+    if args.path:
+        print(f"Meshroom is located at {meshroom._MESHROOM_ROOT}")
+
+
+# ===== NODES =====
+def get_nodes_info(args):
+    import meshroom.core
+    meshroom.setupEnvironment()
+    meshroom.core.initPlugins()
+    meshroom.core.initNodes()
+    nodeName = args.name
+    nodePlugins = meshroom.core.pluginManager.getRegisteredNodePlugins()
+    if nodeName:
+        get_node_info(args, nodePlugins, nodeName)
+    else:
+        get_all_node_info(args, nodePlugins)
+
+
+def get_node_info(args, nodePlugins, name):
+    from meshroom.core.desc import BaseNode
+    if name not in nodePlugins:
+        print(f"Error: Node '{name}' not found.")
+        sys.exit(1)
+
+    nodeDesc = nodePlugins[name].nodeDescriptor
+    nodeBaseClass = [c for c in nodeDesc.__bases__ if issubclass(c, BaseNode)]
+    nodeInfo = nodeDesc.getNodeInfo()
+
+    print(f"Node: {name}" + (f" ({nodeBaseClass[0].__name__})" if nodeBaseClass else ""))
+    print(f"  Category     : {nodeDesc.category}")
+    if doc:=nodeDesc.documentation.strip():
+        print(f"  Description  : {doc}")
+    for name, info in nodeInfo.items():
+        print(f"  {name:13}: {info}")
+
+    print("")
+    if nodeDesc.inputs:
+        print(f"  Inputs:")
+        for input in nodeDesc.inputs:
+            print(f"    - ({input.__class__.__name__}) {input.name} \"{input.label}\"")
+            print(f"        Description   : {input.description}")
+            if args.default_value:
+                print(f"        Default Value : \"{input.value}\"")
+
+    print("")
+    if nodeDesc.outputs:
+        print(f"  Outputs:")
+        for output in nodeDesc.outputs:
+            print(f"    - ({output.__class__.__name__}) {output.name} \"{output.label}\"")
+            print(f"        Description : {output.description}")
+
+
+def get_all_node_info(args, nodePlugins):
+    # Group nodes by category
+    categories = {}
+    for name, nodePlugin in sorted(nodePlugins.items()):
+        category = nodePlugin.nodeDescriptor.category
+        if category not in categories:
+            categories[category] = []
+        categories[category].append(name)
+
+    print(f"Available Nodes ({len(nodePlugins)}):")
+    for category, nodes in sorted(categories.items()):
+        print(f"\n  [{category}]")
+        for name in nodes:
+            print(f"    - {name}")
+
+
+# ===== PIPELINES =====
+def get_pipelines_info(args):
+    import meshroom.core
+    meshroom.setupEnvironment()
+    meshroom.core.initPipelines()
+    meshroom.core.initPlugins()
+
+    templates = meshroom.core.pipelineTemplates
+    pipelineName = args.name
+
+    if pipelineName:
+        get_pipeline_info(args, templates, pipelineName)
+    else:
+        print(f"Available Pipelines ({len(templates)}):")
+        for name in sorted(templates.keys()):
+            print(f"  - {name}")
+
+
+def get_pipeline_info(args, templates, name):
+    if name not in templates:
+        print(f"Error: Pipeline '{name}' not found.")
+        sys.exit(1)
+
+    tplPath = templates.get(name)
+    print(f"Pipeline {name}")
+    print(f"  Path           : {tplPath}")
+    with open(tplPath, "r") as f:
+        content = json.load(f)
+    header = content.get("header", {})
+    print(f"  template       : {header.get('template', False)}")
+    print(f"  releaseVersion : {header.get('releaseVersion')}")
+    print(f"  fileVersion    : {header.get('fileVersion')}")
+    nodesVersions = header.get("nodesVersions")
+    if nodesVersions:
+        length = max(len(k) for k in nodesVersions)
+        print(f"  nodeVersions")
+        print(f"  ------------")
+        for k, v in nodesVersions.items():
+            print(f"    {k:{length+1}}: {v}")
+
+
+# ===== parse args =====
+
+if __name__ == "__main__":
+    args = parser.parse_args()
+    logging.getLogger().setLevel(meshroom.logStringToPython[args.verbose])
+    
+    if args.command == "version":
+        get_version(args)
+    elif args.command == "nodeinfo":
+        get_nodes_info(args)
+    elif args.command == "pipelines":
+        get_pipelines_info(args)
+    else:
+        parser.print_help()
+        sys.exit(0)

--- a/meshroom/core/desc/node.py
+++ b/meshroom/core/desc/node.py
@@ -9,7 +9,7 @@ import shutil
 import sys
 import signal
 import subprocess
-
+from collections import OrderedDict
 import psutil
 
 from meshroom import _MESHROOM_ROOT
@@ -244,6 +244,32 @@ class BaseNode(object):
 
     def getMrNodeType(self):
         return self._mrNodeType
+
+    @classmethod
+    def getNodeInfo(cls):
+        info = OrderedDict([
+            ("module", cls.__module__),
+            ("modulePath", cls.plugin.path),
+        ])
+        # > Info from the plugin module
+        plugin_module = sys.modules.get(cls.__module__)
+        if getattr(plugin_module, "__author__", None):
+            info["author"] = plugin_module.__author__
+        if getattr(plugin_module, "__license__", None):
+            info["license"] = plugin_module.__license__
+        if getattr(plugin_module, "__version__", None):
+            info["version"] = plugin_module.__version__
+        # > Overrides at the node-level
+        if getattr(cls, "author", None):
+            info["author"] = cls.author
+        if getattr(cls, "version", None):
+            info["version"] = cls.version
+        # > Additional node information stored in a __nodeInfo__ parameter
+        additionalNodeInfo = getattr(cls, "__nodeInfo__", None)
+        if additionalNodeInfo:
+            for key, value in additionalNodeInfo:
+                info[key] = value
+        return info
 
     @classmethod
     def resolvedCpu(cls, node):

--- a/meshroom/core/desc/node.py
+++ b/meshroom/core/desc/node.py
@@ -249,7 +249,7 @@ class BaseNode(object):
     def getNodeInfo(cls):
         info = OrderedDict([
             ("module", cls.__module__),
-            ("modulePath", cls.plugin.path),
+            ("modulePath", cls.plugin.path if cls.plugin else ""),
         ])
         # > Info from the plugin module
         plugin_module = sys.modules.get(cls.__module__)
@@ -267,6 +267,8 @@ class BaseNode(object):
         # > Additional node information stored in a __nodeInfo__ parameter
         additionalNodeInfo = getattr(cls, "__nodeInfo__", None)
         if additionalNodeInfo:
+            if isinstance(additionalNodeInfo, dict):
+                additionalNodeInfo = list(additionalNodeInfo.items())
             for key, value in additionalNodeInfo:
                 info[key] = value
         return info

--- a/meshroom/core/node.py
+++ b/meshroom/core/node.py
@@ -1031,28 +1031,7 @@ class BaseNode(BaseObject):
     def getNodeInfo(self):
         if not self.nodeDesc:
             return []
-        info = OrderedDict([
-            ("module", self.nodeDesc.__module__),
-            ("modulePath", self.nodeDesc.plugin.path),
-        ])
-        # > Info from the plugin module
-        plugin_module = sys.modules.get(self.nodeDesc.__module__)
-        if getattr(plugin_module, "__author__", None):
-            info["author"] = plugin_module.__author__
-        if getattr(plugin_module, "__license__", None):
-            info["license"] = plugin_module.__license__
-        if getattr(plugin_module, "__version__", None):
-            info["version"] = plugin_module.__version__
-        # > Overrides at the node-level
-        if getattr(self.nodeDesc, "author", None):
-            info["author"] = self.nodeDesc.author
-        if getattr(self.nodeDesc, "version", None):
-            info["version"] = self.nodeDesc.version
-        # > Additional node information stored in a __nodeInfo__ parameter
-        additionalNodeInfo = getattr(self.nodeDesc, "__nodeInfo__", None)
-        if additionalNodeInfo:
-            for key, value in additionalNodeInfo:
-                info[key] = value
+        info = self.nodeDesc.getNodeInfo()
         return [{"key": k, "value": v} for k, v in info.items()]
 
     def getAnyAttribute(self, name, internal=False):

--- a/setup.py
+++ b/setup.py
@@ -197,6 +197,7 @@ executables = [
     # Command line
     PlatformExecutable("bin/meshroom_batch"),
     PlatformExecutable("bin/meshroom_compute"),
+    PlatformExecutable("bin/meshroom_info"),
     PlatformExecutable("bin/meshroom_newNodeType"),
     PlatformExecutable("bin/meshroom_statistics"),
     PlatformExecutable("bin/meshroom_status"),


### PR DESCRIPTION
## Description

Add a command `meshroom_info` to get infos about meshroom, node or pipelines

## Command args

```
usage: meshroom_info [-h] [-v {fatal,error,warning,info,debug,trace}] {version,nodeinfo,pipelines} ...

Query infos on meshroom.

positional arguments:
  {version,nodeinfo,pipelines}
    version             Display Meshroom version.
    nodeinfo            Display nodes info.
    pipelines           Display pipelines info.

options:
  -h, --help            show this help message and exit
  -v {fatal,error,warning,info,debug,trace}, --verbose {fatal,error,warning,info,debug,trace}
                        Set the verbosity level for logging: - fatal: Show only critical errors. - error: Show errors only. - warning: Show warnings and errors. -
                        info: Show standard informational messages. - debug: Show detailed debug information. - trace: Show all messages, including trace-level
                        details.
```

## Examples

### `version`

```
usage: meshroom_info version [-h] [-p]

options:
  -p, --path
```

```bash
> meshroom_info version
Meshroom version is 2026.1.0+develop

# -p/--path for the path to meshroom
> meshroom_info version -p
Meshroom version is 2026.1.0+develop
Meshroom is located at /apps/meshroom
```

### `nodeinfo`

```
usage: meshroom_info nodeinfo [-h] [-n NAME] [--default_value]

options:
  -n NAME, --name NAME  Get infos for a specific node.
  --default_value       Display input default value.
```

```bash
> meshroom_info nodeinfo
Available Nodes (193):

  [Dense Reconstruction]
    - DepthMap
    - DepthMapFilter
   
  ...

  [Segmentation]
    - ImageSegmentationBox
    - ImageSegmentationPrompt
    - ImageSegmentationSam3
    - VideoSegmentationSam3
    - VideoSegmentationSam3Boxes
    - VideoSegmentationSam3Text

> meshroom_info nodeinfo -n PathJoin
Node: PathJoin (Node)
  Category     : Other
  module       : general.PathJoin
  modulePath   : /apps/meshroom/nodes/general/PathJoin.py
  version      : 1.0

  Inputs:
    - (ListAttribute) paths "Paths"
        Description   : Paths to join.
    - (BoolParam) checkIfExists "Check Exists"
        Description   : Checkl if the output path exists. If it doesn't, the output will be an empty string.

  Outputs:
    - (File) outputPath "Path"
        Description : Path.

```

### `pipelines`

```
usage: meshroom_info pipelines [-h] [-n NAME]

options:
  -n NAME, --name NAME  Get infos for a specific pipeline.
```
```bash
> meshroom_info pipelines
Available Pipelines (50):
  - cameraTracking
  - cameraTrackingDepth
  ...
  - photogrammetry
  - photogrammetryAndCameraTracking

> meshroom_info pipelines -n sam3dObjects
Pipeline sam3dObjects
  Path           : /apps/mrSam3d/pipelines/sam3dObjects.mg
  template       : True
  releaseVersion : 2026.1.0+develop
  fileVersion    : 2.0
  nodeVersions
  ------------
    CameraInit            : 12.0
    CopyFiles             : 1.3
    ImageSegmentationSam3 : 1.0
    Sam3dObjects          : 1.1
```
