### PR TITLE
Advanced submitter settings

### DIFF
--- a/meshroom/core/desc/__init__.py
+++ b/meshroom/core/desc/__init__.py
@@ -49,7 +49,6 @@ from .node import (
     Node,
     NodeVersionType,
     NodeVersionTypeEnum,
-    MeshroomCommandWrapper,
     SubmissionSettings,
     StageSettings,
 )

--- a/meshroom/core/desc/__init__.py
+++ b/meshroom/core/desc/__init__.py
@@ -49,4 +49,7 @@ from .node import (
     Node,
     NodeVersionType,
     NodeVersionTypeEnum,
+    MeshroomCommandWrapper,
+    SubmitionSettings,
+    StageSettings,
 )

--- a/meshroom/core/desc/__init__.py
+++ b/meshroom/core/desc/__init__.py
@@ -50,6 +50,6 @@ from .node import (
     NodeVersionType,
     NodeVersionTypeEnum,
     MeshroomCommandWrapper,
-    SubmitionSettings,
+    SubmissionSettings,
     StageSettings,
 )

--- a/meshroom/core/desc/node.py
+++ b/meshroom/core/desc/node.py
@@ -1,5 +1,3 @@
-# desc/node.py
-
 import enum
 from inspect import getfile, getattr_static
 from pathlib import Path
@@ -63,19 +61,12 @@ class MrNodeType(enum.Enum):
     BACKDROP = enum.auto()
 
 
-class MeshroomCommandWrapper:
-    def __call__(self, node, command: str) -> str:
-        return command
-
-
 class StageSettings(SimpleNamespace):
     def __init__(self, cpu=Level.NORMAL, ram=Level.NORMAL, gpu=Level.NONE, **kwargs):
         super().__init__(**kwargs)
         self.cpu = cpu.value if hasattr(cpu, "value") else cpu
         self.ram = ram.value if hasattr(cpu, "value") else cpu
         self.gpu = gpu.value if hasattr(cpu, "value") else cpu
-        # Wraps the stage command
-        self.wrapCommand = MeshroomCommandWrapper()
 
     def __contains__(self, item):
         return item in self.__dict__

--- a/meshroom/core/desc/node.py
+++ b/meshroom/core/desc/node.py
@@ -10,6 +10,7 @@ import sys
 import signal
 import subprocess
 from collections import OrderedDict
+from types import SimpleNamespace
 import psutil
 
 from meshroom import _MESHROOM_ROOT
@@ -60,6 +61,60 @@ class MrNodeType(enum.Enum):
     COMMANDLINE = enum.auto()
     INIT = enum.auto()
     BACKDROP = enum.auto()
+
+
+class MeshroomCommandWrapper:
+    def __call__(self, node, command: str) -> str:
+        return command
+
+
+class StageSettings(SimpleNamespace):
+    def __init__(self, cpu=Level.NORMAL, ram=Level.NORMAL, gpu=Level.NONE, **kwargs):
+        super().__init__(**kwargs)
+        self.cpu = cpu.value
+        self.ram = ram.value
+        self.gpu = gpu.value
+        # command executed right before the stage
+        if kwargs.get("setup_command"):
+            self.setup_command = kwargs.get("setup_command")
+        # command executed after the stage
+        if kwargs.get("teardown_command"):
+            self.teardown_command = kwargs.get("teardown_command")
+        # wraps the stage command
+        self.wrapCommand = MeshroomCommandWrapper()
+
+    def __contains__(self, item):
+        return item in self.__dict__
+
+
+class SubmitionSettings:
+    def __init__(self, node):
+        """Holds infos used when we submit the node for remote computing.
+
+        Args:
+            node (BaseNode): the BaseNode instance being updated
+        """
+        # Pre/post process use the default settings
+        self.preprocess = StageSettings()
+        self.postprocess = StageSettings()
+        # Process use the values we set on the node description
+        self.process = StageSettings(cpu=node.cpu, ram=node.ram, gpu=node.gpu)
+        self.process.licenses = node.nodeDesc._licenses
+        # Retrocompatibility behaviour
+        if hasattr(node.nodeDesc, "_cuda_tag"):
+            logging.warning(f"DepreciationWarning : Node of type {node.nodeDesc} use '_cuda_tag'. Please use SubmitionSettings instead.")
+            self.process.cuda_tag = node.nodeDesc._cuda_tag
+        if hasattr(node.nodeDesc, "_service_key"):
+            logging.warning(f"DepreciationWarning : Node of type {node.nodeDesc} use '_service_key'. Please use SubmitionSettings instead.")
+            self.process.service_key = node.nodeDesc._service_key
+
+    def getStageSettings(self, stageName="process"):
+        if stageName == "preprocess":
+            return self.preprocess
+        if stageName == "process":
+            return self.process
+        if stageName == "postprocess":
+            return self.postprocess
 
 
 class InternalAttributesFactory:
