### PR TITLE
Add distinction between "released", "beta", and "user" nodes

### DIFF
--- a/meshroom/core/__init__.py
+++ b/meshroom/core/__init__.py
@@ -367,34 +367,24 @@ def loadAllNodes(folder) -> list[Plugin]:
     return plugins
 
 
-def loadPluginFolder(folder) -> list[Plugin]:
+def loadPluginFolder(folder, userPlugin: bool = False) -> list[Plugin]:
     if not os.path.isdir(folder):
         logging.info(f"Plugin folder '{folder}' does not exist.")
-        return
+        return []
 
     mrFolder = Path(folder, 'meshroom')
     if not mrFolder.exists():
         logging.info(f"Plugin folder '{folder}' does not contain a 'meshroom' folder.")
-        return
+        return []
 
     plugins = loadAllNodes(folder=mrFolder)
     if plugins:
         for plugin in plugins:
+            plugin.isUserPlugin = userPlugin
             pluginManager.addPlugin(plugin)
             pipelineTemplates.update(plugin.templates)
 
     return plugins
-
-
-def loadPluginsFolder(folder):
-    if not os.path.isdir(folder):
-        logging.debug(f"PluginSet folder '{folder}' does not exist.")
-        return
-
-    for file in os.listdir(folder):
-        if os.path.isdir(file):
-            subFolder = os.path.join(folder, file)
-            loadPluginFolder(subFolder)
 
 
 def registerSubmitter(s: BaseSubmitter):
@@ -468,12 +458,21 @@ def initPlugins():
     # Classic plugins (with a DirTreeProcessEnv)
     additionalPluginsPath = EnvVar.getList(EnvVar.MESHROOM_PLUGINS_PATH)
     pluginsFolders = [os.path.join(meshroomFolder, "plugins")] + additionalPluginsPath
-    for f in pluginsFolders:
-        plugins = loadPluginFolder(folder=f)
+    for folder in pluginsFolders:
+        plugins = loadPluginFolder(folder)
         # Set the ProcessEnv for each plugin
         if plugins:
             for plugin in plugins:
-                plugin.processEnv = processEnvFactory(f, plugin.configEnv, plugin.name)
+                plugin.processEnv = processEnvFactory(folder, plugin.configEnv, plugin.name)
+
+    # User plugins (with a DirTreeProcessEnv)
+    userPluginsFolders = EnvVar.getList(EnvVar.MESHROOM_USER_PLUGINS_PATH)
+    for folder in userPluginsFolders:
+        plugins = loadPluginFolder(folder, userPlugin=True)
+        # Set the ProcessEnv for each user plugin
+        if plugins:
+            for plugin in plugins:
+                plugin.processEnv = processEnvFactory(folder, plugin.configEnv, plugin.name)
 
     # Rez plugins (with a RezProcessEnv)
     rezPlugins = initRezPlugins()
@@ -484,12 +483,22 @@ def initRezPlugins():
     rezList = EnvVar.getList(EnvVar.MESHROOM_REZ_PLUGINS)
 
     for p in rezList:
-        name, path = p.split("=")
-        rezPlugins[name] = path  # "name" is the name of the Rez package
-        plugins = loadPluginFolder(folder=path)
+        name, folder = p.split("=")
+        rezPlugins[name] = folder  # "name" is the name of the Rez package
+        plugins = loadPluginFolder(folder)
         # Set the ProcessEnv for Rez plugins
         if plugins:
             for plugin in plugins:
-                plugin.processEnv = processEnvFactory(path, plugin.configEnv, plugin.name, envType="rez", uri=name)
+                plugin.processEnv = processEnvFactory(folder, plugin.configEnv, plugin.name, envType="rez", uri=name)
+
+    userRezList = EnvVar.getList(EnvVar.MESHROOM_USER_REZ_PLUGINS)
+    for p in userRezList:
+        name, folder = p.split("=")
+        rezPlugins[name] = folder  # "name" is the name of the Rez package
+        plugins = loadPluginFolder(folder, userPlugin=True)
+        # Set the ProcessEnv for user Rez plugins
+        if plugins:
+            for plugin in plugins:
+                plugin.processEnv = processEnvFactory(folder, plugin.configEnv, plugin.name, envType="rez", uri=name)
 
     return rezPlugins

