### PR TITLE
[core] Plugins: Split `plugin.py` module into a dedicated package and standardize plugin/node terminology

### DIFF
--- a/bin/meshroom_info
+++ b/bin/meshroom_info
@@ -55,20 +55,20 @@ def get_nodes_info(args):
     meshroom.core.initPlugins()
     meshroom.core.initNodes()
     nodeName = args.name
-    nodePlugins = meshroom.core.pluginManager.getLoadedNodeProviders()
+    nodeProviders = meshroom.core.pluginManager.getLoadedNodeProviders()
     if nodeName:
-        get_node_info(args, nodePlugins, nodeName)
+        get_node_info(args, nodeProviders, nodeName)
     else:
-        get_all_node_info(args, nodePlugins)
+        get_all_node_info(args, nodeProviders)
 
 
-def get_node_info(args, nodePlugins, name):
+def get_node_info(args, nodeProviders, name):
     from meshroom.core.desc import BaseNode
-    if name not in nodePlugins:
+    if name not in nodeProviders:
         print(f"Error: Node '{name}' not found.")
         sys.exit(1)
 
-    nodeDesc = nodePlugins[name].nodeDescriptor
+    nodeDesc = nodeProviders[name].nodeDescriptor
     nodeBaseClass = [c for c in nodeDesc.__bases__ if issubclass(c, BaseNode)]
     nodeInfo = nodeDesc.getNodeInfo()
 
@@ -96,16 +96,16 @@ def get_node_info(args, nodePlugins, name):
             print(f"        Description : {output.description}")
 
 
-def get_all_node_info(args, nodePlugins):
+def get_all_node_info(args, nodeProviders):
     # Group nodes by category
     categories = {}
-    for name, nodePlugin in sorted(nodePlugins.items()):
-        category = nodePlugin.nodeDescriptor.category
+    for name, nodeProvider in sorted(nodeProviders.items()):
+        category = nodeProvider.nodeDescriptor.category
         if category not in categories:
             categories[category] = []
         categories[category].append(name)
 
-    print(f"Available Nodes ({len(nodePlugins)}):")
+    print(f"Available Nodes ({len(nodeProviders)}):")
     for category, nodes in sorted(categories.items()):
         print(f"\n  [{category}]")
         for name in nodes:

--- a/bin/meshroom_info
+++ b/bin/meshroom_info
@@ -55,7 +55,7 @@ def get_nodes_info(args):
     meshroom.core.initPlugins()
     meshroom.core.initNodes()
     nodeName = args.name
-    nodePlugins = meshroom.core.pluginManager.getRegisteredNodePlugins()
+    nodePlugins = meshroom.core.pluginManager.getLoadedNodeProviders()
     if nodeName:
         get_node_info(args, nodePlugins, nodeName)
     else:

--- a/meshroom/core/__init__.py
+++ b/meshroom/core/__init__.py
@@ -18,7 +18,8 @@ try:
 except Exception:
     pass
 
-from meshroom.core.plugins import NodeProvider, PluginManager, Plugin, processEnvFactory, formatNodeDescriptionErrorMessage
+from meshroom.core.plugins.env import processEnvFactory
+from meshroom.core.plugins.manager import PluginManager, Plugin, NodeProvider, formatNodeDescriptionErrorMessage
 from meshroom.core.submitter import BaseSubmitter
 from meshroom.env import EnvVar, meshroomFolder
 from . import desc

--- a/meshroom/core/__init__.py
+++ b/meshroom/core/__init__.py
@@ -360,7 +360,7 @@ def loadAllNodes(folder) -> list[Plugin]:
             nodePlugins = loadNodes(folder, package, plugin.uid)
             if nodePlugins:
                 for node in nodePlugins:
-                    plugin.addNodePlugin(node)
+                    plugin.addNodeProvider(node)
                 nodesStr = ', '.join([node.nodeDescriptor.__name__ for node in nodePlugins])
                 logging.debug(f'Nodes loaded [{package}]: {nodesStr}')
             plugins.append(plugin)

--- a/meshroom/core/__init__.py
+++ b/meshroom/core/__init__.py
@@ -18,7 +18,7 @@ try:
 except Exception:
     pass
 
-from meshroom.core.plugins import NodePlugin, NodePluginManager, Plugin, processEnvFactory, formatNodeDescriptionErrorMessage
+from meshroom.core.plugins import NodePlugin, PluginManager, Plugin, processEnvFactory, formatNodeDescriptionErrorMessage
 from meshroom.core.submitter import BaseSubmitter
 from meshroom.env import EnvVar, meshroomFolder
 from . import desc
