### PR TITLE
Breaking API Change: Correct InputNode and InitNode Naming and Responsibilities

### DIFF
--- a/NODE_DEVELOPMENT.md
+++ b/NODE_DEVELOPMENT.md
@@ -3,7 +3,7 @@
 
 ## Node Creation
 
-This guide shows how to implement three common Meshroom node types: Python-based `Node`, external-executable `CommandLineNode`, and non-computational `InputNode`.
+This guide shows how to implement three common Meshroom node types: Python-based `Node`, external-executable `CommandLineNode`, and non-computational `InitNode`.
 
 ### 1. Node (Pure Python)
 
@@ -73,30 +73,30 @@ class MyCmdNode(desc.CommandLineNode):
     ]
 ```
 
-### 3. InputNode (non-computational placeholder)
+### 3. InitNode (non-computational placeholder)
 
-Use `desc.InputNode` for nodes that only hold data and do not run computation.
+Use `desc.InitNode` for nodes that only hold data and do not run computation.
 
-#### Example: Input Node
+#### Example: Init Node
 
 ```python
 from meshroom.core import desc
 
-class MyInputNode(desc.InputNode):
+class MyInitNode(desc.InitNode):
     category = "Custom"
     inputs = [
         desc.File(name="file", label="File", description="", value=""),
     ]
 ```
 
-#### Example: Input Node with Initialization
+#### Example: Init Node with input Initialization
 
-The InitNodes could be combined with `desc.InitNode` to implement `initialize` for command line batching or initialization from drag&drop.
+The InitNodes could be combined with `desc.InputNode` to implement `initialize` for command line batching or initialization from drag&drop.
 
 ```python
 from meshroom.core import desc
 
-class MyInputNode(desc.InputNode, desc.InitNode):
+class MyInitNode(desc.InitNode, desc.InputNode):
     category = "Custom"
     inputs = [
         desc.File(name="file", label="File", description="", value=""),

--- a/bin/meshroom_batch
+++ b/bin/meshroom_batch
@@ -196,33 +196,33 @@ with meshroom.core.graph.GraphModification(graph):
                 node.setInternalAttributeValues({"invalidation": args.setInvalidationString})
 
     if args.input:
-        # get new input nodes
-        newInputNodes = graph.findNewInputNodes()
-        newInputNodesNames = [n.getName() for n in newInputNodes]
+        # get input nodes
+        inputNodes = graph.findInputNodes()
+        inputNodesNames = [n.getName() for n in inputNodes]
 
-        # parse inputs for each new input node
+        # parse inputs for each input node
         mapInput = parseInitInputs(args.input)
 
-        # parse recursive inputs for each new input node
+        # parse recursive inputs for each input node
         mapInputRecursive = parseInitInputs(args.inputRecursive)
 
         # check that input nodes exist in the pipeline template
         for nodeName in mapInput.keys() | mapInputRecursive.keys():
-            if nodeName and nodeName not in newInputNodesNames:
-                raise RuntimeError(f"Failed to find the NewInput Node '{nodeName}' in your pipeline.\nAvailable NewInput Nodes: {newInputNodesNames}")
+            if nodeName and nodeName not in inputNodesNames:
+                raise RuntimeError(f"Failed to find the Input Node '{nodeName}' in your pipeline.\nAvailable Input Nodes: {inputNodesNames}")
 
-        # feed inputs (recursive and non-recursive paths) to corresponding new input nodes
-        for newInputNode in newInputNodes:
-            nodeName = newInputNode.getName()
+        # feed inputs (recursive and non-recursive paths) to corresponding input nodes
+        for inputNode in inputNodes:
+            nodeName = inputNode.getName()
             if nodeName not in mapInput | mapInputRecursive and \
                "" not in mapInput | mapInputRecursive:
                 continue
 
-            # Retrieve input per node and inputs for all new input node types
+            # Retrieve input per node and inputs for all input node types
             input = mapInput.get(nodeName, []) + mapInput.get("", [])
             # Retrieve recursive inputs
             inputRec = mapInputRecursive.get(nodeName, []) + mapInputRecursive.get("", [])
-            newInputNode.nodeDesc.initialize(newInputNode, input, inputRec)
+            inputNode.nodeDesc.initialize(inputNode, input, inputRec)
 
     if not graph.canComputeLeaves:
         raise RuntimeError("Graph cannot be computed. Check for compatibility issues.")

--- a/bin/meshroom_batch
+++ b/bin/meshroom_batch
@@ -196,33 +196,33 @@ with meshroom.core.graph.GraphModification(graph):
                 node.setInternalAttributeValues({"invalidation": args.setInvalidationString})
 
     if args.input:
-        # get init nodes
-        initNodes = graph.findInitNodes()
-        initNodesNames = [n.getName() for n in initNodes]
+        # get new input nodes
+        newInputNodes = graph.findNewInputNodes()
+        newInputNodesNames = [n.getName() for n in newInputNodes]
 
-        # parse inputs for each init node
+        # parse inputs for each new input node
         mapInput = parseInitInputs(args.input)
 
-        # parse recursive inputs for each init node
+        # parse recursive inputs for each new input node
         mapInputRecursive = parseInitInputs(args.inputRecursive)
 
         # check that input nodes exist in the pipeline template
         for nodeName in mapInput.keys() | mapInputRecursive.keys():
-            if nodeName and nodeName not in initNodesNames:
-                raise RuntimeError(f"Failed to find the Init Node '{nodeName}' in your pipeline.\nAvailable Init Nodes: {initNodesNames}")
+            if nodeName and nodeName not in newInputNodesNames:
+                raise RuntimeError(f"Failed to find the NewInput Node '{nodeName}' in your pipeline.\nAvailable NewInput Nodes: {newInputNodesNames}")
 
-        # feed inputs (recursive and non-recursive paths) to corresponding init nodes
-        for initNode in initNodes:
-            nodeName = initNode.getName()
+        # feed inputs (recursive and non-recursive paths) to corresponding new input nodes
+        for newInputNode in newInputNodes:
+            nodeName = newInputNode.getName()
             if nodeName not in mapInput | mapInputRecursive and \
                "" not in mapInput | mapInputRecursive:
                 continue
 
-            # Retrieve input per node and inputs for all init node types
+            # Retrieve input per node and inputs for all new input node types
             input = mapInput.get(nodeName, []) + mapInput.get("", [])
             # Retrieve recursive inputs
             inputRec = mapInputRecursive.get(nodeName, []) + mapInputRecursive.get("", [])
-            initNode.nodeDesc.initialize(initNode, input, inputRec)
+            newInputNode.nodeDesc.initialize(newInputNode, input, inputRec)
 
     if not graph.canComputeLeaves:
         raise RuntimeError("Graph cannot be computed. Check for compatibility issues.")

--- a/bin/meshroom_compute
+++ b/bin/meshroom_compute
@@ -135,8 +135,8 @@ if args.node:
             )
             sys.exit(-1)
 