--- a/meshroom/core/desc/__init__.py
+++ b/meshroom/core/desc/__init__.py
@@ -47,4 +47,5 @@ from .node import (
     InternalAttributesFactory,
     MrNodeType,
     Node,
+    NodeVersionType,
 )

--- a/meshroom/core/desc/__init__.py
+++ b/meshroom/core/desc/__init__.py
@@ -48,4 +48,5 @@ from .node import (
     MrNodeType,
     Node,
     NodeVersionType,
+    NodeVersionTypeEnum,
 )

--- a/meshroom/core/desc/node.py
+++ b/meshroom/core/desc/node.py
@@ -13,6 +13,7 @@ from collections import OrderedDict
 import psutil
 
 from meshroom import _MESHROOM_ROOT
+from meshroom.common import BaseObject, Property
 from meshroom.core import cgroup
 from meshroom.core.desc.anySet import AnySet
 from meshroom.core.utils import VERBOSE_LEVEL
@@ -218,6 +219,16 @@ class NodeVersionType(enum.IntEnum):
     RELEASED = enum.auto()
     BETA = enum.auto()
     USER = enum.auto()
+
+
+NodeVersionTypeEnum = type(
+    "NodeVersionTypeEnum",
+    (BaseObject,),
+    {
+        "__init__": lambda self, parent=None: BaseObject.__init__(self, parent),
+        **{name: Property(int, lambda self, v=int(member): v, constant=True) for name, member in NodeVersionType.__members__.items()},
+    },
+)
 
 
 class BaseNode(object):

--- a/meshroom/core/desc/node.py
+++ b/meshroom/core/desc/node.py
@@ -213,6 +213,13 @@ class InternalAttributesFactory:
         return cls.FLOW_OUT
 
 
+class NodeVersionType(enum.IntEnum):
+    UNKNOWN = enum.auto()
+    RELEASED = enum.auto()
+    BETA = enum.auto()
+    USER = enum.auto()
+
+
 class BaseNode(object):
     """
     """
@@ -234,6 +241,7 @@ class BaseNode(object):
     documentation = ""
     category = "Other"
     plugin = None
+    nodeVersionType: NodeVersionType = NodeVersionType.UNKNOWN
     # Licenses required to run the plugin
     # Only used to select machines on the farm when the node is submitted
     _licenses = []

--- a/meshroom/core/desc/node.py
+++ b/meshroom/core/desc/node.py
@@ -262,6 +262,20 @@ class BaseNode(object):
         self.hasDynamicOutputAttribute = any(output.isDynamicValue or isinstance(output, AnySet) for output in self.outputs)
         self.sourceCodeFolder = Path(getfile(self.__class__)).parent.resolve().as_posix()
 
+        mod = sys.modules[self.__class__.__module__]
+        version = getattr(mod, "__version__", None) if mod else None
+
+        # If "version" is not defined, the node version type remains "UNKNOWN"
+        if version:
+            try:
+                major = int(version.split(".")[0])
+                if major < 1:
+                    self.nodeVersionType = NodeVersionType.BETA
+                else:
+                    self.nodeVersionType = NodeVersionType.RELEASED
+            except ValueError:
+                pass
+
     def getMrNodeType(self):
         return self._mrNodeType
 

--- a/meshroom/core/desc/node.py
+++ b/meshroom/core/desc/node.py
@@ -265,8 +265,11 @@ class BaseNode(object):
         mod = sys.modules[self.__class__.__module__]
         version = getattr(mod, "__version__", None) if mod else None
 
+        if self.plugin and self.plugin.isUserPlugin:
+            self.nodeVersionType = NodeVersionType.USER
+
         # If "version" is not defined, the node version type remains "UNKNOWN"
-        if version:
+        if version and self.nodeVersionType == NodeVersionType.UNKNOWN:
             try:
                 major = int(version.split(".")[0])
                 if major < 1:

--- a/meshroom/core/node.py
+++ b/meshroom/core/node.py
@@ -2317,6 +2317,7 @@ class BaseNode(BaseObject):
     nodeType = Property(str, nodeType.fget, constant=True)
     documentation = Property(str, getDocumentation, constant=True)
     nodeInfo = Property(Variant, getNodeInfo, constant=True)
+    nodeVersionType = Property(int, lambda self: int(self.nodeDesc.nodeVersionType) if self.nodeDesc else int(desc.NodeVersionType.UNKNOWN), constant=True)
     nodeStatusChanged = Signal()
     nodeStatus = Property(Variant, lambda self: self._nodeStatus, notify=nodeStatusChanged)
     nodeStatusNodeName = Property(str, lambda self: self._nodeStatus.nodeName, notify=nodeStatusChanged)

--- a/meshroom/core/plugins.py
+++ b/meshroom/core/plugins.py
@@ -284,6 +284,7 @@ class Plugin(BaseObject):
     Members:
         name: the name of the plugin (e.g. name of the Python module containing the node plugins)
         path: the absolute path of the plugin
+        user: whether the plugin is a user plugin (not maintained by the core Meshroom team)
         nodePlugins: dictionary mapping the name of a node plugin contained in the plugin
                      to its corresponding NodePlugin object
         templates: dictionary mapping the name of templates (.mg files) associated to the plugin
@@ -303,6 +304,7 @@ class Plugin(BaseObject):
         self._uid: str = f"{Plugin._instancesCount:04d}"
         self._name: str = name
         self._path: str = path
+        self._user: bool = False
 
         self._nodePlugins: dict[str: NodePlugin] = {}
         self._templates: dict[str: str] = {}
@@ -334,6 +336,16 @@ class Plugin(BaseObject):
     def path(self):
         """ Return the absolute path of the plugin. """
         return self._path
+
+    @property
+    def isUserPlugin(self):
+        """ Return whether the plugin is a user plugin (not maintained by the core Meshroom team). """
+        return self._user
+
+    @isUserPlugin.setter
+    def isUserPlugin(self, user: bool):
+        """ Set whether the plugin is a user plugin. """
+        self._user = user
 
     @property
     def nodes(self):
@@ -562,6 +574,13 @@ class NodePlugin(BaseObject):
     def plugin(self, plugin: Plugin):
         """ Assign this node plugin to a containing Plugin object. """
         self._plugin = plugin
+
+    @property
+    def isUserPlugin(self):
+        """ Return whether the node plugin belongs to a user plugin. """
+        if self.plugin:
+            return self.plugin.isUserPlugin
+        return False
 
     @property
     def processEnv(self):

--- a/meshroom/env.py
+++ b/meshroom/env.py
@@ -43,10 +43,13 @@ class EnvVar(Enum):
 
     # Core
     MESHROOM_PLUGINS_PATH = VarDefinition(str, "", "Paths to plugins folders containing nodes, submitters and pipeline templates.")
+    MESHROOM_USER_PLUGINS_PATH = VarDefinition(str, "", "Paths to user plugins folders containing nodes, submitters and pipeline templates.")
     MESHROOM_NODES_PATH = VarDefinition(str, "", "Paths to set of nodes folders.")
     MESHROOM_SUBMITTERS_PATH = VarDefinition(str, "", "Paths to set of submitters folders.")
     MESHROOM_PIPELINE_TEMPLATES_PATH = VarDefinition(str, "", "Paths to et of pipeline templates folders.")
     MESHROOM_REZ_PLUGINS = VarDefinition(str, "", "List of Rez plugins, defined by the package name associated with the plugin's root path. "
+                                                  "For example, 'packageA=/path/to/packageA/version/root'.")
+    MESHROOM_USER_REZ_PLUGINS = VarDefinition(str, "", "List of user Rez plugins, defined by the package name associated with the plugin's root path. "
                                                   "For example, 'packageA=/path/to/packageA/version/root'.")
     MESHROOM_TEMP_PATH = VarDefinition(str, tempfile.gettempdir(), "Path to the temporary folder.")
 