@@ -389,6 +444,15 @@ class BaseNode(object):
             NodeBase.updateInternals
         """
         pass
+
+    def getSubmitionSettings(self, node) -> SubmitionSettings:
+        """ Gets invoked when we submit the node on farm.
+        SubmitionSettings contain all the settings that we can use on the submitter
+
+        Args:
+            node: The BaseNode instance about to be processed.
+        """
+        return SubmitionSettings(node)
 
     def preprocess(self, node):
         """ Gets invoked just before the processChunk method for the node.

--- a/meshroom/core/desc/node.py
+++ b/meshroom/core/desc/node.py
@@ -71,16 +71,10 @@ class MeshroomCommandWrapper:
 class StageSettings(SimpleNamespace):
     def __init__(self, cpu=Level.NORMAL, ram=Level.NORMAL, gpu=Level.NONE, **kwargs):
         super().__init__(**kwargs)
-        self.cpu = cpu.value
-        self.ram = ram.value
-        self.gpu = gpu.value
-        # command executed right before the stage
-        if kwargs.get("setup_command"):
-            self.setup_command = kwargs.get("setup_command")
-        # command executed after the stage
-        if kwargs.get("teardown_command"):
-            self.teardown_command = kwargs.get("teardown_command")
-        # wraps the stage command
+        self.cpu = cpu.value if hasattr(cpu, "value") else cpu
+        self.ram = ram.value if hasattr(cpu, "value") else cpu
+        self.gpu = gpu.value if hasattr(cpu, "value") else cpu
+        # Wraps the stage command
         self.wrapCommand = MeshroomCommandWrapper()
 
     def __contains__(self, item):

--- a/meshroom/core/desc/node.py
+++ b/meshroom/core/desc/node.py
@@ -81,7 +81,7 @@ class StageSettings(SimpleNamespace):
         return item in self.__dict__
 
 
-class SubmitionSettings:
+class SubmissionSettings:
     def __init__(self, node):
         """Holds infos used when we submit the node for remote computing.
 
@@ -96,10 +96,10 @@ class SubmitionSettings:
         self.process.licenses = node.nodeDesc._licenses
         # Retrocompatibility behaviour
         if hasattr(node.nodeDesc, "_cuda_tag"):
-            logging.warning(f"DepreciationWarning : Node of type {node.nodeDesc} use '_cuda_tag'. Please use SubmitionSettings instead.")
+            logging.warning(f"DepreciationWarning : Node of type {node.nodeDesc} use '_cuda_tag'. Please use SubmissionSettings instead.")
             self.process.cuda_tag = node.nodeDesc._cuda_tag
         if hasattr(node.nodeDesc, "_service_key"):
-            logging.warning(f"DepreciationWarning : Node of type {node.nodeDesc} use '_service_key'. Please use SubmitionSettings instead.")
+            logging.warning(f"DepreciationWarning : Node of type {node.nodeDesc} use '_service_key'. Please use SubmissionSettings instead.")
             self.process.service_key = node.nodeDesc._service_key
 
     def getStageSettings(self, stageName="process"):
@@ -439,14 +439,14 @@ class BaseNode(object):
         """
         pass
 
