### PR TITLE
Attribute converter nodes

### DIFF
--- a/bin/meshroom_info
+++ b/bin/meshroom_info
@@ -29,6 +29,10 @@ version_mode_parser = subparsers.add_parser(
     "version", help="Display Meshroom version.")
 version_mode_parser.add_argument("-p", "--path", action="store_true")
 
+# Attribute Converter info subparser
+converters_mode_parser = subparsers.add_parser(
+    "attrconvert", help="Display AttributeConverter nodes info.")
+
 # Node info subparser
 nodes_mode_parser = subparsers.add_parser(
     "nodeinfo", help="Display nodes info.")
@@ -46,6 +50,18 @@ def get_version(args):
     print(f"Meshroom version is {meshroom.__version__}")
     if args.path:
         print(f"Meshroom is located at {meshroom._MESHROOM_ROOT}")
+
+
+# ===== ATTRIBUTE CONVERTERS =====
+def get_attributeconverter_info(args):
+    import meshroom.core
+    meshroom.core.initNodes()
+    converterNodes = meshroom.core.AttributeConverterRegistry.getAllConverters()
+    print(f"Available Attribute Converters ({len(converterNodes)}):")
+    for (srcType, dstType), converters in meshroom.core.AttributeConverterRegistry._converters.items():
+        print(f"\n  Convert from {srcType.__name__} to {dstType.__name__}:")
+        for converter in converters:
+            print(f"    - {converter.__name__}")
 
 
 # ===== NODES =====
@@ -161,6 +177,8 @@ if __name__ == "__main__":
     
     if args.command == "version":
         get_version(args)
+    elif args.command == "attrconvert":
+        get_attributeconverter_info(args)
     elif args.command == "nodeinfo":
         get_nodes_info(args)
     elif args.command == "pipelines":

--- a/meshroom/core/__init__.py
+++ b/meshroom/core/__init__.py
@@ -27,7 +27,7 @@ from meshroom.core.plugins import (
     formatNodeDescriptionErrorMessage
 )
 from meshroom.core.submitter import BaseSubmitter
-from meshroom.core.desc.attributeConverter import AttributeConverter
+from meshroom.core.attributeConverter import AttributeConverter
 from meshroom.env import EnvVar, meshroomFolder
 from . import desc
 from .desc import MrNodeType

--- a/meshroom/core/__init__.py
+++ b/meshroom/core/__init__.py
@@ -18,8 +18,16 @@ try:
 except Exception:
     pass
 
-from meshroom.core.plugins import NodePlugin, NodePluginManager, Plugin, processEnvFactory, formatNodeDescriptionErrorMessage
+from meshroom.core.plugins import (
+    NodePlugin,
+    NodePluginManager,
+    AttributeConverterRegistry,
+    Plugin,
+    processEnvFactory,
+    formatNodeDescriptionErrorMessage
+)
 from meshroom.core.submitter import BaseSubmitter
+from meshroom.core.desc.attributeConverter import AttributeConverter
 from meshroom.env import EnvVar, meshroomFolder
 from . import desc
 from .desc import MrNodeType
@@ -195,6 +203,23 @@ def loadClassesSubmitters(folder: str, packageName: str) -> list[BaseSubmitter]:
                              module's search
     """
     return loadClasses(folder, packageName, BaseSubmitter)
+
+
+def loadAttributeConverterClasses(folder: str, packageName: str) -> list[AttributeConverter]:
+    """
+    Return the list of all the AttributeConverter nodes that were found during
+    the search of the Python module named "packageName" that located in the folder
+    "folder". An AttributeConverter node is found if a file within "packageName"
+    contains a class inheriting from `AttributeConverter`.
+
+    Args:
+        folder: the folder to load the module from.
+        packageName: the name of the module to look for nodes in.
+
+    Returns:
+        list[AttributeConverter]: a list of all the atribute converters that were found in the module.
+    """
+    return loadClasses(folder, packageName, AttributeConverter)
 
 
 class Version:
@@ -411,6 +436,28 @@ def loadAllSubmitters(folder) -> list[BaseSubmitter]:
     return submitters
 
 
+def registerAttributeConverter(converter: AttributeConverter):
+    AttributeConverterRegistry.add(converter)
+
+
+def loadAttributeConverter(folder, packageName) -> list[AttributeConverter]:
+    if not os.path.isdir(folder):
+        logging.error(f"AttributeConverter folder '{folder}' does not exist.")
+        return
+
+    return loadAttributeConverterClasses(folder, packageName)
+
+
+def loadAllAttributeConverters(folder) -> list[AttributeConverter]:
+    attributeConverters = []
+    for _, package, ispkg in pkgutil.iter_modules([folder]):
+        if ispkg:
+            converters = loadAttributeConverter(folder, package)
+            if converters:
+                attributeConverters.extend(converters)
+    return attributeConverters
+
+
 def loadPipelineTemplates(folder: str):
     if not os.path.isdir(folder):
         logging.error(f"Pipeline templates folder '{folder}' does not exist.")
@@ -424,6 +471,11 @@ def initNodes():
     additionalNodesPath = EnvVar.getList(EnvVar.MESHROOM_NODES_PATH)
     nodesFolders = [os.path.join(meshroomFolder, "nodes")] + additionalNodesPath
     for f in nodesFolders:
+        # Load converter nodes
+        converterNodes = loadAllAttributeConverters(folder=f)
+        for cn in converterNodes:
+            registerAttributeConverter(cn)
+        # Load nodes
         plugins = loadAllNodes(folder=f)
         if plugins:
             for plugin in plugins:

--- a/meshroom/core/__init__.py
+++ b/meshroom/core/__init__.py
@@ -442,7 +442,7 @@ def registerAttributeConverter(converter: AttributeConverter):
 def loadAttributeConverter(folder, packageName) -> list[AttributeConverter]:
     if not os.path.isdir(folder):
         logging.error(f"AttributeConverter folder '{folder}' does not exist.")
-        return
+        return []
 
     return loadAttributeConverterClasses(folder, packageName)
 

--- a/meshroom/core/__init__.py
+++ b/meshroom/core/__init__.py
@@ -21,13 +21,12 @@ except Exception:
 from meshroom.core.plugins import (
     NodePlugin,
     NodePluginManager,
-    AttributeConverterRegistry,
     Plugin,
     processEnvFactory,
     formatNodeDescriptionErrorMessage
 )
 from meshroom.core.submitter import BaseSubmitter
-from meshroom.core.attributeConverter import AttributeConverter
+from meshroom.core.attributeConverter import AttributeConverter, AttributeConverterRegistry
 from meshroom.env import EnvVar, meshroomFolder
 from . import desc
 from .desc import MrNodeType
@@ -437,7 +436,7 @@ def loadAllSubmitters(folder) -> list[BaseSubmitter]:
 
 
 def registerAttributeConverter(converter: AttributeConverter):
-    AttributeConverterRegistry.add(converter)
+    AttributeConverterRegistry.add(converter())
 
 
 def loadAttributeConverter(folder, packageName) -> list[AttributeConverter]:

--- a/meshroom/core/attribute.py
+++ b/meshroom/core/attribute.py
@@ -324,7 +324,7 @@ class Attribute(BaseObject):
             self._linkExpression = value
         return True
 
-    def _applyExpr(self):
+    def _applyExpr(self, converterMap: dict = None):
         """
         For string parameters with an expression (when loaded from file),
         this function convert the expression into a real edge in the graph
@@ -353,7 +353,13 @@ class Attribute(BaseObject):
             attr = node.attribute(linkAttrName) if node.hasAttribute(linkAttrName) else node.internalAttribute(linkAttrName)
             if attr is None:
                 raise InvalidEdgeError(self.fullName, link, "Source attribute does not exist.")
-            attr.connectTo(self)
+            connectedEdge, _ = attr.connectTo(self)
+            if connectedEdge:
+                src, dst = connectedEdge[0]
+                if converterMap and (converterName:=converterMap.get((src.fullName, dst.fullName))): 
+                    logging.info(f"Edge {src.fullName}->{dst.fullName}: set converter to {converterName}")
+                    edge = self.node.graph.edge(dst)
+                    edge.setConverter(converterName)
         except InvalidEdgeError as err:
             logging.warning(err)
         except Exception as err:
@@ -1039,9 +1045,9 @@ class ListAttribute(Attribute):
             self.requestGraphUpdate()
 
     # Override
-    def _applyExpr(self):
+    def _applyExpr(self, converterMap: dict = None):
         if self._linkExpression:
-            super()._applyExpr()
+            super()._applyExpr(converterMap)
         else:
             for value in self._value:
                 value._applyExpr()
@@ -1288,12 +1294,12 @@ class GroupAttribute(Attribute, Expandable):
             raise AttributeError(f"Failed to set on GroupAttribute: {str(value)}")
 
     # Override
-    def _applyExpr(self):
+    def _applyExpr(self, converterMap: dict = None):
         if self._linkExpression:
-            super()._applyExpr()
+            super()._applyExpr(converterMap)
         else:
             for value in self._value:
-                value._applyExpr()
+                value._applyExpr(converterMap)
 
     # Override
     def resetToDefaultValue(self):

--- a/meshroom/core/attribute.py
+++ b/meshroom/core/attribute.py
@@ -674,7 +674,9 @@ class Attribute(BaseObject):
         Returns:
             True if the connection is valid, False otherwise.
         """
-        return self.baseType == connectingAttribute.baseType
+        if self.baseType == connectingAttribute.baseType:
+            return True
+        return AttributeConverterRegistry.hasConverter(connectingAttribute.baseType, self.baseType)
 
     def connectTo(self, dstAttribute: Attribute) -> tuple[list[list[Attribute]], list[list[Attribute]]]:
         """
@@ -748,8 +750,7 @@ class Attribute(BaseObject):
         Return True if this Attribute can receive a connection from
         "connectingAttribute", False otherwise.
         """
-        return self._validateIncomingConnection(connectingAttribute) or \
-            AttributeConverterRegistry.hasConverter(connectingAttribute.desc.type, self.desc.type)
+        return self._validateIncomingConnection(connectingAttribute)
 
     # Properties and signals
 

--- a/meshroom/core/attribute.py
+++ b/meshroom/core/attribute.py
@@ -872,7 +872,9 @@ class ChoiceParam(Attribute):
 
     def getValues(self):
         if (linkParam := self._getInputLink()) is not None:
-            return linkParam.getValues()
+            edges = [e for e in self.node.graph.edges.values() if e.dst == self]
+            if edges:
+                return edges[0].resolvedValues()
         return self._values if self._values is not None else self._desc._values
 
     def setValues(self, values):

--- a/meshroom/core/attribute.py
+++ b/meshroom/core/attribute.py
@@ -14,7 +14,7 @@ from string import Template
 from meshroom.common import BaseObject, Property, Variant, Signal, ListModel, DictModel, Slot
 from meshroom.core.desc.validators import NotEmptyValidator
 from meshroom.core import desc, hashValue
-
+from meshroom.core.attributeConverter import AttributeConverter, AttributeConverterRegistry
 from meshroom.core.desc import Attribute as AttributeDescription
 
 from meshroom.core.keyValues import KeyValues
@@ -239,7 +239,8 @@ class Attribute(BaseObject):
         if self.keyable:
             raise RuntimeError(f"Cannot get value of {self._getFullName()}, the attribute is keyable.")
         if self.isLink:
-            return self._getInputLink().value
+            edge = self.node.graph.edge(self)
+            return edge.resolvedValue()
         self._resolveValue()
         return self._value
 
@@ -741,7 +742,8 @@ class Attribute(BaseObject):
         Return True if this Attribute can receive a connection from
         "connectingAttribute", False otherwise.
         """
-        return self._validateIncomingConnection(connectingAttribute)
+        return self._validateIncomingConnection(connectingAttribute) or \
+            AttributeConverterRegistry.hasConverter(connectingAttribute.desc.type, self.desc.type)
 
     # Properties and signals
 

--- a/meshroom/core/attribute.py
+++ b/meshroom/core/attribute.py
@@ -14,7 +14,7 @@ from string import Template
 from meshroom.common import BaseObject, Property, Variant, Signal, ListModel, DictModel, Slot
 from meshroom.core.desc.validators import NotEmptyValidator
 from meshroom.core import desc, hashValue
-from meshroom.core.attributeConverter import AttributeConverter, AttributeConverterRegistry
+from meshroom.core.attributeConverter import AttributeConverterRegistry
 from meshroom.core.desc import Attribute as AttributeDescription
 
 from meshroom.core.keyValues import KeyValues

--- a/meshroom/core/attributeConverter.py
+++ b/meshroom/core/attributeConverter.py
@@ -2,8 +2,11 @@
 attributeConverter: base descriptors class for AttributeConverter nodes
 """
 
+import logging
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING
+from collections import defaultdict
+from itertools import chain
 
 if TYPE_CHECKING:
     from meshroom.core.desc.attribute import Attribute
@@ -20,33 +23,72 @@ class AttributeConverter(ABC):
     priority = 10  # Put a higher number to prioritize specific converters
 
     # Input / Output classes
-    srcType: Attribute = None
-    dstType: Attribute = None
+    srcType: "Attribute" = None
+    dstType: "Attribute" = None
 
     @classmethod
     def getName(cls):
         return cls.name or cls.__name__
 
-    @classmethod
-    def canConvert(cls, srcType, dstType):
+    def canConvert(self, srcType, dstType):
         """ Check if this converter corresponds to a source/destination attribute pair.
         """
-        return isinstance(srcType, cls.srcType) and isinstance(dstType, cls.dstType)
+        return isinstance(srcType, self.srcType) and isinstance(dstType, self.dstType)
 
-    @classmethod
     @abstractmethod
-    def convert(cls, value):
+    def convert(self, value):
         """ Convert a value from the source attribute's type to a value for
         the destination attribute's type.
         """
         return value
 
-    @classmethod
-    def isValid(cls, value):
+    def isValid(self, value):
         """ In general case we suppose the conversion is always possible, but
         this method enables optional type checking.
         """
         return True
 
     def __repr__(self):
-        return f"<AttributeConverter '{self.getName()}': {self.srcType} -> {self.dstType}>"
+        return f"<AttributeConverter {self.getName()} ({self.srcType.__name__} -> {self.dstType.__name__})>"
+
+
+class AttributeConverterRegistry:
+    """
+    Registry of available converters
+    """
+
+    # { (srcType, dstType): [converters] }
+    _converters: dict[tuple["Attribute", "Attribute"], list[AttributeConverter]] = defaultdict(list)
+
+    @classmethod
+    def add(cls, converter: AttributeConverter):
+        logging.info(
+            f"Add converter class: {converter.getName()} "
+            f"({converter.srcType.__name__} -> {converter.dstType.__name__})"
+        )
+        if not issubclass(converter.__class__, AttributeConverter):
+            raise TypeError(f"{converter} parent class must subclass AttributeConverter")
+        cls._converters[(converter.srcType.__name__, converter.dstType.__name__)].append(converter)
+
+    @classmethod
+    def getAllConverters(cls) -> list[AttributeConverter]:
+        return list(chain.from_iterable(cls._converters.values()))
+    
+    @classmethod
+    def hasConverter(cls, srcType: "Attribute", dstType: "Attribute") -> list[AttributeConverter]:
+        return  ((srcType, dstType)) in cls._converters
+
+    @classmethod
+    def getConverters(cls, srcType: "Attribute", dstType: "Attribute") -> list[AttributeConverter]:
+        """ Get priority-ordered converters.
+        """
+        converters = cls._converters.get((srcType, dstType), [])
+        return sorted(converters, key=lambda c: -c.priority)
+
+    @classmethod
+    def getConverter(cls, srcType: "Attribute", dstType: "Attribute") -> AttributeConverter:
+        """ Get highest priority converter. """
+        converters = cls.getConverters(srcType, dstType)
+        if not converters:
+            return None
+        return converters[0]

--- a/meshroom/core/attributeConverter.py
+++ b/meshroom/core/attributeConverter.py
@@ -3,7 +3,10 @@ attributeConverter: base descriptors class for AttributeConverter nodes
 """
 
 from abc import ABC, abstractmethod