--- a/meshroom/ui/app.py
+++ b/meshroom/ui/app.py
@@ -15,6 +15,7 @@ from PySide6.QtWidgets import QApplication
 
 import meshroom
 from meshroom.core import pluginManager
+from meshroom.core.desc import NodeVersionTypeEnum
 from meshroom.core.submitter import BaseSubmitter
 from meshroom.core.taskManager import TaskManager
 from meshroom.common import Property, Variant, Signal, Slot
@@ -316,6 +317,7 @@ class MeshroomApp(QApplication):
         self.engine.rootContext().setContextProperty("_PaletteManager", PaletteManager(self.engine, parent=self))
         self.engine.rootContext().setContextProperty("ScriptEditorManager", ScriptEditorManager(parent=self))
         self.engine.rootContext().setContextProperty("MeshroomApp", self)
+        self.engine.rootContext().setContextProperty("NodeVersionType", NodeVersionTypeEnum(parent=self))
 
         # request any potential computation to stop on exit
         self.aboutToQuit.connect(self._activeProject.stopChildThreads)

--- a/meshroom/ui/qml/Controls/Panel.qml
+++ b/meshroom/ui/qml/Controls/Panel.qml
@@ -16,6 +16,8 @@ Page {
     id: root
 
     property alias headerBar: headerLayout.data
+    readonly property color defaultHeaderColor: Qt.darker(palette.window, 1.15)
+    property color headerColor: defaultHeaderColor
     property Component titleComponent: null  // Allow custom component for title
     property alias footerContent: footerLayout.data
     property alias icon: iconPlaceHolder.data
@@ -28,7 +30,7 @@ Page {
         id: m
         property int hPadding: 6
         property int vPadding: 4
-        readonly property color paneBackgroundColor: Qt.darker(root.palette.window, 1.15)
+        readonly property color paneBackgroundColor: root.headerColor
     }
 
     padding: 1

--- a/meshroom/ui/qml/GraphEditor/Node.qml
+++ b/meshroom/ui/qml/GraphEditor/Node.qml
@@ -598,14 +598,14 @@ Item {
                                 }
                             }
 
-                            // BETA version type indicator
+                            // Version type indicator
                             MaterialLabel {
-                                text: MaterialIcons.science
-                                visible: node && node.nodeVersionType === NodeVersionType.BETA
+                                text: node.nodeVersionType === NodeVersionType.BETA ? MaterialIcons.science : MaterialIcons.new_releases
+                                visible: node.nodeVersionType === NodeVersionType.BETA || node.nodeVersionType === NodeVersionType.USER
                                 font.pointSize: 7
                                 padding: 2
                                 palette.text: Colors.sysPalette.text
-                                ToolTip.text: "This node is in beta version."
+                                ToolTip.text: node.nodeVersionType === NodeVersionType.BETA ? "This node is in beta version." : "This node is a user plugin. It is not maintained by the core team."
                             }
                         }
 

--- a/meshroom/ui/qml/GraphEditor/Node.qml
+++ b/meshroom/ui/qml/GraphEditor/Node.qml
@@ -412,7 +412,7 @@ Item {
                             active: node && node.hasInternalAttribute("flowInputs")
                             Layout.leftMargin: 1
 
-                           // flowInputs pin - left side of header
+                            // flowInputs pin - left side of header
                             sourceComponent: AttributePin {
                                 id: flowInputsHeaderPin
                                 attribute: node.internalAttribute("flowInputs")
@@ -596,6 +596,16 @@ Item {
                                     anchors.fill: parent
                                     hoverEnabled: true
                                 }
+                            }
+
+                            // BETA version type indicator
+                            MaterialLabel {
+                                text: MaterialIcons.science
+                                visible: node && node.nodeVersionType === NodeVersionType.BETA
+                                font.pointSize: 7
+                                padding: 2
+                                palette.text: Colors.sysPalette.text
+                                ToolTip.text: "This node is in beta version."
                             }
                         }
 

