### PR TITLE
[ui] grapheditor: Fix the unregister heavy process (closing meshroom …

### DIFF
--- a/meshroom/ui/qml/GraphEditor/GraphEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/GraphEditor.qml
@@ -1590,16 +1590,11 @@ Item {
 
     function unregisterAttributePin(attribute, pin) {
         const attributeToDelegate = Object.assign({}, root._attributeToDelegate)
-        let updated = false
-        for (const key in attributeToDelegate) {
-            if (attributeToDelegate[key] === pin) {
-                delete attributeToDelegate[key]
-                updated = true
-            }
-        }
-        if (updated) {
+        if (attributeToDelegate[attribute.fullName] === pin) {
+            delete attributeToDelegate[attribute.fullName]
             root._attributeToDelegate = attributeToDelegate
         }
+        
     }
 
     function boundingBox() {


### PR DESCRIPTION
## Description
Closing a scene with many node's attributes could take almost 1 minute to close.
It appears that it happen at the unregister attribute pin time.

## Features list

- [X] Fix the complexity in the unregisterpin method

