### PR TITLE
UI: Add buttons to unlock the node

### DIFF
--- a/meshroom/ui/qml/Application.qml
+++ b/meshroom/ui/qml/Application.qml
@@ -1368,18 +1368,22 @@ Page {
                             checked: graphEditorMenu.visible
                             Menu {
                                 id: graphEditorMenu
+                                property int nodeSelection: _currentScene.nodeSelection.selectedIndexes.length
+                                // Must set the width because of Menu Items whose text changes
+                                width: Math.max(implicitWidth, 270)
                                 y: parent.height
                                 x: -width + parent.width
                                 MenuItem {
-                                    text: "Clear Pending Status"
+                                    text: graphEditorMenu.nodeSelection === 0 
+                                        ? "Clear Pending Status" 
+                                        : "Clear Pending Status On Selected Nodes"
                                     enabled: _currentScene ? !_currentScene.computingLocally : false
                                     onTriggered: _currentScene.graph.clearSubmittedNodes(_currentScene.getSelectedNodes())
                                 }
                                 MenuItem {
-                                    text: "Force Unlock Nodes"
+                                    text: graphEditorMenu.nodeSelection === 0 ? "Unlock All Nodes" : "Unlock Selected Nodes"
                                     onTriggered: _currentScene.graph.forceUnlockNodes(_currentScene.getSelectedNodes())
                                 }
-
                                 Menu {
                                     title: "Auto Layout Depth"
 

--- a/meshroom/ui/qml/GraphEditor/GraphEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/GraphEditor.qml
@@ -781,6 +781,17 @@ Item {
                         onTriggered: uigraph.restartJobErrorTasks(nodeMenu.currentNode)
                     }
                     MenuItem {
+                        text: "Unlock Node"
+                        enabled: nodeMenu.currentNode.locked
+                        height: visible ? implicitHeight : 0
+                        onTriggered: uigraph.graph.forceUnlockNodes([nodeMenu.currentNode])
+                    }
+                    MenuItem {
+                        text: "Unlock Selected Nodes"
+                        height: visible ? implicitHeight : 0
+                        onTriggered: uigraph.graph.forceUnlockNodes(_currentScene.getSelectedNodes())
+                    }
+                    MenuItem {
                         text: "Open Folder"
                         visible: nodeMenu.currentNode.isComputableType
                         height: visible ? implicitHeight : 0


### PR DESCRIPTION
## Description

Add 2 buttons on the Graph Editor node context menu:
- "Unlock Node": unlock current node, only available if the node is locked
- "Unlock Selected Nodes": unlock selected nodes

When the node is locked you can simply unlock this node:
<img width="575" height="599" alt="image" src="https://github.com/user-attachments/assets/9cc33068-59cf-410b-bba3-40aa1adb2502" />

Also you can unlock selected nodes:
<img width="1024" height="471" alt="image" src="https://github.com/user-attachments/assets/2d7ccef8-7067-4e6c-a114-86f633584c7f" />