### PR TITLE
Graph Input/Output nodes and API

### DIFF
--- a/NODE_DEVELOPMENT.md
+++ b/NODE_DEVELOPMENT.md
@@ -132,6 +132,7 @@ Meshroom provides several attribute types you can use in a node’s `inputs` and
 |------|-------------|----------|
 | `ListAttribute` | Homogeneous list of elements defined by `elementDesc`. | `elementDesc`, `joinChar` |
 | `GroupAttribute` | Fixed collection of heterogeneous child attributes (`items`). | `items`, `joinChar` |
+| `AnySet` | Flexible, container for any mixed set of child attributes. | N/A (Uses `GroupAttribute`) |
 
 Both inherit from `Attribute` and support nesting (lists of groups, groups with lists).
 

--- a/bin/meshroom_batch
+++ b/bin/meshroom_batch
@@ -4,6 +4,7 @@ import json
 import logging
 import os
 import re
+from collections import defaultdict
 
 import meshroom.core.graph
 from meshroom.common import strtobool
@@ -68,6 +69,14 @@ general_group.add_argument(
     help='Input files and folders to process. '
          'When multiple Init Nodes exist in the pipeline, inputs are applied to all by default. '
          'To target a specific Init Node, use the format Node1=input1,input2 Node2=input3')
