### PR TITLE
Use the node name as the default label in the graph editor

### DIFF
--- a/localfarm/test.py
+++ b/localfarm/test.py
@@ -87,7 +87,6 @@ class TestLocalFarm:
 
 def test():
     farm_path = os.getenv("MR_LOCAL_FARM_PATH", os.path.join(os.path.expanduser("~"), ".local_farm"))
-    # farm_path = "/s/prods/mvg/_source_global/users/sonoleta/tmp/local_farm"
     _test = TestLocalFarm(farm_path)
     try:
         _test.prepare()

--- a/meshroom/core/graph.py
+++ b/meshroom/core/graph.py
@@ -490,7 +490,7 @@ class Graph(BaseObject):
             unavailableNames = set(self.nodes.keys())
             for node in graph.nodes:
                 if node._name in unavailableNames:
-                    node._name = self._createUniqueNodeName(node.nodeType, unavailableNames)
+                    node._name = self._createUniqueNodeName(node._name, unavailableNames)
                 unavailableNames.add(node._name)
 
         def _importNodesAndEdges() -> list[Node]:
@@ -533,7 +533,7 @@ class Graph(BaseObject):
                     node.nodeType, self.name, node.graph.name))
 
         assert uniqueName not in self._nodes.keys()
-        node._name = uniqueName
+        node.name = uniqueName
         node.graph = self
         self._nodes.add(node)
         node.chunksChanged.connect(self.updated)
@@ -758,12 +758,13 @@ class Graph(BaseObject):
         """
         existingNodeNames = existingNames or set(self._nodes.objects.keys())
 
+        baseName = re.sub(r"_\d+$", "", inputName)
         idx = 1
-        newName = inputName
+        newName = baseName
         while idx:
             if newName not in existingNodeNames:
                 return newName
-            newName = f"{inputName}_{idx}"
+            newName = f"{baseName}_{idx}"
             idx += 1
 
     def node(self, nodeName) -> Optional[Node]:

--- a/meshroom/core/graph.py
+++ b/meshroom/core/graph.py
@@ -570,8 +570,7 @@ class Graph(BaseObject):
         # Rename in the dict model
         self._nodes.rename(node._name, newName)
         # Finally rename the node name property and notify Qt
-        node._name = newName
-        node.nodeNameChanged.emit()
+        node.name = newName
 
     def copyNode(self, srcNode: Node, withEdges: bool=False):
         """
@@ -760,10 +759,11 @@ class Graph(BaseObject):
         existingNodeNames = existingNames or set(self._nodes.objects.keys())
 
         idx = 1
+        newName = inputName
         while idx:
-            newName = f"{inputName}_{idx}"
             if newName not in existingNodeNames:
                 return newName
+            newName = f"{inputName}_{idx}"
             idx += 1
 
     def node(self, nodeName) -> Optional[Node]:

--- a/meshroom/core/node.py
+++ b/meshroom/core/node.py
@@ -931,7 +931,11 @@ class BaseNode(BaseObject):
         return self._name
 
     def getDefaultLabel(self):
-        return self.nameToLabel(self._name)
+        return self.nodeType
+
+    def setName(self, value):
+        self._name = value
+        self.nodeNameChanged.emit()
 
     def getLabel(self) -> str:
         """
@@ -2312,7 +2316,7 @@ class BaseNode(BaseObject):
 
 
     nodeNameChanged = Signal()
-    name = Property(str, getName, notify=nodeNameChanged)
+    name = Property(str, getName, setName, notify=nodeNameChanged)
     defaultLabel = Property(str, getDefaultLabel, constant=True)
     nodeType = Property(str, nodeType.fget, constant=True)
     documentation = Property(str, getDocumentation, constant=True)

--- a/meshroom/core/node.py
+++ b/meshroom/core/node.py
@@ -946,7 +946,7 @@ class BaseNode(BaseObject):
             label = self.internalAttribute("label").value.strip()
             if label:
                 return label
-        return self.getDefaultLabel()
+        return self.getName()
 
     def getNodeLogLevel(self) -> str:
         """
