### PR TITLE
nodes: Generate Meshroom Scene - Fix blank line

### DIFF
--- a/meshroom/nodes/general/GenerateMeshroomScene.py
+++ b/meshroom/nodes/general/GenerateMeshroomScene.py
@@ -96,9 +96,10 @@ class GenerateMeshroomScene(desc.Node):
         return overrides
 
     def process(self, node):
-        templateScene = node.templatePath.getValueStr(withQuotes=False)
+        templateScene = node.templatePath.getValueStr(withQuotes=False).strip()
+        templateScene = str(Path(templateScene).resolve())
         if not templateScene or not Path(templateScene).exists():
-            raise ValueError(f"{node} Invalid template scene: {templateScene}")
+            raise ValueError(f"{node} Invalid template scene: '{templateScene}'")
         inputOverrides = self.get_overrides(node.inputOverrides)
         paramOverrides = self.get_overrides(node.paramOverrides)
         sceneDestination = str(node.sceneDestination.getValueStr(withQuotes=False))


### PR DESCRIPTION
## Description

Error log was :
```
ValueError: GenerateMeshroomScene_1 Invalid template scene: '/s/apps/users/sonoleta/packages/mrVfxPipeline/repo/resources/cam_track/export_to_common.mg
'
```

For some reason a blank line was added after `getValueStr`
<img width="641" height="81" alt="image" src="https://github.com/user-attachments/assets/0fa82750-9981-4106-9625-6b8f28d2da09" />

<img width="787" height="341" alt="image" src="https://github.com/user-attachments/assets/d8c6caeb-90db-4873-8dfb-b5d8f79318d4" />

maybe there is a serialization issue