+
+general_group.add_argument(
+    '-gi', '--graphInput', 
+    metavar='ATTRIBUTE=VALUE', 
+    nargs='+',
+    type=lambda item: item.split('=', 1),
+    help='Override graph input parameters. '
+         'When the graph has a GraphInput nodes, it will set the inputs parameters.')
 
 general_group.add_argument(
     '-I', '--inputRecursive',
@@ -231,6 +240,21 @@ with meshroom.core.graph.GraphModification(graph):
             # Retrieve recursive inputs
             inputRec = mapInputRecursive.get(nodeName, []) + mapInputRecursive.get("", [])
             inputNode.nodeDesc.initialize(inputNode, input, inputRec)
+
+    if args.graphInput:
+        # Fetch all parameters
+        inputNodes = graph.findGraphInputNodes()
+        inputParamsNames: dict[str: list["BaseNode"]] = defaultdict(list)
+        for n in inputNodes:
+            params = n.nodeDesc.getParams(n)
+            for p in n.nodeDesc.getParams(n):
+                inputParamsNames[p].append(n)
+        # Fill parameters
+        for attrName, attrValue in args.graphInput:
+            if attrName not in inputParamsNames:
+                raise KeyError(f"No attribute {attrName} on GraphInput nodes of the scene.")
+            for node in inputParamsNames[attrName]:
+                node.nodeDesc.setInputAttribute(node, attrName, attrValue)
 
     if not graph.canComputeLeaves:
         raise RuntimeError("Graph cannot be computed. Check for compatibility issues.")

--- a/bin/meshroom_batch
+++ b/bin/meshroom_batch
@@ -9,7 +9,7 @@ import meshroom.core.graph
 from meshroom.common import strtobool
 from meshroom import setupEnvironment, logStringToPython
 
-def parseInitInputs(inputs: list[str]) -> dict[str, str]:
+def parseInitInputs(inputs: list[str]) -> dict[str, list[str]]:
     """Utility method for parsing the input and inputRecursive arguments.
     Args:
         inputs: Command line values in format 'nodeName=value' or just 'value' to set it on all init nodes
@@ -88,12 +88,13 @@ general_group.add_argument(
 
 general_group.add_argument(
     '-o', '--output', 
-    metavar='FOLDER COPYFILES_INSTANCE=FOLDER',
+    metavar='FOLDER OUTPUT_NODE_INSTANCE=FOLDER OUTPUT_NODE_INSTANCE.ATTRIBUTE=VALUE',
     type=str,
     required=False,
     nargs='*',
-    help='Output folder for copying results. '
-         'Sets output folder for all CopyFiles nodes, or target specific nodes using COPYFILES_INSTANCE=FOLDER.')
+    help='Output folder for results. '
+         'Sets output folder for all output nodes, target specific nodes using OUTPUT_NODE_INSTANCE=FOLDER, '
+         'or target exposed output attributes using OUTPUT_NODE_INSTANCE.ATTRIBUTE=VALUE.')
 
 general_group.add_argument(
     '-s', '--save', metavar='FILE', type=str, required=False,
@@ -183,10 +184,10 @@ with meshroom.core.graph.GraphModification(graph):
     loweredPipelineTemplates = {k.lower(): v for k, v in meshroom.core.pipelineTemplates.items()}
     if args.pipeline.lower() in loweredPipelineTemplates:
         graph.initFromTemplate(loweredPipelineTemplates[args.pipeline.lower()],
-                               copyOutputs=True if args.output else False)
+                               True if args.output else False)
     else:
         # custom pipeline
-        graph.initFromTemplate(args.pipeline, copyOutputs=True if args.output else False)
+        graph.initFromTemplate(args.pipeline, True if args.output else False)
 
     if args.overrideCacheDir is not None:
         # If the graph is not saved yet we need to save it because the
@@ -238,46 +239,24 @@ with meshroom.core.graph.GraphModification(graph):
         graph.setVerbose(args.verbose)
 
     if args.output:
-        # The output folders for CopyFiles nodes can be set as follows:
+        # The output folders for output nodes can be set as follows:
         # - for each node, the output folder is specified following the
-        #   "CopyFiles_name=/output/folder/path" convention.
-        # - a path is provided without specifying which CopyFiles node should be set with it:
-        #   all the CopyFiles nodes will be set with it.
-        # - some CopyFiles nodes have their path specified, and another path is provided
-        #   without specifying a node: all CopyFiles nodes with dedicated will have their own
+        #   "OutputNode_name=/output/folder/path" convention.
+        # - for each exposed output attribute, the value is specified following the
+        #   "OutputNode_name.attribute=value" convention.
+        # - a path is provided without specifying which output node should be set with it:
+        #   all the output nodes will be set with it.
+        # - some output nodes have their path specified, and another path is provided
+        #   without specifying a node: all output nodes with dedicated will have their own
         #   output folders set, and those which have not been specified will be set with the
         #   other path.
-        # - some CopyFiles nodes have their output folder specified while others do not: all
+        # - some output nodes have their output folder specified while others do not: all
         #   the nodes with specified folders will use the provided values, and those without
-        #   any will be set with the output folder of the first specified CopyFiles node.
+        #   any will be set with the output folder of the first specified output node.
         # - several output folders are provided without specifying any node: the last one will
-        #   be used to set all the CopyFiles nodes' output folders.
+        #   be used to set all the output nodes' output folders.
 
-        # Check that there is at least one CopyFiles node
-        copyNodes = graph.nodesOfType('CopyFiles')
-        if len(copyNodes) == 0:
-            raise RuntimeError('meshroom_batch requires a pipeline graph with at least ' +
-                               'one CopyFiles node, none found.')
-
-        reExtract = re.compile(r'(\w+)=(.*)')  # NodeName=value
-        globalCopyPath = ''
-        for p in args.output:
-            result = reExtract.match(p)
-            if not result:  # If the argument is only a path, set it for the global path
-                globalCopyPath = p
-                continue
-
-            node, value = result.groups()
-            for i, n in enumerate(copyNodes):  # Find the correct CopyFiles node in the list
-                if n.name == node:  # If found, set the value, and remove it from the list
-                    n.output.value = value
-                    copyNodes.pop(i)
-                    if globalCopyPath == '':  # Fallback in case some nodes would have no path
-                        globalCopyPath = value
-                    break
-
-        for n in copyNodes:  # Set the remaining CopyPath nodes with the global path
-            n.output.value = globalCopyPath
+        graph.configureOutputNodes(args.output)
     elif args.submit or args.compute:
         print(f'No output set, results will be available in the cache folder: "{graph.cacheDir}"')
 

--- a/bin/meshroom_batch
+++ b/bin/meshroom_batch
@@ -100,10 +100,17 @@ general_group.add_argument(
     metavar='FOLDER OUTPUT_NODE_INSTANCE=FOLDER OUTPUT_NODE_INSTANCE.ATTRIBUTE=VALUE',
     type=str,
     required=False,
+    default=[],
     nargs='*',
     help='Output folder for results. '
          'Sets output folder for all output nodes, target specific nodes using OUTPUT_NODE_INSTANCE=FOLDER, '
          'or target exposed output attributes using OUTPUT_NODE_INSTANCE.ATTRIBUTE=VALUE.')
+
+general_group.add_argument(
+    '-go', '--graphOutput', 
+    metavar='FOLDER', 
+    type=str,
+    help='Set the GraphOutput folder. ')
 
 general_group.add_argument(
     '-s', '--save', metavar='FILE', type=str, required=False,
@@ -189,14 +196,15 @@ meshroom.core.initNodes()
 graph = meshroom.core.graph.Graph(name=args.pipeline)
 
 with meshroom.core.graph.GraphModification(graph):
+    hasOutput = args.output or args.graphOutput
     # initialize template pipeline
     loweredPipelineTemplates = {k.lower(): v for k, v in meshroom.core.pipelineTemplates.items()}
     if args.pipeline.lower() in loweredPipelineTemplates:
         graph.initFromTemplate(loweredPipelineTemplates[args.pipeline.lower()],
-                               True if args.output else False)
+                               True if hasOutput else False)
     else:
         # custom pipeline
-        graph.initFromTemplate(args.pipeline, True if args.output else False)
+        graph.initFromTemplate(args.pipeline, True if hasOutput else False)
 
     if args.overrideCacheDir is not None:
         # If the graph is not saved yet we need to save it because the
@@ -246,7 +254,6 @@ with meshroom.core.graph.GraphModification(graph):
         inputNodes = graph.findGraphInputNodes()
         inputParamsNames: dict[str: list["BaseNode"]] = defaultdict(list)
         for n in inputNodes:
-            params = n.nodeDesc.getParams(n)
             for p in n.nodeDesc.getParams(n):
                 inputParamsNames[p].append(n)
         # Fill parameters
@@ -262,7 +269,7 @@ with meshroom.core.graph.GraphModification(graph):
     if args.verbose:
         graph.setVerbose(args.verbose)
 
-    if args.output:
+    if hasOutput:
         # The output folders for output nodes can be set as follows:
         # - for each node, the output folder is specified following the
         #   "OutputNode_name=/output/folder/path" convention.
@@ -279,6 +286,11 @@ with meshroom.core.graph.GraphModification(graph):
         #   any will be set with the output folder of the first specified output node.
         # - several output folders are provided without specifying any node: the last one will
         #   be used to set all the output nodes' output folders.
+        
+        if args.graphOutput:
+            outputNodes = graph.findGraphOutputNodes()
+            for o in outputNodes:
+                args.output.append(f"{o.name}={args.graphOutput}")
 
         graph.configureOutputNodes(args.output)
     elif args.submit or args.compute:

--- a/bin/meshroom_batch
+++ b/bin/meshroom_batch
@@ -4,7 +4,6 @@ import json
 import logging
 import os
 import re
-from collections import defaultdict
 
 import meshroom.core.graph
 from meshroom.common import strtobool
@@ -250,12 +249,9 @@ with meshroom.core.graph.GraphModification(graph):
             inputNode.nodeDesc.initialize(inputNode, input, inputRec)
 
     if args.graphInput:
-        # Fetch all parameters
-        inputNodes = graph.findGraphInputNodes()
-        inputParamsNames: dict[str: list["BaseNode"]] = defaultdict(list)
-        for n in inputNodes:
-            for p in n.nodeDesc.getParams(n):
-                inputParamsNames[p].append(n)
+        # Fetch input attributes
+        inputParamsNames: dict[str, list["BaseNode"]] = graph.findGraphInputAttributes()
+        print("inputParamsNames",inputParamsNames)
         # Fill parameters
         for attrName, attrValue in args.graphInput:
             if attrName not in inputParamsNames:

--- a/meshroom/core/desc/__init__.py
+++ b/meshroom/core/desc/__init__.py
@@ -49,4 +49,5 @@ from .node import (
     Node,
     NodeVersionType,
     NodeVersionTypeEnum,
+    OutputNode,
 )

--- a/meshroom/core/desc/__init__.py
+++ b/meshroom/core/desc/__init__.py
@@ -45,6 +45,7 @@ from .node import (
     InputNode,
     InitNode,
     InternalAttributesFactory,
+    IONode,
     MrNodeType,
     Node,
     NodeVersionType,

--- a/meshroom/core/desc/node.py
+++ b/meshroom/core/desc/node.py
@@ -10,6 +10,7 @@ import sys
 import signal
 import subprocess
 from collections import OrderedDict
+from typing import Any, ClassVar, Mapping, Optional, Sequence, TYPE_CHECKING
 import psutil
 
 from meshroom import _MESHROOM_ROOT
@@ -19,7 +20,11 @@ from meshroom.core.desc.anySet import AnySet
 from meshroom.core.utils import VERBOSE_LEVEL
 
 from .computation import Level, StaticNodeSize
-from .attribute import Attribute, ChoiceParam, ColorParam, Flow, IntParam, StringParam, ListAttribute
+from .attribute import Attribute, ChoiceParam, ColorParam, File, Flow, IntParam, StringParam, ListAttribute
+
+if TYPE_CHECKING:
+    from meshroom.core.attribute import Attribute as CoreAttribute
+    from meshroom.core.node import Node as CoreNode
 
 _MESHROOM_COMPUTE = (Path(_MESHROOM_ROOT) / "bin" / "meshroom_compute").as_posix()
 _MESHROOM_COMPUTE_DEPS = ["psutil"]
@@ -656,23 +661,11 @@ class AVCommandLineNode(CommandLineNode):
         return commandLineString + AVCommandLineNode.cmdMem + AVCommandLineNode.cmdCore
 
 
-class InputNode(object):
+class IONode(object):
     def __init__(self):
-        super(InputNode, self).__init__()
+        super(IONode, self).__init__()
 
-    def initialize(self, node, inputs, recursiveInputs):
-        """
-        Initialize the attributes that are needed for a node to start running.
-
-        Args:
-            node (Node): the node whose attributes must be initialized
-            inputs (list): the user-provided list of input files/directories
-            recursiveInputs (list): the user-provided list of input directories to search
-                                    recursively for images
-        """
-        pass
-
-    def resetAttributes(self, node, attributeNames):
+    def resetAttributes(self, node: "CoreNode", attributeNames: Sequence[str]) -> None:
         """
         Reset the values of the provided attributes for a node.
 
@@ -684,7 +677,7 @@ class InputNode(object):
             if node.hasAttribute(attrName):
                 node.attribute(attrName).resetToDefaultValue()
 
-    def extendAttributes(self, node, attributesDict):
+    def extendAttributes(self, node: "CoreNode", attributesDict: Mapping[str, Any]) -> None:
         """
         Extend the values of the provided attributes for a node.
 
@@ -697,7 +690,7 @@ class InputNode(object):
             if node.hasAttribute(attr):
                 node.attribute(attr).extend(attributesDict[attr])
 
-    def setAttributes(self, node, attributesDict):
+    def setAttributes(self, node: "CoreNode", attributesDict: Mapping[str, Any]) -> None:
         """
         Set the values of the provided attributes for a node.
 
@@ -709,3 +702,84 @@ class InputNode(object):
         for attr in attributesDict:
             if node.hasAttribute(attr):
                 node.attribute(attr).value = attributesDict[attr]
+
+
+class InputNode(IONode):
+    def __init__(self):
+        super(InputNode, self).__init__()
+
+    def initialize(self, node: "CoreNode", inputs: Sequence[str], recursiveInputs: Sequence[str]) -> None:
+        """
+        Initialize the attributes that are needed for a node to start running.
+
+        Args:
+            node (Node): the node whose attributes must be initialized
+            inputs (list): the user-provided list of input files/directories
+            recursiveInputs (list): the user-provided list of input directories to search
+                                    recursively for images
+        """
+        pass
+
+
+class OutputNode(IONode):
+    outputAttributes: ClassVar[Optional[Sequence[str]]] = None
+    outputAttribute: ClassVar[str] = "output"
+
+    def __init__(self):
+        super(OutputNode, self).__init__()
+
+    def getOutputAttributes(self, node: "CoreNode") -> list["CoreAttribute"]:
+        """
+        Return the attributes explicitly exposed by this output node.
+
+        If "outputAttributes" is not set, "outputAttribute" is used as a
+        backward-compatible fallback.
+        """
+        if self.outputAttributes is None:
+            attributeNames: Sequence[str] = [self.outputAttribute] if self.outputAttribute else []
+            return [node.attribute(attrName) for attrName in attributeNames if node.hasAttribute(attrName)]
+        else:
+            attributeNames = self.outputAttributes
+
+        attributes: list["CoreAttribute"] = []
+        for attrName in attributeNames:
+            if not node.hasAttribute(attrName):
+                raise AttributeError(f"'{node.name}.{attrName}' is not an output node attribute.")
+            attributes.append(node.attribute(attrName))
+        return attributes
+
+    def getOutputFolderAttributes(self, node: "CoreNode") -> list["CoreAttribute"]:
+        """
+        Return the exposed File attributes managed as output folders.
+        """
+        return [attr for attr in self.getOutputAttributes(node) if isinstance(attr.desc, File)]
+
+    def setOutputAttribute(self, node: "CoreNode", attributeName: str, value: Any) -> "CoreAttribute":
+        """
+        Set an explicitly exposed output attribute.
+
+        Args:
+            node (Node): the node whose exposed output attribute must be initialized
+            attributeName (str): the exposed output attribute name
+            value: the value to set on the exposed output attribute
+        """
+        for attr in self.getOutputAttributes(node):
+            if attr.name == attributeName:
+                self.setAttributes(node, {attributeName: value})
+                return attr
+        raise AttributeError(f"'{node.name}.{attributeName}' is not an exposed output attribute.")
+
+    def setOutputFolder(self, node: "CoreNode", outputFolder: str) -> None:
+        """
+        Initialize the exposed File output attributes of a node.
+
+        Args:
+            node (Node): the node whose output folder must be initialized
+            outputFolder (str): the output folder to set
+        """
+        outputFolderAttributes = self.getOutputFolderAttributes(node)
+        if not outputFolderAttributes:
+            raise AttributeError(f"'{node.name}' has no exposed File output attribute.")
+
+        for attr in outputFolderAttributes:
+            self.setAttributes(node, {attr.name: outputFolder})

--- a/meshroom/core/graph.py
+++ b/meshroom/core/graph.py
@@ -989,7 +989,7 @@ class Graph(BaseObject):
             raise RuntimeError('meshroom_batch requires a pipeline graph with at least ' +
                                'one output node, none found.')
 
-        reExtract = re.compile(r'(\w+)(?:\.(\w+))?=(.*)')  # NodeName=value or NodeName.attribute=value
+        reExtract = re.compile(r'(\w+)(?:[:.](\w[\w.]*))?=(.*)')  # NodeName=value or NodeName.attribute=value
         globalOutputPath: Optional[str] = None
         remainingOutputNodes = list(outputNodes)
         for outputValue in outputValues:

--- a/meshroom/core/graph.py
+++ b/meshroom/core/graph.py
@@ -967,6 +967,14 @@ class Graph(BaseObject):
         nodes = [n for n in self._nodes.values() if isinstance(n.nodeDesc, meshroom.core.desc.InputNode)]
         return nodes
 
+    def findGraphInputNodes(self):
+        """
+        Returns:
+            list[Node]: the list of Input nodes of type GraphInput
+        """
+        nodes = [n for n in self.findInputNodes() if n.nodeType == "GraphInput"]
+        return nodes
+
     def findOutputNodes(self) -> list[Node]:
         """
         Returns:
@@ -974,6 +982,14 @@ class Graph(BaseObject):
         """
         nodes = [n for n in self._nodes.values() if isinstance(n.nodeDesc, meshroom.core.desc.OutputNode)]
         return self.sortNodesByIndex(nodes)
+
+    def findGraphOutputNodes(self):
+        """
+        Returns:
+            list[Node]: the list of Input nodes of type GraphOutput
+        """
+        nodes = [n for n in self.findOutputNodes() if n.nodeType == "GraphOutput"]
+        return nodes
 
     def configureOutputNodes(self, outputValues: list[str]) -> None:
         """

--- a/meshroom/core/graph.py
+++ b/meshroom/core/graph.py
@@ -975,6 +975,55 @@ class Graph(BaseObject):
         nodes = [n for n in self._nodes.values() if isinstance(n.nodeDesc, meshroom.core.desc.OutputNode)]
         return self.sortNodesByIndex(nodes)
 
+    def configureOutputNodes(self, outputValues: list[str]) -> None:
+        """
+        Configure output nodes from command line output values.
+
+        Supported formats:
+            - "path": set the output folder on all output nodes.
+            - "OutputNodeName=path": set the output folder on one output node.
+            - "OutputNodeName.attribute=value": set one exposed output attribute.
+        """
+        outputNodes = self.findOutputNodes()
+        if len(outputNodes) == 0:
+            raise RuntimeError('meshroom_batch requires a pipeline graph with at least ' +
+                               'one output node, none found.')
+
+        reExtract = re.compile(r'(\w+)(?:\.(\w+))?=(.*)')  # NodeName=value or NodeName.attribute=value
+        globalOutputPath: Optional[str] = None
+        remainingOutputNodes = list(outputNodes)
+        for outputValue in outputValues:
+            result = reExtract.match(outputValue)
+            if not result:  # If the argument is only a path, set it for the global path
+                globalOutputPath = outputValue
+                continue
+
+            nodeName, attributeName, value = result.groups()
+            outputNode = next((n for n in outputNodes if n.name == nodeName), None)
+            if outputNode is None:
+                raise RuntimeError(f'Unknown output node "{nodeName}".')
+
+            outputFolderSet = False
+            if attributeName:
+                attribute = outputNode.nodeDesc.setOutputAttribute(outputNode, attributeName, value)
+                outputFolderSet = attribute in outputNode.nodeDesc.getOutputFolderAttributes(outputNode)
+                if outputFolderSet and outputNode in remainingOutputNodes:
+                    remainingOutputNodes.remove(outputNode)
+            else:
+                outputNode.nodeDesc.setOutputFolder(outputNode, value)
+                outputFolderSet = True
+                if outputNode in remainingOutputNodes:
+                    remainingOutputNodes.remove(outputNode)
+
+            if outputFolderSet and globalOutputPath is None:  # Fallback in case some nodes would have no path
+                globalOutputPath = value
+
+        if globalOutputPath is None:
+            return
+
+        for node in remainingOutputNodes:  # Set the remaining output nodes with the global path
+            node.nodeDesc.setOutputFolder(node, globalOutputPath)
+
     def findNodeCandidates(self, nodeNameExpr: str) -> list[Node]:
         pattern = re.compile(nodeNameExpr)
         return [v for k, v in self._nodes.objects.items() if pattern.match(k)]

--- a/meshroom/core/graph.py
+++ b/meshroom/core/graph.py
@@ -975,6 +975,17 @@ class Graph(BaseObject):
         nodes = [n for n in self.findInputNodes() if n.nodeType == "GraphInput"]
         return nodes
 
+    def findGraphInputAttributes(self):
+        """
+        Returns:
+            dict[str, list[Node]]: the mapping of attribute names to GraphInput nodes exposing them
+        """
+        inputParamsNames: dict[str, list["BaseNode"]] = defaultdict(list)
+        for n in self.findGraphInputNodes():
+            for p in n.nodeDesc.getParams(n):
+                inputParamsNames[p].append(n)
+        return inputParamsNames
+
     def findOutputNodes(self) -> list[Node]:
         """
         Returns:

--- a/meshroom/core/graph.py
+++ b/meshroom/core/graph.py
@@ -970,7 +970,7 @@ class Graph(BaseObject):
     def findGraphInputNodes(self):
         """
         Returns:
-            list[Node]: the list of Input nodes of type GraphInput
+            list[Node]: the list of InputNode nodes of type GraphInput
         """
         nodes = [n for n in self.findInputNodes() if n.nodeType == "GraphInput"]
         return nodes
@@ -986,7 +986,7 @@ class Graph(BaseObject):
     def findGraphOutputNodes(self):
         """
         Returns:
-            list[Node]: the list of Input nodes of type GraphOutput
+            list[Node]: the list of OutputNode nodes of type GraphOutput
         """
         nodes = [n for n in self.findOutputNodes() if n.nodeType == "GraphOutput"]
         return nodes

--- a/meshroom/core/graph.py
+++ b/meshroom/core/graph.py
@@ -14,6 +14,7 @@ from enum import Enum
 import meshroom
 import meshroom.core
 from meshroom.common import BaseObject, DictModel, Slot, Signal, Property
+from meshroom.common import deprecated
 from meshroom.core import Version
 from meshroom.core import submitters
 from meshroom.core.attribute import Attribute, AnySet, ListAttribute, GroupAttribute
@@ -270,7 +271,11 @@ class Graph(BaseObject):
         self._deserialize(Graph._loadGraphData(filepath))
         self._fileDateVersion = os.path.getmtime(filepath)
 
-    def initFromTemplate(self, filepath: PathLike, copyOutputs: bool = False):
+    @deprecated.depreciateParam(
+        "copyOutputs",
+        "Graph.initFromTemplate 'copyOutputs' parameter is deprecated. Please use 'keepOutputNodes' instead."
+    )
+    def initFromTemplate(self, filepath: PathLike, keepOutputNodes: bool = False, copyOutputs: Optional[bool] = None):
         """
         Deserialize a template Meshroom Graph ".mg" file in place.
 
@@ -279,8 +284,12 @@ class Graph(BaseObject):
 
         Args:
             filepath: The path to the Meshroom Graph file to load.
-            copyOutputs: (optional) Whether to keep 'CopyFiles' nodes.
+            keepOutputNodes: (optional) Whether to keep OutputNode nodes.
+            copyOutputs: Deprecated alias for keepOutputNodes.
         """
+        if copyOutputs is not None:
+            keepOutputNodes = copyOutputs
+
         self._deserialize(Graph._loadGraphData(filepath))
 
         # Creating nodes from a template is conceptually similar to explicit node creation,
@@ -288,9 +297,9 @@ class Graph(BaseObject):
         # node instance created by this process.
         self._triggerNodeCreatedCallback(self.nodes)
 
-        if not copyOutputs:
+        if not keepOutputNodes:
             with GraphModification(self):
-                for node in [node for node in self.nodes if node.nodeType == "CopyFiles"]:
+                for node in self.findOutputNodes():
                     self.removeNode(node.name)
 
     @staticmethod
@@ -957,6 +966,14 @@ class Graph(BaseObject):
         """
         nodes = [n for n in self._nodes.values() if isinstance(n.nodeDesc, meshroom.core.desc.InputNode)]
         return nodes
+
+    def findOutputNodes(self) -> list[Node]:
+        """
+        Returns:
+            list[Node]: the list of Output nodes (nodes inheriting from OutputNode)
+        """
+        nodes = [n for n in self._nodes.values() if isinstance(n.nodeDesc, meshroom.core.desc.OutputNode)]
+        return self.sortNodesByIndex(nodes)
 
     def findNodeCandidates(self, nodeNameExpr: str) -> list[Node]:
         pattern = re.compile(nodeNameExpr)

--- a/meshroom/core/graphIO.py
+++ b/meshroom/core/graphIO.py
@@ -148,6 +148,9 @@ class TemplateGraphSerializer(GraphSerializer):
 
         for attrName in inputKeys:
             attribute = node.attribute(attrName)
+            if isinstance(attribute, AnySet):
+                nodeData["inputs"][attrName] = self._serializeAnySetAttribute(node.attribute(attrName))
+                continue
             # check that attribute is not a link for choice attributes
             if attribute.isDefault and not attribute.isLink:
                 del nodeData["inputs"][attrName]
@@ -167,6 +170,24 @@ class TemplateGraphSerializer(GraphSerializer):
         nodeData.pop("parallelization", None)
 
         return nodeData
+
+    def _serializeAnySetAttribute(self, attribute: Attribute) -> Any:
+        """ Serialize AnySet attributes
+        """
+        serializedChildren = []
+        for child in attribute.value:
+            childData = child.asDict()
+            childLinkAttr = child.inputLink
+
+            # Remove connection if the sourceNode is not in the partialgraph nodes
+            if childLinkAttr and childLinkAttr.node not in self.nodes:
+                childData['value'] = child.getDefaultValue()
+            serializedChildren.append(childData)
+
+        return {
+            "expanded": attribute.expanded,
+            "children": serializedChildren
+        }
 
 
 class PartialGraphSerializer(GraphSerializer):

--- a/meshroom/core/node.py
+++ b/meshroom/core/node.py
@@ -2044,6 +2044,9 @@ class BaseNode(BaseObject):
     def _isInputNode(self):
         return isinstance(self.nodeDesc, desc.InputNode)
 
+    def _isIONode(self) -> bool:
+        return isinstance(self.nodeDesc, desc.IONode)
+
     def _isBackdropNode(self) -> bool:
         return False
 
@@ -2364,6 +2367,7 @@ class BaseNode(BaseObject):
     isCompatibilityNode = Property(bool, lambda self: self._isCompatibilityNode(), constant=True)
     isInitNode = Property(bool, lambda self: self._isInitNode(), constant=True)
     isInputNode = Property(bool, lambda self: self._isInputNode(), constant=True)
+    isIONode = Property(bool, lambda self: self._isIONode(), constant=True)
     isBackdropNode = Property(bool, lambda self: self._isBackdropNode(), constant=True)
 
     globalExecMode = Property(str, globalExecMode.fget, notify=globalStatusChanged)

--- a/meshroom/nodes/general/CopyFiles.py
+++ b/meshroom/nodes/general/CopyFiles.py
@@ -6,10 +6,12 @@ from meshroom.core.utils import VERBOSE_LEVEL
 import shutil
 import glob
 import os
+from typing import ClassVar
 
 
-class CopyFiles(desc.Node):
+class CopyFiles(desc.Node, desc.OutputNode):
     size = desc.DynamicNodeSize("inputFiles")
+    outputAttributes: ClassVar[list[str]] = ["output"]
 
     category = "Export"
     documentation = """

--- a/meshroom/nodes/general/GraphInput.py
+++ b/meshroom/nodes/general/GraphInput.py
@@ -18,10 +18,12 @@ class GraphInput(desc.InputNode, desc.InitNode):
 
     def getParams(self, node):
         serializedAnySet = node.inputs.getSerializedValue()
-        serializedChildren = serializedAnySet.get("children")
+        serializedChildren = serializedAnySet.get("children") or []
         parameters = [p["name"] for p in serializedChildren]
         return parameters
 
     def setInputAttribute(self, node, attrName, attrValue):
         attr = node.getAnyAttribute(f"inputs.{attrName}")
+        if not attr:
+            raise KeyError(f"No GraphInput attribute named {attrName}")
         attr._setValue(attrValue)

--- a/meshroom/nodes/general/GraphInput.py
+++ b/meshroom/nodes/general/GraphInput.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+
+__version__ = "1.0"
+
+from meshroom.core import desc
+
+
+ATTR_TYPES = ["String", "File", "Int", "Float", "Bool"]
+
+
+class GraphInput(desc.InputNode, desc.InitNode):
+    inputs = [
+        desc.AnySet(
+            name="inputs",
+            exposed=True
+        )
+    ]
+
+    def getParams(self, node):
+        serializedAnySet = node.inputs.getSerializedValue()
+        serializedChildren = serializedAnySet.get("children")
+        parameters = [p["name"] for p in serializedChildren]
+        return parameters
+
+    def setInputAttribute(self, node, attrName, attrValue):
+        attr = node.getAnyAttribute(f"inputs.{attrName}")
+        attr._setValue(attrValue)

--- a/meshroom/nodes/general/GraphOutput.py
+++ b/meshroom/nodes/general/GraphOutput.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+
+__version__ = "1.0"
+
+import os
+import json
+import logging
+from pprint import pformat 
+from meshroom.core import desc
+
+
+class GraphOutput(desc.Node, desc.OutputNode):
+    outputAttributes = ["outputFolder", "outputFile"]
+
+    inputs = [
+        desc.File(
+            name="outputFolder",
+            value="",
+        ),
+        desc.File(
+            name="outputFile",
+            value=None
+        ),
+        desc.AnySet(
+            name="outputs",
+            exposed=True
+        )
+    ]
+
+    def setOutputFolder(self, node, outputFolder):
+        node.outputFolder.value = outputFolder
+        node.outputFile.value = os.path.join(node.outputFolder.value, "outputs.json")
+
+    def process(self, node):
+        outputFolder = node.outputFolder.value
+        outputFile = node.outputFile.value
+
+        if not outputFolder:
+            return
+        if not os.path.exists(outputFolder):
+            logging.info(f"Create folder {outputFolder}")
+            os.makedirs(outputFolder)
+
+        serializedOutputs = {}
+        for item in node.outputs._getValue():
+            serializedOutputs[item.name] = item.value
+
+        logging.info(f"Graph outputs:\n{pformat(serializedOutputs, indent=2)}")
+        with open(outputFile, "w") as f:
+            json.dump(serializedOutputs, f, indent=4)
+
+        logging.info(f"Saved outputs inside {outputFile}")

--- a/meshroom/ui/app.py
+++ b/meshroom/ui/app.py
@@ -195,7 +195,7 @@ Additional Resources:
         type=str,
         required=False,
         nargs='*',
-        help='Set the output folder for the CopyFiles nodes.'
+        help='Set the output folder for the output nodes.'
     )
 
     # Pipeline Options