@@ -1020,16 +1020,6 @@ class BaseNode(BaseObject):
         if self.hasInternalAttribute("nodeHeight"):
             return self.internalAttribute("nodeHeight").value
         return 0
-
-
-    @Slot(str, result=str)
-    def nameToLabel(self, name):
-        """
-        Returns:
-            str: the high-level label from the technical node name
-        """
-        t, idx = name.rsplit("_", 1) if "_" in name else (name, "1")
-        return f"{t}{idx if int(idx) > 1 else ''}"
 
     def getDocumentation(self):
         if not self.nodeDesc:

--- a/meshroom/core/taskManager.py
+++ b/meshroom/core/taskManager.py
@@ -453,7 +453,7 @@ class TaskManager(BaseObject):
         compatNodes = []
         for node in nodes:
             if node in graph._compatibilityNodes.values():
-                compatNodes.append(node.nameToLabel(node.name))
+                compatNodes.append(node.name)
         if compatNodes:
             # Warning: Syntax and terms are parsed on QML side to recognize the error
             # Syntax : [Context] ErrorType: ErrorMessage
@@ -469,7 +469,7 @@ class TaskManager(BaseObject):
                     # Syntax : [Context] ErrorType: ErrorMessage
                     raise RuntimeError(f"[{context}] Duplicates Issue:\n"
                                        f"Cannot compute because there are some duplicate nodes to process:\n\n"
-                                       f"First match: '{node.nameToLabel(node.name)}' and '{node.nameToLabel(duplicate.name)}'\n\n"
+                                       f"First match: '{node.name}' and '{duplicate.name}'\n\n"
                                        f"There can be other duplicate nodes in the list. "
                                        f"Please, check the graph and try again.")
 

--- a/meshroom/core/taskManager.py
+++ b/meshroom/core/taskManager.py
@@ -34,7 +34,7 @@ class TaskThread(QThread):
     """
     A thread with a pile of nodes to compute
     """
-    def __init__(self, manager):
+    def __init__(self, manager: "TaskManager"):
         QThread.__init__(self)
         self._state = State.IDLE
         self._manager = manager
@@ -397,6 +397,11 @@ class TaskManager(BaseObject):
         if name in self._nodes.keys():
             return True
         return False
