### PR TITLE
Improve performance on path manipulation nodes

### DIFF
--- a/meshroom/core/desc/__init__.py
+++ b/meshroom/core/desc/__init__.py
@@ -47,6 +47,7 @@ from .node import (
     InternalAttributesFactory,
     MrNodeType,
     Node,
+    InlineNode,
     NodeVersionType,
     NodeVersionTypeEnum,
 )

--- a/meshroom/core/desc/node.py
+++ b/meshroom/core/desc/node.py
@@ -57,6 +57,7 @@ class MrNodeType(enum.Enum):
     NONE = enum.auto()
     BASENODE = enum.auto()
     NODE = enum.auto()
+    INLINE = enum.auto()
     COMMANDLINE = enum.auto()
     INIT = enum.auto()
     BACKDROP = enum.auto()
@@ -527,9 +528,6 @@ class InitNode(BaseNode):
     def __init__(self):
         super(InitNode, self).__init__()
 
-    def getMrNodeType(self):
-        return self._mrNodeType
-
     def processChunk(self, chunk):
         pass
 
@@ -584,6 +582,17 @@ class Node(BaseNode):
         cmdSuffix = chunk.node.nodeDesc.plugin.commandSuffix
         self.executeChunkCommandLine(chunk, cmdPrefix + meshroomComputeCmd + cmdSuffix,
                                      env=runtimeEnv)
+
+
+class InlineNode(BaseNode):
+    """
+    Node that can be computed in the current Meshroom environment.
+    """
+    parallelization = None
+    _mrNodeType: MrNodeType = MrNodeType.INLINE
+
+    def __init__(self):
+        super(InlineNode, self).__init__()
 
 
 class CommandLineNode(BaseNode):

--- a/meshroom/nodes/general/FlattenFiles.py
+++ b/meshroom/nodes/general/FlattenFiles.py
@@ -3,7 +3,7 @@ __version__ = "1.0"
 from meshroom.core import desc
 
 
-class FlattenFiles(desc.Node):
+class FlattenFiles(desc.InlineNode):
     """
     This node takes a list of lists of files as input and produces a single flat list of
     files as output.

--- a/meshroom/nodes/general/GetFileExtension.py
+++ b/meshroom/nodes/general/GetFileExtension.py
@@ -1,0 +1,27 @@
+__version__ = "1.0"
+
+import os
+from meshroom.core import desc
+
+
+class GetFileExtension(desc.InlineNode):
+    inputs = [
+        desc.File(
+            name="path",
+            value="",
+            exposed=True,
+        ),
+    ]
+
+    outputs = [
+        desc.StringParam(
+            name="extension",
+            value=None,
+        ),
+    ]
+
+    def process(self, node):
+        if not node.path.value:
+            node.extension.value = ""
+        else:
+            node.extension.value = os.path.splitext(node.path.value)[1]

--- a/meshroom/nodes/general/GetParentFolder.py
+++ b/meshroom/nodes/general/GetParentFolder.py
@@ -5,7 +5,7 @@ import logging
 from meshroom.core import desc
 
 
-class GetParentFolder(desc.Node):
+class GetParentFolder(desc.InlineNode):
     """ Get the parent folder """
     
     category = "Other"

--- a/meshroom/nodes/general/PathJoin.py
+++ b/meshroom/nodes/general/PathJoin.py
@@ -4,7 +4,7 @@ import os
 from meshroom.core import desc
 
 
-class PathJoin(desc.Node):
+class PathJoin(desc.InlineNode):
     """ Join multiple paths """
     
     category = "Other"

--- a/meshroom/nodes/general/UnwrapMeshroomSceneParam.py
+++ b/meshroom/nodes/general/UnwrapMeshroomSceneParam.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from meshroom.core import desc
 
 
-class UnwrapMeshroomSceneParam(desc.CommandLineNode):
+class UnwrapMeshroomSceneParam(desc.InlineNode):
     """Unwrap the JSON file created by a GetMeshroomSceneParams node
     to expose its items to the graph.
     
@@ -96,5 +96,5 @@ class UnwrapMeshroomSceneParam(desc.CommandLineNode):
         except Exception as e:
             logging.warning(f"[UnwrapMeshroomSceneParam] Failed to set the choices: {e}")
 
-    def processChunk(self, chunk):
-        self.setOutput(chunk.node)
+    def process(self, node):
+        self.setOutput(node)


### PR DESCRIPTION
## Description

- Add a node `GetFileExtension`
- Replace `desc.Node` by `desc.CommandLineNode` on
  - `GetParentFolder`
  - `FlattenFiles`
  - `PathJoin`

Using CommandLineNode bypass the `_processInIsolatedEnvironment` call (see https://github.com/alicevision/Meshroom/issues/3166) that launches a subprocess.
Bypassing it saves several seconds: the node compute takes almost 0 sec.