-    if node.isInputNode:
-        print(f"InputNode: No computation to do.")
+    if node.isInitNode:
+        print(f"InitNode: No computation to do.")
         sys.exit(0)
 
     if args.preprocess:

--- a/meshroom/core/desc/__init__.py
+++ b/meshroom/core/desc/__init__.py
@@ -39,7 +39,7 @@ from .node import (
     BaseNode,
     BackdropNode,
     CommandLineNode,
-    NewInputNode,
+    InputNode,
     InitNode,
     InternalAttributesFactory,
     MrNodeType,

--- a/meshroom/core/desc/__init__.py
+++ b/meshroom/core/desc/__init__.py
@@ -39,7 +39,7 @@ from .node import (
     BaseNode,
     BackdropNode,
     CommandLineNode,
-    InitNode,
+    NewInputNode,
     InputNode,
     InternalAttributesFactory,
     MrNodeType,

--- a/meshroom/core/desc/__init__.py
+++ b/meshroom/core/desc/__init__.py
@@ -40,7 +40,7 @@ from .node import (
     BackdropNode,
     CommandLineNode,
     NewInputNode,
-    InputNode,
+    InitNode,
     InternalAttributesFactory,
     MrNodeType,
     Node,

--- a/meshroom/core/desc/node.py
+++ b/meshroom/core/desc/node.py
@@ -619,9 +619,9 @@ class AVCommandLineNode(CommandLineNode):
         return commandLineString + AVCommandLineNode.cmdMem + AVCommandLineNode.cmdCore
 
 
-class InitNode(object):
+class NewInputNode(object):
     def __init__(self):
-        super(InitNode, self).__init__()
+        super(NewInputNode, self).__init__()
 
     def initialize(self, node, inputs, recursiveInputs):
         """

--- a/meshroom/core/desc/node.py
+++ b/meshroom/core/desc/node.py
@@ -619,9 +619,9 @@ class AVCommandLineNode(CommandLineNode):
         return commandLineString + AVCommandLineNode.cmdMem + AVCommandLineNode.cmdCore
 
 
-class NewInputNode(object):
+class InputNode(object):
     def __init__(self):
-        super(NewInputNode, self).__init__()
+        super(InputNode, self).__init__()
 
     def initialize(self, node, inputs, recursiveInputs):
         """

--- a/meshroom/core/desc/node.py
+++ b/meshroom/core/desc/node.py
@@ -56,7 +56,7 @@ class MrNodeType(enum.Enum):
     BASENODE = enum.auto()
     NODE = enum.auto()
     COMMANDLINE = enum.auto()
-    INPUT = enum.auto()
+    INIT = enum.auto()
     BACKDROP = enum.auto()
 
 
@@ -181,7 +181,7 @@ class InternalAttributesFactory:
             MrNodeType.BASENODE: cls.INVALIDATION + cls.BASIC,
             MrNodeType.NODE: cls.INVALIDATION + cls.BASIC,
             MrNodeType.COMMANDLINE: cls.INVALIDATION + cls.BASIC,
-            MrNodeType.INPUT: cls.BASIC,
+            MrNodeType.INIT: cls.BASIC,
             MrNodeType.BACKDROP: cls.BASIC + cls.RESIZABLE,
         }
 
@@ -478,17 +478,17 @@ class BaseNode(object):
                 logging.info(f"[{chunk.node.name}] Permission denied to kill the process.")
 
 
-class InputNode(BaseNode):
+class InitNode(BaseNode):
     """
-    Node that does not need to be processed, it is just a placeholder for inputs.
+    Node that does not need to be processed, it is just a placeholder for initialization.
     """
-    _mrNodeType: MrNodeType = MrNodeType.INPUT
+    _mrNodeType: MrNodeType = MrNodeType.INIT
     internalInputs = InternalAttributesFactory.getInternalAttributes(_mrNodeType)
     internalFlowInputs = InternalAttributesFactory.getInternalFlowInputs(_mrNodeType)
     internalFlowOutputs = InternalAttributesFactory.getInternalFlowOutputs(_mrNodeType)
 
     def __init__(self):
-        super(InputNode, self).__init__()
+        super(InitNode, self).__init__()
 
     def getMrNodeType(self):
         return self._mrNodeType

--- a/meshroom/core/graph.py
+++ b/meshroom/core/graph.py
@@ -950,12 +950,12 @@ class Graph(BaseObject):
         nodes = [n for n in self._nodes.values() if n.nodeType == nodeType]
         return self.sortNodesByIndex(nodes) if sortedByIndex else nodes
 
-    def findNewInputNodes(self):
+    def findInputNodes(self):
         """
         Returns:
-            list[Node]: the list of NewInput nodes (nodes inheriting from NewInputNode)
+            list[Node]: the list of Input nodes (nodes inheriting from InputNode)
         """
-        nodes = [n for n in self._nodes.values() if isinstance(n.nodeDesc, meshroom.core.desc.NewInputNode)]
+        nodes = [n for n in self._nodes.values() if isinstance(n.nodeDesc, meshroom.core.desc.InputNode)]
         return nodes
 
     def findNodeCandidates(self, nodeNameExpr: str) -> list[Node]:

--- a/meshroom/core/graph.py
+++ b/meshroom/core/graph.py
@@ -950,12 +950,12 @@ class Graph(BaseObject):
         nodes = [n for n in self._nodes.values() if n.nodeType == nodeType]
         return self.sortNodesByIndex(nodes) if sortedByIndex else nodes
 
-    def findInitNodes(self):
+    def findNewInputNodes(self):
         """
         Returns:
-            list[Node]: the list of Init nodes (nodes inheriting from InitNode)
+            list[Node]: the list of NewInput nodes (nodes inheriting from NewInputNode)
         """
-        nodes = [n for n in self._nodes.values() if isinstance(n.nodeDesc, meshroom.core.desc.InitNode)]
+        nodes = [n for n in self._nodes.values() if isinstance(n.nodeDesc, meshroom.core.desc.NewInputNode)]
         return nodes
 
     def findNodeCandidates(self, nodeNameExpr: str) -> list[Node]:

--- a/meshroom/core/node.py
+++ b/meshroom/core/node.py
@@ -51,7 +51,7 @@ class Status(Enum):
     STOPPED = 4
     KILLED = 5
     SUCCESS = 6
-    INPUT = 7  # Special status for input nodes
+    INIT = 7  # Special status for init nodes
 
 
 class ExecMode(Enum):
@@ -1347,8 +1347,8 @@ class BaseNode(BaseObject):
         return self.nodeDesc.resolvedRam(self)
 
     def hasStatus(self, status: Status):
-        if self.isInputNode:
-            return status == Status.INPUT
+        if self.isInitNode:
+            return status == Status.INIT
         if self.isCompatibilityNode:
             # CompatibilityNodes have no chunks but may still have a status
             # Use it instead of defaulting to checking with Status.NONE
@@ -1371,7 +1371,7 @@ class BaseNode(BaseObject):
         """
         # Ambiguous case for NONE, which could be used for compatibility nodes if we do not have
         # any information about the node descriptor.
-        return self.getMrNodeType() != MrNodeType.INPUT and self.getMrNodeType() != MrNodeType.BACKDROP
+        return self.getMrNodeType() != MrNodeType.INIT and self.getMrNodeType() != MrNodeType.BACKDROP
 
     def clearData(self):
         """ Delete this Node internal folder.
@@ -1564,8 +1564,8 @@ class BaseNode(BaseObject):
             # Compatibility nodes are not meant to be updated.
             return
 
-        if attr.isOutput and not self.isInputNode:
-            # Ignore changes on output attributes for non-input nodes
+        if attr.isOutput and not self.isInitNode:
+            # Ignore changes on output attributes for non-init nodes
             # as they are updated during the node's computation.
             # And we do not want notifications during the graph processing.
             return
@@ -1982,8 +1982,8 @@ class BaseNode(BaseObject):
                  Status.RUNNING, Status.SUBMITTED)
         allOf = (Status.SUCCESS,)
         
-        if self.isInputNode:
-            return Status.INPUT
+        if self.isInitNode:
+            return Status.INIT
         if not self._chunksCreated:
             # If the preprocess chunk failed we might not reach the chunk creation part
             if self.hasPreprocessChunk and self._preprocessChunk._status.status in anyOf:
@@ -2030,8 +2030,8 @@ class BaseNode(BaseObject):
     def _isCompatibilityNode(self):
         return False
 
-    def _isInputNode(self):
-        return isinstance(self.nodeDesc, desc.InputNode)
+    def _isInitNode(self):
+        return isinstance(self.nodeDesc, desc.InitNode)
 
     def _isNewInputNode(self):
         return isinstance(self.nodeDesc, desc.NewInputNode)
@@ -2353,7 +2353,7 @@ class BaseNode(BaseObject):
     recursiveElapsedTime = Property(float, lambda self: self.getRecursiveFusedStatus().elapsedTime,
                                     notify=globalStatusChanged)
     isCompatibilityNode = Property(bool, lambda self: self._isCompatibilityNode(), constant=True)
-    isInputNode = Property(bool, lambda self: self._isInputNode(), constant=True)
+    isInitNode = Property(bool, lambda self: self._isInitNode(), constant=True)
     isNewInputNode = Property(bool, lambda self: self._isNewInputNode(), constant=True)
     isBackdropNode = Property(bool, lambda self: self._isBackdropNode(), constant=True)
 
@@ -2603,7 +2603,7 @@ class Node(BaseNode):
         """ Create chunks when computation is about to start. """
         if self._chunksCreated:
             return
-        if self.isInputNode:
+        if self.isInitNode:
             self._chunksCreated = True
             self.chunksChanged.emit()
             return

--- a/meshroom/core/node.py
+++ b/meshroom/core/node.py
@@ -2033,8 +2033,8 @@ class BaseNode(BaseObject):
     def _isInputNode(self):
         return isinstance(self.nodeDesc, desc.InputNode)
 
-    def _isInitNode(self):
-        return isinstance(self.nodeDesc, desc.InitNode)
+    def _isNewInputNode(self):
+        return isinstance(self.nodeDesc, desc.NewInputNode)
 
     def _isBackdropNode(self) -> bool:
         return False
@@ -2354,7 +2354,7 @@ class BaseNode(BaseObject):
                                     notify=globalStatusChanged)
     isCompatibilityNode = Property(bool, lambda self: self._isCompatibilityNode(), constant=True)
     isInputNode = Property(bool, lambda self: self._isInputNode(), constant=True)