+
+    def renameNode(self, node, newName):
+        """ Rename the node in the taskManager model. """
+        if self.containsNodeName(node.name):
+            self._nodes.rename(node.name, newName)
 
     def removeNode(self, node, displayList=True, processList=False, externList=False):
         """ Remove node from the Task Manager.

--- a/meshroom/nodes/general/InputInt.py
+++ b/meshroom/nodes/general/InputInt.py
@@ -19,3 +19,38 @@ class InputInt(desc.InitNode, desc.InputNode):
             exposed=True
         )
     ]
+
+
+class Input_Int2(desc.InitNode, desc.InputNode):
+    """
+    This node is an init node that receives an Integer.
+    """
+
+    category = "Other"
+
+    inputs = [
+        desc.IntParam(
+            name="integer",
+            label="Input Integer",
+            description="An integer.",
+            value=0,
+            exposed=True
+        )
+    ]
+
+class Input_Int_3(desc.InitNode, desc.InputNode):
+    """
+    This node is an init node that receives an Integer.
+    """
+
+    category = "Other"
+
+    inputs = [
+        desc.IntParam(
+            name="integer",
+            label="Input Integer",
+            description="An integer.",
+            value=0,
+            exposed=True
+        )
+    ]

--- a/meshroom/ui/commands.py
+++ b/meshroom/ui/commands.py
@@ -123,7 +123,7 @@ class UndoStack(QUndoStack):
 class GraphCommand(UndoCommand):
     def __init__(self, graph, parent=None):
         super().__init__(parent)
-        self.graph = graph
+        self.graph: Graph = graph
 
 
 class AddNodeCommand(GraphCommand):
@@ -153,20 +153,26 @@ class AddNodeCommand(GraphCommand):
 
 
 class RenameNodeCommand(GraphCommand):
-    def __init__(self, graph, node, name, parent=None):
+    def __init__(self, graph, node, name, taskManager=None, parent=None):
         """ Command to rename a node. The new name should not be used yet.
         """
         super().__init__(graph, parent)
+        self.taskManager = taskManager
         self.node = node
         self.oldName = node._name
         self.name = name
 
+    def renameNodeFromTaskManager(self, name):
+        self.taskManager.renameNode(self.node, name)
+
     def redoImpl(self):
         self.setText(f"Rename Node {self.oldName} to {self.name}")
+        self.renameNodeFromTaskManager(self.name)
         self.graph.renameNode(self.node, self.name)
         return self.node._name
 
     def undoImpl(self):
+        self.renameNodeFromTaskManager(self.oldName)
         self.graph.renameNode(self.node, self.oldName)
 
 

--- a/meshroom/ui/graph.py
+++ b/meshroom/ui/graph.py
@@ -1014,11 +1014,15 @@ class UIGraph(QObject):
         if not newName:
             # Empty string -> reset to default
             newName = node.defaultLabel
-        # Create unique name
-        uniqueName = self._graph._createUniqueNodeName(newName, {n._name for n in self._graph._nodes if n != node})
-        if not newName or uniqueName == node._name:
+        # Eliminate all characters except digits and letters and underscore
+        newName = re.sub(r"[^0-9a-zA-Z\_]", "", newName)
+        if not newName:
             return ""
-        return self.push(commands.RenameNodeCommand(self._graph, node, uniqueName, taskManager=self.taskManager))
+        # Create unique name
+        newName = self._graph._createUniqueNodeName(newName, {n._name for n in self._graph._nodes if n != node})
+        if newName == node._name:
+            return ""
+        return self.push(commands.RenameNodeCommand(self._graph, node, newName, taskManager=self.taskManager))
 
     def moveNode(self, node: Node, position: Position):
         """

--- a/meshroom/ui/graph.py
+++ b/meshroom/ui/graph.py
@@ -1000,12 +1000,9 @@ class UIGraph(QObject):
     @Slot(Node, str, result=str)
     def renameNode(self, node: Node, newName: str):
         """ Triggers the node renaming.
-
-        In this function the last `_N` index is removed, then all special characters
-        (everything except letters and numbers) are removed.
-        The name uniqueness will be ensured later by adding a suffix (e.g. `_1`, `_2`, ...)
-
-        Labels can be used to have special characters in the displayed name.
+        This will also validate the node authorized characters and make sure the
+        name is unique.
+        An empty string will reset the name to the default.
 
         Args:
             node (Node): Node to rename.
@@ -1014,9 +1011,9 @@ class UIGraph(QObject):
         Returns:
             str: The final name of the node.
         """
-        newName = "_".join(newName.split("_")[:-1]) if "_" in newName else newName
-        # Eliminate all characters except digits and letters
-        newName = re.sub(r"[^0-9a-zA-Z]", "", newName)
+        if not newName:
+            # Empty string -> reset to default
+            newName = node.defaultLabel
         # Create unique name
         uniqueName = self._graph._createUniqueNodeName(newName, {n._name for n in self._graph._nodes if n != node})
         if not newName or uniqueName == node._name:

--- a/meshroom/ui/graph.py
+++ b/meshroom/ui/graph.py
@@ -1021,7 +1021,7 @@ class UIGraph(QObject):
         uniqueName = self._graph._createUniqueNodeName(newName, {n._name for n in self._graph._nodes if n != node})
         if not newName or uniqueName == node._name:
             return ""
