### PR TITLE
[core] Reduce log level when loading plugins with no class defined

### DIFF
--- a/meshroom/core/__init__.py
+++ b/meshroom/core/__init__.py
@@ -104,7 +104,7 @@ def loadClasses(folder: str, packageName: str, classType: type) -> list[type]:
                     isPackage = hasattr(pluginMod, "__path__")
                     # Sub-folders/Packages should not raise a warning
                     if not isPackage:
-                        logging.warning(f"No class defined in plugin: {package.__name__}.{pluginName} ('{pluginMod.__file__}')")
+                        logging.debug(f"No class defined in plugin: {package.__name__}.{pluginName} ('{pluginMod.__file__}')")
 
                 for p in plugins:
                     p.packageName = packageName


### PR DESCRIPTION
## Description

This pull request makes a minor change to the logging behavior in the `loadClasses` function. The log level for missing class definitions in plugins has been lowered from `warning` to `debug`, reducing unnecessary warnings during normal operation.

This prevents raising a warning when utility files are present in the Python module that is being loaded. 