-from .attribute import Attribute
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from meshroom.core.desc.attribute import Attribute
 
 
 class AttributeConverter(ABC):
@@ -12,13 +15,17 @@ class AttributeConverter(ABC):
     into a value for a destination Attribute of a different type, 
     so a connection can be made between them.
     """
-    
-    # Put a higher number to prioritize specific converters
-    priority = 10
+
+    name = ""
+    priority = 10  # Put a higher number to prioritize specific converters
 
     # Input / Output classes
     srcType: Attribute = None
     dstType: Attribute = None
+
+    @classmethod
+    def getName(cls):
+        return cls.name or cls.__name__
 
     @classmethod
     def canConvert(cls, srcType, dstType):
@@ -42,4 +49,4 @@ class AttributeConverter(ABC):
         return True
 
     def __repr__(self):
-        return f"<AttributeConverter '{self.__class__.__name__}': {self.srcType} -> {self.dstType}>"
+        return f"<AttributeConverter '{self.getName()}': {self.srcType} -> {self.dstType}>"

--- a/meshroom/core/attributeConverter.py
+++ b/meshroom/core/attributeConverter.py
@@ -43,12 +43,6 @@ class AttributeConverter(ABC):
         """
         return value
 
-    def isValid(self, value):
-        """ In general case we suppose the conversion is always possible, but
-        this method enables optional type checking.
-        """
-        return True
-
     def __repr__(self):
         return f"<AttributeConverter {self.getName()} ({self.srcType.__name__} -> {self.dstType.__name__})>"
 

--- a/meshroom/core/attributeConverter.py
+++ b/meshroom/core/attributeConverter.py
@@ -4,7 +4,7 @@ attributeConverter: base descriptors class for AttributeConverter nodes
 
 import logging
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, ClassVar
 from collections import defaultdict
 from itertools import chain
 
@@ -19,13 +19,19 @@ class AttributeConverter(ABC):
     so a connection can be made between them.
     """
 
-    name = ""
-    description = ""
-    priority = 10  # Put a higher number to prioritize specific converters
+    name: ClassVar[str] = ""
+    description: ClassVar[str] = ""
+    priority: ClassVar[int] = 10  # Put a higher number to prioritize specific converters
 
     # Input / Output classes
-    srcType: "Attribute" = None
-    dstType: "Attribute" = None
+    srcType: ClassVar["Attribute"] = None
+    dstType: ClassVar["Attribute"] = None
+    
+    def __init__(self):
+        if not all ((self.srcType, self.dstType)):
+            raise TypeError(
+                f"Class '{self.__class__.__name__}' must define srcType and dstType."
+            )
 
     @classmethod
     def getName(cls):
@@ -57,12 +63,12 @@ class AttributeConverterRegistry:
 
     @classmethod
     def add(cls, converter: AttributeConverter):
+        if not issubclass(converter.__class__, AttributeConverter):
+            raise TypeError(f"{converter} parent class must subclass AttributeConverter")
         logging.info(
             f"Add converter class: {converter.getName()} "
             f"({converter.srcType.__name__} -> {converter.dstType.__name__})"
         )
-        if not issubclass(converter.__class__, AttributeConverter):
-            raise TypeError(f"{converter} parent class must subclass AttributeConverter")
         cls._converters[(converter.srcType.__name__, converter.dstType.__name__)].append(converter)
 
     @classmethod

--- a/meshroom/core/attributeConverter.py
+++ b/meshroom/core/attributeConverter.py
@@ -20,6 +20,7 @@ class AttributeConverter(ABC):
     """
 
     name = ""
+    description = ""
     priority = 10  # Put a higher number to prioritize specific converters
 
     # Input / Output classes
@@ -73,7 +74,14 @@ class AttributeConverterRegistry:
     @classmethod
     def getAllConverters(cls) -> list[AttributeConverter]:
         return list(chain.from_iterable(cls._converters.values()))
-    
+
+    @classmethod
+    def getConverterByName(cls, name):
+        for c in cls.getAllConverters():
+            if c.getName() == name:
+                return c
+        return None
+
     @classmethod
     def hasConverter(cls, srcType: "Attribute", dstType: "Attribute") -> list[AttributeConverter]:
         return  ((srcType, dstType)) in cls._converters