-        return self.push(commands.RenameNodeCommand(self._graph, node, uniqueName))
+        return self.push(commands.RenameNodeCommand(self._graph, node, uniqueName, taskManager=self.taskManager))
 
     def moveNode(self, node: Node, position: Position):
         """

--- a/meshroom/ui/qml/GraphEditor/Node.qml
+++ b/meshroom/ui/qml/GraphEditor/Node.qml
@@ -232,11 +232,11 @@ Item {
             const currentNode = node.duplicates.at(i)
 
             if (i === node.duplicates.count - 1) {
-                str += currentNode.nameToLabel(currentNode.name)
+                str += currentNode.name
                 return str
             }
 
-            str += (currentNode.nameToLabel(currentNode.name) + ", ")
+            str += (currentNode.name + ", ")
         }
         return str
     }

--- a/meshroom/ui/qml/GraphEditor/NodeEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/NodeEditor.qml
@@ -83,7 +83,7 @@ Panel {
 
     // Function to validate and apply node name change
     function validateNodeNameChange(name) {
-        if (root.node && name.trim() !== "") {
+        if (root.node) {
             const newNodeName = _currentScene.renameNode(_currentScene.selectedNode, name.trim())
             if (newNodeName === "") {
                 root.displayNodeName = root.nodeName

--- a/meshroom/ui/qml/GraphEditor/NodeEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/NodeEditor.qml
@@ -33,7 +33,7 @@ Panel {
             root.validatedNodeName = nodeName
             // Set the display node type only if it is not contained in the node name
             const nodeType = _currentScene.selectedNode.nodeType
-            root.displayNodeType = nodeName.startsWith(nodeType + "_") ? "" : nodeType
+            root.displayNodeType = (nodeName == nodeType || nodeName.startsWith(nodeType + "_")) ? "" : nodeType
         }
     }
 

--- a/meshroom/ui/qml/GraphEditor/TaskManager.qml
+++ b/meshroom/ui/qml/GraphEditor/TaskManager.qml
@@ -334,7 +334,7 @@ Item {
                     }
                 }
                 Label {
-                    text: object.label
+                    text: object.name
                     elide: Text.ElideRight
                     Layout.preferredWidth: 200
                     Layout.preferredHeight: parent.height

--- a/tests/test_anySet_attribute.py
+++ b/tests/test_anySet_attribute.py
@@ -229,7 +229,7 @@ def test_dynamic_inputs_serialized_in_todict():
     assert outputAttribute.get('type') == 'File'
     assert outputAttribute.get('value') == ''
 
-    assert lsNode3.toDict().get('inputs').get('input') == '{DynamicNode_1.outs.input}'  # Check for connection
+    assert lsNode3.toDict().get('inputs').get('input') == '{DynamicNode.outs.input}'  # Check for connection
 
 def test_dynamic_inputs_restored_after_load(tmp_path):
     """Dynamic inputs survive a graph save/load cycle."""

--- a/tests/test_compute.py
+++ b/tests/test_compute.py
@@ -157,7 +157,7 @@ class TestNodeLogger:
         for chunkIndex, logFile in logFiles.items():
             with open(logFile, "r") as f:
                 content = f.read()
-                reg = re.compile(self.logPrefix + r"\(chunk.logger\) TestNodeA_1")
+                reg = re.compile(self.logPrefix + r"\(chunk.logger\) TestNodeA")
                 assert len(reg.findall(content)) == 1
                 reg = re.compile(self.logPrefix + r"\(root logger\) " + f"{chunkIndex}/2")
                 assert len(reg.findall(content)) == 1
@@ -167,7 +167,7 @@ class TestNodeLogger:
         for chunkIndex, logFile in logFiles.items():
             with open(logFile, "r") as f:
                 content = f.read()
-                reg = re.compile(self.logPrefix + r"\(chunk.logger\) TestNodeB_1")
+                reg = re.compile(self.logPrefix + r"\(chunk.logger\) TestNodeB")
                 assert len(reg.findall(content)) == 1
                 reg = re.compile(self.logPrefix + r"\(root logger\) 0/0")
                 assert len(reg.findall(content)) == 1
@@ -181,7 +181,7 @@ class TestNodeLogger:
         for _, logFile in logFiles.items():
             with open(logFile, "r") as f:
                 content = f.read()
-                reg = re.compile(self.logPrefix + "TestNodeC_1")
+                reg = re.compile(self.logPrefix + "TestNodeC")
                 assert len(reg.findall(content)) == 1
 
     def test_processChunkInEnvironment_quotesGraphFilepathWithSpaces(self, tmp_path):
@@ -228,7 +228,7 @@ class TestNodeLogger:
         def check_file(path, suffix=""):
             with open(path, "r") as f:
                 content = f.read()
-                reg = re.compile(self.logPrefix + "TestNodeD_1" + suffix)
+                reg = re.compile(self.logPrefix + "TestNodeD" + suffix)
                 assert len(reg.findall(content)) == 1
 
         check_file(preprocessLog, r" \(preprocess\)")

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -116,9 +116,9 @@ def test_rename_nodes():
     ls2 = graph.addNewNode("Ls")
 
     # Test with empty string
-    assert ls0.name == "Ls_1"
+    assert ls0.name == "Ls"
     graph.renameNode(ls0, "")
-    assert ls0.name == "Ls_1"
+    assert ls0.name == "Ls"
 
     # Rename
     graph.renameNode(ls0, "nodels")

--- a/tests/test_graphIO.py
+++ b/tests/test_graphIO.py
@@ -448,7 +448,7 @@ class TestTemplateSerialization:
             graph.addNewNode("SimpleNode")
 
             data = graph.serialize(asTemplate=True)
-            nodeData = data["graph"]["SimpleNode_1"]
+            nodeData = data["graph"]["SimpleNode"]
 
             assert "outputs" not in nodeData
             assert "uid" not in nodeData
@@ -461,7 +461,7 @@ class TestTemplateSerialization:
             graph.addNewNode("SimpleNode")
 
             data = graph.serialize(asTemplate=True)
-            nodeData = data["graph"]["SimpleNode_1"]
+            nodeData = data["graph"]["SimpleNode"]
 
             # All inputs are at default, so inputs should be empty or absent
             assert nodeData.get("inputs", {}) == {}
@@ -474,7 +474,7 @@ class TestTemplateSerialization:
             node.attribute("input").value = "/some/path"
 
             data = graph.serialize(asTemplate=True)
-            nodeData = data["graph"]["SimpleNode_1"]
+            nodeData = data["graph"]["SimpleNode"]
 
             assert nodeData["inputs"]["input"] == "/some/path"
 

--- a/tests/test_groupAttributes.py
+++ b/tests/test_groupAttributes.py
@@ -38,7 +38,7 @@ class TestGroupAttributes:
         # Reload the graph
         graph = loadGraph(graphFile)
 
-        assert graph.node("GroupAttributes_2").firstGroup.inputLink == graph.node("GroupAttributes_1").firstGroup
+        assert graph.node("GroupAttributes_1").firstGroup.inputLink == graph.node("GroupAttributes").firstGroup
 
     def test_saveLoadGroupConnections(self):
         """