@@ -342,13 +342,14 @@ class MeshroomApp(QApplication):
                 self.addRecentProjectFile(project)
         elif getattr(args, "import", None) or args.importRecursive or args.save or args.pipeline:
             if args.output:
-                # Initialize the template and keep the "CopyFiles" nodes
-                self._activeProject.newWithCopyOutputs()
-                # Use the provided output paths to initialize the "CopyFiles" nodes
-                copyNodes = self._activeProject.graph.nodesOfType("CopyFiles")
-                if len(copyNodes) > 0:
-                    for index, node in enumerate(copyNodes):
-                        node.output.value = args.output[index] if index < len(args.output) else args.output[0]
+                # Initialize the template and keep the output nodes
+                self._activeProject.newWithOutputNodes()
+                # Use the provided output paths to initialize the output nodes
+                outputNodes = self._activeProject.graph.findOutputNodes()
+                if len(outputNodes) > 0:
+                    for index, node in enumerate(outputNodes):
+                        outputFolder = args.output[index] if index < len(args.output) else args.output[0]
+                        node.nodeDesc.setOutputFolder(node, outputFolder)
             else:
                 self._activeProject.new()
 

--- a/meshroom/ui/graph.py
+++ b/meshroom/ui/graph.py
@@ -25,6 +25,7 @@ from PySide6.QtCore import (
 )
 
 from meshroom.core import sessionUid