-    isInitNode = Property(bool, lambda self: self._isInitNode(), constant=True)
+    isNewInputNode = Property(bool, lambda self: self._isNewInputNode(), constant=True)
     isBackdropNode = Property(bool, lambda self: self._isBackdropNode(), constant=True)
 
     globalExecMode = Property(str, globalExecMode.fget, notify=globalStatusChanged)

--- a/meshroom/core/node.py
+++ b/meshroom/core/node.py
@@ -2033,8 +2033,8 @@ class BaseNode(BaseObject):
     def _isInitNode(self):
         return isinstance(self.nodeDesc, desc.InitNode)
 
-    def _isNewInputNode(self):
-        return isinstance(self.nodeDesc, desc.NewInputNode)
+    def _isInputNode(self):
+        return isinstance(self.nodeDesc, desc.InputNode)
 
     def _isBackdropNode(self) -> bool:
         return False
@@ -2354,7 +2354,7 @@ class BaseNode(BaseObject):
                                     notify=globalStatusChanged)
     isCompatibilityNode = Property(bool, lambda self: self._isCompatibilityNode(), constant=True)
     isInitNode = Property(bool, lambda self: self._isInitNode(), constant=True)
-    isNewInputNode = Property(bool, lambda self: self._isNewInputNode(), constant=True)
+    isInputNode = Property(bool, lambda self: self._isInputNode(), constant=True)
     isBackdropNode = Property(bool, lambda self: self._isBackdropNode(), constant=True)
 
     globalExecMode = Property(str, globalExecMode.fget, notify=globalStatusChanged)

