### PR TITLE
Fix the weak mapping of attributeToDelegate by using an uuid instead of fullName

### DIFF
--- a/meshroom/core/attribute.py
+++ b/meshroom/core/attribute.py
@@ -23,6 +23,7 @@ from meshroom.core.exception import InvalidEdgeError
 from typing import TYPE_CHECKING, Optional
 
 from meshroom.core.mixins import Expandable
+import uuid
 
 if TYPE_CHECKING:
     from meshroom.core.graph import Edge
@@ -144,6 +145,7 @@ class Attribute(BaseObject):
         # so that description changes on the node type only affect new nodes.
         self._expressionTemplate: Optional[str] = None
         self._initValue()
+        self._uuid = f'{self._desc._name}-{uuid.uuid4()}'
 
     def _getFullName(self) -> str:
         """
@@ -836,6 +838,8 @@ class Attribute(BaseObject):
     errorMessageChanged = Signal()
     errorMessages = Property(Variant, lambda self: self.getErrorMessages(), notify=errorMessageChanged)
     isMandatory = Property(bool, _isMandatory, constant=True )
+
+    uuid = Property(str, lambda self: self._uuid, constant=True)
 
 def raiseIfLink(func):
     """

--- a/meshroom/ui/qml/GraphEditor/GraphEditor.qml
+++ b/meshroom/ui/qml/GraphEditor/GraphEditor.qml
@@ -502,15 +502,7 @@ Item {
                         }
 
                         // Get the first visible parent of "attribute"
-                        let dstAttributeDelegate = attributeToDelegate[attribute.fullName]
-                        if (!dstAttributeDelegate) {
-                            for (const key in attributeToDelegate) {
-                                if (attributeToDelegate[key].attribute === attribute) {
-                                    dstAttributeDelegate = attributeToDelegate[key]
-                                    break
-                                }
-                            }
-                        }
+                        let dstAttributeDelegate = attributeToDelegate[attribute.uuid]                        
 
                         if (dstAttributeDelegate && dstAttributeDelegate.visible) {
                             return dstAttributeDelegate
@@ -528,7 +520,7 @@ Item {
                             groupAttribute = groupAttribute ? groupAttribute.root : null
 
                             if (groupAttribute) {
-                                groupAttributeDelegate = attributeToDelegate[groupAttribute.fullName]
+                                groupAttributeDelegate = attributeToDelegate[groupAttribute.uuid]
                             }
                         }
 
@@ -1584,22 +1576,23 @@ Item {
 
     function registerAttributePin(attribute, pin) {
         const attributeToDelegate = Object.assign({}, root._attributeToDelegate)
-        attributeToDelegate[attribute.fullName] = pin
+        attributeToDelegate[attribute.uuid] = pin
         root._attributeToDelegate = attributeToDelegate
     }
 
     function unregisterAttributePin(attribute, pin) {
         const attributeToDelegate = Object.assign({}, root._attributeToDelegate)
-        let updated = false
-        for (const key in attributeToDelegate) {
-            if (attributeToDelegate[key] === pin) {
-                delete attributeToDelegate[key]
-                updated = true
-            }
-        }
-        if (updated) {
+
+        if (!attribute || !hasOwnProperty(attribute, 'uid')) { return }
+
+        if (attribute.uuid in attributeToDelegate) {
+
+            if(attributeToDelegate[attribute.uuid] !== pin) { return }
+
+            delete attributeToDelegate[attribute.uuid]
             root._attributeToDelegate = attributeToDelegate
         }
+  
     }
 
     function boundingBox() {


### PR DESCRIPTION
## Description

Fix the closing of Meshroom that was really long.
Fix the inconsistency in deleting edges connected to a ListAttribute

## Features list

- [X] Fix the closing of Meshroom that was really long.
- [X] Fix the inconsistency in deleting edges connected to a ListAttribute

## Implementation remarks
Add a `uuid` property to Attribute class generated from `uuid.uuid4()` + the descName to help debugging

It avoid the transitional state of the attribute child of a ListAttribute that is desindexed in python, but still present in the Qml before it's unregistered.
This transitional state couldn't garanty the `attribute.fullName` value, so the Attribute will never be unregister, or could unregister any attribute of the ListAttribute ComponentPin.