+from meshroom.common import deprecated
 from meshroom.common.qt import QObjectListModel
 from meshroom.core.attribute import Attribute, AnySet, ListAttribute, ShapeAttribute
 from meshroom.core.graph import Graph, Edge, generateTempProjectFilepath
@@ -545,10 +546,17 @@ class UIGraph(QObject):
 
     @Slot(str)
     @Slot(str, bool)
-    def initFromTemplate(self, filepath, copyOutputs=False):
+    @deprecated.depreciateParam(
+        "copyOutputs",
+        "UIGraph.initFromTemplate 'copyOutputs' parameter is deprecated. Please use 'keepOutputNodes' instead."
+    )
+    def initFromTemplate(self, filepath: str, keepOutputNodes: bool = False, copyOutputs: Optional[bool] = None) -> None:
+        if copyOutputs is not None:
+            keepOutputNodes = copyOutputs
+
         graph = Graph("")
         if filepath:
-            graph.initFromTemplate(filepath, copyOutputs=copyOutputs)
+            graph.initFromTemplate(filepath, keepOutputNodes=keepOutputNodes)
         self.setGraph(graph)
 
     @Slot(QUrl, result="QVariantList")

--- a/meshroom/ui/qml/Application.qml
+++ b/meshroom/ui/qml/Application.qml
@@ -654,7 +654,7 @@ Page {
     Action {
         id: loadTemplateAction
 
-        property string tooltip: "Load a template like a regular project file (any \"CopyFiles\" node will be displayed)"
+        property string tooltip: "Load a template like a regular project file (any output node will be displayed)"
         text: "Load Template"
         onTriggered: {
             ensureSaved(function() {

--- a/meshroom/ui/qml/GraphEditor/Node.qml
+++ b/meshroom/ui/qml/GraphEditor/Node.qml
@@ -29,7 +29,15 @@ Item {
     /// Combined x and y
     property point position: Qt.point(x, y)
     /// Styling
-    readonly property color defaultColor: isCompatibilityNode ? activePalette.mid : !node.isComputableType ? "#BA3D69" : activePalette.base
+    readonly property color defaultColor: {
+        if (isCompatibilityNode)
+            return activePalette.mid
+        if (node.isIONode)
+            return Colors.blue
+        if (!node.isComputableType)
+            return "#BA3D69"
+        return activePalette.base
+    }
     property color baseColor: defaultColor
 
     /// Shake Relevance

--- a/meshroom/ui/qml/GraphEditor/Node.qml
+++ b/meshroom/ui/qml/GraphEditor/Node.qml
@@ -35,7 +35,7 @@ Item {
         if (node.isIONode)
             return Colors.blue
         if (!node.isComputableType)
-            return "#BA3D69"
+            return '#2f6352'
         return activePalette.base
     }
     property color baseColor: defaultColor

--- a/meshroom/ui/scene.py
+++ b/meshroom/ui/scene.py
@@ -5,7 +5,7 @@ import os
 from collections.abc import Iterable
 from multiprocessing.pool import ThreadPool
 from threading import Thread
-from typing import Callable
+from typing import Callable, Optional
 
 from PySide6.QtCore import QObject, Slot, Property, Signal, QUrl, QSizeF, QPoint
 from PySide6.QtGui import QMatrix4x4, QMatrix3x3, QQuaternion, QVector3D, QVector2D
@@ -477,17 +477,23 @@ class Scene(UIGraph):
         filepath = loweredPipelineTemplates.get(p.lower(), p)
         return self._loadWithErrorReport(self.initFromTemplate, filepath)
 
-    def _initFromTemplateWithCopyOutputs(self, filepath):
-        self.initFromTemplate(filepath, copyOutputs=True)
+    def _initFromTemplateWithOutputNodes(self, filepath: str) -> None:
+        self.initFromTemplate(filepath, keepOutputNodes=True)
 
     @Slot(result=bool)
     @Slot(str, result=bool)
-    def newWithCopyOutputs(self, pipeline=None):
-        """ Create a new pipeline with all the "CopyFiles" nodes included if the provided template has any. """
+    def newWithOutputNodes(self, pipeline: Optional[str] = None) -> bool:
+        """ Create a new pipeline with all the output nodes included if the provided template has any. """
         p = pipeline if pipeline is not None else self._defaultPipeline
         loweredPipelineTemplates = {k.lower(): v for k, v in meshroom.core.pipelineTemplates.items()}
         filepath = loweredPipelineTemplates.get(p.lower(), p)
-        return self._loadWithErrorReport(self._initFromTemplateWithCopyOutputs, filepath)
+        return self._loadWithErrorReport(self._initFromTemplateWithOutputNodes, filepath)
+
+    @Slot(result=bool)
+    @Slot(str, result=bool)
+    def newWithCopyOutputs(self, pipeline: Optional[str] = None) -> bool:
+        """ Deprecated alias for newWithOutputNodes. """
+        return self.newWithOutputNodes(pipeline)
 
 
     @Slot(str, result=bool)

--- a/tests/nodes/test/OutputNode.py
+++ b/tests/nodes/test/OutputNode.py
@@ -1,0 +1,41 @@
+from typing import ClassVar
+
+from meshroom.core import desc
+
+
+class OutputNodeTest(desc.Node, desc.OutputNode):
+    outputAttributes: ClassVar[list[str]] = ["folder", "outputFile", "exportLabel", "exportEnabled"]
+
+    inputs = [
+        desc.File(
+            name="folder",
+            label="Folder",
+            description="Output folder.",
+            value="/default/output",
+        ),
+        desc.File(
+            name="outputFile",
+            label="File",
+            description="Secondary output path.",
+            value="",
+        ),
+        desc.StringParam(
+            name="exportLabel",
+            label="Label",
+            description="Export label.",
+            value="default",
+        ),
+        desc.BoolParam(
+            name="exportEnabled",
+            label="Enabled",
+            description="Export enabled.",
+            value=True,
+        ),
+        desc.StringParam(
+            name="internalLabel",
+            label="Internal Label",
+            description="Internal label.",
+            value="internal",
+        ),
+    ]
+    outputs = []

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -270,6 +270,14 @@ class TestOutputNode:
         assert node.folder.value == "/anyFolder/export"
         assert node.outputFile.value == ""
 
+    def test_configureOutputNodes_accepts_colon_attribute_separator(self):
+        graph = Graph("")
+        node = graph.addNewNode("OutputNodeTest")
+
+        graph.configureOutputNodes([f"{node.name}:exportLabel=custom"])
+
+        assert node.exportLabel.value == "custom"
+
     def test_configureOutputNodes_sets_global_folder_and_targeted_attributes(self):
         graph = Graph("")
         node = graph.addNewNode("OutputNodeTest")

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -7,6 +7,8 @@ import json
 from pathlib import Path
 import tempfile
 
+import pytest
+
 from meshroom.core import desc, pluginManager, loadClassesNodes, initNodes
 from meshroom.core.node import Position, BaseNode
 from meshroom.core.graph import Graph, loadGraph
@@ -14,6 +16,7 @@ from meshroom.core.plugins import Plugin, ProcessEnv
 from meshroom.nodes.general.InputString import InputString
 from meshroom.nodes.general.GetMgSceneParams import GetMeshroomSceneParams
 
+from .nodes.test.OutputNode import OutputNodeTest
 from .utils import registerNodeDesc, unregisterNodeDesc, registeredNodeTypes
 
 
@@ -172,8 +175,162 @@ class TestInputNode:
         assert len(inputNodes) == 1 and node in inputNodes
         # Check that the InputNode's initialize method has been set
         inputs = ["/path/to/file", "/path/to/file/2"]
-        node.nodeDesc.initialize(node, inputs, None)
+        node.nodeDesc.initialize(node, inputs, [])
         assert node.input.value == inputs[0]
+
+
+class TestOutputNode:
+    loadedPlugins = pluginManager.getPlugins()
+
+    @classmethod
+    def setup_class(cls):
+        initNodes()
+        registerNodeDesc(OutputNodeTest)
+
+    @classmethod
+    def teardown_class(cls):
+        unregisterNodeDesc(OutputNodeTest)
+        for plugin in pluginManager.getPlugins():
+            if plugin not in cls.loadedPlugins:
+                for node in plugin.nodes.values():
+                    pluginManager.unregisterNode(node)
+                pluginManager.removePlugin(plugin)
+
+    def test_copyFiles_is_outputNode(self):
+        g = Graph("")
+
+        node = g.addNewNode("CopyFiles")
+
+        outputNodes = g.findOutputNodes()
+        assert len(outputNodes) == 1 and node in outputNodes
+
+    def test_outputNode_setOutputFolder_uses_configured_attribute(self):
+        g = Graph("")
+        node = g.addNewNode("OutputNodeTest")
+
+        node.nodeDesc.setOutputFolder(node, "/anyFolder/output")
+
+        assert node.folder.value == "/anyFolder/output"
+        assert node.outputFile.value == "/anyFolder/output"
+
+    def test_outputNode_exposes_configured_attributes(self):
+        g = Graph("")
+        node = g.addNewNode("OutputNodeTest")
+
+        outputAttributes = node.nodeDesc.getOutputAttributes(node)
+
+        assert [attr.name for attr in outputAttributes] == ["folder", "outputFile", "exportLabel", "exportEnabled"]
+        node.nodeDesc.setOutputAttribute(node, "exportLabel", "custom")
+        node.nodeDesc.setOutputAttribute(node, "exportEnabled", False)
+        assert node.exportLabel.value == "custom"
+        assert node.exportEnabled.value is False
+
+    def test_configureOutputNodes_sets_global_output_folder(self):
+        graph = Graph("")
+        firstNode = graph.addNewNode("OutputNodeTest")
+        secondNode = graph.addNewNode("OutputNodeTest")
+
+        graph.configureOutputNodes(["/output/results"])
+
+        assert firstNode.folder.value == "/output/results"
+        assert firstNode.outputFile.value == "/output/results"
+        assert secondNode.folder.value == "/output/results"
+        assert secondNode.outputFile.value == "/output/results"
+
+    def test_configureOutputNodes_sets_targeted_output_folder(self):
+        graph = Graph("")
+        node = graph.addNewNode("CopyFiles")
+
+        graph.configureOutputNodes([f"{node.name}=/output/copyfiles"])
+
+        assert node.output.value == "/output/copyfiles"
+
+    def test_configureOutputNodes_sets_multiple_targeted_output_folders(self):
+        graph = Graph("")
+        firstNode = graph.addNewNode("OutputNodeTest")
+        secondNode = graph.addNewNode("OutputNodeTest")
+
+        graph.configureOutputNodes([f"{firstNode.name}=/output/mesh", f"{secondNode.name}=/output/textures"])
+
+        assert firstNode.folder.value == "/output/mesh"
+        assert firstNode.outputFile.value == "/output/mesh"
+        assert secondNode.folder.value == "/output/textures"
+        assert secondNode.outputFile.value == "/output/textures"
+
+    def test_configureOutputNodes_sets_explicit_file_attribute(self):
+        graph = Graph("")
+        node = graph.addNewNode("OutputNodeTest")
+
+        graph.configureOutputNodes([f"{node.name}.folder=/anyFolder/export"])
+
+        assert node.folder.value == "/anyFolder/export"
+        assert node.outputFile.value == ""
+
+    def test_configureOutputNodes_sets_global_folder_and_targeted_attributes(self):
+        graph = Graph("")
+        node = graph.addNewNode("OutputNodeTest")
+
+        graph.configureOutputNodes(
+            ["/output/default", f"{node.name}.exportLabel=final", f"{node.name}.exportEnabled=false"]
+        )
+
+        assert node.folder.value == "/output/default"
+        assert node.outputFile.value == "/output/default"
+        assert node.exportLabel.value == "final"
+        assert node.exportEnabled.value is False
+
+    def test_configureOutputNodes_with_non_file_attribute_keeps_output_folder(self):
+        graph = Graph("")
+        node = graph.addNewNode("OutputNodeTest")
+
+        graph.configureOutputNodes([f"{node.name}.exportLabel=custom"])
+
+        assert node.exportLabel.value == "custom"
+        assert node.folder.value == "/default/output"
+        assert node.outputFile.value == ""
+
+    def test_outputNode_setOutputFolder_only_updates_exposed_file_attributes(self):
+        g = Graph("")
+        node = g.addNewNode("OutputNodeTest")
+
+        node.nodeDesc.setOutputFolder(node, "/anyFolder/output")
+
+        assert node.folder.value == "/anyFolder/output"
+        assert node.outputFile.value == "/anyFolder/output"
+        assert node.exportLabel.value == "default"
+
+    def test_outputNode_rejects_unexposed_attributes(self):
+        g = Graph("")
+        node = g.addNewNode("OutputNodeTest")
+
+        with pytest.raises(AttributeError):
+            node.nodeDesc.setOutputAttribute(node, "internalLabel", "custom")
+
+        assert node.internalLabel.value == "internal"
+
+    def test_initFromTemplate_removes_outputNodes_by_default(self):
+        graph = Graph("Template")
+        graph.addNewNode("OutputNodeTest")
+        graph.addNewNode("PathJoin")
+        graphFile = os.path.join(tempfile.mkdtemp(), "test_output_node_template.mg")
+        graph.save(graphFile, template=True)
+
+        loadedGraph = Graph("")
+        loadedGraph.initFromTemplate(graphFile)
+
+        assert loadedGraph.findOutputNodes() == []
+        assert len(loadedGraph.nodesOfType("PathJoin")) == 1
+
+    def test_initFromTemplate_can_keep_outputNodes(self):
+        graph = Graph("Template")
+        graph.addNewNode("OutputNodeTest")
+        graphFile = os.path.join(tempfile.mkdtemp(), "test_output_node_template.mg")
+        graph.save(graphFile, template=True)
+
+        loadedGraph = Graph("")
+        loadedGraph.initFromTemplate(graphFile, keepOutputNodes=True)
+
+        assert len(loadedGraph.findOutputNodes()) == 1
 
 
 class TestBackdropNode:

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -173,6 +173,8 @@ class TestInputNode:
         # Check that the InputNode is correctly detected
         inputNodes = g.findInputNodes()
         assert len(inputNodes) == 1 and node in inputNodes
+        assert isinstance(node.nodeDesc, desc.IONode)
+        assert node.isIONode
         # Check that the InputNode's initialize method has been set
         inputs = ["/path/to/file", "/path/to/file/2"]
         node.nodeDesc.initialize(node, inputs, [])
@@ -203,6 +205,8 @@ class TestOutputNode:
 
         outputNodes = g.findOutputNodes()
         assert len(outputNodes) == 1 and node in outputNodes
+        assert isinstance(node.nodeDesc, desc.IONode)
+        assert node.isIONode
 
     def test_outputNode_setOutputFolder_uses_configured_attribute(self):
         g = Graph("")


### PR DESCRIPTION
## Description

Add `GraphInput` and `GraphOutput` nodes.

The meshroom_batch API has been modified:

### Fetch the graph input attributes

```python
import meshroom
from meshroom.core.graph import Graph
meshroom.core.initNodes()

g = Graph()
g.load('scene.mg')
attributes = g.findGraphInputAttributes()
# attributes: defaultdict(<class 'list'>, {'myInt': [GraphInput_1], 'inFolder': [GraphInput_1]})
attributeNames = list(attributes.keys())
# attributeNames: ['myInt', 'inFolder']
```

### Set the graph input parameters

A new attribute `-gi/--graphInput` can be used to set a parameter in the inputs.
```bash
meshroom_batch -p scene.mg -gi ATTRNAME=VAL ATTRNAME2=VAL
```
If multiple `GraphInput` nodes have the parameter they will all be set to the given value.
This is similar to using `--paramOverrides GraphInput:ATTRNAME=VAL`.


### Set the graph output parameters

A new attribute `-go/--graphOutput` can be used to set a parameter in the outputs.
```bash
meshroom_batch -p scene.mg -go FOLDER
```

> [!NOTE]
> This is a simple redirection to `output`, this argument is just a way to avoid fetching the GraphOutput nodes names