-    def getSubmitionSettings(self, node) -> SubmitionSettings:
+    def getSubmissionSettings(self, node) -> SubmissionSettings:
         """ Gets invoked when we submit the node on farm.
-        SubmitionSettings contain all the settings that we can use on the submitter
+        SubmissionSettings contain all the settings that we can use on the submitter
 
         Args:
             node: The BaseNode instance about to be processed.
         """
-        return SubmitionSettings(node)
+        return SubmissionSettings(node)
 
     def preprocess(self, node):
         """ Gets invoked just before the processChunk method for the node.

--- a/meshroom/core/desc/node.py
+++ b/meshroom/core/desc/node.py
@@ -96,19 +96,20 @@ class SubmissionSettings:
         self.process.licenses = node.nodeDesc._licenses
         # Retrocompatibility behaviour
         if hasattr(node.nodeDesc, "_cuda_tag"):
-            logging.warning(f"DepreciationWarning : Node of type {node.nodeDesc} use '_cuda_tag'. Please use SubmissionSettings instead.")
+            logging.warning(f"DeprecationWarning : Node of type {node.nodeDesc} uses '_cuda_tag'. Please use SubmissionSettings instead.")
             self.process.cuda_tag = node.nodeDesc._cuda_tag
         if hasattr(node.nodeDesc, "_service_key"):
-            logging.warning(f"DepreciationWarning : Node of type {node.nodeDesc} use '_service_key'. Please use SubmissionSettings instead.")
+            logging.warning(f"DeprecationWarning : Node of type {node.nodeDesc} uses '_service_key'. Please use SubmissionSettings instead.")
             self.process.service_key = node.nodeDesc._service_key
 
     def getStageSettings(self, stageName="process"):
-        if stageName == "preprocess":
-            return self.preprocess
-        if stageName == "process":
-            return self.process
-        if stageName == "postprocess":
-            return self.postprocess
+        stage = getattr(self, stageName, None)
+        if stage:
+            return stage
+        raise ValueError(
+             f"Unknown stageName: {stageName!r}. Expected one of: "
+             "'preprocess', 'process', 'postprocess'."
+         )
 
 
 class InternalAttributesFactory:

--- a/meshroom/core/submitter.py
+++ b/meshroom/core/submitter.py
@@ -7,11 +7,14 @@ import logging
 import operator
 
 from enum import IntFlag, auto
-from typing import Optional, Dict, List
+from typing import Optional, Dict, List, TYPE_CHECKING
 from itertools import accumulate
 
 import meshroom
 from meshroom.common import BaseObject, Property
+
+if TYPE_CHECKING:
+    from meshroom.core.node import BaseNode
 
 
 logger = logging.getLogger("Submitter")
@@ -82,31 +85,24 @@ class OrderedTaskType(IntFlag):
 class OrderedTask:
     _usedUids = set()
 
-    def __init__(self, taskType, node = None, iteration : int = -1):
+    def __init__(self, taskType: OrderedTaskType, node: BaseNode = None, iteration : int = -1):
         self.taskType: OrderedTaskType = taskType
-        self.node = node  # BaseNode
-        self.iteration = iteration
-        self.dependencies = []
-        self.uid = self._generateUid()
+        self.node: BaseNode = node
+        self.iteration: int = iteration
+        self.dependencies : list["OrderedTask"] = []
+        # Generate UID
+        self.uid: int = max(self._usedUids) + 1 if len(self._usedUids) > 0 else 0
+        self._usedUids.add(self.uid)
 
     @property
-    def nodeName(self):
+    def nodeName(self) -> str:
         return self.node.name if self.node else "NONE"
 
-    @classmethod
-    def _generateUid(cls) -> int:
-        nextUid = max(cls._usedUids) + 1 if len(cls._usedUids) > 0 else 0
-        cls._usedUids.add(nextUid)
-        return nextUid
-
-    def addDependency(self, otherTask: OrderedTask):
-        self.dependencies.append(otherTask)
-
     @property
-    def shortName(self):
-        sn = self.nodeName if self.node else "NONE"
+    def name(self) -> str:
+        sn = self.nodeName
         if self.taskType == OrderedTaskType.CHUNK:
-            sn += f"_{self.iteration if self.iteration >=0 else 'allchunks'}"
+            sn += f"_{self.iteration if self.iteration >=0 else 'process'}"
         else:
             sn += f"_{self.taskType.name}"
         return f"{self.uid:03d} {sn}"
@@ -123,6 +119,9 @@ class OrderedTask:
             string += f" iteration={self.iteration}"
         string += f" ({len(self.dependencies)} deps)>"
         return string
+
+    def addDependency(self, otherTask: OrderedTask):
+        self.dependencies.append(otherTask)
 
 
 class OrderedNode:
@@ -220,7 +219,7 @@ class OrderedTasks:
             return allTasks
         tasks: list[OrderedTask] = gatherTasks(self.rootTask)
         for task in set(tasks):
-            logging.debug(f"[{task.shortName}] {task} -> depends on {[t.shortName for t in task.dependencies]}")
+            logging.debug(f"[{task.name}] {task} -> depends on {[t.name for t in task.dependencies]}")
 
     def iterOnTasks(self, current:OrderedTask=None, skipRootTask=False):
         skipCurrent = (current is None) and skipRootTask

--- a/meshroom/core/submitter.py
+++ b/meshroom/core/submitter.py
@@ -83,7 +83,7 @@ class OrderedTaskType(IntFlag):
 
 
 class OrderedTask:
-    _usedUids = set()
+    _lastUid = 0
 
     def __init__(self, taskType: OrderedTaskType, node: BaseNode = None, iteration : int = -1):
         self.taskType: OrderedTaskType = taskType
@@ -91,8 +91,12 @@ class OrderedTask:
         self.iteration: int = iteration
         self.dependencies : list["OrderedTask"] = []
         # Generate UID
-        self.uid: int = max(self._usedUids) + 1 if len(self._usedUids) > 0 else 0
-        self._usedUids.add(self.uid)
+        self.uid: int = self._generateUid()
+
+    @classmethod
+    def _generateUid(cls) -> int:
+        cls._lastUid += 1
+        return cls._lastUid
 
     @property
     def nodeName(self) -> str:


### PR DESCRIPTION
## Description

Add a system to setup advanced settings on submitter

Before this PR there was 2 issues :
- cpu/ram/gpu are the same for preprocess/process/postprocess
- it's quite difficult to add new parameters in a proper way

Also for the [mrSubmitters](https://github.com/meshroomHub/mrSubmitters) submitter it was really challenging to setup a proper job for Windows.


## Details

In this PR we are adding 2 key elements :
- `SubmitionSettings` & `StageSettings` classes to describe settings for a specific processing stage (`preprocess`, `process`/`processChunk` and `postprocess`)
- A new method on `desc.BaseNode` : `getSubmitionSettings`. By default it is built using the nodeDesc : `cpu`/`ram`/`gpu` are settings used for the `process` stage only, `pre/post process` are using default settings.

## Features
- by default use the same behaviour as currently, except for preprocess/postprocess stages that use default parameters which is more logical.
- by stage we can set :
  - cpu, ram, gpu
  - a setup/teardown commands that the submitter can use
  - a command wrapper
- the `StageSettings` is built using `SimpleNamespace` so we can technically set anything on a stage settings and use it later on the submitter.


## Example

```python
class TestWindowsNode(desc.Node):
    def getSubmitSettings(self, node) -> desc.SubmitionSettings:
        nodeSubmitSettings = desc.SubmitionSettings(node)
        nodeSubmitSettings.process.env_key = {
            "PROD_ROOT": self.get_win_path("P:\\my_prod"),
            "PROD_TMP": self.get_win_path("P:\\my_prod\\tmp"),
            "PYTHONPATH": convert_to_windows(os.getenv("PYTHONPATH")),
            "USER": "me",
        }
        nodeSubmitSettings.process.target_os = "windows"
        nodeSubmitSettings.process.wrapCommand = windowsCommandWrapper
        nodeSubmitSettings.process.setup_command = get_mount_volumes_command()
        return nodeSubmitSettings

    def processChunk(self, chunk):
        ...
```