@@ -31,7 +31,7 @@ logging.basicConfig(format='[%(asctime)s][%(levelname)s] %(message)s', level=log
 sessionUid = str(uuid.uuid1())
 
 cacheFolderName = 'MeshroomCache'
-pluginManager: NodePluginManager = NodePluginManager()
+pluginManager: PluginManager = PluginManager()
 submitters: dict[str, BaseSubmitter] = {}
 pipelineTemplates: dict[str, str] = {}
 

--- a/meshroom/core/__init__.py
+++ b/meshroom/core/__init__.py
@@ -18,7 +18,7 @@ try:
 except Exception:
     pass
 
-from meshroom.core.plugins import NodePlugin, PluginManager, Plugin, processEnvFactory, formatNodeDescriptionErrorMessage
+from meshroom.core.plugins import NodeProvider, PluginManager, Plugin, processEnvFactory, formatNodeDescriptionErrorMessage
 from meshroom.core.submitter import BaseSubmitter
 from meshroom.env import EnvVar, meshroomFolder
 from . import desc
@@ -128,13 +128,13 @@ def loadClasses(folder: str, packageName: str, classType: type, pluginUid: str =
                     p.packageName = f"{pluginUid}_{packageName}"
                     p.packagePath = packagePath
                     if classType == desc.BaseNode:
-                        nodePlugin = NodePlugin(p)
-                        if nodePlugin.errors:
+                        nodeProvider = NodeProvider(p)
+                        if nodeProvider.errors:
                             explicitErrors = []
-                            for err in nodePlugin.errors:
+                            for err in nodeProvider.errors:
                                 explicitErrors.append(f"\n\t - {formatNodeDescriptionErrorMessage(err)}")
                             errors.append(f"  * {pluginName}: The following parameters have issues: {''.join(explicitErrors)}")
-                        classes.append(nodePlugin)
+                        classes.append(nodeProvider)
                     else:
                         classes.append(p)
             except Exception as exc:
@@ -160,11 +160,11 @@ def loadClasses(folder: str, packageName: str, classType: type, pluginUid: str =
     return classes
 
 
-def loadClassesNodes(folder: str, packageName: str, pluginUid: str) -> list[NodePlugin]:
+def loadClassesNodes(folder: str, packageName: str, pluginUid: str) -> list[NodeProvider]:
     """
-    Return the list of all the NodePlugins that were created following the search of the
+    Return the list of all the NodeProviders that were created following the search of the
     Python module named "packageName" located in the folder "folder".
-    A NodePlugin is created when a file within "packageName" that contains a class inheriting
+    A NodeProvider is created when a file within "packageName" that contains a class inheriting
     desc.BaseNode is found.
 
     Args:
@@ -173,7 +173,7 @@ def loadClassesNodes(folder: str, packageName: str, pluginUid: str) -> list[Node
         pluginUid: A unique node for the plugin where will be the nodes.
 
     Returns:
-        list[NodePlugin]: a list of all the NodePlugins that were created based on the
+        list[NodeProvider]: a list of all the NodeProviders that were created based on the
                           module's search. If none has been created, an empty list is returned.
     """
     return loadClasses(folder, packageName, desc.BaseNode, pluginUid=pluginUid)
@@ -343,7 +343,7 @@ def nodeVersion(nodeDesc: desc.Node, default=None):
     return moduleVersion(nodeDesc.__module__, default)
 
 
-def loadNodes(folder, packageName, pluginUid) -> list[NodePlugin]:
+def loadNodes(folder, packageName, pluginUid) -> list[NodeProvider]:
     if not os.path.isdir(folder):
         logging.error(f"Node folder '{folder}' does not exist.")
         return []
@@ -357,11 +357,11 @@ def loadAllNodes(folder) -> list[Plugin]:
     for _, package, ispkg in pkgutil.iter_modules([folder]):
         if ispkg:
             plugin = Plugin(package, folder)
-            nodePlugins = loadNodes(folder, package, plugin.uid)
-            if nodePlugins:
-                for node in nodePlugins:
+            nodeProviders = loadNodes(folder, package, plugin.uid)
+            if nodeProviders:
+                for node in nodeProviders:
                     plugin.addNodeProvider(node)
-                nodesStr = ', '.join([node.nodeDescriptor.__name__ for node in nodePlugins])
+                nodesStr = ', '.join([node.nodeDescriptor.__name__ for node in nodeProviders])
                 logging.debug(f'Nodes loaded [{package}]: {nodesStr}')
             plugins.append(plugin)
     return plugins

--- a/meshroom/core/attribute.py
+++ b/meshroom/core/attribute.py
@@ -218,7 +218,7 @@ class Attribute(BaseObject):
         For string, expressions will be evaluated.
         """
         if isinstance(self.value, str):
-            env = self.node.nodePlugin.configFullEnv if self.node.nodePlugin else os.environ
+            env = self.node.nodeProvider.configFullEnv if self.node.nodeProvider else os.environ
             substituted = Template(self.value).safe_substitute(env)
             try:
                 varResolved = substituted.format(**self.node._expVars, **self.node._staticExpVars)

--- a/meshroom/core/desc/node.py
+++ b/meshroom/core/desc/node.py
@@ -251,8 +251,9 @@ class BaseNode(object):
     parallelization = None
     documentation = ""
     category = "Other"
-    plugin = None
     nodeVersionType: NodeVersionType = NodeVersionType.UNKNOWN
+    # The plugin NodeProvider that supplied this node
+    provider = None
     # Licenses required to run the plugin
     # Only used to select machines on the farm when the node is submitted
     _licenses = []
@@ -265,7 +266,7 @@ class BaseNode(object):
         mod = sys.modules[self.__class__.__module__]
         version = getattr(mod, "__version__", None) if mod else None
 
-        if self.plugin and self.plugin.isUserPlugin:
+        if self.provider and self.provider.isUserPlugin:
             self.nodeVersionType = NodeVersionType.USER
 
         # If "version" is not defined, the node version type remains "UNKNOWN"
@@ -286,7 +287,7 @@ class BaseNode(object):
     def getNodeInfo(cls):
         info = OrderedDict([
             ("module", cls.__module__),
-            ("modulePath", cls.plugin.path if cls.plugin else ""),
+            ("modulePath", cls.provider.path if cls.provider else ""),
         ])
         # > Info from the plugin module
         plugin_module = sys.modules.get(cls.__module__)
@@ -579,9 +580,9 @@ class Node(BaseNode):
         elif len(chunk.node.getChunks()) >= 1:
             meshroomComputeCmd += f" --iteration {chunk.range.iteration}"
 
-        runtimeEnv = chunk.node.nodeDesc.plugin.runtimeEnv
-        cmdPrefix = chunk.node.nodeDesc.plugin.commandPrefix
-        cmdSuffix = chunk.node.nodeDesc.plugin.commandSuffix
+        runtimeEnv = chunk.node.nodeDesc.provider.runtimeEnv
+        cmdPrefix = chunk.node.nodeDesc.provider.commandPrefix
+        cmdSuffix = chunk.node.nodeDesc.provider.commandSuffix
         self.executeChunkCommandLine(chunk, cmdPrefix + meshroomComputeCmd + cmdSuffix,
                                      env=runtimeEnv)
 
@@ -604,9 +605,9 @@ class CommandLineNode(BaseNode):
         cmdLineVars = chunk.node.createCmdLineVars()
         cmdPrefix = ""
         cmdSuffix = ""
-        if chunk.node.nodeDesc.plugin:
-            cmdPrefix = chunk.node.nodeDesc.plugin.commandPrefix
-            cmdSuffix = chunk.node.nodeDesc.plugin.commandSuffix
+        if chunk.node.nodeDesc.provider:
+            cmdPrefix = chunk.node.nodeDesc.provider.commandPrefix
+            cmdSuffix = chunk.node.nodeDesc.provider.commandSuffix
         if chunk.node.isParallelized and chunk.node.size > 1:
             cmdSuffix = " " + self.commandLineRange.format(**chunk.range.toDict()) + " " + cmdSuffix
 
@@ -622,7 +623,7 @@ class CommandLineNode(BaseNode):
 
     def processChunk(self, chunk):
         cmd = self.buildCommandLine(chunk)
-        runtimeEnv = chunk.node.nodeDesc.plugin.runtimeEnv
+        runtimeEnv = chunk.node.nodeDesc.provider.runtimeEnv
         self.executeChunkCommandLine(chunk, cmd, env=runtimeEnv)
 
 

--- a/meshroom/core/graph.py
+++ b/meshroom/core/graph.py
@@ -847,7 +847,7 @@ class Graph(BaseObject):
             for nodeName in nodeNames:
                 self.upgradeNode(nodeName)
 
-    def reloadNodePlugins(self, nodeTypes: list[str]):
+    def reloadNodeProviders(self, nodeTypes: list[str]):
         """
         Replace all the node instances of "nodeTypes" in the current graph with new node instances of the
         same type. If the description of the nodes has changed, the reloaded nodes will reflect theses

--- a/meshroom/core/node.py
+++ b/meshroom/core/node.py
@@ -859,12 +859,12 @@ class BaseNode(BaseObject):
         super().__init__(parent)
         self._nodeType: str = nodeType
         self.nodeDesc: desc.BaseNode = None
-        self.nodePlugin: plugins.Plugin = None
+        self.nodeProvider: plugins.Plugin = None
 
         # instantiate node description if nodeType is valid
         if meshroom.core.pluginManager.getLoadedNodeProvider(nodeType):
             self.nodeDesc = meshroom.core.pluginManager.getLoadedNodeProvider(nodeType).nodeDescriptor()
-            self.nodePlugin = meshroom.core.pluginManager.getLoadedNodeProvider(nodeType)
+            self.nodeProvider = meshroom.core.pluginManager.getLoadedNodeProvider(nodeType)
 
         self.packageName: str = ""
         self._internalFolder: str = ""

--- a/meshroom/core/node.py
+++ b/meshroom/core/node.py
@@ -862,9 +862,9 @@ class BaseNode(BaseObject):
         self.nodePlugin: plugins.Plugin = None
 
         # instantiate node description if nodeType is valid
-        if meshroom.core.pluginManager.getRegisteredNodePlugin(nodeType):
-            self.nodeDesc = meshroom.core.pluginManager.getRegisteredNodePlugin(nodeType).nodeDescriptor()
-            self.nodePlugin = meshroom.core.pluginManager.getRegisteredNodePlugin(nodeType)
+        if meshroom.core.pluginManager.getLoadedNodeProvider(nodeType):
+            self.nodeDesc = meshroom.core.pluginManager.getLoadedNodeProvider(nodeType).nodeDescriptor()
+            self.nodePlugin = meshroom.core.pluginManager.getLoadedNodeProvider(nodeType)
 
         self.packageName: str = ""
         self._internalFolder: str = ""

--- a/meshroom/core/node.py
+++ b/meshroom/core/node.py
@@ -859,7 +859,7 @@ class BaseNode(BaseObject):
         super().__init__(parent)
         self._nodeType: str = nodeType
         self.nodeDesc: desc.BaseNode = None
-        self.nodeProvider: plugins.Plugin = None
+        self.nodeProvider: plugins.NodeProvider = None
 
         # instantiate node description if nodeType is valid
         if meshroom.core.pluginManager.getLoadedNodeProvider(nodeType):

--- a/meshroom/core/node.py
+++ b/meshroom/core/node.py
@@ -863,8 +863,9 @@ class BaseNode(BaseObject):
 
         # instantiate node description if nodeType is valid
         if meshroom.core.pluginManager.getLoadedNodeProvider(nodeType):
-            self.nodeDesc = meshroom.core.pluginManager.getLoadedNodeProvider(nodeType).nodeDescriptor()
             self.nodeProvider = meshroom.core.pluginManager.getLoadedNodeProvider(nodeType)
+            self.nodeDesc = self.nodeProvider.nodeDescriptor()
+
 
         self.packageName: str = ""
         self._internalFolder: str = ""

--- a/meshroom/core/nodeFactory.py
+++ b/meshroom/core/nodeFactory.py
@@ -72,7 +72,7 @@ class _NodeCreator:
         self.position = Position(*self.nodeData.get("position", []))
         self.uid = self.nodeData.get("uid", None)
         self.nodeDesc = None
-        if meshroom.core.pluginManager.isRegistered(self.nodeType):
+        if meshroom.core.pluginManager.isLoaded(self.nodeType):
             self.nodeDesc = meshroom.core.pluginManager.getRegisteredNodePlugin(self.nodeType).nodeDescriptor
 
     def create(self) -> Union[Node, BackdropNode, CompatibilityNode]:

--- a/meshroom/core/nodeFactory.py
+++ b/meshroom/core/nodeFactory.py
@@ -73,7 +73,7 @@ class _NodeCreator:
         self.uid = self.nodeData.get("uid", None)
         self.nodeDesc = None
         if meshroom.core.pluginManager.isLoaded(self.nodeType):
-            self.nodeDesc = meshroom.core.pluginManager.getRegisteredNodePlugin(self.nodeType).nodeDescriptor
+            self.nodeDesc = meshroom.core.pluginManager.getLoadedNodeProvider(self.nodeType).nodeDescriptor
 
     def create(self) -> Union[Node, BackdropNode, CompatibilityNode]:
         compatibilityIssue = self._checkCompatibilityIssues()

--- a/meshroom/core/plugins.py
+++ b/meshroom/core/plugins.py
@@ -710,7 +710,7 @@ class PluginManager(BaseObject):
         self._plugins[pluginUName] = plugin
         if registerNodePlugins:
             for node in plugin.nodes:
-                self.registerNode(plugin.nodes[node])
+                self.loadNodeProvider(plugin.nodes[node])
 
     def removePlugin(self, plugin: Plugin, unregisterNodePlugins: bool = True):
         """
@@ -726,7 +726,7 @@ class PluginManager(BaseObject):
         if self.getPlugin(plugin.uname):
             if unregisterNodePlugins:
                 for node in plugin.nodes.values():
-                    self.unregisterNode(node)
+                    self.unloadNodeProvider(node)
             del self._plugins[plugin.uname]
 
     def getRegisteredNodePlugins(self) -> dict[str: NodePlugin]:
@@ -750,7 +750,7 @@ class PluginManager(BaseObject):
             return self._nodePlugins[name]
         return None
 
-    def registerNode(self, nodePlugin: NodePlugin):
+    def loadNodeProvider(self, nodePlugin: NodePlugin):
         """
         Register a node plugin. A registered node plugin will become instantiable.
         If it is already registered, or if there is an issue with the node description,
@@ -782,7 +782,7 @@ class PluginManager(BaseObject):
             logging.error(f"NodePlugin {name} could not be loaded: {exc}")
             nodePlugin.status = NodeProviderStatus.LOADING_ERROR
 
-    def unregisterNode(self, nodePlugin: NodePlugin):
+    def unloadNodeProvider(self, nodePlugin: NodePlugin):
         """
         Unregister a node plugin. When unregistered, a node plugin cannot be instantiated anymore.
         If it is not registered already, nothing happens.

--- a/meshroom/core/plugins.py
+++ b/meshroom/core/plugins.py
@@ -268,25 +268,25 @@ def processEnvFactory(folder: str, configEnv: dict[str: str], pluginName: str, e
 
 class NodeProviderStatus(Enum):
     """
-    Loading status for NodePlugin objects.
+    Loading status for NodeProvider objects.
     """
-    NOT_LOADED = 0  # The node plugin exists but is not loaded and cannot be used (not registered)
-    LOADED = 1  # The node plugin is currently loaded and functional (it has been registered)
-    DESC_ERROR = 2  # The node plugin exists but has an invalid description
-    LOADING_ERROR = 3  # The node plugin exists and is valid but could not be successfully registered
-    ERROR = 4  # Error when importing the node plugin from its module
+    NOT_LOADED = 0  # The node provider exists but is not loaded and cannot be used (not registered)
+    LOADED = 1  # The node provider is currently loaded and functional (it has been registered)
+    DESC_ERROR = 2  # The node provider exists but has an invalid description
+    LOADING_ERROR = 3  # The node provider exists and is valid but could not be successfully registered
+    ERROR = 4  # Error when importing the node provider from its module
 
 
 class Plugin(BaseObject):
     """
-    A collection of node plugins.
+    A collection of node providers.
 
     Members:
-        name: the name of the plugin (e.g. name of the Python module containing the node plugins)
+        name: the name of the plugin (e.g. name of the Python module containing the node providers)
         path: the absolute path of the plugin
         user: whether the plugin is a user plugin (not maintained by the core Meshroom team)
-        nodePlugins: dictionary mapping the name of a node plugin contained in the plugin
-                     to its corresponding NodePlugin object
+        nodeProviders: dictionary mapping the name of a node provider contained in the plugin
+                     to its corresponding NodeProvider object
         templates: dictionary mapping the name of templates (.mg files) associated to the plugin
                    with their absolute paths
         configEnv: the environment variables and their values, as described in the plugin's
@@ -306,7 +306,7 @@ class Plugin(BaseObject):
         self._path: str = path
         self._user: bool = False
 
-        self._nodePlugins: dict[str: NodePlugin] = {}
+        self._nodeProviders: dict[str: NodeProvider] = {}
         self._templates: dict[str: str] = {}
         self._configEnv: dict[str: str] = {}
         self._configFullEnv: dict[str: str] = {}
@@ -350,10 +350,10 @@ class Plugin(BaseObject):
     @property
     def nodes(self):
         """
-        Return the dictionary containing the NodePlugin objects associated to
+        Return the dictionary containing the NodeProvider objects associated to
         the plugin.
         """
-        return self._nodePlugins
+        return self._nodeProviders
 
     @property
     def templates(self):
@@ -383,30 +383,30 @@ class Plugin(BaseObject):
         """ Return the fusion of the os.environ dictionary with the configEnv dictionary. """
         return self._configFullEnv
 
-    def addNodeProvider(self, nodePlugin: NodePlugin):
+    def addNodeProvider(self, nodeProvider: NodeProvider):
         """
-        Add a node plugin to the current plugin object and assign it as its containing plugin.
-        The node plugin is added to the dictionary of node plugins with the name of the node
+        Add a node provider to the current plugin object and assign it as its containing plugin.
+        The node provider is added to the dictionary of node providers with the name of the node
         descriptor as its key.
 
         Args:
-            nodePlugin: the NodePlugin object to add to the Plugin.
+            nodeProvider: the NodeProvider object to add to the Plugin.
         """
-        self._nodePlugins[nodePlugin.nodeDescriptor.__name__] = nodePlugin
-        nodePlugin.plugin = self
+        self._nodeProviders[nodeProvider.nodeDescriptor.__name__] = nodeProvider
+        nodeProvider.plugin = self
 
     def removeNodeProvider(self, name: str):
         """
-        Remove a node plugin from the current plugin object and delete any container relationship.
+        Remove a node provider from the current plugin object and delete any container relationship.
 
         Args:
-            name: the name of the NodePlugin to remove.
+            name: the name of the NodeProvider to remove.
         """
-        if name in self._nodePlugins:
-            self._nodePlugins[name].plugin = None
-            del self._nodePlugins[name]
+        if name in self._nodeProviders:
+            self._nodeProviders[name].plugin = None
+            del self._nodeProviders[name]
         else:
-            logging.warning(f"Node plugin {name} is not part of the plugin {self.name}.")
+            logging.warning(f"node provider {name} is not part of the plugin {self.name}.")
 
     def loadTemplates(self):
         """
@@ -467,28 +467,28 @@ class Plugin(BaseObject):
 
     def containsNodeProvider(self, name: str) -> bool:
         """
-        Return whether the node plugin "name" is part of the plugin, independently from its
+        Return whether the node provider "name" is part of the plugin, independently from its
         status.
 
         Args:
-            name: the name of the node plugin to be checked.
+            name: the name of the node provider to be checked.
         """
-        return name in self._nodePlugins
+        return name in self._nodeProviders
 
 
-class NodePlugin(BaseObject):
+class NodeProvider(BaseObject):
     """
-    Based on a node description, a NodePlugin represents a loadable node.
+    Based on a node description, a NodeProvider represents a loadable node.
 
     Members:
-        plugin: the Plugin object that contains this node plugin
+        plugin: the Plugin object that contains this node provider
         path: absolute path to the file containing the node's description
         nodeDescriptor: the description of the node
-        status: the loading status on the node plugin
+        status: the loading status on the node provider
         errors: the list of errors (if there are any) when validating the description
                 of the node or attempting to load it
-        processEnv: the environment required for the node plugin's process. It can either
-                    be specific to this node plugin, or be common for all the node plugins within
+        processEnv: the environment required for the node provider's process. It can either
+                    be specific to this node provider, or be common for all the node providers within
                     the plugin
         timestamp: the timestamp corresponding to the last time the node description's file has been
                    modified
@@ -512,11 +512,11 @@ class NodePlugin(BaseObject):
 
     def reload(self) -> bool:
         """
-        Reload the node plugin and update its status accordingly. If the timestamp of the node plugin's
+        Reload the node provider and update its status accordingly. If the timestamp of the node provider's
         path has not changed since the last time the plugin has been loaded, then nothing will happen.
 
         Returns:
-            bool: True if the node plugin has successfully been reloaded (i.e. there was no error, and
+            bool: True if the node provider has successfully been reloaded (i.e. there was no error, and
                   some changes were made since its last loading), False otherwise.
         """
         timestamp = 0.0
@@ -564,15 +564,15 @@ class NodePlugin(BaseObject):
     @property
     def plugin(self):
         """
-        Return the Plugin object that contains this node plugin.
-        If the node plugin has not been assigned to a plugin yet, this value will
+        Return the Plugin object that contains this node provider.
+        If the node provider has not been assigned to a plugin yet, this value will
         be set to None.
         """
         return self._plugin
 
     @plugin.setter
     def plugin(self, plugin: Plugin):
-        """ Assign this node plugin to a containing Plugin object. """
+        """ Assign this node provider to a containing Plugin object. """
         self._plugin = plugin
 
     @property
@@ -585,7 +585,7 @@ class NodePlugin(BaseObject):
     @property
     def processEnv(self):
         """"
-        Return the process environment that is specific to the node plugin if it has any.
+        Return the process environment that is specific to the node provider if it has any.
         Otherwise, the Plugin's is returned.
         """
         if self._processEnv:
@@ -601,14 +601,14 @@ class NodePlugin(BaseObject):
 
     @property
     def commandPrefix(self) -> str:
-        """ Return the command prefix for the NodePlugin's execution. """
+        """ Return the command prefix for the NodeProvider's execution. """
         if not self.processEnv:
             return ""
         return self.processEnv.getCommandPrefix()
 
     @property
     def commandSuffix(self) -> str:
-        """ Return the command suffix for the NodePlugin's execution. """
+        """ Return the command suffix for the NodeProvider's execution. """
         if not self.processEnv:
             return ""
         return self.processEnv.getCommandSuffix()
@@ -622,12 +622,12 @@ class NodePlugin(BaseObject):
 
 class PluginManager(BaseObject):
     """
-    Manager for all the loaded Plugin objects as well as the registered NodePlugin objects.
+    Manager for all the loaded Plugin objects as well as the registered NodeProvider objects.
 
     Members:
         plugins: dictionary containing all the loaded Plugins, with their name as the key
-        nodePlugins: dictionary containing all the NodePlugins that have been registered
-                      (a NodePlugin may exist without having been registered) with their name as
+        nodeProviders: dictionary containing all the NodeProviders that have been registered
+                      (a NodeProvider may exist without having been registered) with their name as
                       the key
     """
 
@@ -635,24 +635,24 @@ class PluginManager(BaseObject):
         super().__init__()
 
         self._plugins: dict[str: Plugin] = {}  # loaded plugins
-        self._nodePlugins: dict[str: NodePlugin] = {}  # registered node plugins
+        self._nodeProviders: dict[str: NodeProvider] = {}  # registered node providers
 
     def isLoaded(self, name: str) -> bool:
         """
-        Return whether the node plugin has been loaded already.
+        Return whether the node provider has been loaded already.
 
         Args:
-            name: the name of the node plugin.
+            name: the name of the node provider.
         """
-        return name in self._nodePlugins
+        return name in self._nodeProviders
 
     def belongsToPlugin(self, name: str) -> Plugin:
         """
-        Check whether the node plugin belongs to a loaded plugin, independently from
+        Check whether the node provider belongs to a loaded plugin, independently from
         whether it has been registered or not.
 
         Args:
-            name: the name of the node plugin that needs to be searched for across plugins.
+            name: the name of the node provider that needs to be searched for across plugins.
 
         Returns:
             Plugin | None: the Plugin the node belongs to if it exists, None otherwise.
@@ -693,107 +693,107 @@ class PluginManager(BaseObject):
                     return plugin
         return None
 
-    def addPlugin(self, plugin: Plugin, registerNodePlugins: bool = True):
+    def addPlugin(self, plugin: Plugin, registerNodeProviders: bool = True):
         """
         Load a Plugin object.
 
         Args:
             plugin: the Plugin to load and add to the list of loaded plugins.
-            registerNodePlugins: True if all the NodePlugins from the plugin should be registered
+            registerNodeProviders: True if all the NodeProviders from the plugin should be registered
                                  at the same time the plugin is being loaded. Otherwise, the
-                                 NodePlugins will have to be registered at a later occasion.
+                                 NodeProviders will have to be registered at a later occasion.
         """
         pluginUName = plugin.uname
         if self.getPlugin(pluginUName):
             logging.warning(f"Plugin {pluginUName} is already registered.")
             return
         self._plugins[pluginUName] = plugin
-        if registerNodePlugins:
+        if registerNodeProviders:
             for node in plugin.nodes:
                 self.loadNodeProvider(plugin.nodes[node])
 
-    def removePlugin(self, plugin: Plugin, unregisterNodePlugins: bool = True):
+    def removePlugin(self, plugin: Plugin, unregisterNodeProviders: bool = True):
         """
         Remove a loaded Plugin object.
 
         Args:
             plugin: the Plugin to remove from the list of loaded plugins.
-            unregisterNodePlugins: True if all the nodes from the plugin should be unregistered (if they
+            unregisterNodeProviders: True if all the nodes from the plugin should be unregistered (if they
                                    are registered) at the same time as the plugin is unloaded. Otherwise,
-                                   the registered NodePlugins will remain while the Plugin itself will
+                                   the registered NodeProviders will remain while the Plugin itself will
                                    be unloaded.
         """
         if self.getPlugin(plugin.uname):
-            if unregisterNodePlugins:
+            if unregisterNodeProviders:
                 for node in plugin.nodes.values():
                     self.unloadNodeProvider(node)
             del self._plugins[plugin.uname]
 
-    def getLoadedNodeProviders(self) -> dict[str: NodePlugin]:
+    def getLoadedNodeProviders(self) -> dict[str: NodeProvider]:
         """
-        Return a dictionary containing all the registered NodePlugins, with
-        {key, value} = {name, NodePlugin}.
+        Return a dictionary containing all the registered NodeProviders, with
+        {key, value} = {name, NodeProvider}.
         """
-        return self._nodePlugins
+        return self._nodeProviders
 
-    def getLoadedNodeProvider(self, name: str) -> NodePlugin:
+    def getLoadedNodeProvider(self, name: str) -> NodeProvider:
         """
-        Return the NodePlugin object that has been registered under the name "name" if it exists.
+        Return the NodeProvider object that has been registered under the name "name" if it exists.
 
         Args:
-            name: the name of the NodePlugin used for its registration.
+            name: the name of the NodeProvider used for its registration.
 
         Returns:
-            NodePlugin | None: the loaded NodePlugin object if it exists, None otherwise.
+            NodeProvider | None: the loaded NodeProvider object if it exists, None otherwise.
         """
         if self.isLoaded(name):
-            return self._nodePlugins[name]
+            return self._nodeProviders[name]
         return None
 
-    def loadNodeProvider(self, nodePlugin: NodePlugin):
+    def loadNodeProvider(self, nodeProvider: NodeProvider):
         """
-        Register a node plugin. A registered node plugin will become instantiable.
+        Register a node provider. A registered node provider will become instantiable.
         If it is already registered, or if there is an issue with the node description,
-        the node plugin will not be registered and its status will be updated.
+        the node provider will not be registered and its status will be updated.
 
         Args:
-            nodePlugin: the node plugin to register.
+            nodeProvider: the node provider to register.
         """
-        name = nodePlugin.nodeDescriptor.__name__
+        name = nodeProvider.nodeDescriptor.__name__
         if self.isLoaded(name):
-            existingPlugin: NodePlugin = self._nodePlugins[name]
+            existingPlugin: NodeProvider = self._nodeProviders[name]
             logging.warning(
-                f"Could not register node {name} ({nodePlugin.path}) "
+                f"Could not register node {name} ({nodeProvider.path}) "
                 f"because another node is already registered with this name ({existingPlugin.path})"
             )
             return
-        if nodePlugin.status in (NodeProviderStatus.DESC_ERROR,
+        if nodeProvider.status in (NodeProviderStatus.DESC_ERROR,
                                  NodeProviderStatus.ERROR):
             logging.warning(
-                f"Could not register node {name} ({nodePlugin.path}) "
-                f"because the node is in error ({nodePlugin.status})."
+                f"Could not register node {name} ({nodeProvider.path}) "
+                f"because the node is in error ({nodeProvider.status})."
             )
             return
 
         try:
-            self._nodePlugins[name] = nodePlugin
-            nodePlugin.status = NodeProviderStatus.LOADED
+            self._nodeProviders[name] = nodeProvider
+            nodeProvider.status = NodeProviderStatus.LOADED
         except Exception as exc:
-            logging.error(f"NodePlugin {name} could not be loaded: {exc}")
-            nodePlugin.status = NodeProviderStatus.LOADING_ERROR
+            logging.error(f"NodeProvider {name} could not be loaded: {exc}")
+            nodeProvider.status = NodeProviderStatus.LOADING_ERROR
 
-    def unloadNodeProvider(self, nodePlugin: NodePlugin):
+    def unloadNodeProvider(self, nodeProvider: NodeProvider):
         """
-        Unregister a node plugin. When unregistered, a node plugin cannot be instantiated anymore.
+        Unregister a node provider. When unregistered, a node provider cannot be instantiated anymore.
         If it is not registered already, nothing happens.
 
         Args:
-            nodePlugin: the node plugin to unregister.
+            nodeProvider: the node provider to unregister.
         """
-        name = nodePlugin.nodeDescriptor.__name__
+        name = nodeProvider.nodeDescriptor.__name__
         if self.isLoaded(name):
-            if nodePlugin.status != NodeProviderStatus.LOADED:
-                logging.warning(f"NodePlugin {name} is registered but is not correctly loaded.")
+            if nodeProvider.status != NodeProviderStatus.LOADED:
+                logging.warning(f"NodeProvider {name} is registered but is not correctly loaded.")
             else:
-                nodePlugin.status = NodeProviderStatus.NOT_LOADED
-            del self._nodePlugins[name]
+                nodeProvider.status = NodeProviderStatus.NOT_LOADED
+            del self._nodeProviders[name]

--- a/meshroom/core/plugins.py
+++ b/meshroom/core/plugins.py
@@ -383,7 +383,7 @@ class Plugin(BaseObject):
         """ Return the fusion of the os.environ dictionary with the configEnv dictionary. """
         return self._configFullEnv
 
-    def addNodePlugin(self, nodePlugin: NodePlugin):
+    def addNodeProvider(self, nodePlugin: NodePlugin):
         """
         Add a node plugin to the current plugin object and assign it as its containing plugin.
         The node plugin is added to the dictionary of node plugins with the name of the node

--- a/meshroom/core/plugins.py
+++ b/meshroom/core/plugins.py
@@ -691,13 +691,13 @@ class PluginManager(BaseObject):
                     return plugin
         return None
 
-    def addPlugin(self, plugin: Plugin, registerNodeProviders: bool = True):
+    def addPlugin(self, plugin: Plugin, loadNodeProviders: bool = True):
         """
         Load a Plugin object.
 
         Args:
             plugin: the Plugin to load and add to the list of loaded plugins.
-            registerNodeProviders: True if all the NodeProviders from the plugin should be loaded
+            loadNodeProviders: True if all the NodeProviders from the plugin should be loaded
                                  at the same time the plugin is being loaded. Otherwise, the
                                  NodeProviders will have to be loaded at a later occasion.
         """
@@ -706,23 +706,23 @@ class PluginManager(BaseObject):
             logging.warning(f"Plugin {pluginUName} is already loaded.")
             return
         self._plugins[pluginUName] = plugin
-        if registerNodeProviders:
+        if loadNodeProviders:
             for node in plugin.nodes:
                 self.loadNodeProvider(plugin.nodes[node])
 
-    def removePlugin(self, plugin: Plugin, unregisterNodeProviders: bool = True):
+    def removePlugin(self, plugin: Plugin, unloadNodeProviders: bool = True):
         """
         Remove a loaded Plugin object.
 
         Args:
             plugin: the Plugin to remove from the list of loaded plugins.
-            unregisterNodeProviders: True if all the nodes from the plugin should be unloaded (if they
+            unloadNodeProviders: True if all the nodes from the plugin should be unloaded (if they
                                    are loaded) at the same time as the plugin is unloaded. Otherwise,
                                    the loaded NodeProviders will remain while the Plugin itself will
                                    be unloaded.
         """
         if self.getPlugin(plugin.uname):
-            if unregisterNodeProviders:
+            if unloadNodeProviders:
                 for node in plugin.nodes.values():
                     self.unloadNodeProvider(node)
             del self._plugins[plugin.uname]

--- a/meshroom/core/plugins.py
+++ b/meshroom/core/plugins.py
@@ -266,7 +266,7 @@ def processEnvFactory(folder: str, configEnv: dict[str: str], pluginName: str, e
     return RezProcessEnv(folder, configEnv, pluginName, uri=uri)
 
 
-class NodePluginStatus(Enum):
+class NodeProviderStatus(Enum):
     """
     Loading status for NodePlugin objects.
     """
@@ -501,11 +501,11 @@ class NodePlugin(BaseObject):
         self.nodeDescriptor: desc.BaseNode = nodeDesc
         self.nodeDescriptor.plugin = self
 
-        self.status: NodePluginStatus = NodePluginStatus.NOT_LOADED
+        self.status: NodeProviderStatus = NodeProviderStatus.NOT_LOADED
         self.errors: list[tuple[str, ValueTypeErrors]] = validateNodeDesc(nodeDesc)
 
         if self.errors:
-            self.status = NodePluginStatus.DESC_ERROR
+            self.status = NodeProviderStatus.DESC_ERROR
 
         self._processEnv = None
         self._timestamp = os.path.getmtime(self.path)
@@ -523,7 +523,7 @@ class NodePlugin(BaseObject):
         try:
             timestamp = os.path.getmtime(self.path)
         except FileNotFoundError:
-            self.status = NodePluginStatus.ERROR
+            self.status = NodeProviderStatus.ERROR
             logging.error(f"[Reload] {self.nodeDescriptor.__name__}: The path at {self.path} was not "
                           f"not found.")
             return False
@@ -537,19 +537,19 @@ class NodePlugin(BaseObject):
             updated = importlib.reload(sys.modules.get(self.nodeDescriptor.__module__))
         except Exception as exc:
             logging.error(f"[Reload] {self.nodeDescriptor.__name__}: {exc} ({type(exc).__name__})")
-            self.status = NodePluginStatus.DESC_ERROR
+            self.status = NodeProviderStatus.DESC_ERROR
             return False
         descriptor = getattr(updated, self.nodeDescriptor.__name__)
 
         if not descriptor:
-            self.status = NodePluginStatus.ERROR
+            self.status = NodeProviderStatus.ERROR
             logging.error(f"[Reload] {self.nodeDescriptor.__name__}: The node description at {self.path} "
                           f"was not found.")
             return False
 
         self.errors = validateNodeDesc(descriptor)
         if self.errors:
-            self.status = NodePluginStatus.DESC_ERROR
+            self.status = NodeProviderStatus.DESC_ERROR
             logging.error(f"[Reload] {self.nodeDescriptor.__name__}: The node description at {self.path} "
                           f"has description errors.")
             return False
@@ -557,7 +557,7 @@ class NodePlugin(BaseObject):
         self.nodeDescriptor = descriptor
         self.nodeDescriptor.plugin = self
         self._timestamp = timestamp
-        self.status = NodePluginStatus.NOT_LOADED
+        self.status = NodeProviderStatus.NOT_LOADED
         logging.info(f"[Reload] {self.nodeDescriptor.__name__}: Successful reloading.")
         return True
 
@@ -767,8 +767,8 @@ class PluginManager(BaseObject):
                 f"because another node is already registered with this name ({existingPlugin.path})"
             )
             return
-        if nodePlugin.status in (NodePluginStatus.DESC_ERROR,
-                                 NodePluginStatus.ERROR):
+        if nodePlugin.status in (NodeProviderStatus.DESC_ERROR,
+                                 NodeProviderStatus.ERROR):
             logging.warning(
                 f"Could not register node {name} ({nodePlugin.path}) "
                 f"because the node is in error ({nodePlugin.status})."
@@ -777,10 +777,10 @@ class PluginManager(BaseObject):
 
         try:
             self._nodePlugins[name] = nodePlugin
-            nodePlugin.status = NodePluginStatus.LOADED
+            nodePlugin.status = NodeProviderStatus.LOADED
         except Exception as exc:
             logging.error(f"NodePlugin {name} could not be loaded: {exc}")
-            nodePlugin.status = NodePluginStatus.LOADING_ERROR
+            nodePlugin.status = NodeProviderStatus.LOADING_ERROR
 
     def unregisterNode(self, nodePlugin: NodePlugin):
         """
@@ -792,8 +792,8 @@ class PluginManager(BaseObject):
         """
         name = nodePlugin.nodeDescriptor.__name__
         if self.isRegistered(name):
-            if nodePlugin.status != NodePluginStatus.LOADED:
+            if nodePlugin.status != NodeProviderStatus.LOADED:
                 logging.warning(f"NodePlugin {name} is registered but is not correctly loaded.")
             else:
-                nodePlugin.status = NodePluginStatus.NOT_LOADED
+                nodePlugin.status = NodeProviderStatus.NOT_LOADED
             del self._nodePlugins[name]

--- a/meshroom/core/plugins.py
+++ b/meshroom/core/plugins.py
@@ -465,7 +465,7 @@ class Plugin(BaseObject):
         # If both dictionaries have identical keys, os.environ overwrites existing values from _configEnv
         self._configFullEnv = self._configEnv | os.environ
 
-    def containsNodePlugin(self, name: str) -> bool:
+    def containsNodeProvider(self, name: str) -> bool:
         """
         Return whether the node plugin "name" is part of the plugin, independently from its
         status.
@@ -658,7 +658,7 @@ class PluginManager(BaseObject):
             Plugin | None: the Plugin the node belongs to if it exists, None otherwise.
         """
         for plugin in self._plugins.values():
-            if plugin.containsNodePlugin(name):
+            if plugin.containsNodeProvider(name):
                 return plugin
         return None
 

--- a/meshroom/core/plugins.py
+++ b/meshroom/core/plugins.py
@@ -729,14 +729,14 @@ class PluginManager(BaseObject):
                     self.unloadNodeProvider(node)
             del self._plugins[plugin.uname]
 
-    def getRegisteredNodePlugins(self) -> dict[str: NodePlugin]:
+    def getLoadedNodeProviders(self) -> dict[str: NodePlugin]:
         """
         Return a dictionary containing all the registered NodePlugins, with
         {key, value} = {name, NodePlugin}.
         """
         return self._nodePlugins
 
-    def getRegisteredNodePlugin(self, name: str) -> NodePlugin:
+    def getLoadedNodeProvider(self, name: str) -> NodePlugin:
         """
         Return the NodePlugin object that has been registered under the name "name" if it exists.
 

--- a/meshroom/core/plugins.py
+++ b/meshroom/core/plugins.py
@@ -499,7 +499,7 @@ class NodeProvider(BaseObject):
         self.plugin: Plugin = plugin
         self.path: str = Path(getfile(nodeDesc)).resolve().as_posix()
         self.nodeDescriptor: desc.BaseNode = nodeDesc
-        self.nodeDescriptor.plugin = self
+        self.nodeDescriptor.provider = self
 
         self.status: NodeProviderStatus = NodeProviderStatus.NOT_LOADED
         self.errors: list[tuple[str, ValueTypeErrors]] = validateNodeDesc(nodeDesc)
@@ -555,7 +555,7 @@ class NodeProvider(BaseObject):
             return False
 
         self.nodeDescriptor = descriptor
-        self.nodeDescriptor.plugin = self
+        self.nodeDescriptor.provider = self
         self._timestamp = timestamp
         self.status = NodeProviderStatus.NOT_LOADED
         logging.info(f"[Reload] {self.nodeDescriptor.__name__}: Successful reloading.")

--- a/meshroom/core/plugins.py
+++ b/meshroom/core/plugins.py
@@ -637,12 +637,12 @@ class PluginManager(BaseObject):
         self._plugins: dict[str: Plugin] = {}  # loaded plugins
         self._nodePlugins: dict[str: NodePlugin] = {}  # registered node plugins
 
-    def isRegistered(self, name: str) -> bool:
+    def isLoaded(self, name: str) -> bool:
         """
-        Return whether the node plugin has been registered already.
+        Return whether the node plugin has been loaded already.
 
         Args:
-            name: the name of the node plugin whose registration needs to be checked.
+            name: the name of the node plugin.
         """
         return name in self._nodePlugins
 
@@ -746,7 +746,7 @@ class PluginManager(BaseObject):
         Returns:
             NodePlugin | None: the loaded NodePlugin object if it exists, None otherwise.
         """
-        if self.isRegistered(name):
+        if self.isLoaded(name):
             return self._nodePlugins[name]
         return None
 
@@ -760,7 +760,7 @@ class PluginManager(BaseObject):
             nodePlugin: the node plugin to register.
         """
         name = nodePlugin.nodeDescriptor.__name__
-        if self.isRegistered(name):
+        if self.isLoaded(name):
             existingPlugin: NodePlugin = self._nodePlugins[name]
             logging.warning(
                 f"Could not register node {name} ({nodePlugin.path}) "
@@ -791,7 +791,7 @@ class PluginManager(BaseObject):
             nodePlugin: the node plugin to unregister.
         """
         name = nodePlugin.nodeDescriptor.__name__
-        if self.isRegistered(name):
+        if self.isLoaded(name):
             if nodePlugin.status != NodeProviderStatus.LOADED:
                 logging.warning(f"NodePlugin {name} is registered but is not correctly loaded.")
             else:

--- a/meshroom/core/plugins.py
+++ b/meshroom/core/plugins.py
@@ -270,10 +270,10 @@ class NodeProviderStatus(Enum):
     """
     Loading status for NodeProvider objects.
     """
-    NOT_LOADED = 0  # The node provider exists but is not loaded and cannot be used (not registered)
-    LOADED = 1  # The node provider is currently loaded and functional (it has been registered)
+    NOT_LOADED = 0  # The node provider exists but is not loaded and cannot be used
+    LOADED = 1  # The node provider is currently loaded and functional
     DESC_ERROR = 2  # The node provider exists but has an invalid description
-    LOADING_ERROR = 3  # The node provider exists and is valid but could not be successfully registered
+    LOADING_ERROR = 3  # The node provider exists and is valid but could not be successfully loaded
     ERROR = 4  # Error when importing the node provider from its module
 
 
@@ -622,20 +622,18 @@ class NodeProvider(BaseObject):
 
 class PluginManager(BaseObject):
     """
-    Manager for all the loaded Plugin objects as well as the registered NodeProvider objects.
+    Manager for all the loaded Plugin objects as well as the loaded NodeProvider objects.
 
     Members:
         plugins: dictionary containing all the loaded Plugins, with their name as the key
-        nodeProviders: dictionary containing all the NodeProviders that have been registered
-                      (a NodeProvider may exist without having been registered) with their name as
-                      the key
+        nodeProviders: dictionary containing all the loaded NodeProviders 
     """
 
     def __init__(self):
         super().__init__()
 
         self._plugins: dict[str: Plugin] = {}  # loaded plugins
-        self._nodeProviders: dict[str: NodeProvider] = {}  # registered node providers
+        self._nodeProviders: dict[str: NodeProvider] = {}  # loaded node providers
 
     def isLoaded(self, name: str) -> bool:
         """
@@ -649,7 +647,7 @@ class PluginManager(BaseObject):
     def belongsToPlugin(self, name: str) -> Plugin:
         """
         Check whether the node provider belongs to a loaded plugin, independently from
-        whether it has been registered or not.
+        whether it has been loaded or not.
 
         Args:
             name: the name of the node provider that needs to be searched for across plugins.
@@ -699,13 +697,13 @@ class PluginManager(BaseObject):
 
         Args:
             plugin: the Plugin to load and add to the list of loaded plugins.
-            registerNodeProviders: True if all the NodeProviders from the plugin should be registered
+            registerNodeProviders: True if all the NodeProviders from the plugin should be loaded
                                  at the same time the plugin is being loaded. Otherwise, the
-                                 NodeProviders will have to be registered at a later occasion.
+                                 NodeProviders will have to be loaded at a later occasion.
         """
         pluginUName = plugin.uname
         if self.getPlugin(pluginUName):
-            logging.warning(f"Plugin {pluginUName} is already registered.")
+            logging.warning(f"Plugin {pluginUName} is already loaded.")
             return
         self._plugins[pluginUName] = plugin
         if registerNodeProviders:
@@ -718,9 +716,9 @@ class PluginManager(BaseObject):
 
         Args:
             plugin: the Plugin to remove from the list of loaded plugins.
-            unregisterNodeProviders: True if all the nodes from the plugin should be unregistered (if they
-                                   are registered) at the same time as the plugin is unloaded. Otherwise,
-                                   the registered NodeProviders will remain while the Plugin itself will
+            unregisterNodeProviders: True if all the nodes from the plugin should be unloaded (if they
+                                   are loaded) at the same time as the plugin is unloaded. Otherwise,
+                                   the loaded NodeProviders will remain while the Plugin itself will
                                    be unloaded.
         """
         if self.getPlugin(plugin.uname):
@@ -731,17 +729,17 @@ class PluginManager(BaseObject):
 
     def getLoadedNodeProviders(self) -> dict[str: NodeProvider]:
         """
-        Return a dictionary containing all the registered NodeProviders, with
+        Return a dictionary containing all the loaded NodeProviders, with
         {key, value} = {name, NodeProvider}.
         """
         return self._nodeProviders
 
     def getLoadedNodeProvider(self, name: str) -> NodeProvider:
         """
-        Return the NodeProvider object that has been registered under the name "name" if it exists.
+        Return the NodeProvider object that has been loaded under the name "name" if it exists.
 
         Args:
-            name: the name of the NodeProvider used for its registration.
+            name: the name of the NodeProvider.
 
         Returns:
             NodeProvider | None: the loaded NodeProvider object if it exists, None otherwise.
@@ -752,25 +750,25 @@ class PluginManager(BaseObject):
 
     def loadNodeProvider(self, nodeProvider: NodeProvider):
         """
-        Register a node provider. A registered node provider will become instantiable.
-        If it is already registered, or if there is an issue with the node description,
-        the node provider will not be registered and its status will be updated.
+        Load a node provider. A loaded node provider will become instantiable.
+        If it is already loaded, or if there is an issue with the node description,
+        the node provider will not be loaded and its status will be updated.
 
         Args:
-            nodeProvider: the node provider to register.
+            nodeProvider: the node provider to load.
         """
         name = nodeProvider.nodeDescriptor.__name__
         if self.isLoaded(name):
             existingPlugin: NodeProvider = self._nodeProviders[name]
             logging.warning(
-                f"Could not register node {name} ({nodeProvider.path}) "
-                f"because another node is already registered with this name ({existingPlugin.path})"
+                f"Could not load node {name} ({nodeProvider.path}) "
+                f"because another node is already loaded with this name ({existingPlugin.path})"
             )
             return
         if nodeProvider.status in (NodeProviderStatus.DESC_ERROR,
                                  NodeProviderStatus.ERROR):
             logging.warning(
-                f"Could not register node {name} ({nodeProvider.path}) "
+                f"Could not load node {name} ({nodeProvider.path}) "
                 f"because the node is in error ({nodeProvider.status})."
             )
             return
@@ -784,16 +782,16 @@ class PluginManager(BaseObject):
 
     def unloadNodeProvider(self, nodeProvider: NodeProvider):
         """
-        Unregister a node provider. When unregistered, a node provider cannot be instantiated anymore.
-        If it is not registered already, nothing happens.
+        Unload a node provider. When unloaded, a node provider cannot be instantiated anymore.
+        If it is not loaded already, nothing happens.
 
         Args:
-            nodeProvider: the node provider to unregister.
+            nodeProvider: the node provider to unload.
         """
         name = nodeProvider.nodeDescriptor.__name__
         if self.isLoaded(name):
             if nodeProvider.status != NodeProviderStatus.LOADED:
-                logging.warning(f"NodeProvider {name} is registered but is not correctly loaded.")
+                logging.warning(f"NodeProvider {name} is not correctly loaded.")
             else:
                 nodeProvider.status = NodeProviderStatus.NOT_LOADED
             del self._nodeProviders[name]

--- a/meshroom/core/plugins.py
+++ b/meshroom/core/plugins.py
@@ -395,7 +395,7 @@ class Plugin(BaseObject):
         self._nodePlugins[nodePlugin.nodeDescriptor.__name__] = nodePlugin
         nodePlugin.plugin = self
 
-    def removeNodePlugin(self, name: str):
+    def removeNodeProvider(self, name: str):
         """
         Remove a node plugin from the current plugin object and delete any container relationship.
 

--- a/meshroom/core/plugins.py
+++ b/meshroom/core/plugins.py
@@ -620,7 +620,7 @@ class NodePlugin(BaseObject):
             return {}
         return self.plugin.configFullEnv
 
-class NodePluginManager(BaseObject):
+class PluginManager(BaseObject):
     """
     Manager for all the loaded Plugin objects as well as the registered NodePlugin objects.
 

--- a/meshroom/core/plugins/env.py
+++ b/meshroom/core/plugins/env.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+
+import glob
+import logging
+import os
+import re
+import sys
+
+from enum import Enum
+from pathlib import Path
+
+from meshroom.common import BaseObject
+from meshroom import _MESHROOM_ROOT
+from meshroom.core.desc.node import _MESHROOM_COMPUTE_DEPS
+
+
+def processEnvFactory(folder: str, configEnv: dict[str: str], pluginName: str, envType: str = "dirtree", uri: str = "") -> ProcessEnv:
+    if envType == "dirtree":
+        return DirTreeProcessEnv(folder, configEnv, pluginName)
+    return RezProcessEnv(folder, configEnv, pluginName, uri=uri)
+
+
+class ProcessEnvType(Enum):
+    """ Supported process environments. """
+    DIRTREE = "dirtree",
+    REZ = "rez"
+
+
+class ProcessEnv(BaseObject):
+    """
+    Describes the environment required by a node's process.
+
+    Args:
+        folder: the source folder for the process.
+        configEnv: the dictionary containing the environment variables defined in a configuration file
+                   for the process to run.
+        pluginName: the name of the plugin object.
+        envType: (optional) the type of process environment.
+        uri: (optional) the Unique Resource Identifier to activate the environment.
+    """
+
+    def __init__(self, folder: str, configEnv: dict[str, str], pluginName: str,
+                 envType: ProcessEnvType = ProcessEnvType.DIRTREE, uri: str = ""):
+        super().__init__()
+        self._folder: str = folder
+        self._configEnv: dict[str: str] = configEnv
+        self.pluginName: str = pluginName
+        self._processEnvType: ProcessEnvType = envType
+        self.uri: str = uri
+        self._env: dict = None
+
+    def getEnvDict(self) -> dict:
+        """ Return the environment dictionary if it has been modified, None otherwise. """
+        return self._env
+
+    def getCommandPrefix(self) -> str:
+        """ Return the prefix to the command line that will be executed by the process. """
+        return ""
+
+    def getCommandSuffix(self) -> str:
+        """ Return the suffix to the command line that will be executed by the process. """
+        return ""
+
+
+class DirTreeProcessEnv(ProcessEnv):
+    """
+    """
+    def __init__(self, folder: str, configEnv: dict[str: str], pluginName: str):
+        super().__init__(folder, configEnv, pluginName, envType=ProcessEnvType.DIRTREE)
+
+        # If there is a virtual environment, it is expected to be named "venv".
+        # Beside the virtual environment, a standard "bin"/"lib"/"lib64" hierarchy at
+        # the top level of the plugin folder is expected.
+        venvFolder = Path(folder, "venv")
+
+        # Find all the libs that are not directly at the "lib*"-level
+        envLibPaths = glob.glob(f'{folder}/lib*/python[0-9].[0-9]*/site-packages',
+                                recursive=False)
+        venvLibPaths = glob.glob(f'{venvFolder}/lib*/python[0-9].[0-9]*/site-packages',
+                                 recursive=False)
+
+        self.binPaths: list = [str(Path(folder, "bin")), str(Path(venvFolder, "bin"))]
+        self.libPaths: list = [str(Path(folder, "lib")), str(Path(folder, "lib64")),
+                               str(Path(venvFolder, "lib")), str(Path(venvFolder, "lib64"))]
+        self.pythonPaths: list = [str(Path(folder)), str(Path(venvFolder))] + \
+                                 self.binPaths + envLibPaths + venvLibPaths
+
+        if sys.platform == "win32":
+            # For Windows platforms, try and include the content of the virtual env if it exists
+            # The virtual env is expected to be named "venv"
+            venvLibPath = Path(venvFolder, "Lib", "site-packages")
+            if venvLibPath.exists():
+                self.pythonPaths.append(venvLibPath.as_posix())
+        else:
+            # For Linux platforms, lib paths may need to be discovered recursively to be properly
+            # added to LD_LIBRARY_PATH
+            extraLibPaths = []
+            regex = re.compile(r"^lib(\d{2})?$")
+            for envPath in envLibPaths + venvLibPaths:
+                for path, directories, _ in os.walk(envPath):
+                    for directory in directories:
+                        if re.match(regex, directory):
+                            extraLibPaths.append(os.path.join(path, directory))
+            self.libPaths = self.libPaths + extraLibPaths
+
+        # Setup the environment dictionary
+        self._env = os.environ.copy()
+        self._env["PYTHONPATH"] = os.pathsep.join(
+            [f"{_MESHROOM_ROOT}"] + self.pythonPaths + [os.getenv('PYTHONPATH', '')])
+        self._env["LD_LIBRARY_PATH"] = f"{os.pathsep.join(self.libPaths)}{os.pathsep}{os.getenv('LD_LIBRARY_PATH', '')}"
+        self._env["PATH"] = f"{os.pathsep.join(self.binPaths)}{os.pathsep}{os.getenv('PATH', '')}"
+
+        for k, val in self._configEnv.items():
+            # Preserve user-defined environment variables:
+            # manually set environment variable values take precedence over config file defaults.
+            if k in self._env:
+                continue
+
+            self._env[k] = val
+
+
+class RezProcessEnv(ProcessEnv):
+    """
+    """
+
+    REZ_DELIMITER_PATTERN = re.compile(r"-|==|>=|>|<=|<")
+
+    def __init__(self, folder: str, configEnv: dict[str: str], pluginName: str, uri: str = ""):
+        if not uri:
+            raise RuntimeError("Missing name of the Rez environment needs to be provided.")
+        super().__init__(folder, configEnv, pluginName, envType=ProcessEnvType.REZ, uri=uri)
+
+    def resolveRezSubrequires(self) -> list[str]:
+        """
+        Return the list of packages defined for the node execution. These execution packages are
+        named subrequires.
+        Note: If a package does not have a version number, the version is aligned with the main
+        Meshroom environment (if this package is defined).
+        """
+        if os.getenv(f"{self.uri.upper()}_{self.pluginName.upper()}_SUBREQUIRES"):
+            subrequires = os.environ.get(f"{self.uri.upper()}_{self.pluginName.upper()}_SUBREQUIRES", "").split(os.pathsep)
+        else:
+            subrequires = os.environ.get(f"{self.uri.upper()}_SUBREQUIRES", "").split(os.pathsep)
+        if not subrequires:
+            return []
+
+        packages = []
+        # Packages that are resolved in the current environment
+        currentEnvPackages = []
+        resolvedVersions = {}
+        if "REZ_USED_RESOLVE" in os.environ:
+            resolvedPackages = os.getenv("REZ_USED_RESOLVE", "").split()
+            for package in resolvedPackages:
+                if package.startswith("~"):
+                    continue
+                currentEnvPackages.append(package)
+                name, version = self.REZ_DELIMITER_PATTERN.split(package, maxsplit=1)
+                resolvedVersions[name] = version
+        logging.debug("Packages in the current environment: " + ", ".join(currentEnvPackages))
+
+        # Take packages with the set versions for those which have one, and try to take packages
+        # in the current environment (if they are resolved in it)
+        for package in subrequires:
+            packageTuple = self.REZ_DELIMITER_PATTERN.split(package, maxsplit=1)
+            if len(packageTuple) == 1:
+                # Only the package name in the subrequires.
+                # Search for a corresponding version in the parent environment.
+                packageName = packageTuple[0]
+                parentResolvedVersion = resolvedVersions.get(packageName)
+                if parentResolvedVersion:
+                    packages.append(f"{packageName}=={parentResolvedVersion}")
+                else:
+                    packages.append(package)
+            elif len(packageTuple) == 2:
+                # The subrequires ask for a specific version
+                packages.append(package)
+
+        def extractPackageName(packageString: str) -> str:
+            return self.REZ_DELIMITER_PATTERN.split(packageString, maxsplit=1)[0]
+        packageNames = [extractPackageName(package) for package in packages]
+
+        for package in _MESHROOM_COMPUTE_DEPS:
+            # For packages that are required by meshroom_compute, do not specify any version
+            # or align it with Meshroom's: the version will be found during the resolution of
+            # the environment based on the other packages.
+            # If any of these packages is already part of the environment a plugin's dependency,
+            # do not add it
+            if package not in packageNames:
+                packages.append(package)
+
+        logging.debug("Packages for the execution environment: " + ", ".join(packages))
+        return packages
+
+    def getCommandPrefix(self):
+        # TODO: make Windows-compatible
+
+        # Use the PYTHONPATH from the subrequires' environment (which will only be resolved once
+        # inside the execution environment) and add MESHROOM_ROOT and the plugin's folder itself
+        # to it
+        pythonPaths = f"{os.pathsep.join(['$PYTHONPATH', f'{_MESHROOM_ROOT}', f'{self._folder}'])}"
+
+        return f"rez env {' '.join(self.resolveRezSubrequires())} -c 'PYTHONPATH={pythonPaths} "
+
+    def getCommandSuffix(self):
+        return "'"

--- a/meshroom/core/plugins/manager.py
+++ b/meshroom/core/plugins/manager.py
@@ -1,11 +1,9 @@
 from __future__ import annotations
 
-import glob
 import importlib
 import json
 import logging
 import os
-import re
 import sys
 
 from enum import Enum
@@ -15,8 +13,7 @@ from pathlib import Path
 from meshroom.common import BaseObject
 from meshroom.core import desc
 from meshroom.core.desc.attribute import ValueTypeErrors
-from meshroom import _MESHROOM_ROOT
-from meshroom.core.desc.node import _MESHROOM_COMPUTE_DEPS
+from meshroom.core.plugins.env import ProcessEnv
 
 
 def validateNodeDesc(nodeDesc: desc.BaseNode) -> list[tuple[str, ValueTypeErrors]]:
@@ -75,197 +72,6 @@ def formatNodeDescriptionErrorMessage(error: tuple[str, ValueTypeErrors]) -> str
     return f"Unknown error for parameter '{errMsg}'."
 
 
-class ProcessEnvType(Enum):
-    """ Supported process environments. """
-    DIRTREE = "dirtree",
-    REZ = "rez"
-
-
-class ProcessEnv(BaseObject):
-    """
-    Describes the environment required by a node's process.
-
-    Args:
-        folder: the source folder for the process.
-        configEnv: the dictionary containing the environment variables defined in a configuration file
-                   for the process to run.
-        pluginName: the name of the plugin object.
-        envType: (optional) the type of process environment.
-        uri: (optional) the Unique Resource Identifier to activate the environment.
-    """
-
-    def __init__(self, folder: str, configEnv: dict[str, str], pluginName: str,
-                 envType: ProcessEnvType = ProcessEnvType.DIRTREE, uri: str = ""):
-        super().__init__()
-        self._folder: str = folder
-        self._configEnv: dict[str: str] = configEnv
-        self.pluginName: str = pluginName
-        self._processEnvType: ProcessEnvType = envType
-        self.uri: str = uri
-        self._env: dict = None
-
-    def getEnvDict(self) -> dict:
-        """ Return the environment dictionary if it has been modified, None otherwise. """
-        return self._env
-
-    def getCommandPrefix(self) -> str:
-        """ Return the prefix to the command line that will be executed by the process. """
-        return ""
-
-    def getCommandSuffix(self) -> str:
-        """ Return the suffix to the command line that will be executed by the process. """
-        return ""
-
-
-class DirTreeProcessEnv(ProcessEnv):
-    """
-    """
-    def __init__(self, folder: str, configEnv: dict[str: str], pluginName: str):
-        super().__init__(folder, configEnv, pluginName, envType=ProcessEnvType.DIRTREE)
-
-        # If there is a virtual environment, it is expected to be named "venv".
-        # Beside the virtual environment, a standard "bin"/"lib"/"lib64" hierarchy at
-        # the top level of the plugin folder is expected.
-        venvFolder = Path(folder, "venv")
-
-        # Find all the libs that are not directly at the "lib*"-level
-        envLibPaths = glob.glob(f'{folder}/lib*/python[0-9].[0-9]*/site-packages',
-                                recursive=False)
-        venvLibPaths = glob.glob(f'{venvFolder}/lib*/python[0-9].[0-9]*/site-packages',
-                                 recursive=False)
-
-        self.binPaths: list = [str(Path(folder, "bin")), str(Path(venvFolder, "bin"))]
-        self.libPaths: list = [str(Path(folder, "lib")), str(Path(folder, "lib64")),
-                               str(Path(venvFolder, "lib")), str(Path(venvFolder, "lib64"))]
-        self.pythonPaths: list = [str(Path(folder)), str(Path(venvFolder))] + \
-                                 self.binPaths + envLibPaths + venvLibPaths
-
-        if sys.platform == "win32":
-            # For Windows platforms, try and include the content of the virtual env if it exists
-            # The virtual env is expected to be named "venv"
-            venvLibPath = Path(venvFolder, "Lib", "site-packages")
-            if venvLibPath.exists():
-                self.pythonPaths.append(venvLibPath.as_posix())
-        else:
-            # For Linux platforms, lib paths may need to be discovered recursively to be properly
-            # added to LD_LIBRARY_PATH
-            extraLibPaths = []
-            regex = re.compile(r"^lib(\d{2})?$")
-            for envPath in envLibPaths + venvLibPaths:
-                for path, directories, _ in os.walk(envPath):
-                    for directory in directories:
-                        if re.match(regex, directory):
-                            extraLibPaths.append(os.path.join(path, directory))
-            self.libPaths = self.libPaths + extraLibPaths
-
-        # Setup the environment dictionary
-        self._env = os.environ.copy()
-        self._env["PYTHONPATH"] = os.pathsep.join(
-            [f"{_MESHROOM_ROOT}"] + self.pythonPaths + [os.getenv('PYTHONPATH', '')])
-        self._env["LD_LIBRARY_PATH"] = f"{os.pathsep.join(self.libPaths)}{os.pathsep}{os.getenv('LD_LIBRARY_PATH', '')}"
-        self._env["PATH"] = f"{os.pathsep.join(self.binPaths)}{os.pathsep}{os.getenv('PATH', '')}"
-
-        for k, val in self._configEnv.items():
-            # Preserve user-defined environment variables:
-            # manually set environment variable values take precedence over config file defaults.
-            if k in self._env:
-                continue
-
-            self._env[k] = val
-
-
-class RezProcessEnv(ProcessEnv):
-    """
-    """
-
-    REZ_DELIMITER_PATTERN = re.compile(r"-|==|>=|>|<=|<")
-
-    def __init__(self, folder: str, configEnv: dict[str: str], pluginName: str, uri: str = ""):
-        if not uri:
-            raise RuntimeError("Missing name of the Rez environment needs to be provided.")
-        super().__init__(folder, configEnv, pluginName, envType=ProcessEnvType.REZ, uri=uri)
-
-    def resolveRezSubrequires(self) -> list[str]:
-        """
-        Return the list of packages defined for the node execution. These execution packages are
-        named subrequires.
-        Note: If a package does not have a version number, the version is aligned with the main
-        Meshroom environment (if this package is defined).
-        """
-        if os.getenv(f"{self.uri.upper()}_{self.pluginName.upper()}_SUBREQUIRES"):
-            subrequires = os.environ.get(f"{self.uri.upper()}_{self.pluginName.upper()}_SUBREQUIRES", "").split(os.pathsep)
-        else:
-            subrequires = os.environ.get(f"{self.uri.upper()}_SUBREQUIRES", "").split(os.pathsep)
-        if not subrequires:
-            return []
-
-        packages = []
-        # Packages that are resolved in the current environment
-        currentEnvPackages = []
-        resolvedVersions = {}
-        if "REZ_USED_RESOLVE" in os.environ:
-            resolvedPackages = os.getenv("REZ_USED_RESOLVE", "").split()
-            for package in resolvedPackages:
-                if package.startswith("~"):
-                    continue
-                currentEnvPackages.append(package)
-                name, version = self.REZ_DELIMITER_PATTERN.split(package, maxsplit=1)
-                resolvedVersions[name] = version
-        logging.debug("Packages in the current environment: " + ", ".join(currentEnvPackages))
-
-        # Take packages with the set versions for those which have one, and try to take packages
-        # in the current environment (if they are resolved in it)
-        for package in subrequires:
-            packageTuple = self.REZ_DELIMITER_PATTERN.split(package, maxsplit=1)
-            if len(packageTuple) == 1:
-                # Only the package name in the subrequires.
-                # Search for a corresponding version in the parent environment.
-                packageName = packageTuple[0]
-                parentResolvedVersion = resolvedVersions.get(packageName)
-                if parentResolvedVersion:
-                    packages.append(f"{packageName}=={parentResolvedVersion}")
-                else:
-                    packages.append(package)
-            elif len(packageTuple) == 2:
-                # The subrequires ask for a specific version
-                packages.append(package)
-
-        def extractPackageName(packageString: str) -> str:
-            return self.REZ_DELIMITER_PATTERN.split(packageString, maxsplit=1)[0]
-        packageNames = [extractPackageName(package) for package in packages]
-
-        for package in _MESHROOM_COMPUTE_DEPS:
-            # For packages that are required by meshroom_compute, do not specify any version
-            # or align it with Meshroom's: the version will be found during the resolution of
-            # the environment based on the other packages.
-            # If any of these packages is already part of the environment a plugin's dependency,
-            # do not add it
-            if package not in packageNames:
-                packages.append(package)
-
-        logging.debug("Packages for the execution environment: " + ", ".join(packages))
-        return packages
-
-    def getCommandPrefix(self):
-        # TODO: make Windows-compatible
-
-        # Use the PYTHONPATH from the subrequires' environment (which will only be resolved once
-        # inside the execution environment) and add MESHROOM_ROOT and the plugin's folder itself
-        # to it
-        pythonPaths = f"{os.pathsep.join(['$PYTHONPATH', f'{_MESHROOM_ROOT}', f'{self._folder}'])}"
-
-        return f"rez env {' '.join(self.resolveRezSubrequires())} -c 'PYTHONPATH={pythonPaths} "
-
-    def getCommandSuffix(self):
-        return "'"
-
-
-def processEnvFactory(folder: str, configEnv: dict[str: str], pluginName: str, envType: str = "dirtree", uri: str = "") -> ProcessEnv:
-    if envType == "dirtree":
-        return DirTreeProcessEnv(folder, configEnv, pluginName)
-    return RezProcessEnv(folder, configEnv, pluginName, uri=uri)
-
-
 class NodeProviderStatus(Enum):
     """
     Loading status for NodeProvider objects.
@@ -275,6 +81,151 @@ class NodeProviderStatus(Enum):
     DESC_ERROR = 2  # The node provider exists but has an invalid description
     LOADING_ERROR = 3  # The node provider exists and is valid but could not be successfully loaded
     ERROR = 4  # Error when importing the node provider from its module
+
+
+class NodeProvider(BaseObject):
+    """
+    Based on a node description, a NodeProvider represents a loadable node.
+
+    Members:
+        plugin: the Plugin object that contains this node provider
+        path: absolute path to the file containing the node's description
+        nodeDescriptor: the description of the node
+        status: the loading status on the node provider
+        errors: the list of errors (if there are any) when validating the description
+                of the node or attempting to load it
+        processEnv: the environment required for the node provider's process. It can either
+                    be specific to this node provider, or be common for all the node providers within
+                    the plugin
+        timestamp: the timestamp corresponding to the last time the node description's file has been
+                   modified
+    """
+
+    def __init__(self, nodeDesc: desc.BaseNode, plugin: Plugin = None):
+        super().__init__()
+        self.plugin: Plugin = plugin
+        self.path: str = Path(getfile(nodeDesc)).resolve().as_posix()
+        self.nodeDescriptor: desc.BaseNode = nodeDesc
+        self.nodeDescriptor.provider = self
+
+        self.status: NodeProviderStatus = NodeProviderStatus.NOT_LOADED
+        self.errors: list[tuple[str, ValueTypeErrors]] = validateNodeDesc(nodeDesc)
+
+        if self.errors:
+            self.status = NodeProviderStatus.DESC_ERROR
+
+        self._processEnv = None
+        self._timestamp = os.path.getmtime(self.path)
+
+    def reload(self) -> bool:
+        """
+        Reload the node provider and update its status accordingly. If the timestamp of the node provider's
+        path has not changed since the last time the plugin has been loaded, then nothing will happen.
+
+        Returns:
+            bool: True if the node provider has successfully been reloaded (i.e. there was no error, and
+                  some changes were made since its last loading), False otherwise.
+        """
+        timestamp = 0.0
+        try:
+            timestamp = os.path.getmtime(self.path)
+        except FileNotFoundError:
+            self.status = NodeProviderStatus.ERROR
+            logging.error(f"[Reload] {self.nodeDescriptor.__name__}: The path at {self.path} was not "
+                          f"not found.")
+            return False
+
+        if self._timestamp == timestamp:
+            logging.info(f"[Reload] {self.nodeDescriptor.__name__}: Not reloading. The node description "
+                         f"at {self.path} has not been modified since the last load.")
+            return False
+
+        try:
+            updated = importlib.reload(sys.modules.get(self.nodeDescriptor.__module__))
+        except Exception as exc:
+            logging.error(f"[Reload] {self.nodeDescriptor.__name__}: {exc} ({type(exc).__name__})")
+            self.status = NodeProviderStatus.DESC_ERROR
+            return False
+        descriptor = getattr(updated, self.nodeDescriptor.__name__)
+
+        if not descriptor:
+            self.status = NodeProviderStatus.ERROR
+            logging.error(f"[Reload] {self.nodeDescriptor.__name__}: The node description at {self.path} "
+                          f"was not found.")
+            return False
+
+        self.errors = validateNodeDesc(descriptor)
+        if self.errors:
+            self.status = NodeProviderStatus.DESC_ERROR
+            logging.error(f"[Reload] {self.nodeDescriptor.__name__}: The node description at {self.path} "
+                          f"has description errors.")
+            return False
+
+        self.nodeDescriptor = descriptor
+        self.nodeDescriptor.provider = self
+        self._timestamp = timestamp
+        self.status = NodeProviderStatus.NOT_LOADED
+        logging.info(f"[Reload] {self.nodeDescriptor.__name__}: Successful reloading.")
+        return True
+
+    @property
+    def plugin(self):
+        """
+        Return the Plugin object that contains this node provider.
+        If the node provider has not been assigned to a plugin yet, this value will
+        be set to None.
+        """
+        return self._plugin
+
+    @plugin.setter
+    def plugin(self, plugin: Plugin):
+        """ Assign this node provider to a containing Plugin object. """
+        self._plugin = plugin
+
+    @property
+    def isUserPlugin(self):
+        """ Return whether the node plugin belongs to a user plugin. """
+        if self.plugin:
+            return self.plugin.isUserPlugin
+        return False
+
+    @property
+    def processEnv(self):
+        """"
+        Return the process environment that is specific to the node provider if it has any.
+        Otherwise, the Plugin's is returned.
+        """
+        if self._processEnv:
+            return self._processEnv
+        if self.plugin:
+            return self.plugin.processEnv
+        return None
+
+    @property
+    def runtimeEnv(self) -> dict:
+        """ Return the environment dictionary for the runtime. """
+        return self.processEnv.getEnvDict()
+
+    @property
+    def commandPrefix(self) -> str:
+        """ Return the command prefix for the NodeProvider's execution. """
+        if not self.processEnv:
+            return ""
+        return self.processEnv.getCommandPrefix()
+
+    @property
+    def commandSuffix(self) -> str:
+        """ Return the command suffix for the NodeProvider's execution. """
+        if not self.processEnv:
+            return ""
+        return self.processEnv.getCommandSuffix()
+
+    @property
+    def configFullEnv(self) -> dict[str: str]:
+        """ Return the plugin's full environment dictionary. """
+        if not self.plugin:
+            return {}
+        return self.plugin.configFullEnv
 
 
 class Plugin(BaseObject):
@@ -476,150 +427,6 @@ class Plugin(BaseObject):
         return name in self._nodeProviders
 
 
-class NodeProvider(BaseObject):
-    """
-    Based on a node description, a NodeProvider represents a loadable node.
-
-    Members:
-        plugin: the Plugin object that contains this node provider
-        path: absolute path to the file containing the node's description
-        nodeDescriptor: the description of the node
-        status: the loading status on the node provider
-        errors: the list of errors (if there are any) when validating the description
-                of the node or attempting to load it
-        processEnv: the environment required for the node provider's process. It can either
-                    be specific to this node provider, or be common for all the node providers within
-                    the plugin
-        timestamp: the timestamp corresponding to the last time the node description's file has been
-                   modified
-    """
-
-    def __init__(self, nodeDesc: desc.BaseNode, plugin: Plugin = None):
-        super().__init__()
-        self.plugin: Plugin = plugin
-        self.path: str = Path(getfile(nodeDesc)).resolve().as_posix()
-        self.nodeDescriptor: desc.BaseNode = nodeDesc
-        self.nodeDescriptor.provider = self
-
-        self.status: NodeProviderStatus = NodeProviderStatus.NOT_LOADED
-        self.errors: list[tuple[str, ValueTypeErrors]] = validateNodeDesc(nodeDesc)
-
-        if self.errors:
-            self.status = NodeProviderStatus.DESC_ERROR
-
-        self._processEnv = None
-        self._timestamp = os.path.getmtime(self.path)
-
-    def reload(self) -> bool:
-        """
-        Reload the node provider and update its status accordingly. If the timestamp of the node provider's
-        path has not changed since the last time the plugin has been loaded, then nothing will happen.
-
-        Returns:
-            bool: True if the node provider has successfully been reloaded (i.e. there was no error, and
-                  some changes were made since its last loading), False otherwise.
-        """
-        timestamp = 0.0
-        try:
-            timestamp = os.path.getmtime(self.path)
-        except FileNotFoundError:
-            self.status = NodeProviderStatus.ERROR
-            logging.error(f"[Reload] {self.nodeDescriptor.__name__}: The path at {self.path} was not "
-                          f"not found.")
-            return False
-
-        if self._timestamp == timestamp:
-            logging.info(f"[Reload] {self.nodeDescriptor.__name__}: Not reloading. The node description "
-                         f"at {self.path} has not been modified since the last load.")
-            return False
-
-        try:
-            updated = importlib.reload(sys.modules.get(self.nodeDescriptor.__module__))
-        except Exception as exc:
-            logging.error(f"[Reload] {self.nodeDescriptor.__name__}: {exc} ({type(exc).__name__})")
-            self.status = NodeProviderStatus.DESC_ERROR
-            return False
-        descriptor = getattr(updated, self.nodeDescriptor.__name__)
-
-        if not descriptor:
-            self.status = NodeProviderStatus.ERROR
-            logging.error(f"[Reload] {self.nodeDescriptor.__name__}: The node description at {self.path} "
-                          f"was not found.")
-            return False
-
-        self.errors = validateNodeDesc(descriptor)
-        if self.errors:
-            self.status = NodeProviderStatus.DESC_ERROR
-            logging.error(f"[Reload] {self.nodeDescriptor.__name__}: The node description at {self.path} "
-                          f"has description errors.")
-            return False
-
-        self.nodeDescriptor = descriptor
-        self.nodeDescriptor.provider = self
-        self._timestamp = timestamp
-        self.status = NodeProviderStatus.NOT_LOADED
-        logging.info(f"[Reload] {self.nodeDescriptor.__name__}: Successful reloading.")
-        return True
-
-    @property
-    def plugin(self):
-        """
-        Return the Plugin object that contains this node provider.
-        If the node provider has not been assigned to a plugin yet, this value will
-        be set to None.
-        """
-        return self._plugin
-
-    @plugin.setter
-    def plugin(self, plugin: Plugin):
-        """ Assign this node provider to a containing Plugin object. """
-        self._plugin = plugin
-
-    @property
-    def isUserPlugin(self):
-        """ Return whether the node plugin belongs to a user plugin. """
-        if self.plugin:
-            return self.plugin.isUserPlugin
-        return False
-
-    @property
-    def processEnv(self):
-        """"
-        Return the process environment that is specific to the node provider if it has any.
-        Otherwise, the Plugin's is returned.
-        """
-        if self._processEnv:
-            return self._processEnv
-        if self.plugin:
-            return self.plugin.processEnv
-        return None
-
-    @property
-    def runtimeEnv(self) -> dict:
-        """ Return the environment dictionary for the runtime. """
-        return self.processEnv.getEnvDict()
-
-    @property
-    def commandPrefix(self) -> str:
-        """ Return the command prefix for the NodeProvider's execution. """
-        if not self.processEnv:
-            return ""
-        return self.processEnv.getCommandPrefix()
-
-    @property
-    def commandSuffix(self) -> str:
-        """ Return the command suffix for the NodeProvider's execution. """
-        if not self.processEnv:
-            return ""
-        return self.processEnv.getCommandSuffix()
-
-    @property
-    def configFullEnv(self) -> dict[str: str]:
-        """ Return the plugin's full environment dictionary. """
-        if not self.plugin:
-            return {}
-        return self.plugin.configFullEnv
-
 class PluginManager(BaseObject):
     """
     Manager for all the loaded Plugin objects as well as the loaded NodeProvider objects.
@@ -634,31 +441,6 @@ class PluginManager(BaseObject):
 
         self._plugins: dict[str: Plugin] = {}  # loaded plugins
         self._nodeProviders: dict[str: NodeProvider] = {}  # loaded node providers
-
-    def isLoaded(self, name: str) -> bool:
-        """
-        Return whether the node provider has been loaded already.
-
-        Args:
-            name: the name of the node provider.
-        """
-        return name in self._nodeProviders
-
-    def belongsToPlugin(self, name: str) -> Plugin:
-        """
-        Check whether the node provider belongs to a loaded plugin, independently from
-        whether it has been loaded or not.
-
-        Args:
-            name: the name of the node provider that needs to be searched for across plugins.
-
-        Returns:
-            Plugin | None: the Plugin the node belongs to if it exists, None otherwise.
-        """
-        for plugin in self._plugins.values():
-            if plugin.containsNodeProvider(name):
-                return plugin
-        return None
 
     def getPlugins(self) -> dict[str: Plugin]:
         """
@@ -726,6 +508,31 @@ class PluginManager(BaseObject):
                 for node in plugin.nodes.values():
                     self.unloadNodeProvider(node)
             del self._plugins[plugin.uname]
+
+    def belongsToPlugin(self, name: str) -> Plugin:
+        """
+        Check whether the node provider belongs to a loaded plugin, independently from
+        whether it has been loaded or not.
+
+        Args:
+            name: the name of the node provider that needs to be searched for across plugins.
+
+        Returns:
+            Plugin | None: the Plugin the node belongs to if it exists, None otherwise.
+        """
+        for plugin in self._plugins.values():
+            if plugin.containsNodeProvider(name):
+                return plugin
+        return None
+
+    def isLoaded(self, name: str) -> bool:
+        """
+        Return whether the node provider has been loaded already.
+
+        Args:
+            name: the name of the node provider.
+        """
+        return name in self._nodeProviders
 
     def getLoadedNodeProviders(self) -> dict[str: NodeProvider]:
         """

--- a/meshroom/core/test.py
+++ b/meshroom/core/test.py
@@ -30,7 +30,7 @@ def checkTemplateVersions(path: str, nodesAlreadyLoaded: bool = False) -> bool:
 
         for _, nodeData in graphData.items():
             nodeType = nodeData["nodeType"]
-            if not meshroom.core.pluginManager.isRegistered(nodeType):
+            if not meshroom.core.pluginManager.isLoaded(nodeType):
                 print(f"'{nodeType}' in '{path}' is an unknown type.")
                 return False
 

--- a/meshroom/core/test.py
+++ b/meshroom/core/test.py
@@ -63,8 +63,8 @@ def checkTemplateVersions(path: str, nodesAlreadyLoaded: bool = False) -> bool:
 
     finally:
         if not nodesAlreadyLoaded:
-            nodePlugins = meshroom.core.pluginManager.getLoadedNodeProviders()
-            for node in nodePlugins:
+            nodeProviders = meshroom.core.pluginManager.getLoadedNodeProviders()
+            for node in nodeProviders:
                 meshroom.core.pluginManager.unloadNodeProvider(node)
 
 

--- a/meshroom/core/test.py
+++ b/meshroom/core/test.py
@@ -65,7 +65,7 @@ def checkTemplateVersions(path: str, nodesAlreadyLoaded: bool = False) -> bool:
         if not nodesAlreadyLoaded:
             nodePlugins = meshroom.core.pluginManager.getRegisteredNodePlugins()
             for node in nodePlugins:
-                meshroom.core.pluginManager.unregisterNode(node)
+                meshroom.core.pluginManager.unloadNodeProvider(node)
 
 
 def checkAllTemplatesVersions() -> bool:

--- a/meshroom/core/test.py
+++ b/meshroom/core/test.py
@@ -34,7 +34,7 @@ def checkTemplateVersions(path: str, nodesAlreadyLoaded: bool = False) -> bool:
                 print(f"'{nodeType}' in '{path}' is an unknown type.")
                 return False
 
-            nodeDesc = meshroom.core.pluginManager.getRegisteredNodePlugin(nodeType).nodeDescriptor
+            nodeDesc = meshroom.core.pluginManager.getLoadedNodeProvider(nodeType).nodeDescriptor
             currentNodeVersion = meshroom.core.nodeVersion(nodeDesc)
 
             inputs = nodeData.get("inputs", {})
@@ -63,7 +63,7 @@ def checkTemplateVersions(path: str, nodesAlreadyLoaded: bool = False) -> bool:
 
     finally:
         if not nodesAlreadyLoaded:
-            nodePlugins = meshroom.core.pluginManager.getRegisteredNodePlugins()
+            nodePlugins = meshroom.core.pluginManager.getLoadedNodeProviders()
             for node in nodePlugins:
                 meshroom.core.pluginManager.unloadNodeProvider(node)
 

--- a/meshroom/ui/app.py
+++ b/meshroom/ui/app.py
@@ -289,7 +289,7 @@ class MeshroomApp(QApplication):
             self.engine.addImportPath(pyside6QmlPath)
 
         # expose available node types that can be instantiated
-        self.engine.rootContext().setContextProperty("_nodeTypes", {n: {"category": pluginManager.getRegisteredNodePlugins()[n].nodeDescriptor.category} for n in sorted(pluginManager.getRegisteredNodePlugins().keys())})
+        self.engine.rootContext().setContextProperty("_nodeTypes", {n: {"category": pluginManager.getLoadedNodeProviders()[n].nodeDescriptor.category} for n in sorted(pluginManager.getLoadedNodeProviders().keys())})
 
         # instantiate the 3D Scene object
         self._undoStack = commands.UndoStack(self)

--- a/meshroom/ui/qml/Application.qml
+++ b/meshroom/ui/qml/Application.qml
@@ -593,7 +593,7 @@ Page {
 
     Action {
         id: reloadPluginsAction
-        property string tooltip: "Reload the source code for all nodes from all registered plugins"
+        property string tooltip: "Reload the source code for all nodes from all plugins"
         text: "Reload Plugins Source Code"
         shortcut: "Ctrl+Shift+R"
         onTriggered: {

--- a/meshroom/ui/scene.py
+++ b/meshroom/ui/scene.py
@@ -19,7 +19,7 @@ from meshroom.core import Version
 from meshroom.core.node import Node, CompatibilityNode, Status, Position, CompatibilityIssue
 from meshroom.core.taskManager import TaskManager
 from meshroom.core.evaluation import MathEvaluator
-from meshroom.core.plugins import NodeProviderStatus
+from meshroom.core.plugins.manager import NodeProviderStatus
 
 from meshroom.ui import commands
 from meshroom.ui.graph import UIGraph

--- a/meshroom/ui/scene.py
+++ b/meshroom/ui/scene.py
@@ -417,7 +417,7 @@ class Scene(UIGraph):
             self._activeNodes.add(ActiveNode(category, parent=self))
         # For all nodes declared to be accessed by the UI
         usedNodeTypes = {j for i in self.activeNodeCategories.values() for j in i}
-        allLoadedNodeTypes = set(meshroom.core.pluginManager.getRegisteredNodePlugins().keys())
+        allLoadedNodeTypes = set(meshroom.core.pluginManager.getLoadedNodeProviders().keys())
         allUiNodes = set(self.uiNodes) | usedNodeTypes | allLoadedNodeTypes
 
         for nodeType in allUiNodes:
@@ -609,7 +609,7 @@ class Scene(UIGraph):
         if not sfmFile or not os.path.isfile(sfmFile):
             self.tempCameraInit = None
             return
-        nodeDesc = meshroom.core.pluginManager.getRegisteredNodePlugin("CameraInit").nodeDescriptor()
+        nodeDesc = meshroom.core.pluginManager.getLoadedNodeProvider("CameraInit").nodeDescriptor()
         views, intrinsics = nodeDesc.readSfMData(sfmFile)
         tmpCameraInit = Node("CameraInit", viewpoints=views, intrinsics=intrinsics)
         tmpCameraInit.locked = True

--- a/meshroom/ui/scene.py
+++ b/meshroom/ui/scene.py
@@ -441,7 +441,7 @@ class Scene(UIGraph):
 
     def _reloadPlugins(self):
         """
-        Reload all the NodePlugins from all the registered plugins.
+        Reload all the NodeProviders from all the registered plugins.
         The nodes in the graph will be updated to match the changes in the description, if
         there was any.
         """
@@ -459,7 +459,7 @@ class Scene(UIGraph):
 
     @Slot(list)
     def _onPluginsReloaded(self, reloadedNodes: list, errorNodes: list):
-        self._graph.reloadNodePlugins(reloadedNodes)
+        self._graph.reloadNodeProviders(reloadedNodes)
         if len(errorNodes) > 0:
             self.parent().showMessage(f"Some plugins failed to reload: {', '.join(errorNodes)}", "error")
         else:

--- a/meshroom/ui/scene.py
+++ b/meshroom/ui/scene.py
@@ -19,7 +19,7 @@ from meshroom.core import Version
 from meshroom.core.node import Node, CompatibilityNode, Status, Position, CompatibilityIssue
 from meshroom.core.taskManager import TaskManager
 from meshroom.core.evaluation import MathEvaluator
-from meshroom.core.plugins import NodePluginStatus
+from meshroom.core.plugins import NodeProviderStatus
 
 from meshroom.ui import commands
 from meshroom.ui.graph import UIGraph
@@ -452,7 +452,7 @@ class Scene(UIGraph):
                 if node.reload():
                     reloadedNodes.append(node.nodeDescriptor.__name__)
                 else:
-                    if node.status == NodePluginStatus.DESC_ERROR or node.status == NodePluginStatus.ERROR:
+                    if node.status == NodeProviderStatus.DESC_ERROR or node.status == NodeProviderStatus.ERROR:
                         errorNodes.append(node.nodeDescriptor.__name__)
 
         self.pluginsReloaded.emit(reloadedNodes, errorNodes)

--- a/meshroom/ui/scene.py
+++ b/meshroom/ui/scene.py
@@ -441,7 +441,7 @@ class Scene(UIGraph):
 
     def _reloadPlugins(self):
         """
-        Reload all the NodeProviders from all the registered plugins.
+        Reload all the NodeProviders from all the loaded plugins.
         The nodes in the graph will be updated to match the changes in the description, if
         there was any.
         """

--- a/tests/test_compatibility.py
+++ b/tests/test_compatibility.py
@@ -195,7 +195,7 @@ class OutputTemplateNodeV2(desc.Node):
 
 def replaceNodeTypeDesc(nodeType: str, nodeDesc: Type[desc.Node]):
     """ Change the `nodeDesc` associated to `nodeType`. """
-    pluginManager.getRegisteredNodePlugins()[nodeType] = NodePlugin(nodeDesc)
+    pluginManager.getLoadedNodeProviders()[nodeType] = NodePlugin(nodeDesc)
 
 
 def test_unknown_node_type():
@@ -239,7 +239,7 @@ def test_description_conflict():
     Test compatibility behavior for conflicting node descriptions.
     """
     # Copy registered node types to be able to restore them
-    originalNodeTypes = copy.deepcopy(pluginManager.getRegisteredNodePlugins())
+    originalNodeTypes = copy.deepcopy(pluginManager.getLoadedNodeProviders())
 
     nodeTypes = [SampleNodeV1, SampleNodeV2, SampleNodeV3, SampleNodeV4, SampleNodeV5]
     nodes = []
@@ -265,7 +265,7 @@ def test_description_conflict():
     # Offset node types register to create description conflicts
     # Each node type name now reference the next one's implementation
     for i, nt in enumerate(nodeTypes[:-1]):
-        pluginManager.getRegisteredNodePlugins()[nt.__name__] = NodePlugin(nodeTypes[i + 1])
+        pluginManager.getLoadedNodeProviders()[nt.__name__] = NodePlugin(nodeTypes[i + 1])
 
     # Reload file
     g = loadGraph(graphFile)
@@ -377,10 +377,10 @@ def test_upgradeAllNodes(tmp_path):
     g.save(graphFile)
 
     # Replace SampleNodeV1 by SampleNodeV2 and SampleInitNodeV1 by SampleInitNodeV2
-    pluginManager.getRegisteredNodePlugins()[SampleNodeV1.__name__] = \
-        pluginManager.getRegisteredNodePlugin(SampleNodeV2.__name__)
-    pluginManager.getRegisteredNodePlugins()[SampleInitNodeV1.__name__] = \
-        pluginManager.getRegisteredNodePlugin(SampleInitNodeV2.__name__)
+    pluginManager.getLoadedNodeProviders()[SampleNodeV1.__name__] = \
+        pluginManager.getLoadedNodeProvider(SampleNodeV2.__name__)
+    pluginManager.getLoadedNodeProviders()[SampleInitNodeV1.__name__] = \
+        pluginManager.getLoadedNodeProvider(SampleInitNodeV2.__name__)
     # Make SampleNodeV2 and SampleInitNodeV2 an unknown type
     unregisterNodeDesc(SampleNodeV2)
     unregisterNodeDesc(SampleInitNodeV2)
@@ -420,8 +420,8 @@ def test_conformUpgrade():
     g.save(graphFile)
 
     # Replace SampleNodeV5 by SampleNodeV6
-    pluginManager.getRegisteredNodePlugins()[SampleNodeV5.__name__] = \
-        pluginManager.getRegisteredNodePlugin(SampleNodeV6.__name__)
+    pluginManager.getLoadedNodeProviders()[SampleNodeV5.__name__] = \
+        pluginManager.getLoadedNodeProvider(SampleNodeV6.__name__)
 
     # Reload file
     g = loadGraph(graphFile)

--- a/tests/test_compatibility.py
+++ b/tests/test_compatibility.py
@@ -8,10 +8,10 @@ from typing import Type
 import pytest
 
 from meshroom.core import desc, pluginManager
-from meshroom.core.plugins import NodeProvider
 from meshroom.core.exception import GraphCompatibilityError, NodeUpgradeError
 from meshroom.core.graph import Graph, loadGraph
 from meshroom.core.node import CompatibilityNode, CompatibilityIssue, Node
+from meshroom.core.plugins.manager import NodeProvider
 
 from .utils import registeredNodeTypes, overrideNodeTypeVersion, registerNodeDesc, unregisterNodeDesc
 

--- a/tests/test_compatibility.py
+++ b/tests/test_compatibility.py
@@ -238,7 +238,7 @@ def test_description_conflict():
     """
     Test compatibility behavior for conflicting node descriptions.
     """
-    # Copy registered node types to be able to restore them
+    # Copy loaded node types to be able to restore them
     originalNodeTypes = copy.deepcopy(pluginManager.getLoadedNodeProviders())
 
     nodeTypes = [SampleNodeV1, SampleNodeV2, SampleNodeV3, SampleNodeV4, SampleNodeV5]

--- a/tests/test_compatibility.py
+++ b/tests/test_compatibility.py
@@ -8,7 +8,7 @@ from typing import Type
 import pytest
 
 from meshroom.core import desc, pluginManager
-from meshroom.core.plugins import NodePlugin
+from meshroom.core.plugins import NodeProvider
 from meshroom.core.exception import GraphCompatibilityError, NodeUpgradeError
 from meshroom.core.graph import Graph, loadGraph
 from meshroom.core.node import CompatibilityNode, CompatibilityIssue, Node
@@ -195,7 +195,7 @@ class OutputTemplateNodeV2(desc.Node):
 
 def replaceNodeTypeDesc(nodeType: str, nodeDesc: Type[desc.Node]):
     """ Change the `nodeDesc` associated to `nodeType`. """
-    pluginManager.getLoadedNodeProviders()[nodeType] = NodePlugin(nodeDesc)
+    pluginManager.getLoadedNodeProviders()[nodeType] = NodeProvider(nodeDesc)
 
 
 def test_unknown_node_type():
@@ -265,7 +265,7 @@ def test_description_conflict():
     # Offset node types register to create description conflicts
     # Each node type name now reference the next one's implementation
     for i, nt in enumerate(nodeTypes[:-1]):
-        pluginManager.getLoadedNodeProviders()[nt.__name__] = NodePlugin(nodeTypes[i + 1])
+        pluginManager.getLoadedNodeProviders()[nt.__name__] = NodeProvider(nodeTypes[i + 1])
 
     # Reload file
     g = loadGraph(graphFile)
@@ -355,7 +355,7 @@ def test_description_conflict():
             raise ValueError("Unexpected node type: " + srcNode.nodeType)
 
     # Restore original node types
-    pluginManager._nodePlugins = originalNodeTypes
+    pluginManager._nodeProviders = originalNodeTypes
 
 
 def test_upgradeAllNodes(tmp_path):

--- a/tests/test_compute.py
+++ b/tests/test_compute.py
@@ -250,7 +250,7 @@ class TestLockUpdates:
         cls.plugin = Plugin(package, folder)
         nodes = loadClassesNodes(folder, package, pluginUid=cls.plugin.uid)
         for node in nodes:
-            cls.plugin.addNodePlugin(node)
+            cls.plugin.addNodeProvider(node)
         pluginManager.addPlugin(cls.plugin)
 
     @classmethod

--- a/tests/test_compute.py
+++ b/tests/test_compute.py
@@ -256,7 +256,7 @@ class TestLockUpdates:
     @classmethod
     def teardown_class(cls):
         for node in cls.plugin.nodes.values():
-            pluginManager.unregisterNode(node)
+            pluginManager.unloadNodeProvider(node)
         pluginManager.removePlugin(cls.plugin)
         cls.plugin = None
 

--- a/tests/test_compute.py
+++ b/tests/test_compute.py
@@ -196,11 +196,11 @@ class TestNodeLogger:
             executed["env"] = env
 
         nodeDesc.executeChunkCommandLine = executeChunkCommandLine
-        plugin = SimpleNamespace(runtimeEnv=None, commandPrefix="", commandSuffix="")
+        provider = SimpleNamespace(runtimeEnv=None, commandPrefix="", commandSuffix="")
         node = SimpleNamespace(
             name="TestNode_1",
             graph=SimpleNamespace(filepath=graphFilepath.as_posix()),
-            nodeDesc=SimpleNamespace(pythonExecutable="python", plugin=plugin),
+            nodeDesc=SimpleNamespace(pythonExecutable="python", provider=provider),
             getChunks=lambda: [object(), object()],
         )
         chunk = SimpleNamespace(

--- a/tests/test_compute.py
+++ b/tests/test_compute.py
@@ -17,7 +17,7 @@ import logging
 from meshroom.core.graph import Graph, loadGraph
 from meshroom.core import desc, pluginManager, loadClassesNodes
 from meshroom.core.node import Status, ChunkIndex
-from meshroom.core.plugins import Plugin
+from meshroom.core.plugins.manager import Plugin
 from .utils import registerNodeDesc, unregisterNodeDesc
 
 LOGGER = logging.getLogger("TestCompute")

--- a/tests/test_invalidation.py
+++ b/tests/test_invalidation.py
@@ -20,7 +20,7 @@ class SampleNode(desc.Node):
 
 
 def test_output_invalidation():
-    registerNodeDesc(SampleNode)  # Register standalone NodePlugin
+    registerNodeDesc(SampleNode)  # Register standalone NodeProvider
     graph = Graph("")
     n1 = graph.addNewNode("SampleNode", input="/tmp")
     n2 = graph.addNewNode("SampleNode")
@@ -53,7 +53,7 @@ def test_inputLinkInvalidation():
     """
     Input links should not change the invalidation.
     """
-    registerNodeDesc(SampleNode)  # Register standalone NodePlugin
+    registerNodeDesc(SampleNode)  # Register standalone NodeProvider
     graph = Graph("")
     n1 = graph.addNewNode("SampleNode")
     n2 = graph.addNewNode("SampleNode")

--- a/tests/test_nodeAttributeChangedCallback.py
+++ b/tests/test_nodeAttributeChangedCallback.py
@@ -343,8 +343,8 @@ class NodeWithDynamicOutputValue(desc.BaseNode):
 
 
 class TestAttributeCallbackBehaviorWithUpstreamDynamicOutputs:
-    # nodePluginAttributeChangedCallback = NodePlugin(NodeWithAttributeChangedCallback)
-    # nodePluginDynamicOutputValue = NodePlugin(NodeWithDynamicOutputValue)
+    # nodeProviderAttributeChangedCallback = NodeProvider(NodeWithAttributeChangedCallback)
+    # nodeProviderDynamicOutputValue = NodeProvider(NodeWithDynamicOutputValue)
 
     @classmethod
     def setup_class(cls):

--- a/tests/test_nodeDynamicOutputs.py
+++ b/tests/test_nodeDynamicOutputs.py
@@ -4,7 +4,7 @@ from meshroom.core import desc
 from meshroom.core import pluginManager
 from meshroom.core.exception import UnknownNodeTypeError
 from meshroom.core.graph import Graph, loadGraph
-from meshroom.core.plugins import NodeProviderStatus
+from meshroom.core.plugins.manager import NodeProviderStatus
 
 from .utils import registerNodeDesc, unregisterNodeDesc
 

--- a/tests/test_nodeDynamicOutputs.py
+++ b/tests/test_nodeDynamicOutputs.py
@@ -227,7 +227,7 @@ class TestInitNodeWithDynamicOutputs:
         registerNodeDesc(InitNodeWithDynamicOutputs)
 
         # Check that the plugin has been correctly registered (there has been attempt to load it)
-        assert pluginManager.isRegistered(InitNodeWithDynamicOutputs.__name__)
+        assert pluginManager.isLoaded(InitNodeWithDynamicOutputs.__name__)
 
         # Check that the plugin's status is DESC_ERROR, since the node description is invalid
         # Additionally, the list of errors should include an error about having a dynamic output in an InitNode

--- a/tests/test_nodeDynamicOutputs.py
+++ b/tests/test_nodeDynamicOutputs.py
@@ -231,7 +231,7 @@ class TestInitNodeWithDynamicOutputs:
 
         # Check that the plugin's status is DESC_ERROR, since the node description is invalid
         # Additionally, the list of errors should include an error about having a dynamic output in an InitNode
-        plugin = pluginManager.getRegisteredNodePlugin(InitNodeWithDynamicOutputs.__name__)
+        plugin = pluginManager.getLoadedNodeProvider(InitNodeWithDynamicOutputs.__name__)
         assert plugin
         assert plugin.status == NodeProviderStatus.DESC_ERROR
         assert len(plugin.errors) == 1

--- a/tests/test_nodeDynamicOutputs.py
+++ b/tests/test_nodeDynamicOutputs.py
@@ -4,7 +4,7 @@ from meshroom.core import desc
 from meshroom.core import pluginManager
 from meshroom.core.exception import UnknownNodeTypeError
 from meshroom.core.graph import Graph, loadGraph
-from meshroom.core.plugins import NodePluginStatus
+from meshroom.core.plugins import NodeProviderStatus
 
 from .utils import registerNodeDesc, unregisterNodeDesc
 
@@ -233,7 +233,7 @@ class TestInitNodeWithDynamicOutputs:
         # Additionally, the list of errors should include an error about having a dynamic output in an InitNode
         plugin = pluginManager.getRegisteredNodePlugin(InitNodeWithDynamicOutputs.__name__)
         assert plugin
-        assert plugin.status == NodePluginStatus.DESC_ERROR
+        assert plugin.status == NodeProviderStatus.DESC_ERROR
         assert len(plugin.errors) == 1
         errType = plugin.errors[0][1]
         assert errType == desc.ValueTypeErrors.DYNAMIC_OUTPUT

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -28,7 +28,7 @@ class TestNodeInfo:
         cls.plugin = Plugin(package, cls.folder)
         nodes = loadClassesNodes(cls.folder, package, pluginUid=cls.plugin.uid)
         for node in nodes:
-            cls.plugin.addNodePlugin(node)
+            cls.plugin.addNodeProvider(node)
         pluginManager.addPlugin(cls.plugin)
 
     @classmethod
@@ -73,7 +73,7 @@ class TestNodeVariables:
         cls.plugin = Plugin(package, folder)
         nodes = loadClassesNodes(folder, package, pluginUid=cls.plugin.uid)
         for node in nodes:
-            cls.plugin.addNodePlugin(node)
+            cls.plugin.addNodeProvider(node)
         pluginManager.addPlugin(cls.plugin)
 
     @classmethod
@@ -128,7 +128,7 @@ class TestInputNode:
         cls.plugin = Plugin(package, folder)
         nodes = loadClassesNodes(folder, package, pluginUid=cls.plugin.uid)
         for node in nodes:
-            cls.plugin.addNodePlugin(node)
+            cls.plugin.addNodeProvider(node)
         pluginManager.addPlugin(cls.plugin)
 
     @classmethod

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -34,7 +34,7 @@ class TestNodeInfo:
     @classmethod
     def teardown_class(cls):
         for node in cls.plugin.nodes.values():
-            pluginManager.unregisterNode(node)
+            pluginManager.unloadNodeProvider(node)
         pluginManager.removePlugin(cls.plugin)
         cls.plugin = None
 
@@ -79,7 +79,7 @@ class TestNodeVariables:
     @classmethod
     def teardown_class(cls):
         for node in cls.plugin.nodes.values():
-            pluginManager.unregisterNode(node)
+            pluginManager.unloadNodeProvider(node)
         pluginManager.removePlugin(cls.plugin)
         cls.plugin = None
 
@@ -134,7 +134,7 @@ class TestInputNode:
     @classmethod
     def teardown_class(cls):
         for node in cls.plugin.nodes.values():
-            pluginManager.unregisterNode(node)
+            pluginManager.unloadNodeProvider(node)
         pluginManager.removePlugin(cls.plugin)
         cls.plugin = None
 
@@ -164,7 +164,7 @@ class TestBackdropNode:
         for plugin in pluginManager.getPlugins():
             if plugin not in cls.loadedPlugins:
                 for node in plugin.nodes.values():
-                    pluginManager.unregisterNode(node)
+                    pluginManager.unloadNodeProvider(node)
                 pluginManager.removePlugin(plugin)
 
     def test_backdropNode(self):
@@ -594,7 +594,7 @@ class TestGenerateMgScene:
         for plugin in pluginManager.getPlugins():
             if plugin not in cls.loadedPlugins:
                 for node in plugin.nodes.values():
-                    pluginManager.unregisterNode(node)
+                    pluginManager.unloadNodeProvider(node)
                 pluginManager.removePlugin(plugin)
 
     @staticmethod

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -10,7 +10,7 @@ import tempfile
 from meshroom.core import desc, pluginManager, loadClassesNodes, initNodes
 from meshroom.core.node import Position
 from meshroom.core.graph import Graph, loadGraph
-from meshroom.core.plugins import Plugin
+from meshroom.core.plugins.manager import Plugin
 
 from .utils import registerNodeDesc, unregisterNodeDesc, registeredNodeTypes
 

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -113,7 +113,7 @@ class TestPluginWithValidNodesOnly:
         #   - it is still part of pluginA
         #   - it is not in the list of registered plugins anymore (and returns None when requested)
         assert nodeA.status == NodeProviderStatus.NOT_LOADED
-        assert plugin.containsNodePlugin(nodeAName)
+        assert plugin.containsNodeProvider(nodeAName)
         assert nodeA.plugin == plugin
 
         assert pluginManager.getLoadedNodeProvider(nodeAName) is None

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -49,8 +49,8 @@ class TestPluginWithValidNodesOnly:
         plugin = pluginManager.getPlugin("pluginA", uname=False)
         # Assert that the nodes of pluginA have been successfully registered
         assert len(pluginManager.getLoadedNodeProviders()) >= 2
-        for nodeName, nodePlugin in plugin.nodes.items():
-            assert nodePlugin.status == NodeProviderStatus.LOADED
+        for nodeName, nodeProvider in plugin.nodes.items():
+            assert nodeProvider.status == NodeProviderStatus.LOADED
             assert pluginManager.isLoaded(nodeName)
 
         # Assert the template has been loaded
@@ -64,19 +64,19 @@ class TestPluginWithValidNodesOnly:
         assert plugin == self.plugin
 
         # Unload the plugin without unregistering the nodes
-        pluginManager.removePlugin(plugin, unregisterNodePlugins=False)
+        pluginManager.removePlugin(plugin, unregisterNodeProviders=False)
 
         # Assert the plugin is not loaded anymore
         assert pluginManager.getPlugin(plugin.name, uname=False) is None
 
         # Assert the nodes are still registered and belong to an unloaded plugin
-        for nodeName, nodePlugin in plugin.nodes.items():
-            assert nodePlugin.status == NodeProviderStatus.LOADED
+        for nodeName, nodeProvider in plugin.nodes.items():
+            assert nodeProvider.status == NodeProviderStatus.LOADED
             assert pluginManager.isLoaded(nodeName)
             assert pluginManager.belongsToPlugin(nodeName) is None
 
         # Re-add the plugin
-        pluginManager.addPlugin(plugin, registerNodePlugins=False)
+        pluginManager.addPlugin(plugin, registerNodeProviders=False)
         assert pluginManager.getPlugin(plugin.name, uname=False)
 
         # Unload the plugin with a full unregistration of the nodes
@@ -86,15 +86,15 @@ class TestPluginWithValidNodesOnly:
         assert pluginManager.getPlugin(plugin.name, uname=False) is None
 
         # Assert the nodes have been successfully unregistered
-        for nodeName, nodePlugin in plugin.nodes.items():
-            assert nodePlugin.status == NodeProviderStatus.NOT_LOADED
+        for nodeName, nodeProvider in plugin.nodes.items():
+            assert nodeProvider.status == NodeProviderStatus.NOT_LOADED
             assert not pluginManager.isLoaded(nodeName)
 
         # Re-add the plugin and re-register the nodes
         pluginManager.addPlugin(plugin)
         assert pluginManager.getPlugin(plugin.name, uname=False)
-        for nodeName, nodePlugin in plugin.nodes.items():
-            assert nodePlugin.status == NodeProviderStatus.LOADED
+        for nodeName, nodeProvider in plugin.nodes.items():
+            assert nodeProvider.status == NodeProviderStatus.LOADED
             assert pluginManager.isLoaded(nodeName)
 
     def test_updateRegisteredNodes(self):
@@ -171,7 +171,7 @@ class TestPluginWithInvalidNodes:
         assert name == "sharedTemplate"
         assert plugin.templates[name] == os.path.join(str(plugin.path), "sharedTemplate.mg")
 
-    def test_reloadNodePluginInvalidDescrpition(self):
+    def test_reloadNodeProviderInvalidDescrpition(self):
         plugin = pluginManager.getPlugin("pluginB", uname=False)
         assert plugin == self.plugin
         node = plugin.nodes["PluginBNodeB"]
@@ -199,7 +199,7 @@ class TestPluginWithInvalidNodes:
         node.reload()
         assert node.status == NodeProviderStatus.NOT_LOADED
 
-        # Attempt to register node plugin
+        # Attempt to register node provider
         pluginManager.loadNodeProvider(node)
         assert pluginManager.isLoaded(nodeName)
 
@@ -230,7 +230,7 @@ class TestPluginWithInvalidNodes:
         assert node.status == NodeProviderStatus.DESC_ERROR  # Not NOT_LOADED
         assert not pluginManager.isLoaded(nodeName)
 
-    def test_reloadNodePluginSyntaxError(self):
+    def test_reloadNodeProviderSyntaxError(self):
         plugin = pluginManager.getPlugin("pluginB", uname=False)
         assert plugin == self.plugin
         node = plugin.nodes["PluginBNodeA"]

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -2,7 +2,7 @@
 
 from meshroom.core import pluginManager, loadClassesNodes
 from meshroom.core.desc.node import NodeVersionType
-from meshroom.core.plugins import NodeProviderStatus, Plugin
+from meshroom.core.plugins.manager import NodeProviderStatus, Plugin
 from .utils import overrideOsEnvironmentVariables, loadedPlugins, loadedUserPlugins
 
 

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -51,7 +51,7 @@ class TestPluginWithValidNodesOnly:
         assert len(pluginManager.getRegisteredNodePlugins()) >= 2
         for nodeName, nodePlugin in plugin.nodes.items():
             assert nodePlugin.status == NodeProviderStatus.LOADED
-            assert pluginManager.isRegistered(nodeName)
+            assert pluginManager.isLoaded(nodeName)
 
         # Assert the template has been loaded
         assert len(plugin.templates) == 1
@@ -72,7 +72,7 @@ class TestPluginWithValidNodesOnly:
         # Assert the nodes are still registered and belong to an unloaded plugin
         for nodeName, nodePlugin in plugin.nodes.items():
             assert nodePlugin.status == NodeProviderStatus.LOADED
-            assert pluginManager.isRegistered(nodeName)
+            assert pluginManager.isLoaded(nodeName)
             assert pluginManager.belongsToPlugin(nodeName) is None
 
         # Re-add the plugin
@@ -88,14 +88,14 @@ class TestPluginWithValidNodesOnly:
         # Assert the nodes have been successfully unregistered
         for nodeName, nodePlugin in plugin.nodes.items():
             assert nodePlugin.status == NodeProviderStatus.NOT_LOADED
-            assert not pluginManager.isRegistered(nodeName)
+            assert not pluginManager.isLoaded(nodeName)
 
         # Re-add the plugin and re-register the nodes
         pluginManager.addPlugin(plugin)
         assert pluginManager.getPlugin(plugin.name, uname=False)
         for nodeName, nodePlugin in plugin.nodes.items():
             assert nodePlugin.status == NodeProviderStatus.LOADED
-            assert pluginManager.isRegistered(nodeName)
+            assert pluginManager.isLoaded(nodeName)
 
     def test_updateRegisteredNodes(self):
         nbRegisteredNodes = len(pluginManager.getRegisteredNodePlugins())
@@ -156,12 +156,12 @@ class TestPluginWithInvalidNodes:
         assert str(plugin.path) == os.path.join(os.path.dirname(__file__), "plugins", "meshroom")
 
         # Assert that PluginBNodeA is successfully registered
-        assert pluginManager.isRegistered("PluginBNodeA")
+        assert pluginManager.isLoaded("PluginBNodeA")
         assert plugin.nodes["PluginBNodeA"].status == NodeProviderStatus.LOADED
         assert plugin.nodes["PluginBNodeA"].plugin == plugin
 
         # Assert that PluginBNodeB has not been registered (description error)
-        assert not pluginManager.isRegistered("PluginBNodeB")
+        assert not pluginManager.isLoaded("PluginBNodeB")
         assert plugin.nodes["PluginBNodeB"].status == NodeProviderStatus.DESC_ERROR
         assert plugin.nodes["PluginBNodeB"].plugin == plugin
 
@@ -179,11 +179,11 @@ class TestPluginWithInvalidNodes:
 
         # Check that the node has not been registered
         assert node.status == NodeProviderStatus.DESC_ERROR
-        assert not pluginManager.isRegistered(nodeName)
+        assert not pluginManager.isLoaded(nodeName)
 
         # Check that the node cannot be registered
         pluginManager.registerNode(node)
-        assert not pluginManager.isRegistered(nodeName)
+        assert not pluginManager.isLoaded(nodeName)
 
         # Replace directly in the node file the line that fails the validation
         # on the description with a line that will pass
@@ -201,11 +201,11 @@ class TestPluginWithInvalidNodes:
 
         # Attempt to register node plugin
         pluginManager.registerNode(node)
-        assert pluginManager.isRegistered(nodeName)
+        assert pluginManager.isLoaded(nodeName)
 
         # Reload the node again without any change
         node.reload()
-        assert pluginManager.isRegistered(nodeName)
+        assert pluginManager.isLoaded(nodeName)
 
         # Hack to ensure that the timestamp of the file will be different after being rewritten
         # Without it, on some systems, the operation is too fast and the timestamp does not change,
@@ -223,12 +223,12 @@ class TestPluginWithInvalidNodes:
         # Reload the node and assert it is invalid while still registered
         node.reload()
         assert node.status == NodeProviderStatus.DESC_ERROR
-        assert pluginManager.isRegistered(nodeName)
+        assert pluginManager.isLoaded(nodeName)
 
         # Unregister it
         pluginManager.unregisterNode(node)
         assert node.status == NodeProviderStatus.DESC_ERROR  # Not NOT_LOADED
-        assert not pluginManager.isRegistered(nodeName)
+        assert not pluginManager.isLoaded(nodeName)
 
     def test_reloadNodePluginSyntaxError(self):
         plugin = pluginManager.getPlugin("pluginB", uname=False)
@@ -238,7 +238,7 @@ class TestPluginWithInvalidNodes:
 
         # Check that the node has been registered
         assert node.status == NodeProviderStatus.LOADED
-        assert pluginManager.isRegistered(nodeName)
+        assert pluginManager.isLoaded(nodeName)
 
         # Introduce a syntax error in the description
         originalFileContent = None
@@ -252,7 +252,7 @@ class TestPluginWithInvalidNodes:
         # Reload the node and assert it is invalid but still registered
         node.reload()
         assert node.status == NodeProviderStatus.DESC_ERROR
-        assert pluginManager.isRegistered(nodeName)
+        assert pluginManager.isLoaded(nodeName)
 
         # Restore the node file to its original state (with a description error)
         with open(node.path, "w") as f:
@@ -261,7 +261,7 @@ class TestPluginWithInvalidNodes:
         # Assert the status is correct and the node is still registered
         node.reload()
         assert node.status == NodeProviderStatus.NOT_LOADED
-        assert pluginManager.isRegistered(nodeName)
+        assert pluginManager.isLoaded(nodeName)
 
 
 class TestPluginsConfiguration:

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -64,7 +64,7 @@ class TestPluginWithValidNodesOnly:
         assert plugin == self.plugin
 
         # Unload the plugin without unloading the nodes
-        pluginManager.removePlugin(plugin, unregisterNodeProviders=False)
+        pluginManager.removePlugin(plugin, unloadNodeProviders=False)
 
         # Assert the plugin is not loaded anymore
         assert pluginManager.getPlugin(plugin.name, uname=False) is None
@@ -76,7 +76,7 @@ class TestPluginWithValidNodesOnly:
             assert pluginManager.belongsToPlugin(nodeName) is None
 
         # Re-add the plugin
-        pluginManager.addPlugin(plugin, registerNodeProviders=False)
+        pluginManager.addPlugin(plugin, loadNodeProviders=False)
         assert pluginManager.getPlugin(plugin.name, uname=False)
 
         # Unload the plugin with a full unload of the nodes

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -3,7 +3,7 @@
 from meshroom.core import pluginManager, loadClassesNodes
 from meshroom.core.desc.node import NodeVersionType
 from meshroom.core.plugins import NodeProviderStatus, Plugin
-from .utils import overrideOsEnvironmentVariables, loadedPlugins, registeredUserPlugins
+from .utils import overrideOsEnvironmentVariables, loadedPlugins, loadedUserPlugins
 
 
 from pathlib import Path
@@ -401,7 +401,7 @@ class TestVersionPlugins:
             assert nodeInput
             assert nodeInput.nodeDescriptor().nodeVersionType == NodeVersionType.UNKNOWN
 
-        with registeredUserPlugins(folder):
+        with loadedUserPlugins(folder):
             pluginA = pluginManager.getPlugin("pluginA", uname=False)
             assert pluginA
             nodeA = pluginManager.getLoadedNodeProvider("PluginANodeA")

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -48,7 +48,7 @@ class TestPluginWithValidNodesOnly:
         # Assert that there are loaded plugins, and that "pluginA" is one of them
         plugin = pluginManager.getPlugin("pluginA", uname=False)
         # Assert that the nodes of pluginA have been successfully registered
-        assert len(pluginManager.getRegisteredNodePlugins()) >= 2
+        assert len(pluginManager.getLoadedNodeProviders()) >= 2
         for nodeName, nodePlugin in plugin.nodes.items():
             assert nodePlugin.status == NodeProviderStatus.LOADED
             assert pluginManager.isLoaded(nodeName)
@@ -98,10 +98,10 @@ class TestPluginWithValidNodesOnly:
             assert pluginManager.isLoaded(nodeName)
 
     def test_updateRegisteredNodes(self):
-        nbRegisteredNodes = len(pluginManager.getRegisteredNodePlugins())
+        nbRegisteredNodes = len(pluginManager.getLoadedNodeProviders())
         plugin = pluginManager.getPlugin("pluginA", uname=False)
         assert plugin == self.plugin
-        nodeA = pluginManager.getRegisteredNodePlugin("PluginANodeA")
+        nodeA = pluginManager.getLoadedNodeProvider("PluginANodeA")
         nodeAName = nodeA.nodeDescriptor.__name__
 
         # Unregister a node
@@ -116,16 +116,16 @@ class TestPluginWithValidNodesOnly:
         assert plugin.containsNodePlugin(nodeAName)
         assert nodeA.plugin == plugin
 
-        assert pluginManager.getRegisteredNodePlugin(nodeAName) is None
-        assert nodeAName not in pluginManager.getRegisteredNodePlugins()
-        assert len(pluginManager.getRegisteredNodePlugins()) == nbRegisteredNodes - 1
+        assert pluginManager.getLoadedNodeProvider(nodeAName) is None
+        assert nodeAName not in pluginManager.getLoadedNodeProviders()
+        assert len(pluginManager.getLoadedNodeProviders()) == nbRegisteredNodes - 1
 
         # Re-register the node
         pluginManager.loadNodeProvider(nodeA)
 
         assert nodeA.status == NodeProviderStatus.LOADED
-        assert pluginManager.getRegisteredNodePlugin(nodeAName)
-        assert len(pluginManager.getRegisteredNodePlugins()) == nbRegisteredNodes
+        assert pluginManager.getLoadedNodeProvider(nodeAName)
+        assert len(pluginManager.getLoadedNodeProviders()) == nbRegisteredNodes
 
 
 class TestPluginWithInvalidNodes:
@@ -388,29 +388,29 @@ class TestVersionPlugins:
         with registeredPlugins(folder):
             pluginA = pluginManager.getPlugin("pluginA", uname=False)
             assert pluginA
-            nodeA = pluginManager.getRegisteredNodePlugin("PluginANodeA")
+            nodeA = pluginManager.getLoadedNodeProvider("PluginANodeA")
             assert nodeA
             assert nodeA.nodeDescriptor().nodeVersionType == NodeVersionType.RELEASED
 
-            nodeB = pluginManager.getRegisteredNodePlugin("PluginANodeB")
+            nodeB = pluginManager.getLoadedNodeProvider("PluginANodeB")
             assert nodeB
             assert nodeB.nodeDescriptor().nodeVersionType == NodeVersionType.BETA
 
-            nodeInput = pluginManager.getRegisteredNodePlugin("PluginAInitNode")
+            nodeInput = pluginManager.getLoadedNodeProvider("PluginAInitNode")
             assert nodeInput
             assert nodeInput.nodeDescriptor().nodeVersionType == NodeVersionType.UNKNOWN
 
         with registeredUserPlugins(folder):
             pluginA = pluginManager.getPlugin("pluginA", uname=False)
             assert pluginA
-            nodeA = pluginManager.getRegisteredNodePlugin("PluginANodeA")
+            nodeA = pluginManager.getLoadedNodeProvider("PluginANodeA")
             assert nodeA
             assert nodeA.nodeDescriptor().nodeVersionType == NodeVersionType.USER
 
-            nodeB = pluginManager.getRegisteredNodePlugin("PluginANodeB")
+            nodeB = pluginManager.getLoadedNodeProvider("PluginANodeB")
             assert nodeB
             assert nodeB.nodeDescriptor().nodeVersionType == NodeVersionType.USER
 
-            nodeInput = pluginManager.getRegisteredNodePlugin("PluginAInitNode")
+            nodeInput = pluginManager.getLoadedNodeProvider("PluginAInitNode")
             assert nodeInput
             assert nodeInput.nodeDescriptor().nodeVersionType == NodeVersionType.USER

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -2,7 +2,7 @@
 
 from meshroom.core import pluginManager, loadClassesNodes
 from meshroom.core.desc.node import NodeVersionType
-from meshroom.core.plugins import NodePluginStatus, Plugin
+from meshroom.core.plugins import NodeProviderStatus, Plugin
 from .utils import overrideOsEnvironmentVariables, registeredPlugins, registeredUserPlugins
 
 from pathlib import Path
@@ -50,7 +50,7 @@ class TestPluginWithValidNodesOnly:
         # Assert that the nodes of pluginA have been successfully registered
         assert len(pluginManager.getRegisteredNodePlugins()) >= 2
         for nodeName, nodePlugin in plugin.nodes.items():
-            assert nodePlugin.status == NodePluginStatus.LOADED
+            assert nodePlugin.status == NodeProviderStatus.LOADED
             assert pluginManager.isRegistered(nodeName)
 
         # Assert the template has been loaded
@@ -71,7 +71,7 @@ class TestPluginWithValidNodesOnly:
 
         # Assert the nodes are still registered and belong to an unloaded plugin
         for nodeName, nodePlugin in plugin.nodes.items():
-            assert nodePlugin.status == NodePluginStatus.LOADED
+            assert nodePlugin.status == NodeProviderStatus.LOADED
             assert pluginManager.isRegistered(nodeName)
             assert pluginManager.belongsToPlugin(nodeName) is None
 
@@ -87,14 +87,14 @@ class TestPluginWithValidNodesOnly:
 
         # Assert the nodes have been successfully unregistered
         for nodeName, nodePlugin in plugin.nodes.items():
-            assert nodePlugin.status == NodePluginStatus.NOT_LOADED
+            assert nodePlugin.status == NodeProviderStatus.NOT_LOADED
             assert not pluginManager.isRegistered(nodeName)
 
         # Re-add the plugin and re-register the nodes
         pluginManager.addPlugin(plugin)
         assert pluginManager.getPlugin(plugin.name, uname=False)
         for nodeName, nodePlugin in plugin.nodes.items():
-            assert nodePlugin.status == NodePluginStatus.LOADED
+            assert nodePlugin.status == NodeProviderStatus.LOADED
             assert pluginManager.isRegistered(nodeName)
 
     def test_updateRegisteredNodes(self):
@@ -112,7 +112,7 @@ class TestPluginWithValidNodesOnly:
         #   - its status is "NOT_LOADED"
         #   - it is still part of pluginA
         #   - it is not in the list of registered plugins anymore (and returns None when requested)
-        assert nodeA.status == NodePluginStatus.NOT_LOADED
+        assert nodeA.status == NodeProviderStatus.NOT_LOADED
         assert plugin.containsNodePlugin(nodeAName)
         assert nodeA.plugin == plugin
 
@@ -123,7 +123,7 @@ class TestPluginWithValidNodesOnly:
         # Re-register the node
         pluginManager.registerNode(nodeA)
 
-        assert nodeA.status == NodePluginStatus.LOADED
+        assert nodeA.status == NodeProviderStatus.LOADED
         assert pluginManager.getRegisteredNodePlugin(nodeAName)
         assert len(pluginManager.getRegisteredNodePlugins()) == nbRegisteredNodes
 
@@ -157,12 +157,12 @@ class TestPluginWithInvalidNodes:
 
         # Assert that PluginBNodeA is successfully registered
         assert pluginManager.isRegistered("PluginBNodeA")
-        assert plugin.nodes["PluginBNodeA"].status == NodePluginStatus.LOADED
+        assert plugin.nodes["PluginBNodeA"].status == NodeProviderStatus.LOADED
         assert plugin.nodes["PluginBNodeA"].plugin == plugin
 
         # Assert that PluginBNodeB has not been registered (description error)
         assert not pluginManager.isRegistered("PluginBNodeB")
-        assert plugin.nodes["PluginBNodeB"].status == NodePluginStatus.DESC_ERROR
+        assert plugin.nodes["PluginBNodeB"].status == NodeProviderStatus.DESC_ERROR
         assert plugin.nodes["PluginBNodeB"].plugin == plugin
 
         # Assert the template has been loaded
@@ -178,7 +178,7 @@ class TestPluginWithInvalidNodes:
         nodeName = node.nodeDescriptor.__name__
 
         # Check that the node has not been registered
-        assert node.status == NodePluginStatus.DESC_ERROR
+        assert node.status == NodeProviderStatus.DESC_ERROR
         assert not pluginManager.isRegistered(nodeName)
 
         # Check that the node cannot be registered
@@ -197,7 +197,7 @@ class TestPluginWithInvalidNodes:
 
         # Reload the node and assert it is valid
         node.reload()
-        assert node.status == NodePluginStatus.NOT_LOADED
+        assert node.status == NodeProviderStatus.NOT_LOADED
 
         # Attempt to register node plugin
         pluginManager.registerNode(node)
@@ -222,12 +222,12 @@ class TestPluginWithInvalidNodes:
 
         # Reload the node and assert it is invalid while still registered
         node.reload()
-        assert node.status == NodePluginStatus.DESC_ERROR
+        assert node.status == NodeProviderStatus.DESC_ERROR
         assert pluginManager.isRegistered(nodeName)
 
         # Unregister it
         pluginManager.unregisterNode(node)
-        assert node.status == NodePluginStatus.DESC_ERROR  # Not NOT_LOADED
+        assert node.status == NodeProviderStatus.DESC_ERROR  # Not NOT_LOADED
         assert not pluginManager.isRegistered(nodeName)
 
     def test_reloadNodePluginSyntaxError(self):
@@ -237,7 +237,7 @@ class TestPluginWithInvalidNodes:
         nodeName = node.nodeDescriptor.__name__
 
         # Check that the node has been registered
-        assert node.status == NodePluginStatus.LOADED
+        assert node.status == NodeProviderStatus.LOADED
         assert pluginManager.isRegistered(nodeName)
 
         # Introduce a syntax error in the description
@@ -251,7 +251,7 @@ class TestPluginWithInvalidNodes:
 
         # Reload the node and assert it is invalid but still registered
         node.reload()
-        assert node.status == NodePluginStatus.DESC_ERROR
+        assert node.status == NodeProviderStatus.DESC_ERROR
         assert pluginManager.isRegistered(nodeName)
 
         # Restore the node file to its original state (with a description error)
@@ -260,7 +260,7 @@ class TestPluginWithInvalidNodes:
 
         # Assert the status is correct and the node is still registered
         node.reload()
-        assert node.status == NodePluginStatus.NOT_LOADED
+        assert node.status == NodeProviderStatus.NOT_LOADED
         assert pluginManager.isRegistered(nodeName)
 
 

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -26,7 +26,7 @@ class TestPluginWithValidNodesOnly:
     @classmethod
     def teardown_class(cls):
         for node in cls.plugin.nodes.values():
-            pluginManager.unregisterNode(node)
+            pluginManager.unloadNodeProvider(node)
         pluginManager.removePlugin(cls.plugin)
         cls.plugin = None
 
@@ -106,7 +106,7 @@ class TestPluginWithValidNodesOnly:
 
         # Unregister a node
         assert nodeA
-        pluginManager.unregisterNode(nodeA)
+        pluginManager.unloadNodeProvider(nodeA)
 
         # Check that the node has been fully unregistered:
         #   - its status is "NOT_LOADED"
@@ -121,7 +121,7 @@ class TestPluginWithValidNodesOnly:
         assert len(pluginManager.getRegisteredNodePlugins()) == nbRegisteredNodes - 1
 
         # Re-register the node
-        pluginManager.registerNode(nodeA)
+        pluginManager.loadNodeProvider(nodeA)
 
         assert nodeA.status == NodeProviderStatus.LOADED
         assert pluginManager.getRegisteredNodePlugin(nodeAName)
@@ -144,7 +144,7 @@ class TestPluginWithInvalidNodes:
     @classmethod
     def teardown_class(cls):
         for node in cls.plugin.nodes.values():
-            pluginManager.unregisterNode(node)
+            pluginManager.unloadNodeProvider(node)
         pluginManager.removePlugin(cls.plugin)
         cls.plugin = None
 
@@ -182,7 +182,7 @@ class TestPluginWithInvalidNodes:
         assert not pluginManager.isLoaded(nodeName)
 
         # Check that the node cannot be registered
-        pluginManager.registerNode(node)
+        pluginManager.loadNodeProvider(node)
         assert not pluginManager.isLoaded(nodeName)
 
         # Replace directly in the node file the line that fails the validation
@@ -200,7 +200,7 @@ class TestPluginWithInvalidNodes:
         assert node.status == NodeProviderStatus.NOT_LOADED
 
         # Attempt to register node plugin
-        pluginManager.registerNode(node)
+        pluginManager.loadNodeProvider(node)
         assert pluginManager.isLoaded(nodeName)
 
         # Reload the node again without any change
@@ -226,7 +226,7 @@ class TestPluginWithInvalidNodes:
         assert pluginManager.isLoaded(nodeName)
 
         # Unregister it
-        pluginManager.unregisterNode(node)
+        pluginManager.unloadNodeProvider(node)
         assert node.status == NodeProviderStatus.DESC_ERROR  # Not NOT_LOADED
         assert not pluginManager.isLoaded(nodeName)
 

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -47,7 +47,7 @@ class TestPluginWithValidNodesOnly:
     def test_loadedPlugin(self):
         # Assert that there are loaded plugins, and that "pluginA" is one of them
         plugin = pluginManager.getPlugin("pluginA", uname=False)
-        # Assert that the nodes of pluginA have been successfully registered
+        # Assert that the nodes of pluginA have been successfully loaded
         assert len(pluginManager.getLoadedNodeProviders()) >= 2
         for nodeName, nodeProvider in plugin.nodes.items():
             assert nodeProvider.status == NodeProviderStatus.LOADED
@@ -63,13 +63,13 @@ class TestPluginWithValidNodesOnly:
         plugin = pluginManager.getPlugin("pluginA", uname=False)
         assert plugin == self.plugin
 
-        # Unload the plugin without unregistering the nodes
+        # Unload the plugin without unloading the nodes
         pluginManager.removePlugin(plugin, unregisterNodeProviders=False)
 
         # Assert the plugin is not loaded anymore
         assert pluginManager.getPlugin(plugin.name, uname=False) is None
 
-        # Assert the nodes are still registered and belong to an unloaded plugin
+        # Assert the nodes are still loaded and belong to an unloaded plugin
         for nodeName, nodeProvider in plugin.nodes.items():
             assert nodeProvider.status == NodeProviderStatus.LOADED
             assert pluginManager.isLoaded(nodeName)
@@ -79,18 +79,18 @@ class TestPluginWithValidNodesOnly:
         pluginManager.addPlugin(plugin, registerNodeProviders=False)
         assert pluginManager.getPlugin(plugin.name, uname=False)
 
-        # Unload the plugin with a full unregistration of the nodes
+        # Unload the plugin with a full unload of the nodes
         pluginManager.removePlugin(plugin)
 
         # Assert the plugin is not loaded anymore
         assert pluginManager.getPlugin(plugin.name, uname=False) is None
 
-        # Assert the nodes have been successfully unregistered
+        # Assert the nodes have been successfully unloaded
         for nodeName, nodeProvider in plugin.nodes.items():
             assert nodeProvider.status == NodeProviderStatus.NOT_LOADED
             assert not pluginManager.isLoaded(nodeName)
 
-        # Re-add the plugin and re-register the nodes
+        # Re-add the plugin and re-load the nodes
         pluginManager.addPlugin(plugin)
         assert pluginManager.getPlugin(plugin.name, uname=False)
         for nodeName, nodeProvider in plugin.nodes.items():
@@ -104,14 +104,14 @@ class TestPluginWithValidNodesOnly:
         nodeA = pluginManager.getLoadedNodeProvider("PluginANodeA")
         nodeAName = nodeA.nodeDescriptor.__name__
 
-        # Unregister a node
+        # Unload a node
         assert nodeA
         pluginManager.unloadNodeProvider(nodeA)
 
-        # Check that the node has been fully unregistered:
+        # Check that the node has been fully unloaded:
         #   - its status is "NOT_LOADED"
         #   - it is still part of pluginA
-        #   - it is not in the list of registered plugins anymore (and returns None when requested)
+        #   - it is not in the list of loaded plugins anymore (and returns None when requested)
         assert nodeA.status == NodeProviderStatus.NOT_LOADED
         assert plugin.containsNodeProvider(nodeAName)
         assert nodeA.plugin == plugin
@@ -120,7 +120,7 @@ class TestPluginWithValidNodesOnly:
         assert nodeAName not in pluginManager.getLoadedNodeProviders()
         assert len(pluginManager.getLoadedNodeProviders()) == nbRegisteredNodes - 1
 
-        # Re-register the node
+        # Re-load the node
         pluginManager.loadNodeProvider(nodeA)
 
         assert nodeA.status == NodeProviderStatus.LOADED
@@ -155,12 +155,12 @@ class TestPluginWithInvalidNodes:
         assert plugin == self.plugin
         assert str(plugin.path) == os.path.join(os.path.dirname(__file__), "plugins", "meshroom")
 
-        # Assert that PluginBNodeA is successfully registered
+        # Assert that PluginBNodeA is successfully loaded
         assert pluginManager.isLoaded("PluginBNodeA")
         assert plugin.nodes["PluginBNodeA"].status == NodeProviderStatus.LOADED
         assert plugin.nodes["PluginBNodeA"].plugin == plugin
 
-        # Assert that PluginBNodeB has not been registered (description error)
+        # Assert that PluginBNodeB has not been loaded (description error)
         assert not pluginManager.isLoaded("PluginBNodeB")
         assert plugin.nodes["PluginBNodeB"].status == NodeProviderStatus.DESC_ERROR
         assert plugin.nodes["PluginBNodeB"].plugin == plugin
@@ -177,11 +177,11 @@ class TestPluginWithInvalidNodes:
         node = plugin.nodes["PluginBNodeB"]
         nodeName = node.nodeDescriptor.__name__
 
-        # Check that the node has not been registered
+        # Check that the node has not been loaded
         assert node.status == NodeProviderStatus.DESC_ERROR
         assert not pluginManager.isLoaded(nodeName)
 
-        # Check that the node cannot be registered
+        # Check that the node cannot be loaded
         pluginManager.loadNodeProvider(node)
         assert not pluginManager.isLoaded(nodeName)
 
@@ -199,11 +199,11 @@ class TestPluginWithInvalidNodes:
         node.reload()
         assert node.status == NodeProviderStatus.NOT_LOADED
 
-        # Attempt to register node provider
+        # Attempt to load the node provider
         pluginManager.loadNodeProvider(node)
         assert pluginManager.isLoaded(nodeName)
 
-        # Reload the node again without any change
+        # Reload the node provider again without any change
         node.reload()
         assert pluginManager.isLoaded(nodeName)
 
@@ -220,12 +220,12 @@ class TestPluginWithInvalidNodes:
         print(f"New timestamp: {timestampOr2}")
         print(os.stat(node.path))
 
-        # Reload the node and assert it is invalid while still registered
+        # Reload the node and assert it is invalid while still loaded
         node.reload()
         assert node.status == NodeProviderStatus.DESC_ERROR
         assert pluginManager.isLoaded(nodeName)
 
-        # Unregister it
+        # Unload it
         pluginManager.unloadNodeProvider(node)
         assert node.status == NodeProviderStatus.DESC_ERROR  # Not NOT_LOADED
         assert not pluginManager.isLoaded(nodeName)
@@ -236,7 +236,7 @@ class TestPluginWithInvalidNodes:
         node = plugin.nodes["PluginBNodeA"]
         nodeName = node.nodeDescriptor.__name__
 
-        # Check that the node has been registered
+        # Check that the node has been loaded
         assert node.status == NodeProviderStatus.LOADED
         assert pluginManager.isLoaded(nodeName)
 
@@ -249,7 +249,7 @@ class TestPluginWithInvalidNodes:
         with open(node.path, "w") as f:
             f.write(replaceFileContent)
 
-        # Reload the node and assert it is invalid but still registered
+        # Reload the node and assert it is invalid but still loaded
         node.reload()
         assert node.status == NodeProviderStatus.DESC_ERROR
         assert pluginManager.isLoaded(nodeName)
@@ -258,7 +258,7 @@ class TestPluginWithInvalidNodes:
         with open(node.path, "w") as f:
             f.write(originalFileContent)
 
-        # Assert the status is correct and the node is still registered
+        # Assert the status is correct and the node is still loaded
         node.reload()
         assert node.status == NodeProviderStatus.NOT_LOADED
         assert pluginManager.isLoaded(nodeName)

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -20,7 +20,7 @@ class TestPluginWithValidNodesOnly:
         cls.plugin = Plugin(package, folder)
         nodes = loadClassesNodes(folder, package, pluginUid=cls.plugin.uid)
         for node in nodes:
-            cls.plugin.addNodePlugin(node)
+            cls.plugin.addNodeProvider(node)
         pluginManager.addPlugin(cls.plugin)
 
     @classmethod
@@ -138,7 +138,7 @@ class TestPluginWithInvalidNodes:
         cls.plugin = Plugin(package, folder)
         nodes = loadClassesNodes(folder, package, pluginUid=cls.plugin.uid)
         for node in nodes:
-            cls.plugin.addNodePlugin(node)
+            cls.plugin.addNodeProvider(node)
         pluginManager.addPlugin(cls.plugin)
 
     @classmethod

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -3,7 +3,8 @@
 from meshroom.core import pluginManager, loadClassesNodes
 from meshroom.core.desc.node import NodeVersionType
 from meshroom.core.plugins import NodeProviderStatus, Plugin
-from .utils import overrideOsEnvironmentVariables, registeredPlugins, registeredUserPlugins
+from .utils import overrideOsEnvironmentVariables, loadedPlugins, registeredUserPlugins
+
 
 from pathlib import Path
 import os
@@ -275,7 +276,7 @@ class TestPluginsConfiguration:
         # Check that the config.json file for the plugins in the "plugins" directory is
         # correctly loaded
         folder = os.path.join(os.path.dirname(__file__), "plugins")
-        with registeredPlugins(folder):
+        with loadedPlugins(folder):
             plugin = pluginManager.getPlugin("pluginA", uname=False)
             assert plugin
 
@@ -313,7 +314,7 @@ class TestPluginsConfiguration:
         }
 
         folder = os.path.join(os.path.dirname(__file__), "plugins")
-        with (overrideOsEnvironmentVariables(environment), registeredPlugins(folder)):
+        with (overrideOsEnvironmentVariables(environment), loadedPlugins(folder)):
             plugin = pluginManager.getPlugin("pluginA", uname=False)
             assert plugin
 
@@ -350,7 +351,7 @@ class TestPluginsConfiguration:
         }
 
         folder = os.path.join(os.path.dirname(__file__), "plugins")
-        with (overrideOsEnvironmentVariables(environment), registeredPlugins(folder)):
+        with (overrideOsEnvironmentVariables(environment), loadedPlugins(folder)):
             plugin = pluginManager.getPlugin("pluginA", uname=False)
             assert plugin
 
@@ -385,7 +386,7 @@ class TestPluginsConfiguration:
 class TestVersionPlugins:
     def test_nodeVersionType(self):
         folder = os.path.join(os.path.dirname(__file__), "plugins")
-        with registeredPlugins(folder):
+        with loadedPlugins(folder):
             pluginA = pluginManager.getPlugin("pluginA", uname=False)
             assert pluginA
             nodeA = pluginManager.getLoadedNodeProvider("PluginANodeA")

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -98,8 +98,8 @@ class TestPluginWithValidNodesOnly:
             assert nodeProvider.status == NodeProviderStatus.LOADED
             assert pluginManager.isLoaded(nodeName)
 
-    def test_updateRegisteredNodes(self):
-        nbRegisteredNodes = len(pluginManager.getLoadedNodeProviders())
+    def test_updateLoadedNodeProviders(self):
+        nbLoadedNodeProviders = len(pluginManager.getLoadedNodeProviders())
         plugin = pluginManager.getPlugin("pluginA", uname=False)
         assert plugin == self.plugin
         nodeA = pluginManager.getLoadedNodeProvider("PluginANodeA")
@@ -119,14 +119,14 @@ class TestPluginWithValidNodesOnly:
 
         assert pluginManager.getLoadedNodeProvider(nodeAName) is None
         assert nodeAName not in pluginManager.getLoadedNodeProviders()
-        assert len(pluginManager.getLoadedNodeProviders()) == nbRegisteredNodes - 1
+        assert len(pluginManager.getLoadedNodeProviders()) == nbLoadedNodeProviders - 1
 
         # Re-load the node
         pluginManager.loadNodeProvider(nodeA)
 
         assert nodeA.status == NodeProviderStatus.LOADED
         assert pluginManager.getLoadedNodeProvider(nodeAName)
-        assert len(pluginManager.getLoadedNodeProviders()) == nbRegisteredNodes
+        assert len(pluginManager.getLoadedNodeProviders()) == nbLoadedNodeProviders
 
 
 class TestPluginWithInvalidNodes:

--- a/tests/test_submit.py
+++ b/tests/test_submit.py
@@ -13,8 +13,8 @@ from .utils import registerNodeDesc
 import meshroom
 from meshroom.core import pluginManager, loadClassesNodes, loadSubmitters, registerSubmitter, meshroomFolder
 from meshroom.core.graph import Graph
-from meshroom.core.plugins import Plugin
 from meshroom.core.node import Node, Status
+from meshroom.core.plugins.manager import Plugin
 from meshroom.core.submitter import jobManager
 from meshroom.core.submitter import OrderedTask, OrderedTasks, OrderedTaskType
 from meshroom.submitters.localFarm.localFarmSubmitter import LocalFarmSubmitter, LocalFarmJob

--- a/tests/test_submit.py
+++ b/tests/test_submit.py
@@ -144,11 +144,11 @@ class TestNodeSubmit:
     @classmethod
     def teardown_class(cls):
         for node in cls.plugin.nodes.values():
-            pluginManager.unregisterNode(node)
+            pluginManager.unloadNodeProvider(node)
         pluginManager.removePlugin(cls.plugin)
         cls.plugin = None
 
-    def registerNode(self, name):
+    def loadNodeProvider(self, name):
         plugin = pluginManager.getPlugin("pluginSubmitter", uname=False)
         node = plugin.nodes[name]
         nodeType = node.nodeDescriptor
@@ -156,7 +156,7 @@ class TestNodeSubmit:
         return nodeType.__name__
 
     def addNewNode(self, graph, name, nodeParams=None):
-        nodeTypeName = self.registerNode(name)
+        nodeTypeName = self.loadNodeProvider(name)
         nodeParams = nodeParams or {}
         node = graph.addNewNode(nodeTypeName, **nodeParams)
         return node

--- a/tests/test_submit.py
+++ b/tests/test_submit.py
@@ -138,7 +138,7 @@ class TestNodeSubmit:
         cls.plugin = Plugin(package, cls.folder)
         nodes = loadClassesNodes(cls.folder, package, pluginUid=cls.plugin.uid)
         for node in nodes:
-            cls.plugin.addNodePlugin(node)
+            cls.plugin.addNodeProvider(node)
         pluginManager.addPlugin(cls.plugin)
 
     @classmethod

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -3,23 +3,23 @@ from unittest.mock import patch
 
 import meshroom
 from meshroom.core import desc, pluginManager, loadPluginFolder
-from meshroom.core.plugins import NodePlugin
+from meshroom.core.plugins import NodeProvider
 
 import os
 
 
 @contextmanager
 def registeredNodeTypes(nodeTypes: list[desc.Node]):
-    nodePluginsList = {}
+    nodeProvidersList = {}
     for nodeType in nodeTypes:
-        nodePlugin = NodePlugin(nodeType)
-        pluginManager.loadNodeProvider(nodePlugin)
-        nodePluginsList[nodeType] = nodePlugin
+        nodeProvider = NodeProvider(nodeType)
+        pluginManager.loadNodeProvider(nodeProvider)
+        nodeProvidersList[nodeType] = nodeProvider
 
     yield
 
     for nodeType in nodeTypes:
-        pluginManager.unloadNodeProvider(nodePluginsList[nodeType])
+        pluginManager.unloadNodeProvider(nodeProvidersList[nodeType])
 
 
 @contextmanager
@@ -37,13 +37,13 @@ def overrideNodeTypeVersion(nodeType: desc.Node, version: str):
 def registerNodeDesc(nodeDesc: desc.Node):
     name = nodeDesc.__name__
     if not pluginManager.isLoaded(name):
-        pluginManager._nodePlugins[name] = NodePlugin(nodeDesc)
+        pluginManager._nodeProviders[name] = NodeProvider(nodeDesc)
 
 
 def unregisterNodeDesc(nodeDesc: desc.Node):
     name = nodeDesc.__name__
     if pluginManager.isLoaded(name):
-        del pluginManager._nodePlugins[name]
+        del pluginManager._nodeProviders[name]
 
 
 @contextmanager

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -56,7 +56,7 @@ def loadedPlugins(folder: str):
         pluginManager.removePlugin(plugin)
 
 @contextmanager
-def registeredUserPlugins(folder: str):
+def loadedUserPlugins(folder: str):
     plugins = loadPluginFolder(folder, userPlugin=True)
 
     yield

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 
 import meshroom
 from meshroom.core import desc, pluginManager, loadPluginFolder
-from meshroom.core.plugins import NodeProvider
+from meshroom.core.plugins.manager import NodeProvider
 
 import os
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -47,7 +47,7 @@ def unregisterNodeDesc(nodeDesc: desc.Node):
 
 
 @contextmanager
-def registeredPlugins(folder: str):
+def loadedPlugins(folder: str):
     plugins = loadPluginFolder(folder)
 
     yield

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -13,13 +13,13 @@ def registeredNodeTypes(nodeTypes: list[desc.Node]):
     nodePluginsList = {}
     for nodeType in nodeTypes:
         nodePlugin = NodePlugin(nodeType)
-        pluginManager.registerNode(nodePlugin)
+        pluginManager.loadNodeProvider(nodePlugin)
         nodePluginsList[nodeType] = nodePlugin
 
     yield
 
     for nodeType in nodeTypes:
-        pluginManager.unregisterNode(nodePluginsList[nodeType])
+        pluginManager.unloadNodeProvider(nodePluginsList[nodeType])
 
 
 @contextmanager

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -36,13 +36,13 @@ def overrideNodeTypeVersion(nodeType: desc.Node, version: str):
 
 def registerNodeDesc(nodeDesc: desc.Node):
     name = nodeDesc.__name__
-    if not pluginManager.isRegistered(name):
+    if not pluginManager.isLoaded(name):
         pluginManager._nodePlugins[name] = NodePlugin(nodeDesc)
 
 
 def unregisterNodeDesc(nodeDesc: desc.Node):
     name = nodeDesc.__name__
-    if pluginManager.isRegistered(name):
+    if pluginManager.isLoaded(name):
         del pluginManager._nodePlugins[name]
 
 


### PR DESCRIPTION
## Description

Splits the monolithic `meshroom/core/plugins.py` into a dedicated `meshroom/core/plugins/` package and renames the plugin/node terminology throughout the core and tests for clarity. A **Plugin** is now cleanly distinguished from the  **NodeProvider** and the **PluginManager**.


## Features list

- [x] Rename `NodePluginManager` → `PluginManager`
- [x] Rename `NodePluginStatus` → `NodeProviderStatus`
- [x] Rename method `isRegistered()` → `isLoaded()`
- [x] Rename methods `registerNode`/`unregisterNode` → `loadNodeProvider`/`unloadNodeProvider`
- [x] Rename methods `getRegisteredNodePlugin(s)` → `getLoadedNodeProvider(s)`
- [x] Rename `containsNodePlugin` → `containsNodeProvider`
- [x] Rename `removeNodePlugin` → `removeNodeProvider`
- [x] Rename `addNodePlugin` → `addNodeProvider`
- [x] Rename `NodePlugin` → `NodeProvider`
- [x] Rename params `registerNodeProviders`/`unregisterNodeProviders` → `loadNodeProviders`/`unloadNodeProviders`
- [x] Rename (tests/utils) `registeredPlugins` → `loadedPlugins`
- [x] Rename (tests/utils) `registeredUserPlugins` → `loadedUserPlugins`
- [x] Rename (tests) `registeredNodes` → `loadedNodeProviders`
- [x] Rename desc.Node member `plugin` → `provider`
- [x] Package split `meshroom/core/plugins.py` → `meshroom/core/plugins/`:
  - `env.py` — `ProcessEnv` and related process-environment handling
  - `manager.py` — `PluginManager`, node-provider loading/validation