@@ -202,8 +202,8 @@ class TestGroupAttributes:
 
         # Reload the graph
         graph = loadGraph(graphFile)
-        nestedPosition = graph.node("NestedPosition_1")
-        nestedColor = graph.node("NestedColor_1")
+        nestedPosition = graph.node("NestedPosition")
+        nestedColor = graph.node("NestedColor")
 
         assert nestedPosition.xyz.isLink and \
             nestedPosition.xyz.inputLink.asLinkExpr() == nestedColor.rgb.asLinkExpr()

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -80,7 +80,8 @@ class TestNodeInfo:
         nodeInfo = {item["key"]: item["value"] for item in node.getNodeInfo()}
         assert nodeInfo["module"].endswith("pluginC.PluginCNodeA")
         pluginPath = os.path.join(self.folder, "pluginC", "PluginCNodeA.py")
-        assert nodeInfo["modulePath"] == Path(pluginPath).as_posix()  # modulePath seems to follow Linux convention
+        # modulePath seems to follow Linux convention
+        assert nodeInfo["modulePath"] == Path(pluginPath).resolve().as_posix()
         assert nodeInfo["author"] == "testAuthor"
         assert nodeInfo["license"] == "no-license"
         assert nodeInfo["version"] == "1.0"
@@ -256,7 +257,7 @@ class TestBackdropNode:
 
         # Reload the graph and check the values for the backdrop node are the default ones
         g = loadGraph(graphFile)