--- a/meshroom/core/plugins.py
+++ b/meshroom/core/plugins.py
@@ -45,7 +45,7 @@ def validateNodeDesc(nodeDesc: desc.BaseNode) -> list[tuple[str, ValueTypeErrors
 
     for param in nodeDesc.outputs:
         if param.value is None:
-            if issubclass(nodeDesc, desc.InputNode):
+            if issubclass(nodeDesc, desc.InitNode):
                 errors.append((f"{param.name}", ValueTypeErrors.DYNAMIC_OUTPUT))
             continue
         errMsg, errType = param.checkValueTypes()

--- a/meshroom/core/taskManager.py
+++ b/meshroom/core/taskManager.py
@@ -478,10 +478,10 @@ class TaskManager(BaseObject):
         """
         ready = []
         computed = []
-        inputNodes = []
+        initNodes = []
         for node in toNodes:
-            if node.isInputNode:
-                inputNodes.append(node)
+            if node.isInitNode:
+                initNodes.append(node)
             elif context == "COMPUTATION":
                 if graph.canComputeTopologically(node) and graph.canSubmitOrCompute(node) % 2 == 1:
                     ready.append(node)
@@ -495,7 +495,7 @@ class TaskManager(BaseObject):
             else:
                 raise ValueError("Argument 'context' must be: 'COMPUTATION' or 'SUBMITTING'")
 
-        if len(ready) + len(computed) + len(inputNodes) != len(toNodes):
+        if len(ready) + len(computed) + len(initNodes) != len(toNodes):
             toNodes.clear()
             toNodes.extend(ready)
             return False

--- a/meshroom/nodes/general/InputFile.py
+++ b/meshroom/nodes/general/InputFile.py
@@ -5,9 +5,9 @@ import os
 
 from meshroom.core import desc
 
-class InputFile(desc.InputNode, desc.NewInputNode):
+class InputFile(desc.InitNode, desc.NewInputNode):
     """
-This node is an input node that receives a File.
+This node is an init node that receives a File.
 """
     category = "Other"
 

--- a/meshroom/nodes/general/InputFile.py
+++ b/meshroom/nodes/general/InputFile.py
@@ -5,7 +5,7 @@ import os
 
 from meshroom.core import desc
 
-class InputFile(desc.InputNode, desc.InitNode):
+class InputFile(desc.InputNode, desc.NewInputNode):
     """
 This node is an input node that receives a File.
 """

--- a/meshroom/nodes/general/InputFile.py
+++ b/meshroom/nodes/general/InputFile.py
@@ -5,7 +5,7 @@ import os
 
 from meshroom.core import desc
 
-class InputFile(desc.InitNode, desc.NewInputNode):
+class InputFile(desc.InitNode, desc.InputNode):
     """
 This node is an init node that receives a File.
 """

--- a/meshroom/nodes/general/InputInt.py
+++ b/meshroom/nodes/general/InputInt.py
@@ -3,7 +3,7 @@ __version__ = "1.0"
 from meshroom.core import desc
 
 
-class InputInt(desc.InputNode, desc.InitNode):
+class InputInt(desc.InputNode, desc.NewInputNode):
     """
     This node is an input node that receives a String.
     """

--- a/meshroom/nodes/general/InputInt.py
+++ b/meshroom/nodes/general/InputInt.py
@@ -3,9 +3,9 @@ __version__ = "1.0"
 from meshroom.core import desc
 
 
-class InputInt(desc.InputNode, desc.NewInputNode):
+class InputInt(desc.InitNode, desc.NewInputNode):
     """
-    This node is an input node that receives a String.
+    This node is an init node that receives an Integer.
     """
 
     category = "Other"

--- a/meshroom/nodes/general/InputInt.py
+++ b/meshroom/nodes/general/InputInt.py
@@ -3,7 +3,7 @@ __version__ = "1.0"
 from meshroom.core import desc
 
 
-class InputInt(desc.InitNode, desc.NewInputNode):
+class InputInt(desc.InitNode, desc.InputNode):
     """
     This node is an init node that receives an Integer.
     """

--- a/meshroom/nodes/general/InputString.py
+++ b/meshroom/nodes/general/InputString.py
@@ -3,7 +3,7 @@ __version__ = "1.0"
 from meshroom.core import desc
 
 
-class InputString(desc.InitNode, desc.NewInputNode):
+class InputString(desc.InitNode, desc.InputNode):
     """
     This node is an init node that receives a String.
     """

--- a/meshroom/nodes/general/InputString.py
+++ b/meshroom/nodes/general/InputString.py
@@ -3,9 +3,9 @@ __version__ = "1.0"
 from meshroom.core import desc
 
 
-class InputString(desc.InputNode, desc.NewInputNode):
+class InputString(desc.InitNode, desc.NewInputNode):
     """
-    This node is an input node that receives a String.
+    This node is an init node that receives a String.
     """
 
     size = desc.StaticNodeSize(0)

--- a/meshroom/nodes/general/InputString.py
+++ b/meshroom/nodes/general/InputString.py
@@ -3,7 +3,7 @@ __version__ = "1.0"
 from meshroom.core import desc
 
 
-class InputString(desc.InputNode, desc.InitNode):
+class InputString(desc.InputNode, desc.NewInputNode):
     """
     This node is an input node that receives a String.
     """

--- a/meshroom/nodes/general/ReadEnvironmentVariable.py
+++ b/meshroom/nodes/general/ReadEnvironmentVariable.py
@@ -4,7 +4,7 @@ import os
 from meshroom.core import desc
 
 
-class ReadEnvVar(desc.InputNode):
+class ReadEnvVar(desc.InitNode):
     """
     Read a variable from an env
     """

--- a/meshroom/ui/qml/GraphEditor/GraphEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/GraphEditor.qml
@@ -59,11 +59,11 @@ Item {
         return undefined
     }
 
-    /// Get the InitNode delegate at the given position in 'draggable' coordinates, or null
-    function initNodeDelegateAt(draggableX, draggableY) {
+    /// Get the NewInputNode delegate at the given position in 'draggable' coordinates, or null
+    function newInputNodeDelegateAt(draggableX, draggableY) {
         for (var i = 0; i < nodeRepeater.count; ++i) {
             var delegate = nodeRepeater.getItemAt(i)
-            if (delegate && delegate.node && delegate.node.isInitNode && !delegate.readOnly) {
+            if (delegate && delegate.node && delegate.node.isNewInputNode && !delegate.readOnly) {
                 if (draggableX >= delegate.x && draggableX <= delegate.x + delegate.width &&
                     draggableY >= delegate.y && draggableY <= delegate.y + delegate.height) {
                     return delegate
@@ -1254,8 +1254,8 @@ Item {
             anchors.fill: parent
             keys: ["text/uri-list"]
 
-            /// The InitNode delegate currently being hovered during a file drag, if any
-            property var hoveredInitNodeDelegate: null
+            /// The NewInputNode delegate currently being hovered during a file drag, if any
+            property var hoveredNewInputNodeDelegate: null
 
             onEntered: function(drag) {
                 nbMeshroomScenes = 0
@@ -1267,46 +1267,46 @@ Item {
                     }
                 })
 
-                // Check if the drag enters directly over an InitNode
+                // Check if the drag enters directly over a NewInputNode
                 var draggablePos = mapToItem(draggable, drag.x, drag.y)
-                hoveredInitNodeDelegate = initNodeDelegateAt(draggablePos.x, draggablePos.y)
-                if (hoveredInitNodeDelegate) {
-                    hoveredInitNodeDelegate.initNodeDragHover = true
+                hoveredNewInputNodeDelegate = newInputNodeDelegateAt(draggablePos.x, draggablePos.y)
+                if (hoveredNewInputNodeDelegate) {
+                    hoveredNewInputNodeDelegate.newInputNodeDragHover = true
                 }
             }
 
             onPositionChanged: function(drag) {
-                // Update which InitNode (if any) the drag is currently over
+                // Update which NewInputNode (if any) the drag is currently over
                 var draggablePos = mapToItem(draggable, drag.x, drag.y)
-                var newDelegate = initNodeDelegateAt(draggablePos.x, draggablePos.y)
-                if (newDelegate !== hoveredInitNodeDelegate) {
-                    if (hoveredInitNodeDelegate) {
-                        hoveredInitNodeDelegate.initNodeDragHover = false
+                var newDelegate = newInputNodeDelegateAt(draggablePos.x, draggablePos.y)
+                if (newDelegate !== hoveredNewInputNodeDelegate) {
+                    if (hoveredNewInputNodeDelegate) {
+                        hoveredNewInputNodeDelegate.newInputNodeDragHover = false
                     }
-                    hoveredInitNodeDelegate = newDelegate
-                    if (hoveredInitNodeDelegate) {
-                        hoveredInitNodeDelegate.initNodeDragHover = true
+                    hoveredNewInputNodeDelegate = newDelegate
+                    if (hoveredNewInputNodeDelegate) {
+                        hoveredNewInputNodeDelegate.newInputNodeDragHover = true
                     }
                 }
             }
 
             onExited: {
-                if (hoveredInitNodeDelegate) {
-                    hoveredInitNodeDelegate.initNodeDragHover = false
-                    hoveredInitNodeDelegate = null
+                if (hoveredNewInputNodeDelegate) {
+                    hoveredNewInputNodeDelegate.newInputNodeDragHover = false
+                    hoveredNewInputNodeDelegate = null
                 }
             }
 
             onDropped: function(drop) {
                 // Clear visual feedback
-                if (hoveredInitNodeDelegate) {
-                    hoveredInitNodeDelegate.initNodeDragHover = false
+                if (hoveredNewInputNodeDelegate) {
+                    hoveredNewInputNodeDelegate.newInputNodeDragHover = false
                 }
 
-                // If dropped on an InitNode, forward the files to its initialize() method
-                if (hoveredInitNodeDelegate) {
-                    _currentScene.initializeNode(hoveredInitNodeDelegate.node, drop.urls)
-                    hoveredInitNodeDelegate = null
+                // If dropped on a NewInputNode, forward the files to its initialize() method
+                if (hoveredNewInputNodeDelegate) {
+                    _currentScene.initializeNode(hoveredNewInputNodeDelegate.node, drop.urls)
+                    hoveredNewInputNodeDelegate = null
                     return
                 }
 

--- a/meshroom/ui/qml/GraphEditor/GraphEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/GraphEditor.qml
@@ -59,11 +59,11 @@ Item {
         return undefined
     }
 
-    /// Get the NewInputNode delegate at the given position in 'draggable' coordinates, or null
-    function newInputNodeDelegateAt(draggableX, draggableY) {
+    /// Get the InputNode delegate at the given position in 'draggable' coordinates, or null
+    function inputNodeDelegateAt(draggableX, draggableY) {
         for (var i = 0; i < nodeRepeater.count; ++i) {
             var delegate = nodeRepeater.getItemAt(i)
-            if (delegate && delegate.node && delegate.node.isNewInputNode && !delegate.readOnly) {
+            if (delegate && delegate.node && delegate.node.isInputNode && !delegate.readOnly) {
                 if (draggableX >= delegate.x && draggableX <= delegate.x + delegate.width &&
                     draggableY >= delegate.y && draggableY <= delegate.y + delegate.height) {
                     return delegate
@@ -1254,8 +1254,8 @@ Item {
             anchors.fill: parent
             keys: ["text/uri-list"]
 
-            /// The NewInputNode delegate currently being hovered during a file drag, if any
-            property var hoveredNewInputNodeDelegate: null
+            /// The InputNode delegate currently being hovered during a file drag, if any
+            property var hoveredInputNodeDelegate: null
 
             onEntered: function(drag) {
                 nbMeshroomScenes = 0
@@ -1267,46 +1267,46 @@ Item {
                     }
                 })
 
-                // Check if the drag enters directly over a NewInputNode
+                // Check if the drag enters directly over an InputNode
                 var draggablePos = mapToItem(draggable, drag.x, drag.y)
-                hoveredNewInputNodeDelegate = newInputNodeDelegateAt(draggablePos.x, draggablePos.y)
-                if (hoveredNewInputNodeDelegate) {
-                    hoveredNewInputNodeDelegate.newInputNodeDragHover = true
+                hoveredInputNodeDelegate = inputNodeDelegateAt(draggablePos.x, draggablePos.y)
+                if (hoveredInputNodeDelegate) {
+                    hoveredInputNodeDelegate.inputNodeDragHover = true
                 }
             }
 
             onPositionChanged: function(drag) {
-                // Update which NewInputNode (if any) the drag is currently over
+                // Update which InputNode (if any) the drag is currently over
                 var draggablePos = mapToItem(draggable, drag.x, drag.y)
-                var newDelegate = newInputNodeDelegateAt(draggablePos.x, draggablePos.y)
-                if (newDelegate !== hoveredNewInputNodeDelegate) {
-                    if (hoveredNewInputNodeDelegate) {
-                        hoveredNewInputNodeDelegate.newInputNodeDragHover = false
+                var newDelegate = inputNodeDelegateAt(draggablePos.x, draggablePos.y)
+                if (newDelegate !== hoveredInputNodeDelegate) {
+                    if (hoveredInputNodeDelegate) {
+                        hoveredInputNodeDelegate.inputNodeDragHover = false
                     }
-                    hoveredNewInputNodeDelegate = newDelegate
-                    if (hoveredNewInputNodeDelegate) {
-                        hoveredNewInputNodeDelegate.newInputNodeDragHover = true
+                    hoveredInputNodeDelegate = newDelegate
+                    if (hoveredInputNodeDelegate) {
+                        hoveredInputNodeDelegate.inputNodeDragHover = true
                     }
                 }
             }
 
             onExited: {
-                if (hoveredNewInputNodeDelegate) {
-                    hoveredNewInputNodeDelegate.newInputNodeDragHover = false
-                    hoveredNewInputNodeDelegate = null
+                if (hoveredInputNodeDelegate) {
+                    hoveredInputNodeDelegate.inputNodeDragHover = false
+                    hoveredInputNodeDelegate = null
                 }
             }
 
             onDropped: function(drop) {
                 // Clear visual feedback
-                if (hoveredNewInputNodeDelegate) {
-                    hoveredNewInputNodeDelegate.newInputNodeDragHover = false
+                if (hoveredInputNodeDelegate) {
+                    hoveredInputNodeDelegate.inputNodeDragHover = false
                 }
 
-                // If dropped on a NewInputNode, forward the files to its initialize() method
-                if (hoveredNewInputNodeDelegate) {
-                    _currentScene.initializeNode(hoveredNewInputNodeDelegate.node, drop.urls)
-                    hoveredNewInputNodeDelegate = null
+                // If dropped on an InputNode, forward the files to its initialize() method
+                if (hoveredInputNodeDelegate) {
+                    _currentScene.initializeNode(hoveredInputNodeDelegate.node, drop.urls)
+                    hoveredInputNodeDelegate = null
                     return
                 }
 

--- a/meshroom/ui/qml/GraphEditor/Node.qml
+++ b/meshroom/ui/qml/GraphEditor/Node.qml
@@ -962,13 +962,13 @@ Item {
         }
     }
 
-    /// Set to true by the GraphEditor's DropArea when files are dragged over this InitNode
-    property bool initNodeDragHover: false
+    /// Set to true by the GraphEditor's DropArea when files are dragged over this NewInputNode
+    property bool newInputNodeDragHover: false
 
-    // Highlight overlay shown when files are dragged over this InitNode
+    // Highlight overlay shown when files are dragged over this NewInputNode
     Rectangle {
         anchors.fill: mouseArea
-        visible: root.node && root.node.isInitNode && root.initNodeDragHover
+        visible: root.node && root.node.isNewInputNode && root.newInputNodeDragHover
         color: Colors.sysPalette.highlight
         opacity: 0.35
         radius: background.radius

--- a/meshroom/ui/qml/GraphEditor/Node.qml
+++ b/meshroom/ui/qml/GraphEditor/Node.qml
@@ -962,13 +962,13 @@ Item {
         }
     }
 
-    /// Set to true by the GraphEditor's DropArea when files are dragged over this NewInputNode
-    property bool newInputNodeDragHover: false
+    /// Set to true by the GraphEditor's DropArea when files are dragged over this InputNode
+    property bool inputNodeDragHover: false
 
-    // Highlight overlay shown when files are dragged over this NewInputNode
+    // Highlight overlay shown when files are dragged over this InputNode
     Rectangle {
         anchors.fill: mouseArea
-        visible: root.node && root.node.isNewInputNode && root.newInputNodeDragHover
+        visible: root.node && root.node.isInputNode && root.inputNodeDragHover
         color: Colors.sysPalette.highlight
         opacity: 0.35
         radius: background.radius

--- a/meshroom/ui/scene.py
+++ b/meshroom/ui/scene.py
@@ -823,17 +823,17 @@ class Scene(UIGraph):
     @Slot(QObject, "QList<QUrl>")
     def initializeNode(self, node, urls):
         """
-        Initialize a NewInputNode with the provided list of dropped files/URLs.
+        Initialize an InputNode with the provided list of dropped files/URLs.
 
         Converts the list of QUrls to local file paths and calls the node descriptor's
         initialize() method with those paths as inputs.
 
         Args:
-            node (Node): the NewInputNode to initialize
+            node (Node): the InputNode to initialize
             urls (list of QUrl): the list of dropped file/directory URLs
         """
-        if not node.isNewInputNode:
-            logging.warning(f"initializeNode called on non-NewInputNode '{node.name}' — ignoring.")
+        if not node.isInputNode:
+            logging.warning(f"initializeNode called on non-InputNode '{node.name}' — ignoring.")
             return
         inputs = [localFile for url in urls if (localFile := url.toLocalFile())]
         node.nodeDesc.initialize(node, inputs, [])

--- a/meshroom/ui/scene.py
+++ b/meshroom/ui/scene.py
@@ -823,17 +823,17 @@ class Scene(UIGraph):
     @Slot(QObject, "QList<QUrl>")
     def initializeNode(self, node, urls):
         """
-        Initialize an InitNode with the provided list of dropped files/URLs.
+        Initialize a NewInputNode with the provided list of dropped files/URLs.
 
         Converts the list of QUrls to local file paths and calls the node descriptor's
         initialize() method with those paths as inputs.
 
         Args:
-            node (Node): the InitNode to initialize
+            node (Node): the NewInputNode to initialize
             urls (list of QUrl): the list of dropped file/directory URLs
         """
-        if not node.isInitNode:
-            logging.warning(f"initializeNode called on non-InitNode '{node.name}' — ignoring.")
+        if not node.isNewInputNode:
+            logging.warning(f"initializeNode called on non-NewInputNode '{node.name}' — ignoring.")
             return
         inputs = [localFile for url in urls if (localFile := url.toLocalFile())]
         node.nodeDesc.initialize(node, inputs, [])

--- a/tests/nodes/test/InitDynamicOutputs.py
+++ b/tests/nodes/test/InitDynamicOutputs.py
@@ -1,7 +1,7 @@
 from meshroom.core import desc
 
 
-class InputDynamicOutputs(desc.InputNode):
+class InputDynamicOutputs(desc.InitNode):
     inputs = [
         desc.File(
             name="fileInput",

--- a/tests/nodes/test/InitDynamicOutputs.py
+++ b/tests/nodes/test/InitDynamicOutputs.py
@@ -1,7 +1,6 @@
 from meshroom.core import desc
 
-
-class InputDynamicOutputs(desc.InitNode):
+class InitDynamicOutputs(desc.InitNode):
     inputs = [
         desc.File(
             name="fileInput",

--- a/tests/plugins/meshroom/pluginA/PluginAInitInputNode.py
+++ b/tests/plugins/meshroom/pluginA/PluginAInitInputNode.py
@@ -3,7 +3,7 @@ __version__ = "1.0"
 from meshroom.core import desc
 
 
-class PluginAInitNewInputNode(desc.InitNode, desc.NewInputNode):
+class PluginAInitInputNode(desc.InitNode, desc.InputNode):
     inputs = [
         desc.File(
             name="input",

--- a/tests/plugins/meshroom/pluginA/PluginAInitNewInputNode.py
+++ b/tests/plugins/meshroom/pluginA/PluginAInitNewInputNode.py
@@ -3,7 +3,7 @@ __version__ = "1.0"
 from meshroom.core import desc
 
 
-class PluginAInputNode(desc.InputNode):
+class PluginAInitNewInputNode(desc.InitNode, desc.NewInputNode):
     inputs = [
         desc.File(
             name="input",
@@ -21,3 +21,7 @@ class PluginAInputNode(desc.InputNode):
             value="",
         ),
     ]
+
+    def initialize(self, node, inputs, recursiveInputs):
+        if len(inputs) >= 1:
+            self.setAttributes(node, {"input": inputs[0]})

--- a/tests/plugins/meshroom/pluginA/PluginAInitNode.py
+++ b/tests/plugins/meshroom/pluginA/PluginAInitNode.py
@@ -3,7 +3,7 @@ __version__ = "1.0"
 from meshroom.core import desc
 
 
-class PluginAInputNewInputNode(desc.InputNode, desc.NewInputNode):
+class PluginAInitNode(desc.InitNode):
     inputs = [
         desc.File(
             name="input",
@@ -21,7 +21,3 @@ class PluginAInputNewInputNode(desc.InputNode, desc.NewInputNode):
             value="",
         ),
     ]
-
-    def initialize(self, node, inputs, recursiveInputs):
-        if len(inputs) >= 1:
-            self.setAttributes(node, {"input": inputs[0]})

--- a/tests/plugins/meshroom/pluginA/PluginAInputNewInputNode.py
+++ b/tests/plugins/meshroom/pluginA/PluginAInputNewInputNode.py
@@ -3,7 +3,7 @@ __version__ = "1.0"
 from meshroom.core import desc
 
 
-class PluginAInputInitNode(desc.InputNode, desc.InitNode):
+class PluginAInputNewInputNode(desc.InputNode, desc.NewInputNode):
     inputs = [
         desc.File(
             name="input",

--- a/tests/test_compatibility.py
+++ b/tests/test_compatibility.py
@@ -143,8 +143,8 @@ class SampleNodeV6(desc.Node):
     ]
 
 
-class SampleInputNodeV1(desc.InputNode):
-    """ Version 1 Sample Input Node """
+class SampleInitNodeV1(desc.InitNode):
+    """ Version 1 Sample Init Node """
     inputs = [
         desc.StringParam(name="path", label="Path", description="",
                          value="", invalidate=False)  # No impact on UID
@@ -154,7 +154,7 @@ class SampleInputNodeV1(desc.InputNode):
     ]
 
 
-class SampleInputNodeV2(desc.InputNode):
+class SampleInitNodeV2(desc.InitNode):
     """
     Changes from V1:
         * 'path' has been renamed to 'in'
@@ -361,14 +361,14 @@ def test_description_conflict():
 def test_upgradeAllNodes(tmp_path):
     registerNodeDesc(SampleNodeV1)
     registerNodeDesc(SampleNodeV2)
-    registerNodeDesc(SampleInputNodeV1)
-    registerNodeDesc(SampleInputNodeV2)
+    registerNodeDesc(SampleInitNodeV1)
+    registerNodeDesc(SampleInitNodeV2)
 
     g = Graph("")
     n1 = g.addNewNode("SampleNodeV1")
     n2 = g.addNewNode("SampleNodeV2")
-    n3 = g.addNewNode("SampleInputNodeV1")
-    n4 = g.addNewNode("SampleInputNodeV2")
+    n3 = g.addNewNode("SampleInitNodeV1")
+    n4 = g.addNewNode("SampleInitNodeV2")
     n1Name = n1.name
     n2Name = n2.name
     n3Name = n3.name
@@ -376,15 +376,14 @@ def test_upgradeAllNodes(tmp_path):
     graphFile = os.path.join(tmp_path, "test_description_conflict.mg")
     g.save(graphFile)
 
-    # Replace SampleNodeV1 by SampleNodeV2 and SampleInputNodeV1 by SampleInputNodeV2
+    # Replace SampleNodeV1 by SampleNodeV2 and SampleInitNodeV1 by SampleInitNodeV2
     pluginManager.getRegisteredNodePlugins()[SampleNodeV1.__name__] = \
         pluginManager.getRegisteredNodePlugin(SampleNodeV2.__name__)
-    pluginManager.getRegisteredNodePlugins()[SampleInputNodeV1.__name__] = \
-        pluginManager.getRegisteredNodePlugin(SampleInputNodeV2.__name__)
-
-    # Make SampleNodeV2 and SampleInputNodeV2 an unknown type
+    pluginManager.getRegisteredNodePlugins()[SampleInitNodeV1.__name__] = \
+        pluginManager.getRegisteredNodePlugin(SampleInitNodeV2.__name__)
+    # Make SampleNodeV2 and SampleInitNodeV2 an unknown type
     unregisterNodeDesc(SampleNodeV2)
-    unregisterNodeDesc(SampleInputNodeV2)
+    unregisterNodeDesc(SampleInitNodeV2)
 
     # Reload file
     g = loadGraph(graphFile)
@@ -406,7 +405,7 @@ def test_upgradeAllNodes(tmp_path):
     assert n4Name in g.compatibilityNodes.keys()
 
     unregisterNodeDesc(SampleNodeV1)
-    unregisterNodeDesc(SampleInputNodeV1)
+    unregisterNodeDesc(SampleInitNodeV1)
 
 
 def test_conformUpgrade():

--- a/tests/test_nodeCallbacks.py
+++ b/tests/test_nodeCallbacks.py
@@ -5,7 +5,7 @@ from meshroom.core.graph import Graph, loadGraph
 from .utils import registerNodeDesc, unregisterNodeDesc
 
 
-class NodeWithCreationCallback(desc.InputNode):
+class NodeWithCreationCallback(desc.InitNode):
     """Node defining an 'onNodeCreated' callback, triggered a new node is added to a Graph."""
 
     inputs = [

--- a/tests/test_nodeDynamicOutputs.py
+++ b/tests/test_nodeDynamicOutputs.py
@@ -113,7 +113,7 @@ class NodeWithDynamicListOutput(desc.Node):
         chunk.node.listOutput.value = outputValues
 
 
-class InputNodeWithDynamicOutputs(desc.InputNode):
+class InitNodeWithDynamicOutputs(desc.InitNode):
     inputs = [
         desc.File(
             name="fileInput",
@@ -218,36 +218,36 @@ class TestNodesWithDynamicOutputs:
         assert loadedNode.floatOutput.value == 10.0
 
 
-class TestInputNodeWithDynamicOutputs:
-    def test_registerInputNodeWithDynamicOutputs(self):
+class TestInitNodeWithDynamicOutputs:
+    def test_registerInitNodeWithDynamicOutputs(self):
         """
         Force the registration of a node with an invalid description and check that its description is rejected
         and its status states it clearly.
         """
-        registerNodeDesc(InputNodeWithDynamicOutputs)
+        registerNodeDesc(InitNodeWithDynamicOutputs)
 
         # Check that the plugin has been correctly registered (there has been attempt to load it)
-        assert pluginManager.isRegistered(InputNodeWithDynamicOutputs.__name__)
+        assert pluginManager.isRegistered(InitNodeWithDynamicOutputs.__name__)
 
         # Check that the plugin's status is DESC_ERROR, since the node description is invalid
-        # Additionally, the list of errors should include an error about having a dynamic output in an InputNode
-        plugin = pluginManager.getRegisteredNodePlugin(InputNodeWithDynamicOutputs.__name__)
+        # Additionally, the list of errors should include an error about having a dynamic output in an InitNode
+        plugin = pluginManager.getRegisteredNodePlugin(InitNodeWithDynamicOutputs.__name__)
         assert plugin
         assert plugin.status == NodePluginStatus.DESC_ERROR
         assert len(plugin.errors) == 1
         errType = plugin.errors[0][1]
         assert errType == desc.ValueTypeErrors.DYNAMIC_OUTPUT
 
-        unregisterNodeDesc(InputNodeWithDynamicOutputs)
+        unregisterNodeDesc(InitNodeWithDynamicOutputs)
 
-    def test_registerInputNodeWithDynamicOutputsV2(self):
-        """" Check that an input node with dynamic outputs has not been registered because it is invalid. """
+    def test_registerInitNodeWithDynamicOutputsV2(self):
+        """" Check that an init node with dynamic outputs has not been registered because it is invalid. """
         graph = Graph("")
         with pytest.raises(UnknownNodeTypeError):
-            # InputDynamicOutputs is located in tests/nodes/test/InputDynamicOutputs.py
-            # InputDynamicOutputs has the same description as InputNodeWithDynamicOutputs: had it been valid, it would
+            # InitDynamicOutputs is located in tests/nodes/test/InitDynamicOutputs.py
+            # InitDynamicOutputs has the same description as InitNodeWithDynamicOutputs: had it been valid, it would
             # have been loaded and registered by the plugin manager at the upper level of the test suite.
-            graph.addNewNode("InputDynamicOutputs")
+            graph.addNewNode("InitDynamicOutputs")
 
 
 class TestDynamicListOutputs:

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -139,7 +139,7 @@ class TestNewInputNode:
     def test_newInputNode(self):
         g = Graph("")
 
-        node = g.addNewNode("PluginAInputNewInputNode")
+        node = g.addNewNode("PluginAInitNewInputNode")
 
         # Check that the NewInputNode is correctly detected
         newInputNodes = g.findNewInputNodes()

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -116,7 +116,7 @@ class TestNodeVariables:
             assert n._expVars["node"] is n
 
 
-class TestInitNode:
+class TestNewInputNode:
     plugin = None
 
     @classmethod
@@ -136,16 +136,16 @@ class TestInitNode:
         pluginManager.removePlugin(cls.plugin)
         cls.plugin = None
 
-    def test_initNode(self):
+    def test_newInputNode(self):
         g = Graph("")
 
-        node = g.addNewNode("PluginAInputInitNode")
+        node = g.addNewNode("PluginAInputNewInputNode")
 
-        # Check that the init node is correctly detected
-        initNodes = g.findInitNodes()
-        assert len(initNodes) == 1 and node in initNodes
+        # Check that the NewInputNode is correctly detected
+        newInputNodes = g.findNewInputNodes()
+        assert len(newInputNodes) == 1 and node in newInputNodes
 
-        # Check that the init node's initialize method has been set
+        # Check that the NewInputNode's initialize method has been set
         inputs = ["/path/to/file", "/path/to/file/2"]
         node.nodeDesc.initialize(node, inputs, None)
         assert node.input.value == inputs[0]

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -116,7 +116,7 @@ class TestNodeVariables:
             assert n._expVars["node"] is n
 
 
-class TestNewInputNode:
+class TestInputNode:
     plugin = None
 
     @classmethod
@@ -136,16 +136,15 @@ class TestNewInputNode:
         pluginManager.removePlugin(cls.plugin)
         cls.plugin = None
 
-    def test_newInputNode(self):
+    def test_inputNode(self):
         g = Graph("")
 
-        node = g.addNewNode("PluginAInitNewInputNode")
+        node = g.addNewNode("PluginAInitInputNode")
 
-        # Check that the NewInputNode is correctly detected
-        newInputNodes = g.findNewInputNodes()
-        assert len(newInputNodes) == 1 and node in newInputNodes
-
-        # Check that the NewInputNode's initialize method has been set
+        # Check that the InputNode is correctly detected
+        inputNodes = g.findInputNodes()
+        assert len(inputNodes) == 1 and node in inputNodes
+        # Check that the InputNode's initialize method has been set
         inputs = ["/path/to/file", "/path/to/file/2"]
         node.nodeDesc.initialize(node, inputs, None)
         assert node.input.value == inputs[0]


### PR DESCRIPTION
## Description

This PR swaps the roles of `InputNode` and `InitNode`. As a result, it introduces a breaking change for any nodes inheriting from these classes.

We decided to accept this compatibility break because these concepts were introduced relatively recently and have not yet seen widespread adoption.

Historically, `InitNode` was [introduced first in 2022](https://github.com/alicevision/Meshroom/pull/1750) to initialize the graph, that could be better reframed now as `set inputs to this graph`. Later, when a second concept was needed, `InputNode` was [added in 2024](https://github.com/alicevision/Meshroom/pull/2364) to have specific nodes without computation at the inputs of the graph, that could be better reframed now as `initialization nodes at the beginning of the graph`. As the framework evolved, it became clear that the naming and responsibilities of these classes were not aligned with their actual purpose.

The goal of this change is to make the API more intuitive, reduce confusion, and improve the onboarding experience for new users or contributors.

With this PR:

* `InputNode`s are now responsible for exposing inputs to the graph (with corresponding `OutputNode`s planned in the near future).
* `InitNode`s are now responsible for initializing a graph with live-evaluated values that do not require any computation.


Related AliceVision pull request: https://github.com/alicevision/AliceVision/pull/2143