--- a/meshroom/core/desc/__init__.py
+++ b/meshroom/core/desc/__init__.py
@@ -29,7 +29,7 @@ from .shapeAttribute import (
 from .anySet import (
     AnySet
 )
-from .attributeConverter import (
+from ..attributeConverter import (
     AttributeConverter
 )
 from .computation import (

--- a/meshroom/core/desc/__init__.py
+++ b/meshroom/core/desc/__init__.py
@@ -29,6 +29,9 @@ from .shapeAttribute import (
 from .anySet import (
     AnySet
 )
+from .attributeConverter import (
+    AttributeConverter
+)
 from .computation import (
     DynamicNodeSize,
     Level,

--- a/meshroom/core/desc/__init__.py
+++ b/meshroom/core/desc/__init__.py
@@ -29,9 +29,6 @@ from .shapeAttribute import (
 from .anySet import (
     AnySet
 )
-from ..attributeConverter import (
-    AttributeConverter
-)
 from .computation import (
     DynamicNodeSize,
     Level,

--- a/meshroom/core/desc/attributeConverter.py
+++ b/meshroom/core/desc/attributeConverter.py
@@ -1,0 +1,40 @@
+"""
+attributeConverter: base descriptors class for AttributeConverter nodes
+"""
+
+from abc import ABC, abstractmethod
+from .attribute import Attribute
+
+
+class AttributeConverter(ABC):
+    """
+    Base class for converting the value of a source Attribute
+    into a value for a destination Attribute of a different type, 
+    so a connection can be made between them.
+    """
+
+    # Input / Output classes
+    srcType: Attribute = None
+    dstType: Attribute = None
+
+    @classmethod
+    def canConvert(cls, srcType, dstType):
+        """ Check if this converter corresponds to a source/destination attribute pair.
+        """
+        return isinstance(srcType, cls.srcType) and isinstance(dstType, cls.dstType)
+
+    @abstractmethod
+    def convert(self, value):
+        """ Convert a value from the source attribute's type to a value for
+        the destination attribute's type.
+        """
+        return value
+
+    def isValid(self, value):
+        """ In general case we suppose the conversion is always possible, but
+        this method enables optional type checking.
+        """
+        return True
+
+    def __repr__(self):
+        return f"<AttributeConverter '{self.__class__.__name__}': {self.srcType} -> {self.dstType}>"

--- a/meshroom/core/desc/attributeConverter.py
+++ b/meshroom/core/desc/attributeConverter.py
@@ -12,6 +12,9 @@ class AttributeConverter(ABC):
     into a value for a destination Attribute of a different type, 
     so a connection can be made between them.
     """
+    
+    # Put a higher number to prioritize specific converters
+    priority = 10
 
     # Input / Output classes
     srcType: Attribute = None
@@ -23,14 +26,16 @@ class AttributeConverter(ABC):
         """
         return isinstance(srcType, cls.srcType) and isinstance(dstType, cls.dstType)
 
+    @classmethod
     @abstractmethod
-    def convert(self, value):
+    def convert(cls, value):
         """ Convert a value from the source attribute's type to a value for
         the destination attribute's type.
         """
         return value
 
-    def isValid(self, value):
+    @classmethod
+    def isValid(cls, value):
         """ In general case we suppose the conversion is always possible, but
         this method enables optional type checking.
         """

--- a/meshroom/core/graph.py
+++ b/meshroom/core/graph.py
@@ -401,6 +401,8 @@ class Graph(BaseObject):
         self.header = graphData.get(GraphIO.Keys.Header, {})
         fileVersion = Version(self.header.get(GraphIO.Keys.FileVersion, "0.0"))
         graphContent = self._normalizeGraphContent(graphData, fileVersion)
+        graphConverters = graphData.get(GraphIO.Keys.Converters, {})
+        converterMap = {tuple(v): k for k, v in graphConverters.items()}
         isTemplate = self.header.get(GraphIO.Keys.Template, False)
         explicitCachePaths = self.header.get(GraphIO.Keys.CacheDir)
         if explicitCachePaths:
@@ -414,7 +416,7 @@ class Graph(BaseObject):
                 self._deserializeNode(nodeData, nodeName, self)
 
             # Create graph edges by resolving attributes expressions
-            self._applyExpr()
+            self._applyExpr(converterMap)
 
         # Templates are specific: they contain only the minimal amount of
         # serialized data to describe the graph structure.
@@ -571,15 +573,30 @@ class Graph(BaseObject):
         Returns:
             The list of newly created Nodes.
         """
+        
+        edgesWithConverters = [e for e in graph.edges if e._converter]
+        converterMap = {
+            (e.src.fullName, e.dst.fullName): e._converter.getName()
+            for e in edgesWithConverters
+        }
 
-        def _renameClashingNodes():
+        def replaceKey(src, dst, oldName, newName):
+            return (src.replace(oldName, newName, 1), dst.replace(oldName, newName, 1))
+
+        def _renameClashingNodes(converterMap):
             if not self.nodes:
                 return
             unavailableNames = set(self.nodes.keys())
             for node in graph.nodes:
-                if node._name in unavailableNames:
+                oldName = node._name
+                if oldName in unavailableNames:
                     node._name = self._createUniqueNodeName(node.nodeType, unavailableNames)
+                    converterMap = {
+                        replaceKey(src, dst, oldName, node._name): value
+                        for (src, dst), value in converterMap.items()
+                    }
                 unavailableNames.add(node._name)
+            return converterMap
 
         def _importNodesAndEdges() -> list[Node]:
             importedNodes = []
@@ -590,10 +607,10 @@ class Graph(BaseObject):
                 for srcNode in nodes:
                     node = self._deserializeNode(srcNode.toDict(), srcNode.name, graph)
                     importedNodes.append(node)
-                self._applyExpr()
+                self._applyExpr(converterMap)
             return importedNodes
 
-        _renameClashingNodes()
+        converterMap = _renameClashingNodes(converterMap)
         importedNodes = _importNodesAndEdges()
         return importedNodes
 
@@ -1489,10 +1506,10 @@ class Graph(BaseObject):
         self.dfs(visitor=visitor, startNodes=[startNode])
         return visitor.canCompute + (2 * visitor.canSubmit)
 
-    def _applyExpr(self):
+    def _applyExpr(self, converterMap: dict = None):
         with GraphModification(self):
             for node in self._nodes:
-                node._applyExpr()
+                node._applyExpr(converterMap)
 
     def toDict(self):
         nodes = {k: node.toDict() for k, node in self._nodes.objects.items()}

--- a/meshroom/core/graph.py
+++ b/meshroom/core/graph.py
@@ -153,6 +153,14 @@ class Edge(BaseObject):
             return self._converter.convert(self.src.value)
         return self.src.value
 
+    def resolvedValues(self):
+        if self.isConverted():
+            srcAttr = self.src
+            if hasattr(srcAttr, "values"):
+                return srcAttr.values
+            return [srcAttr.value]
+        return self.src.values
+
     src = Property(Attribute, src.fget, constant=True)
     dst = Property(Attribute, dst.fget, constant=True)
     converterChanged = Signal()

--- a/meshroom/core/graph.py
+++ b/meshroom/core/graph.py
@@ -70,8 +70,11 @@ class Edge(BaseObject):
         super().__init__(parent)
         self._src = weakref.ref(src)
         self._dst = weakref.ref(dst)
+        self._availableConverters = self.getAvailableConverters()
         self._converter: "AttributeConverter" = converter
         self._resolveConverter()
+        if self._converter:
+            self.converterChanged.emit()
 
     def __repr__(self):
         converter = f">-({self._converter.getName()})->" if self._converter else "->"
@@ -85,15 +88,38 @@ class Edge(BaseObject):
     def dst(self):
         return self._dst()
 
+    def getAvailableConverters(self) -> list[dict]:
+        converters = AttributeConverterRegistry.getConverters(self.src.desc.type, self.dst.desc.type)
+        return [
+            {
+                "name": c.getName(), 
+                "description": c.description
+            } 
+            for c in converters
+        ]
+
     def isConverted(self):
         return self._converter is not None
 
-    def setConverter(self, converter: "AttributeConverter"):
+    def getConverterDescription(self) -> str:
+        if not self._converter:
+            return ""
+        desc = f"<b>{self._converter.getName()}</b>"
+        if self._converter.description:
+            desc += f"<b>:</b><br/>{self._converter.description}"
+        return desc
+
+    @Slot(str)
+    def setConverter(self, converterName: str):
         """ Change the converter used on this edge. """
+        converter = AttributeConverterRegistry.getConverterByName(converterName)
+        if not converter:
+            raise KeyError(f"No converter named {converterName}.")
         oldConverter = self._converter
         self._converter = converter
         try:
             self._resolveConverter()
+            self.converterChanged.emit()
         except GraphCompatibilityError as e:
             self._converter = oldConverter
             self._resolveConverter()
@@ -131,6 +157,9 @@ class Edge(BaseObject):
     dst = Property(Attribute, dst.fget, constant=True)
     converterChanged = Signal()
     hasConverter = Property(bool, isConverted, notify=converterChanged)
+    converterName = Property(str, lambda self: self._converter.getName() if self._converter else "", notify=converterChanged)
+    converterDescription = Property(str, getConverterDescription, notify=converterChanged)
+    availableConverters = Property("QVariantList", lambda self: self._availableConverters, constant=True)
 
 
 WHITE = 0

--- a/meshroom/core/graph.py
+++ b/meshroom/core/graph.py
@@ -585,7 +585,7 @@ class Graph(BaseObject):
 
         def _renameClashingNodes(converterMap):
             if not self.nodes:
-                return
+                return converterMap
             unavailableNames = set(self.nodes.keys())
             for node in graph.nodes:
                 oldName = node._name

--- a/meshroom/core/graph.py
+++ b/meshroom/core/graph.py
@@ -135,7 +135,7 @@ class Edge(BaseObject):
                     f"{srcDesc.__class__.__name__} -> {dstDesc.__class__.__name__}"
                 )
             return
-        if type(srcDesc) is type(dstDesc) or isinstance(srcDesc, type(dstDesc)):
+        if self.src.baseType == self.dst.baseType:
             self._converter = None
             return
         # Find a default converter

--- a/meshroom/core/graph.py
+++ b/meshroom/core/graph.py
@@ -23,6 +23,8 @@ from meshroom.core.node import BaseNode, Status, Node, CompatibilityNode
 from meshroom.core.nodeFactory import nodeFactory, getNodeConstructor
 from meshroom.core.mtyping import PathLike
 from meshroom.core.submitter import BaseSubmittedJob, jobManager
+from meshroom.core.attributeConverter import AttributeConverter, AttributeConverterRegistry
+
 
 # Replace default encoder to support Enums
 
@@ -64,11 +66,16 @@ def GraphModification(graph):
 
 class Edge(BaseObject):
 
-    def __init__(self, src, dst, parent=None):
+    def __init__(self, src, dst, converter=None, parent=None):
         super().__init__(parent)
         self._src = weakref.ref(src)
         self._dst = weakref.ref(dst)
-        self._repr = f"<Edge> {self._src()} -> {self._dst()}"
+        self._converter: "AttributeConverter" = converter
+        self._resolveConverter()
+
+    def __repr__(self):
+        converter = f">-({self._converter.getName()})->" if self._converter else "->"
+        return f"<Edge {self._src()} {converter} {self._dst()}>"
 
     @property
     def src(self):
@@ -78,8 +85,52 @@ class Edge(BaseObject):
     def dst(self):
         return self._dst()
 
+    def isConverted(self):
+        return self._converter is not None
+
+    def setConverter(self, converter: "AttributeConverter"):
+        """ Change the converter used on this edge. """
+        oldConverter = self._converter
+        self._converter = converter
+        try:
+            self._resolveConverter()
+        except GraphCompatibilityError as e:
+            self._converter = oldConverter
+            self._resolveConverter()
+            raise e
+
+    def _resolveConverter(self):
+        srcDesc, dstDesc = self.src.desc, self.dst.desc
+        if self._converter:
+            if not self._converter.canConvert(srcDesc, dstDesc):
+                raise InvalidEdgeError(
+                    srcDesc.name, dstDesc.name, 
+                    f"Converter '{self._converter}' cannot convert "
+                    f"{srcDesc.__class__.__name__} -> {dstDesc.__class__.__name__}"
+                )
+            return
+        if type(srcDesc) is type(dstDesc) or isinstance(srcDesc, type(dstDesc)):
+            self._converter = None
+            return
+        # Find a default converter
+        conv = AttributeConverterRegistry.getConverter(srcDesc.type, dstDesc.type)
+        if conv is None:
+            raise InvalidEdgeError(
+                srcDesc.name, dstDesc.name, 
+                f"No AttributeConverter available for edge between attribute types "
+                f"{srcDesc.__class__.__name__} -> {dstDesc.__class__.__name__}"
+            )
+        self._converter = conv
+
+    def resolvedValue(self):
+        if self.isConverted():
+            return self._converter.convert(self.src.value)
+        return self.src.value
+
     src = Property(Attribute, src.fget, constant=True)
     dst = Property(Attribute, dst.fget, constant=True)
+    converterChanged = Signal()
+    hasConverter = Property(bool, isConverted, notify=converterChanged)
 
 
 WHITE = 0

--- a/meshroom/core/graphIO.py
+++ b/meshroom/core/graphIO.py
@@ -25,6 +25,7 @@ class GraphIO:
         FileVersion = "fileVersion"
         CacheDir = "cacheDir"
         Graph = "graph"
+        Converters = "converters"
         Template = "template"
 
     class Features(Enum):
@@ -76,6 +77,7 @@ class GraphSerializer:
         return {
             GraphIO.Keys.Header: self.serializeHeader(),
             GraphIO.Keys.Graph: self.serializeContent(),
+            GraphIO.Keys.Converters: self.serializeConverters(),
         }
 
     @property
@@ -118,6 +120,13 @@ class GraphSerializer:
     def serializeContent(self) -> dict:
         """Graph content serialization logic."""
         return {node.name: self.serializeNode(node) for node in sorted(self.nodes, key=lambda n: n.name)}
+
+    def serializeConverters(self) -> dict:
+        """Graph converters serialization logic."""
+        edgesWithConverters = [e for e in self._graph.edges if e._converter]
+        return {
+            e._converter.getName(): (e.src.fullName, e.dst.fullName) for e in edgesWithConverters
+        }
 
     def serializeNode(self, node: Node) -> dict:
         """Node serialization logic."""

--- a/meshroom/core/node.py
+++ b/meshroom/core/node.py
@@ -1106,9 +1106,9 @@ class BaseNode(BaseObject):
             return p[0][0] in self._internalAttributes.keys() or p[0][1] in self._internalAttributes.keys()
         return name in self._internalAttributes.keys()
 
-    def _applyExpr(self):
+    def _applyExpr(self, converterMap: dict = None):
         for attr in self._attributes:
-            attr._applyExpr()
+            attr._applyExpr(converterMap)
         for attr in self._internalAttributes:
             attr._applyExpr()
 

--- a/meshroom/core/plugins.py
+++ b/meshroom/core/plugins.py
@@ -7,7 +7,8 @@ import logging
 import os
 import re
 import sys
-
+from itertools import chain
+from collections import defaultdict
 from enum import Enum
 from inspect import getfile
 from pathlib import Path
@@ -475,6 +476,41 @@ class Plugin(BaseObject):
         """
         return name in self._nodePlugins
 
+class AttributeConverterRegistry:
+    """
+    Registry of available converters
+    """
+
+    _converters = defaultdict(list)  # { (srcType, dstType): [converters] }
+
+    @classmethod
+    def add(cls, converterClass):
+        logging.info(
+            f"Add converter class: {converterClass.__name__} "
+            f"({converterClass.srcType.__name__} -> {converterClass.dstType.__name__})"
+        )
+        if not issubclass(converterClass, desc.AttributeConverter):
+            raise TypeError(f"{converterClass} must subclass AttributeConverter")
+        cls._converters[(converterClass.srcType, converterClass.dstType)].append(converterClass)
+
+    @classmethod
+    def all(cls) -> list[desc.AttributeConverter]:
+        return list(chain.from_iterable(cls._converters.values()))
+
+    @classmethod
+    def getConverters(cls, srcType, dstType) -> list[desc.AttributeConverter]:
+        """ Get priority-ordered converters.
+        """
+        converters = cls._converters.get((srcType, dstType))
+        return sorted(converters, key=lambda c: -c.priority)
+
+    @classmethod
+    def getConverter(cls, srcType, dstType) -> desc.AttributeConverter:
+        """ Get highest priority converter. """
+        converters = cls.getConverters(srcType, dstType)
+        if not converters:
+            return None
+        return converters[0]
 
 class NodePlugin(BaseObject):
     """

--- a/meshroom/core/plugins.py
+++ b/meshroom/core/plugins.py
@@ -7,8 +7,6 @@ import logging
 import os
 import re
 import sys
-from itertools import chain
-from collections import defaultdict
 from enum import Enum
 from inspect import getfile
 from pathlib import Path
@@ -18,7 +16,6 @@ from meshroom.core import desc
 from meshroom.core.desc.attribute import ValueTypeErrors
 from meshroom import _MESHROOM_ROOT
 from meshroom.core.desc.node import _MESHROOM_COMPUTE_DEPS
-from meshroom.core.attributeConverter import AttributeConverter
 
 
 def validateNodeDesc(nodeDesc: desc.BaseNode) -> list[tuple[str, ValueTypeErrors]]:
@@ -477,41 +474,6 @@ class Plugin(BaseObject):
         """
         return name in self._nodePlugins
 
-class AttributeConverterRegistry:
-    """
-    Registry of available converters
-    """
-
-    _converters = defaultdict(list)  # { (srcType, dstType): [converters] }
-
-    @classmethod
-    def add(cls, converterClass):
-        logging.info(
-            f"Add converter class: {converterClass.__name__} "
-            f"({converterClass.srcType.__name__} -> {converterClass.dstType.__name__})"
-        )
-        if not issubclass(converterClass, AttributeConverter):
-            raise TypeError(f"{converterClass} must subclass AttributeConverter")
-        cls._converters[(converterClass.srcType, converterClass.dstType)].append(converterClass)
-
-    @classmethod
-    def getAllConverters(cls) -> list[AttributeConverter]:
-        return list(chain.from_iterable(cls._converters.values()))
-
-    @classmethod
-    def getConverters(cls, srcType, dstType) -> list[AttributeConverter]:
-        """ Get priority-ordered converters.
-        """
-        converters = cls._converters.get((srcType, dstType))
-        return sorted(converters, key=lambda c: -c.priority)
-
-    @classmethod
-    def getConverter(cls, srcType, dstType) -> AttributeConverter:
-        """ Get highest priority converter. """
-        converters = cls.getConverters(srcType, dstType)
-        if not converters:
-            return None
-        return converters[0]
 
 class NodePlugin(BaseObject):
     """

--- a/meshroom/core/plugins.py
+++ b/meshroom/core/plugins.py
@@ -18,6 +18,7 @@ from meshroom.core import desc
 from meshroom.core.desc.attribute import ValueTypeErrors
 from meshroom import _MESHROOM_ROOT
 from meshroom.core.desc.node import _MESHROOM_COMPUTE_DEPS
+from meshroom.core.attributeConverter import AttributeConverter
 
 
 def validateNodeDesc(nodeDesc: desc.BaseNode) -> list[tuple[str, ValueTypeErrors]]:
@@ -489,23 +490,23 @@ class AttributeConverterRegistry:
             f"Add converter class: {converterClass.__name__} "
             f"({converterClass.srcType.__name__} -> {converterClass.dstType.__name__})"
         )
-        if not issubclass(converterClass, desc.AttributeConverter):
+        if not issubclass(converterClass, AttributeConverter):
             raise TypeError(f"{converterClass} must subclass AttributeConverter")
         cls._converters[(converterClass.srcType, converterClass.dstType)].append(converterClass)
 
     @classmethod
-    def getAllConverters(cls) -> list[desc.AttributeConverter]:
+    def getAllConverters(cls) -> list[AttributeConverter]:
         return list(chain.from_iterable(cls._converters.values()))
 
     @classmethod
-    def getConverters(cls, srcType, dstType) -> list[desc.AttributeConverter]:
+    def getConverters(cls, srcType, dstType) -> list[AttributeConverter]:
         """ Get priority-ordered converters.
         """
         converters = cls._converters.get((srcType, dstType))
         return sorted(converters, key=lambda c: -c.priority)
 
     @classmethod
-    def getConverter(cls, srcType, dstType) -> desc.AttributeConverter:
+    def getConverter(cls, srcType, dstType) -> AttributeConverter:
         """ Get highest priority converter. """
         converters = cls.getConverters(srcType, dstType)
         if not converters:

--- a/meshroom/core/plugins.py
+++ b/meshroom/core/plugins.py
@@ -494,7 +494,7 @@ class AttributeConverterRegistry:
         cls._converters[(converterClass.srcType, converterClass.dstType)].append(converterClass)
 
     @classmethod
-    def all(cls) -> list[desc.AttributeConverter]:
+    def getAllConverters(cls) -> list[desc.AttributeConverter]:
         return list(chain.from_iterable(cls._converters.values()))
 
     @classmethod

--- a/meshroom/nodes/converters/BoolToInt.py
+++ b/meshroom/nodes/converters/BoolToInt.py
@@ -1,0 +1,10 @@
+from meshroom.core import desc
+
+
+class IntToBool(desc.AttributeConverter):
+    srcType = desc.BoolParam
+    dstType = desc.IntParam
+
+    @classmethod
+    def convert(cls, value):
+        return int(bool(value))

--- a/meshroom/nodes/converters/BoolToInt.py
+++ b/meshroom/nodes/converters/BoolToInt.py
@@ -2,7 +2,7 @@ from meshroom.core import desc
 from meshroom.core.attributeConverter import AttributeConverter
 
 
-class IntToBool(AttributeConverter):
+class BoolToInt(AttributeConverter):
     srcType = desc.BoolParam
     dstType = desc.IntParam
 

--- a/meshroom/nodes/converters/BoolToInt.py
+++ b/meshroom/nodes/converters/BoolToInt.py
@@ -1,7 +1,8 @@
 from meshroom.core import desc
+from meshroom.core.attributeConverter import AttributeConverter
 
 
-class IntToBool(desc.AttributeConverter):
+class IntToBool(AttributeConverter):
     srcType = desc.BoolParam
     dstType = desc.IntParam
 

--- a/meshroom/nodes/converters/ChoiceToString.py
+++ b/meshroom/nodes/converters/ChoiceToString.py
@@ -1,0 +1,10 @@
+from meshroom.core import desc
+
+
+class ChoiceToString(desc.AttributeConverter):
+    srcType = desc.ChoiceParam
+    dstType = desc.StringParam
+
+    @classmethod
+    def convert(cls, value):
+        return str(value)

--- a/meshroom/nodes/converters/ChoiceToString.py
+++ b/meshroom/nodes/converters/ChoiceToString.py
@@ -1,7 +1,8 @@
 from meshroom.core import desc
+from meshroom.core.attributeConverter import AttributeConverter
 
 
-class ChoiceToString(desc.AttributeConverter):
+class ChoiceToString(AttributeConverter):
     srcType = desc.ChoiceParam
     dstType = desc.StringParam
 

--- a/meshroom/nodes/converters/FileToString.py
+++ b/meshroom/nodes/converters/FileToString.py
@@ -1,0 +1,10 @@
+from meshroom.core import desc
+
+
+class FileToString(desc.AttributeConverter):
+    srcType = desc.File
+    dstType = desc.StringParam
+
+    @classmethod
+    def convert(cls, value):
+        return str(value) if value is not None else ""

--- a/meshroom/nodes/converters/FileToString.py
+++ b/meshroom/nodes/converters/FileToString.py
@@ -1,7 +1,8 @@
 from meshroom.core import desc
+from meshroom.core.attributeConverter import AttributeConverter
 
 
-class FileToString(desc.AttributeConverter):
+class FileToString(AttributeConverter):
     srcType = desc.File
     dstType = desc.StringParam
 

--- a/meshroom/nodes/converters/FloatToInt.py
+++ b/meshroom/nodes/converters/FloatToInt.py
@@ -1,0 +1,20 @@
+from meshroom.core import desc
+
+
+class FloatToIntRound(desc.AttributeConverter):
+    srcType = desc.FloatParam
+    dstType = desc.IntParam
+
+    @classmethod
+    def convert(cls, value):
+        return int(round(value))
+
+
+class FloatToIntTruncate(desc.AttributeConverter):
+    priority = 20
+    srcType = desc.FloatParam
+    dstType = desc.IntParam
+
+    @classmethod
+    def convert(cls, value):
+        return int(value)

--- a/meshroom/nodes/converters/FloatToInt.py
+++ b/meshroom/nodes/converters/FloatToInt.py
@@ -3,6 +3,10 @@ from meshroom.core.attributeConverter import AttributeConverter
 
 
 class FloatToIntRound(AttributeConverter):
+    description = (
+        "Convert a FloatParam to an IntParam by rounding the value."
+    )
+
     srcType = desc.FloatParam
     dstType = desc.IntParam
 
@@ -12,6 +16,10 @@ class FloatToIntRound(AttributeConverter):
 
 
 class FloatToIntTruncate(AttributeConverter):
+    description = (
+        "Convert a FloatParam to an IntParam by truncating the value."
+    )
+
     priority = 20
     srcType = desc.FloatParam
     dstType = desc.IntParam

--- a/meshroom/nodes/converters/FloatToInt.py
+++ b/meshroom/nodes/converters/FloatToInt.py
@@ -1,7 +1,8 @@
 from meshroom.core import desc
+from meshroom.core.attributeConverter import AttributeConverter
 
 
-class FloatToIntRound(desc.AttributeConverter):
+class FloatToIntRound(AttributeConverter):
     srcType = desc.FloatParam
     dstType = desc.IntParam
 
@@ -10,7 +11,7 @@ class FloatToIntRound(desc.AttributeConverter):
         return int(round(value))
 
 
-class FloatToIntTruncate(desc.AttributeConverter):
+class FloatToIntTruncate(AttributeConverter):
     priority = 20
     srcType = desc.FloatParam
     dstType = desc.IntParam

--- a/meshroom/nodes/converters/IntToBool.py
+++ b/meshroom/nodes/converters/IntToBool.py
@@ -1,7 +1,8 @@
 from meshroom.core import desc
+from meshroom.core.attributeConverter import AttributeConverter
 
 
-class IntToBool(desc.AttributeConverter):
+class IntToBool(AttributeConverter):
     srcType = desc.IntParam
     dstType = desc.BoolParam
 

--- a/meshroom/nodes/converters/IntToBool.py
+++ b/meshroom/nodes/converters/IntToBool.py
@@ -1,0 +1,10 @@
+from meshroom.core import desc
+
+
+class IntToBool(desc.AttributeConverter):
+    srcType = desc.IntParam
+    dstType = desc.BoolParam
+
+    @classmethod
+    def convert(cls, value):
+        return bool(value)

--- a/meshroom/nodes/converters/IntToFloat.py
+++ b/meshroom/nodes/converters/IntToFloat.py
@@ -1,7 +1,8 @@
 from meshroom.core import desc
+from meshroom.core.attributeConverter import AttributeConverter
 
 
-class IntToFloat(desc.AttributeConverter):
+class IntToFloat(AttributeConverter):
     srcType = desc.IntParam
     dstType = desc.FloatParam
 

--- a/meshroom/nodes/converters/IntToFloat.py
+++ b/meshroom/nodes/converters/IntToFloat.py
@@ -1,0 +1,10 @@
+from meshroom.core import desc
+
+
+class IntToFloat(desc.AttributeConverter):
+    srcType = desc.IntParam
+    dstType = desc.FloatParam
+
+    @classmethod
+    def convert(cls, value):
+        return float(value)

--- a/meshroom/nodes/converters/StringToChoice.py
+++ b/meshroom/nodes/converters/StringToChoice.py
@@ -1,0 +1,32 @@
+from meshroom.core import desc
+
+
+class StringToChoice(desc.AttributeConverter):
+    priority = 20
+    srcType = desc.StringParam
+    dstType = desc.ChoiceParam
+
+    @classmethod
+    def convert(cls, value):
+        return str(value)
+
+
+class StringToChoiceStrict(desc.AttributeConverter):
+    """
+    StringToChoice with enforcement that the converted 
+    value is included in the destination values.
+    """
+
+    srcType = desc.StringParam
+    dstType = desc.ChoiceParam
+
+    @classmethod
+    def convert(cls, value):
+        return str(value)
+
+    @classmethod
+    def isValid(cls, srcAttr, dstAttr):
+        values = dstAttr.desc.values
+        if callable(values):
+            values = values(dstAttr.node) if hasattr(dstAttr, "node") else values
+        return values is None or srcAttr.value in values

--- a/meshroom/nodes/converters/StringToChoice.py
+++ b/meshroom/nodes/converters/StringToChoice.py
@@ -3,6 +3,10 @@ from meshroom.core.attributeConverter import AttributeConverter
 
 
 class StringToChoice(AttributeConverter):
+    description = (
+        "Convert a StringParam to a ChoiceParam."
+    )
+    
     priority = 20
     srcType = desc.StringParam
     dstType = desc.ChoiceParam
@@ -17,6 +21,12 @@ class StringToChoiceStrict(AttributeConverter):
     StringToChoice with enforcement that the converted 
     value is included in the destination values.
     """
+    
+    description = (
+        "Convert a StringParam to a ChoiceParam "
+        "if the value is already included in the "
+        "possible values."
+    )
 
     srcType = desc.StringParam
     dstType = desc.ChoiceParam

--- a/meshroom/nodes/converters/StringToChoice.py
+++ b/meshroom/nodes/converters/StringToChoice.py
@@ -14,30 +14,3 @@ class StringToChoice(AttributeConverter):
     @classmethod
     def convert(cls, value):
         return str(value)
-
-
-class StringToChoiceStrict(AttributeConverter):
-    """
-    StringToChoice with enforcement that the converted 
-    value is included in the destination values.
-    """
-    
-    description = (
-        "Convert a StringParam to a ChoiceParam "
-        "if the value is already included in the "
-        "possible values."
-    )
-
-    srcType = desc.StringParam
-    dstType = desc.ChoiceParam
-
-    @classmethod
-    def convert(cls, value):
-        return str(value)
-
-    @classmethod
-    def isValid(cls, srcAttr, dstAttr):
-        values = dstAttr.desc.values
-        if callable(values):
-            values = values(dstAttr.node) if hasattr(dstAttr, "node") else values
-        return values is None or srcAttr.value in values

--- a/meshroom/nodes/converters/StringToChoice.py
+++ b/meshroom/nodes/converters/StringToChoice.py
@@ -1,7 +1,8 @@
 from meshroom.core import desc
+from meshroom.core.attributeConverter import AttributeConverter
 
 
-class StringToChoice(desc.AttributeConverter):
+class StringToChoice(AttributeConverter):
     priority = 20
     srcType = desc.StringParam
     dstType = desc.ChoiceParam
@@ -11,7 +12,7 @@ class StringToChoice(desc.AttributeConverter):
         return str(value)
 
 
-class StringToChoiceStrict(desc.AttributeConverter):
+class StringToChoiceStrict(AttributeConverter):
     """
     StringToChoice with enforcement that the converted 
     value is included in the destination values.

--- a/meshroom/nodes/converters/StringToFile.py
+++ b/meshroom/nodes/converters/StringToFile.py
@@ -1,7 +1,8 @@
 from meshroom.core import desc
+from meshroom.core.attributeConverter import AttributeConverter
 
 
-class StringToFile(desc.AttributeConverter):
+class StringToFile(AttributeConverter):
     srcType = desc.StringParam
     dstType = desc.File
 

--- a/meshroom/nodes/converters/StringToFile.py
+++ b/meshroom/nodes/converters/StringToFile.py
@@ -1,0 +1,10 @@
+from meshroom.core import desc
+
+
+class StringToFile(desc.AttributeConverter):
+    srcType = desc.StringParam
+    dstType = desc.File
+
+    @classmethod
+    def convert(cls, value):
+        return str(value)

--- a/meshroom/submitters/localFarm/localFarmSubmitter.py
+++ b/meshroom/submitters/localFarm/localFarmSubmitter.py
@@ -94,6 +94,7 @@ def rezWrapCommand(cmd: str,
         the final command to execute
     """
     packages = set()
+    additionalEnv = additionalEnv or {}
     if useCurrentContext:
         # In this case we want to use the full context
         packages.update([p for p in os.environ.get('REZ_RESOLVE', '').split(" ") if p])
@@ -109,9 +110,10 @@ def rezWrapCommand(cmd: str,
             rezBin = os.path.join(os.environ["REZ_PACKAGES_ROOT"], "bin/rez")
         elif shutil.which("rez"):
             rezBin = shutil.which("rez")
-        if additionalEnv:
-            envVars = " ".join([f'{k}="{v}"' for k, v in additionalEnv.items()])
-        return f"{rezBin} env {packagesStr} -- {envVars} {cmd}"
+        envVars = " ".join([f'{k}="{v}"' for k, v in additionalEnv.items()])
+        cmd = f"{envVars} {cmd}" if envVars else cmd
+        if rezBin:
+            cmd = f"{rezBin} env {packagesStr} -- {cmd}"
     return cmd
 
 

--- a/meshroom/ui/qml/GraphEditor/Edge.qml
+++ b/meshroom/ui/qml/GraphEditor/Edge.qml
@@ -1,5 +1,6 @@
 import QtQuick
 import QtQuick.Controls
+import QtQuick.Layouts
 import QtQuick.Shapes 1.6
 
 import GraphEditor 1.0
@@ -112,75 +113,73 @@ Item {
         }
     }
 
-    // For-loop badge
     Item {
         // Place the label at the middle of the edge
         x: (root.startX + root.endX) / 2
         y: (root.startY + root.endY) / 2
-        visible: root.isForLoop
-
-        Rectangle {
-            anchors.centerIn: parent
-            property int margin: 2
-            width: icon.width + 2 * margin
-            height: icon.height + 2 * margin
-            radius: width
-            color: path.strokeColor
-
-            MaterialToolLabel {
-                id: icon
-                anchors.centerIn: parent
-
-                iconText: MaterialIcons.loop
-                label.text: (root.iteration + 1) + "/" + root.loopSize + " "
-
-                labelIconColor: palette.base
-                ToolTip.text: "Foreach Loop"
-            }
-
-            MouseArea {
-                id: loopArea
-                anchors.fill: parent
-                hoverEnabled: true
-                onClicked: root.pressed(arguments[0])
-            }
-        }
-    }
-
-    // Converter badge (hide if there is the for-loop badge)
-    Item {
         z: 1
-        x: (root.startX + root.endX) / 2
-        y: (root.startY + root.endY) / 2
-        enabled: root.hasConverter && !root.isForLoop
-        visible: enabled
+        visible: root.isForLoop || root.hasConverter
 
-        Rectangle {
-            id: converterBadge
+        RowLayout {
             anchors.centerIn: parent
-            property int margin: 2
-            width: 10
-            height: width
-            radius: width
-            color: Colors.lightpurple
-            border.color: "#aaa"
-            border.width: 0.5
+            spacing: 4
 
-            MouseArea {
-                id: converterArea
-                anchors.fill: parent
-                hoverEnabled: true
-                cursorShape: Qt.PointingHandCursor
-                acceptedButtons: Qt.RightButton
-                onClicked: (mouse) => converterMenu.popup()
+            // For-loop badge
+            Rectangle {
+                visible: root.isForLoop
+                property int margin: 2
+                Layout.preferredWidth: icon.width + 2 * margin
+                Layout.preferredHeight: icon.height + 2 * margin
+                radius: width
+                color: path.strokeColor
+
+                MaterialToolLabel {
+                    id: icon
+                    anchors.centerIn: parent
+
+                    iconText: MaterialIcons.loop
+                    label.text: (root.iteration + 1) + "/" + root.loopSize + " "
+
+                    labelIconColor: palette.base
+                    ToolTip.text: "Foreach Loop"
+                }
+
+                MouseArea {
+                    id: loopArea
+                    anchors.fill: parent
+                    hoverEnabled: true
+                    onClicked: root.pressed(arguments[0])
+                }
             }
 
-            ToolTip {
-                visible: converterArea.containsMouse
-                delay: 400
-                text: root.edge ? qsTr(root.edge.converterDescription) : ""
-                x: converterBadge.width + 4
-                y: converterBadge.height - height / 2
+            // Converter badge
+            Rectangle {
+                id: converterBadge
+                visible: root.hasConverter
+                property int margin: 2
+                Layout.preferredWidth: 10
+                Layout.preferredHeight: 10
+                radius: width
+                color: Colors.lightpurple
+                border.color: "#aaa"
+                border.width: 0.5
+
+                MouseArea {
+                    id: converterArea
+                    anchors.fill: parent
+                    hoverEnabled: true
+                    cursorShape: Qt.PointingHandCursor
+                    acceptedButtons: Qt.RightButton
+                    onClicked: (mouse) => converterMenu.popup()
+                }
+
+                ToolTip {
+                    visible: converterArea.containsMouse
+                    delay: 400
+                    text: root.edge ? qsTr(root.edge.converterDescription) : ""
+                    x: converterBadge.width + 4
+                    y: converterBadge.height - height / 2
+                }
             }
         }
     }

--- a/meshroom/ui/qml/GraphEditor/Edge.qml
+++ b/meshroom/ui/qml/GraphEditor/Edge.qml
@@ -4,6 +4,7 @@ import QtQuick.Shapes 1.6
 
 import GraphEditor 1.0
 import MaterialIcons 2.2
+import Utils 1.0
 
 /**
  * A cubic spline representing an edge, going from point1 to point2, providing mouse interaction.
@@ -22,6 +23,8 @@ Item {
     property bool isForLoop: false
     property int loopSize: 0
     property int iteration: 0
+
+    readonly property bool hasConverter: edge !== undefined && edge !== null && edge.hasConverter === true
 
     // Note: edgeArea is destroyed before path, so we need to test if not null to avoid warnings.
     readonly property bool containsMouse: (loopArea && loopArea.containsMouse) || (edgeArea && edgeArea.containsMouse)
@@ -109,6 +112,7 @@ Item {
         }
     }
 
+    // For-loop badge
     Item {
         // Place the label at the middle of the edge
         x: (root.startX + root.endX) / 2
@@ -139,6 +143,33 @@ Item {
                 anchors.fill: parent
                 hoverEnabled: true
                 onClicked: root.pressed(arguments[0])
+            }
+        }
+    }
+
+    // Converter badge (hide if there is the for-loop badge)
+    Item {
+        x: (root.startX + root.endX) / 2
+        y: (root.startY + root.endY) / 2
+        visible: root.hasConverter && !root.isForLoop
+
+        Rectangle {
+            id: convreterBadge
+            anchors.centerIn: parent
+            property int margin: 2
+            width: 10
+            height: width
+            radius: width
+            color: Colors.lightpurple
+            border.color: "#aaa"
+            border.width: 0.5
+
+            MouseArea {
+                id: converterArea
+                anchors.fill: parent
+                hoverEnabled: true
+                cursorShape: Qt.PointingHandCursor
+                onClicked: root.pressed(arguments[0])  // TODO: Select converter
             }
         }
     }

--- a/meshroom/ui/qml/GraphEditor/Edge.qml
+++ b/meshroom/ui/qml/GraphEditor/Edge.qml
@@ -149,12 +149,14 @@ Item {
 
     // Converter badge (hide if there is the for-loop badge)
     Item {
+        z: 1
         x: (root.startX + root.endX) / 2
         y: (root.startY + root.endY) / 2
-        visible: root.hasConverter && !root.isForLoop
+        enabled: root.hasConverter && !root.isForLoop
+        visible: enabled
 
         Rectangle {
-            id: convreterBadge
+            id: converterBadge
             anchors.centerIn: parent
             property int margin: 2
             width: 10
@@ -169,13 +171,23 @@ Item {
                 anchors.fill: parent
                 hoverEnabled: true
                 cursorShape: Qt.PointingHandCursor
-                onClicked: root.pressed(arguments[0])  // TODO: Select converter
+                acceptedButtons: Qt.RightButton
+                onClicked: (mouse) => converterMenu.popup()
+            }
+
+            ToolTip {
+                visible: converterArea.containsMouse
+                delay: 400
+                text: root.edge ? qsTr(root.edge.converterDescription) : ""
+                x: converterBadge.width + 4
+                y: converterBadge.height - height / 2
             }
         }
     }
 
     EdgeMouseArea {
         id: edgeArea
+        z: 0
         anchors.fill: parent
         acceptedButtons: Qt.LeftButton | Qt.RightButton
         thickness: root.thickness + 4
@@ -187,5 +199,29 @@ Item {
             root.released(event)
         }
 
+    }
+
+    Menu {
+        id: converterMenu
+        title: "Convert Attribute"
+
+        ButtonGroup {
+            id: converterChoices
+        }
+
+        Instantiator {
+            model: root.edge ? root.edge.availableConverters : []
+            RadioButton {
+                text: modelData.name
+                ButtonGroup.group: converterChoices
+                checked: root.edge && root.edge.converterName === modelData.name
+                onToggled: {
+                    if (checked) root.edge.setConverter(modelData.name)
+                    converterMenu.close()
+                }
+            }
+            onObjectAdded: (index, object) => converterMenu.insertItem(index, object)
+            onObjectRemoved: (index, object) => converterMenu.removeItem(object)
+        }
     }
 }

--- a/meshroom/ui/qml/Utils/Colors.qml
+++ b/meshroom/ui/qml/Utils/Colors.qml
@@ -23,6 +23,7 @@ QtObject {
     readonly property color grey: "#555555"
     readonly property color lightgrey: "#999999"
     readonly property color warning: "#FF9800"
+    readonly property color lightpurple: "#ab70b3"
     readonly property color darkpurple: "#5c4885"
 
     readonly property var statusColors: {

--- a/tests/test_submit.py
+++ b/tests/test_submit.py
@@ -40,7 +40,14 @@ def getJobEnv():
     """ Required to have meshroom recognize plugins that were created here """
     pluginFolder = os.path.join(os.path.dirname(__file__), "plugins")
     return {
-        "MESHROOM_PLUGINS_PATH": pluginFolder
+        "MESHROOM_PLUGINS_PATH": pluginFolder,
+        # Disable all rez variables that could lead to using rez in the test env
+        "REZ_RESOLVE": "",
+        "REZ_BIN": "",
+        "REZ_PACKAGES_ROOT": "",
+        "REZ_REQUEST": "",
+        "REZ_USED_REQUEST": "",
+        "REZ_MESHROOM_VERSION": ""
     }
 
 
@@ -50,7 +57,7 @@ def checkTask(task, taskType, nbDependencies):
     assert len(task.dependencies) == nbDependencies
 
 
-def waitForNodeCompletion(job: LocalFarmJob, node: Node, timeout=15):
+def waitForNodeCompletion(job: LocalFarmJob, node: Node, timeout=20):
     """
     Wait for a node to complete processing
     """


### PR DESCRIPTION
## Description

Register nodes for attribute conversion.
<img width="763" height="445" alt="image" src="https://github.com/user-attachments/assets/0216e627-b223-49ac-b065-a0037461992d" />

### How does it work

- `AttributeConverter` nodes are declaring what type conversion they are doing, and they implement a `convert` method to handle the conversion. A notion of `priority` is used to know what is the default conversion from a type to another.
- These nodes are registered through the plugin system.
- We allow connection from type `A` and type `B` if `A=B` or if a converter exist for `A->B`.
- When an edge is created with a converter, the converter is saved on the `Edge` object.
- When the graph is saved, we serialize the converters, and when the graph is loaded we unserialize them.
- We can change the converter through the interface with a right click on the converter badge:
<img width="743" height="199" alt="image" src="https://github.com/user-attachments/assets/46556295-b576-4179-bbee-806dcff6500f" />