--- a/meshroom/ui/qml/GraphEditor/Node.qml
+++ b/meshroom/ui/qml/GraphEditor/Node.qml
@@ -389,7 +389,26 @@ Item {
                     id: header
                     width: parent.width
                     height: headerLayout.height
-                    color: root.baseColor
+                    color: {
+                        if (!node)
+                            return root.baseColor
+
+                        if (node.nodeVersionType === NodeVersionType.USER)
+                            return Qt.hsla(0.0,
+                                        Math.max(root.baseColor.hslSaturation, 0.5),
+                                        root.baseColor.hslLightness > 0.5 ?  // Handle light palette
+                                                root.baseColor.hslLightness * 0.75 : root.baseColor.hslLightness,
+                                        1.0)
+                        else if (node.nodeVersionType === NodeVersionType.BETA)
+                            return Qt.hsla(0.083,
+                                        Math.max(root.baseColor.hslSaturation, 0.45),
+                                        root.baseColor.hslLightness > 0.5 ?
+                                                root.baseColor.hslLightness * 0.6 :
+                                                Math.max(root.baseColor.hslLightness, 0.5),
+                                        1.0)
+
+                        return root.baseColor
+                    }
                     radius: background.radius
 
                     // Fill header's bottom radius
@@ -535,7 +554,6 @@ Item {
                                 text: MaterialIcons.comment
                                 padding: 2
                                 font.pointSize: 7
-
                                 ToolTip {
                                     id: nodeCommentTooltip
                                     parent: header

--- a/meshroom/ui/qml/GraphEditor/NodeEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/NodeEditor.qml
@@ -100,6 +100,26 @@ Panel {
         root.displayNodeName = root.validatedNodeName
     }
 
+    headerColor: {
+        if (!node)
+            return defaultHeaderColor
+
+        if (node && node.nodeVersionType === NodeVersionType.USER)
+            return Qt.hsla(0.0,
+                           Math.max(defaultHeaderColor.hslSaturation, 0.3),
+                           defaultHeaderColor.hslLightness > 0.5 ?  // Handle light palette
+                                defaultHeaderColor.hslLightness * 0.85 : defaultHeaderColor.hslLightness,
+                           1.0)
+        else if (node && node.nodeVersionType === NodeVersionType.BETA)
+            return Qt.hsla(0.083,
+                        Math.max(defaultHeaderColor.hslSaturation, 0.45),
+                        defaultHeaderColor.hslLightness > 0.5 ?
+                                defaultHeaderColor.hslLightness * 0.75 :
+                                Math.max(defaultHeaderColor.hslLightness, 0.5),
+                        1.0)
+        return defaultHeaderColor
+    }
+
     // Add custom title component for editing
     titleComponent: Component {
         RowLayout {

--- a/tests/plugins/meshroom/pluginA/PluginAInitNode.py
+++ b/tests/plugins/meshroom/pluginA/PluginAInitNode.py
@@ -1,5 +1,3 @@
-__version__ = "1.0"
-
 from meshroom.core import desc
 
 

--- a/tests/plugins/meshroom/pluginA/PluginANodeB.py
+++ b/tests/plugins/meshroom/pluginA/PluginANodeB.py
@@ -1,4 +1,4 @@
-__version__ = "1.0"
+__version__ = "0.1"
 
 import time
 

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1,8 +1,9 @@
 # coding:utf-8
 
 from meshroom.core import pluginManager, loadClassesNodes
+from meshroom.core.desc.node import NodeVersionType
 from meshroom.core.plugins import NodePluginStatus, Plugin
-from .utils import overrideOsEnvironmentVariables, registeredPlugins
+from .utils import overrideOsEnvironmentVariables, registeredPlugins, registeredUserPlugins
 
 from pathlib import Path
 import os
@@ -379,3 +380,37 @@ class TestPluginsConfiguration:
 
             assert config[self.CONFIG_STRING[0]] != self.CONFIG_STRING[2]
             assert configFullEnv[self.CONFIG_STRING[0]] == self.CONFIG_STRING[2]
+
+
+class TestVersionPlugins:
+    def test_nodeVersionType(self):
+        folder = os.path.join(os.path.dirname(__file__), "plugins")
+        with registeredPlugins(folder):
+            pluginA = pluginManager.getPlugin("pluginA", uname=False)
+            assert pluginA
+            nodeA = pluginManager.getRegisteredNodePlugin("PluginANodeA")
+            assert nodeA
+            assert nodeA.nodeDescriptor().nodeVersionType == NodeVersionType.RELEASED
+
+            nodeB = pluginManager.getRegisteredNodePlugin("PluginANodeB")
+            assert nodeB
+            assert nodeB.nodeDescriptor().nodeVersionType == NodeVersionType.BETA
+
+            nodeInput = pluginManager.getRegisteredNodePlugin("PluginAInitNode")
+            assert nodeInput
+            assert nodeInput.nodeDescriptor().nodeVersionType == NodeVersionType.UNKNOWN
+
+        with registeredUserPlugins(folder):
+            pluginA = pluginManager.getPlugin("pluginA", uname=False)
+            assert pluginA
+            nodeA = pluginManager.getRegisteredNodePlugin("PluginANodeA")
+            assert nodeA
+            assert nodeA.nodeDescriptor().nodeVersionType == NodeVersionType.USER
+
+            nodeB = pluginManager.getRegisteredNodePlugin("PluginANodeB")
+            assert nodeB
+            assert nodeB.nodeDescriptor().nodeVersionType == NodeVersionType.USER
+
+            nodeInput = pluginManager.getRegisteredNodePlugin("PluginAInitNode")
+            assert nodeInput
+            assert nodeInput.nodeDescriptor().nodeVersionType == NodeVersionType.USER

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -55,6 +55,15 @@ def registeredPlugins(folder: str):
     for plugin in plugins:
         pluginManager.removePlugin(plugin)
 
+@contextmanager
+def registeredUserPlugins(folder: str):
+    plugins = loadPluginFolder(folder, userPlugin=True)
+
+    yield
+
+    for plugin in plugins:
+        pluginManager.removePlugin(plugin)
+
 
 @contextmanager
 def overrideOsEnvironmentVariables(envVariables: dict):


### PR DESCRIPTION
## Description

This PR introduces a new concept pertaining to the version of nodes, which are now classified into three different types:
- `RELEASED`: the node has a version that is at least 1.0.
- `BETA`: the node has a version that is below 1.0.
- `USER`: the node comes from a user plugin, meaning it is not maintained by Meshroom's core team.

`USER` nodes are loaded through new environment variables, `MESHROOM_USER_PLUGINS_PATH` and `MESHROOM_USER_REZ_PLUGINS`. Once loaded, they appear with a specific icon (and a tooltip) and an easy-to-identify header (red-tinted), both on the node itself and in the Node Editor. 


<div align="center">
<img width="450" alt="image" src="https://github.com/user-attachments/assets/1dade929-4813-4f81-960e-5f489439e95b" />
<img width="450" alt="image" src="https://github.com/user-attachments/assets/2bbc745d-b66b-44dc-af6a-13f9f76f4b88" /></div>

`RELEASED` nodes appear as they used to, nothing changes when it comes to them.

`BETA` nodes appear with a specific icon (and a tooltip) indicating their status and an easy-to-identify header (orange-tinted), both on the node itself and in the Node Editor. 

<div align="center"><img width="450" alt="image" src="https://github.com/user-attachments/assets/e09e07e8-640a-41e6-b8c6-6e14f1d13b4b" /><img width="450" alt="image" src="https://github.com/user-attachments/assets/6c92b045-9c64-438b-a148-f5ee6fc59ef4" /></div>

## Features list

- [X] Add a new `NodeVersionType` enum for nodes and expose it to the QML engine.
- [X] Add a new notion of "user plugin".
- [X] Update the node and panel QML components to visually distinguish user plugins (red-tinted headers) and beta nodes, including new icons and tooltips indicating node version type.