-        backdrop = g.node("Backdrop_1")
+        backdrop = g.node("Backdrop")
         assert backdrop is not None
         assert backdrop.nodeWidth == 600
         assert backdrop.nodeHeight == 400
@@ -290,7 +291,7 @@ class TestBackdropNode:
 
         # Reload the graph and check the values for the backdrop node are the default ones
         g = loadGraph(graphFile)
-        backdrop = g.node("Backdrop_1")
+        backdrop = g.node("Backdrop")
         assert backdrop is not None
         assert backdrop.nodeWidth == 400
         assert backdrop.nodeHeight == 200
@@ -310,7 +311,7 @@ class TestBackdropNode:
 
         # Reload the graph and check both nodes are present
         g = loadGraph(templateFile)
-        assert g.node("Backdrop_1") is not None
+        assert g.node("Backdrop") is not None
 
     def test_backdropNode_templateSerialization_customAttributes(self):
         """ Test that a backdrop node with custom values is correctly saved as a template. """
@@ -326,7 +327,7 @@ class TestBackdropNode:
 
         # Reload and verify custom values are preserved
         g = loadGraph(templateFile)
-        backdrop = g.node("Backdrop_1")
+        backdrop = g.node("Backdrop")
         assert backdrop is not None
         assert backdrop.nodeWidth == 400
         assert backdrop.comment == "Template backdrop"


### PR DESCRIPTION
## Description

1. This PR will make sure the node name and displayed name in the graph editor are the same (_Fig. 1_).
2. This PR fixes an issue in the task manager. When a node is computed, it is added to the task manager dict model. If the node is renamed the node is still in the dict model but with the wrong key. It used to block relaunching the compute on this node. Now renaming the node will also update the key in the task manager dict model.
3. Now copying nodes will set the correct name, not reset the node name to the node type.
4. Node name by default has no index suffix (only if the name is taken). Then if we create a new node with the same name the node will have the suffix `_1`, then `_2`, and so on (_Fig. 2_).
5. Now, setting the name to an empty string will reset the name to the default label

<p align="center">
    <img width="700" alt="image" src="https://github.com/user-attachments/assets/3930cd59-6570-4636-8afb-8691e36efd66" />
    <img width="700 alt="image" src="https://github.com/user-attachments/assets/dcd3b5a2-b926-447f-9802-9c1a5a5b94af" />
    <br/>
    <i>Fig. 1: Before (top) / After (bottom)</i>
</p>

<p align="center">
    <img width="700" alt="image" src="https://github.com/user-attachments/assets/2f9139e3-3f76-4754-8815-245cafb19e36" />
    <br/>
    <i>Fig. 2: Nodes have no more index suffix by default</i>
</p>

> [!IMPORTANT]
> Even though the node name edition box blocks typing underscores, nodes can technically have underscores in their names : if the underscore character is c/p in the node name; if we edit the graph on disk; or if the node description class name have the symbol.
> Now the unique name generation rely on removing the end `_N` suffix, so underscores are preserved.
> The only exception are node types named "`XXX_N`" (e.g. `NodeType_Test_3`) : if nodes with this node type are created, the name will be stripped from the `_N`prefix (in our case: `NodeType_Test` for the first instance, then `NodeType_Test_1`, etc)