### PR TITLE
[core] Ensure Python 3.7 compatibility for all the features called by `meshroom_compute`

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -79,7 +79,7 @@ jobs:
           report_type: test_results
 
       # ── meshroom_compute smoke test (Python 3.9) ─────────────
-      # Verifies that the CLI entry-point works on the minimum supported version.
+      # Verifies that the CLI entry-point works on the minimum "ideal" supported version.
       - name: Set up Python 3.9 – meshroom_compute smoke test
         uses: actions/setup-python@v6
         with:
@@ -89,7 +89,35 @@ jobs:
         shell: bash
         run: |
           python3 -m pip install --upgrade pip
-          python3 -m pip install -r requirements.txt --timeout 45
+          python3 -m pip install -r requirements.txt -r dev_requirements.txt --timeout 45
 
       - name: Run meshroom_compute –h (Python 3.9)
         run: python3 bin/meshroom_compute -h
+
+      - name: Run tests for plugins (Python 3.9)
+        run: |
+          pytest tests/test_plugins.py
+      
+      # ── meshroom_compute smoke test (Python 3.7) ─────────────
+      # Verifies that the CLI entry-point works on the minimum supported version.
+      - name: Set up Python 3.7 – meshroom_compute smoke test
+        uses: actions/setup-python@v6
+        if: runner.os == 'Windows'
+        with:
+          python-version: '3.7'
+
+      - name: Install runtime dependencies (Python 3.7)
+        if: runner.os == 'Windows'
+        shell: bash
+        run: |
+          python3 -m pip install --upgrade pip
+          python3 -m pip install -r requirements.txt -r dev_requirements.txt --timeout 45
+
+      - name: Run meshroom_compute –h (Python 3.7)
+        if: runner.os == 'Windows'
+        run: python3 bin/meshroom_compute -h
+
+      - name: Run tests for plugins (Python 3.7)
+        if: runner.os == 'Windows'
+        run: |
+          pytest tests/test_plugins.py

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,5 +1,6 @@
 # packaging
-cx_Freeze==8.6.4
+cx_Freeze==8.6.4; python_version >= "3.10"
+cx_Freeze==6.15.16; python_version < "3.10"
 
 # Python binding packaging
 numpy==1.*

--- a/meshroom/core/__init__.py
+++ b/meshroom/core/__init__.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import pkgutil
 import sys
 import traceback
+from typing import Dict, List
 import uuid
 
 try:
@@ -34,8 +35,8 @@ sessionUid = str(uuid.uuid1())
 
 cacheFolderName = 'MeshroomCache'
 pluginManager: PluginManager = PluginManager()
-submitters: dict[str, BaseSubmitter] = {}
-pipelineTemplates: dict[str, str] = {}
+submitters: Dict[str, BaseSubmitter] = {}
+pipelineTemplates: Dict[str, str] = {}
 
 
 def hashValue(value) -> str:
@@ -73,7 +74,7 @@ def add_to_path(p, packageName=None, pluginUid: str = None):
                             attr.__module__ = uniqueModName
 
 
-def loadClasses(folder: str, packageName: str, classType: type, pluginUid: str = None) -> list[type]:
+def loadClasses(folder: str, packageName: str, classType: type, pluginUid: str = None) -> List[type]:
     """
     Go over the Python module named "packageName" located in "folder" to find files
     that contain classes of type "classType" and return these classes in a list.
@@ -162,7 +163,7 @@ def loadClasses(folder: str, packageName: str, classType: type, pluginUid: str =
     return classes
 
 
-def loadClassesNodes(folder: str, packageName: str, pluginUid: str) -> list[NodeDescProvider]:
+def loadClassesNodes(folder: str, packageName: str, pluginUid: str) -> List[NodeDescProvider]:
     """
     Return the list of all the NodeDescProviders that were created following the search of the
     Python module named "packageName" located in the folder "folder".
@@ -181,7 +182,7 @@ def loadClassesNodes(folder: str, packageName: str, pluginUid: str) -> list[Node
     return loadClasses(folder, packageName, desc.BaseNode, pluginUid=pluginUid)
 
 
-def loadClassesSubmitters(folder: str, packageName: str) -> list[BaseSubmitter]:
+def loadClassesSubmitters(folder: str, packageName: str) -> List[BaseSubmitter]:
     """
     Return the list of all the submitters that were found during the search of the
     Python module named "packageName" that located in the folder "folder".
@@ -345,7 +346,7 @@ def nodeVersion(nodeDesc: desc.Node, default=None):
     return moduleVersion(nodeDesc.__module__, default)
 
 
-def loadNodes(folder, packageName, pluginUid) -> list[NodeDescProvider]:
+def loadNodes(folder, packageName, pluginUid) -> List[NodeDescProvider]:
     if not os.path.isdir(folder):
         logging.error(f"Node folder '{folder}' does not exist.")
         return []
@@ -354,7 +355,7 @@ def loadNodes(folder, packageName, pluginUid) -> list[NodeDescProvider]:
     return nodes
 
 
-def loadAllNodes(folder) -> list[Plugin]:
+def loadAllNodes(folder) -> List[Plugin]:
     plugins = []
     for _, package, ispkg in pkgutil.iter_modules([folder]):
         if ispkg:
@@ -369,7 +370,7 @@ def loadAllNodes(folder) -> list[Plugin]:
     return plugins
 
 
-def loadPluginFolder(folder, userPlugin: bool = False) -> list[Plugin]:
+def loadPluginFolder(folder, userPlugin: bool = False) -> List[Plugin]:
     if not os.path.isdir(folder):
         logging.info(f"Plugin folder '{folder}' does not exist.")
         return []
@@ -395,7 +396,7 @@ def registerSubmitter(s: BaseSubmitter):
     submitters[s.name] = s
 
 
-def loadSubmitters(folder, packageName) -> list[BaseSubmitter]:
+def loadSubmitters(folder, packageName) -> List[BaseSubmitter]:
     if not os.path.isdir(folder):
         logging.error(f"Submitters folder '{folder}' does not exist.")
         return
@@ -403,7 +404,7 @@ def loadSubmitters(folder, packageName) -> list[BaseSubmitter]:
     return loadClassesSubmitters(folder, packageName)
 
 
-def loadAllSubmitters(folder) -> list[BaseSubmitter]:
+def loadAllSubmitters(folder) -> List[BaseSubmitter]:
     submitters = []
     for _, package, ispkg in pkgutil.iter_modules([folder]):
         if ispkg:

--- a/meshroom/core/attribute.py
+++ b/meshroom/core/attribute.py
@@ -334,7 +334,8 @@ class Attribute(BaseObject):
         if not self.isInput or not self._linkExpression:
             return
 
-        if not (graph := self.node.graph):
+        graph = self.node.graph
+        if not graph:
             return
 
         link = self._linkExpression[1:-1]
@@ -683,7 +684,8 @@ class Attribute(BaseObject):
                 - a list containing pairs of the source and destination Attributes (as lists) for every created edge
                 - a list containing pairs of the source and destination Attributes (as lists) for every deleted edge
         """
-        if not (graph := self.node.graph):
+        graph = self.node.graph
+        if not graph:
             return [], []
 
         deletedEdges = []
@@ -703,7 +705,8 @@ class Attribute(BaseObject):
         Returns:
             A list of all the Edge objects that were deleted during the disconnection.
         """
-        if not (graph := self.node.graph):
+        graph = self.node.graph
+        if not graph:
             return []
 
         deletedEdges = []
@@ -873,7 +876,8 @@ class ChoiceParam(Attribute):
         return len(self.getValues())
 
     def getValues(self):
-        if (linkParam := self._getInputLink()) is not None:
+        linkParam = self._getInputLink()
+        if linkParam is not None:
             return linkParam.getValues()
         return self._values if self._values is not None else self._desc._values
 

--- a/meshroom/core/desc/node.py
+++ b/meshroom/core/desc/node.py
@@ -3,6 +3,7 @@
 import enum
 from inspect import getfile, getattr_static
 from pathlib import Path
+from typing import List
 import logging
 import shlex
 import shutil
@@ -182,7 +183,7 @@ class InternalAttributesFactory:
     ]
 
     @classmethod
-    def getInternalAttributes(cls, mrNodeType: MrNodeType) -> list[Attribute]:
+    def getInternalAttributes(cls, mrNodeType: MrNodeType) -> List[Attribute]:
         paramMap = {
             MrNodeType.NONE: cls.BASIC,
             MrNodeType.BASENODE: cls.INVALIDATION + cls.BASIC,
@@ -195,7 +196,7 @@ class InternalAttributesFactory:
         return paramMap.get(mrNodeType)
 
     @classmethod
-    def getInternalFlowInputs(cls, mrNodeType: MrNodeType) -> list[Attribute]:
+    def getInternalFlowInputs(cls, mrNodeType: MrNodeType) -> List[Attribute]:
         """
         Return the list of internal input Flow attributes for a given node type.
 
@@ -207,7 +208,7 @@ class InternalAttributesFactory:
         return cls.FLOW_IN
 
     @classmethod
-    def getInternalFlowOutputs(cls, mrNodeType: MrNodeType) -> list[Attribute]:
+    def getInternalFlowOutputs(cls, mrNodeType: MrNodeType) -> List[Attribute]:
         """
         Return the list of internal output Flow attributes for a given node type.
 
@@ -731,7 +732,7 @@ class OutputNode(IONode):
     def __init__(self):
         super(OutputNode, self).__init__()
 
-    def getOutputAttributes(self, node: "CoreNode") -> list["CoreAttribute"]:
+    def getOutputAttributes(self, node: "CoreNode") -> List["CoreAttribute"]:
         """
         Return the attributes explicitly exposed by this output node.
 
@@ -744,14 +745,14 @@ class OutputNode(IONode):
         else:
             attributeNames = self.outputAttributes
 
-        attributes: list["CoreAttribute"] = []
+        attributes: List["CoreAttribute"] = []
         for attrName in attributeNames:
             if not node.hasAttribute(attrName):
                 raise AttributeError(f"'{node.name}.{attrName}' is not an output node attribute.")
             attributes.append(node.attribute(attrName))
         return attributes
 
-    def getOutputFolderAttributes(self, node: "CoreNode") -> list["CoreAttribute"]:
+    def getOutputFolderAttributes(self, node: "CoreNode") -> List["CoreAttribute"]:
         """
         Return the exposed File attributes managed as output folders.
         """

--- a/meshroom/core/desc/validators.py
+++ b/meshroom/core/desc/validators.py
@@ -1,14 +1,22 @@
-from typing import TYPE_CHECKING, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, List, Tuple
 
 if TYPE_CHECKING:
     from meshroom.core.attribute import Attribute
     from meshroom.core.node import Node
+    from typing import Protocol, runtime_checkable
+else:
+    try:
+        from typing import Protocol, runtime_checkable
+    except ImportError:
+        Protocol = object
+        def runtime_checkable(cls):
+            return cls
 
 
-def success() -> tuple[bool, list[str]]:
+def success() -> Tuple[bool, List[str]]:
     return (True, [])
 
-def error(*messages: str) -> tuple[bool, list[str]]:
+def error(*messages: str) -> Tuple[bool, List[str]]:
     return (False, list(messages))
 
 @runtime_checkable
@@ -23,7 +31,7 @@ class AttributeValidator(Protocol):
         lambda node, attribute: success() if attribute.value and attribute.value != "" else error("attribute have no value")
     """
 
-    def __call__(self, node: "Node", attribute: "Attribute") -> tuple[bool, list[str]]:
+    def __call__(self, node: "Node", attribute: "Attribute") -> Tuple[bool, List[str]]:
         """
         This method can be overridden to implement any custom attribute validation logic.
         The `success()` and `error()` helpers can be used to encapsulate the returning responses.
@@ -42,7 +50,7 @@ class NotEmptyValidator(AttributeValidator):
     This class is used to determine if an attribute value should be considered as mandatory/required.
     """
 
-    def __call__(self, node: "Node", attribute: "Attribute") -> tuple[bool, list[str]]:
+    def __call__(self, node: "Node", attribute: "Attribute") -> Tuple[bool, List[str]]:
         if attribute.value is None or attribute.value == "":
             return error("An empty value is not allowed.")
 
@@ -56,7 +64,7 @@ class RangeValidator(AttributeValidator):
         self._min = min
         self._max = max
 
-    def __call__(self, node: "Node", attribute: "Attribute") -> tuple[bool, list[str]]:
+    def __call__(self, node: "Node", attribute: "Attribute") -> Tuple[bool, List[str]]:
         if attribute.value < self._min or attribute.value > self._max:
             return error(f"Value should be greater than {self._min} and less than {self._max} ",
                          f"({self._min} < {attribute.value} < {self._max}).")

--- a/meshroom/core/exception.py
+++ b/meshroom/core/exception.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from typing import Dict
 
 class MeshroomException(Exception):
     """ Base class for Meshroom exceptions """
@@ -25,7 +26,7 @@ class GraphCompatibilityError(GraphException):
         filepath: The path to the file that caused the error.
         issues: A dictionnary of node names and their respective compatibility issues.
     """
-    def __init__(self, filepath, issues: dict[str, str]) -> None:
+    def __init__(self, filepath, issues: Dict[str, str]) -> None:
         self.filepath = filepath
         self.issues = issues
         msg = f"Compatibility issues found when loading {self.filepath}: {self.issues}"

--- a/meshroom/core/graph.py
+++ b/meshroom/core/graph.py
@@ -2,8 +2,8 @@ import json
 import logging
 import os
 import re
-from typing import Any, Optional
-from collections.abc import Iterable
+from typing import Any, Dict, Iterable, List, Optional, Set, Tuple
+# from collections.abc import Iterable
 from collections import defaultdict, OrderedDict
 import weakref
 from contextlib import contextmanager
@@ -407,7 +407,8 @@ class Graph(BaseObject):
         #   2. nodesVersion in file header: node saved from a Node
         # If unvailable, the "version" field will not be set in `nodeData`.
         if "version" not in nodeData:
-            if version := fromGraph._getNodeTypeVersionFromHeader(nodeData["nodeType"]):
+            version = fromGraph._getNodeTypeVersionFromHeader(nodeData["nodeType"])
+            if version:
                 nodeData["version"] = version
         inTemplate = fromGraph.header.get(GraphIO.Keys.Template, False)
         node = nodeFactory(nodeData, nodeName, inTemplate=inTemplate)
@@ -466,7 +467,7 @@ class Graph(BaseObject):
             self.replaceNode(node.name, compatibilityNode)
 
 
-    def importGraphContentFromFile(self, filepath: PathLike) -> list[Node]:
+    def importGraphContentFromFile(self, filepath: PathLike) -> List[Node]:
         """Import the content (nodes and edges) of another Graph file into this Graph instance.
 
         Args:
@@ -479,7 +480,7 @@ class Graph(BaseObject):
         return self.importGraphContent(graph)
 
     @blockNodeCallbacks
-    def importGraphContent(self, graph: "Graph") -> list[Node]:
+    def importGraphContent(self, graph: "Graph") -> List[Node]:
         """
         Import the content (node and edges) of another `graph` into this Graph instance.
 
@@ -594,7 +595,7 @@ class Graph(BaseObject):
             The created node instance and the mapping of skipped edges per attribute
             (always empty if `withEdges` is True)
         """
-        def _removeLinkExpressions(attribute: Attribute, removed: dict[Attribute, str]):
+        def _removeLinkExpressions(attribute: Attribute, removed: Dict[Attribute, str]):
             """ Recursively remove link expressions from the given root `attribute`. """
             # Link expressions are only stored on input attributes
             if attribute.isOutput:
@@ -758,7 +759,7 @@ class Graph(BaseObject):
                 if node.nodeDesc:
                     node.nodeDesc.onNodeCreated(node)
 
-    def _createUniqueNodeName(self, inputName: str, existingNames: Optional[set[str]] = None):
+    def _createUniqueNodeName(self, inputName: str, existingNames: Optional[Set[str]] = None):
         """
         Create a unique node name based on the input name.
 
@@ -815,7 +816,7 @@ class Graph(BaseObject):
             self.addNode(newNode, nodeName)
             self._restoreOutEdges(outEdges, outListAttributes)
 
-    def _restoreOutEdges(self, outEdges: dict[str, str], outListAttributes):
+    def _restoreOutEdges(self, outEdges: Dict[str, str], outListAttributes):
         """
         Restore output edges that were removed during a call to "removeNode".
 
@@ -856,7 +857,7 @@ class Graph(BaseObject):
             for nodeName in nodeNames:
                 self.upgradeNode(nodeName)
 
-    def reloadNodeDescProviders(self, nodeTypes: list[str]):
+    def reloadNodeDescProviders(self, nodeTypes: List[str]):
         """
         Replace all the node instances of "nodeTypes" in the current graph with new node instances of the
         same type. If the description of the nodes has changed, the reloaded nodes will reflect theses
@@ -967,7 +968,7 @@ class Graph(BaseObject):
         nodes = [n for n in self._nodes.values() if isinstance(n.nodeDesc, meshroom.core.desc.InputNode)]
         return nodes
 
-    def findOutputNodes(self) -> list[Node]:
+    def findOutputNodes(self) -> List[Node]:
         """
         Returns:
             list[Node]: the list of Output nodes (nodes inheriting from OutputNode)
@@ -975,7 +976,7 @@ class Graph(BaseObject):
         nodes = [n for n in self._nodes.values() if isinstance(n.nodeDesc, meshroom.core.desc.OutputNode)]
         return self.sortNodesByIndex(nodes)
 
-    def configureOutputNodes(self, outputValues: list[str]) -> None:
+    def configureOutputNodes(self, outputValues: List[str]) -> None:
         """
         Configure output nodes from command line output values.
 
@@ -1032,7 +1033,7 @@ class Graph(BaseObject):
         for node in remainingOutputNodes:  # Set the remaining output nodes with the global path
             node.nodeDesc.setOutputFolder(node, globalOutputPath)
 
-    def findNodeCandidates(self, nodeNameExpr: str) -> list[Node]:
+    def findNodeCandidates(self, nodeNameExpr: str) -> List[Node]:
         pattern = re.compile(nodeNameExpr)
         return [v for k, v in self._nodes.objects.items() if pattern.match(k)]
 
@@ -1064,7 +1065,7 @@ class Graph(BaseObject):
         return set(self._nodes) - nodesWithInputLink
 
     @changeTopology
-    def addEdge(self, srcAttr: Attribute, dstAttr: Attribute) -> tuple[list[Attribute], list[Attribute]]:
+    def addEdge(self, srcAttr: Attribute, dstAttr: Attribute) -> Tuple[List[Attribute], List[Attribute]]:
         if not srcAttr.node.graph == dstAttr.node.graph == self:
             raise InvalidEdgeError(srcAttr.fullName, dstAttr.fullName,
                                    "Attributes do not belong to this graph.")
@@ -1508,7 +1509,7 @@ class Graph(BaseObject):
         SerializerClass = TemplateGraphSerializer if asTemplate else GraphSerializer
         return SerializerClass(self).serialize()
 
-    def serializePartial(self, nodes: list[Node]) -> dict:
+    def serializePartial(self, nodes: List[Node]) -> dict:
         """
         Partially serialize this graph considering only the given list of `nodes`.
 

--- a/meshroom/core/graphIO.py
+++ b/meshroom/core/graphIO.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Any, TYPE_CHECKING, Union
+from typing import Any, Dict, List, Tuple, TYPE_CHECKING, Union
 
 import meshroom
 from meshroom.core import Version
@@ -37,7 +37,7 @@ class GraphIO:
         NodesPositions = "nodesPositions"
 
     @staticmethod
-    def getFeaturesForVersion(fileVersion: Union[str, Version]) -> tuple["GraphIO.Features", ...]:
+    def getFeaturesForVersion(fileVersion: Union[str, Version]) -> Tuple["GraphIO.Features", ...]:
         """Return the list of supported features based on a file version.
 
         Args:
@@ -79,7 +79,7 @@ class GraphSerializer:
         }
 
     @property
-    def nodes(self) -> list[Node]:
+    def nodes(self) -> List[Node]:
         return self._graph.nodes
 
     def serializeHeader(self) -> dict:
@@ -104,13 +104,13 @@ class GraphSerializer:
             }
         return header
 
-    def _getNodeTypesVersions(self) -> dict[str, str]:
+    def _getNodeTypesVersions(self) -> Dict[str, str]:
         """Get registered versions of each node types in `nodes`, excluding CompatibilityNode instances."""
         nodeTypes = {node.nodeDesc.__class__ for node in self.nodes if isinstance(node, Node)}
         nodeTypesVersions = {
-            nodeType.__name__: version
+            nodeType.__name__: meshroom.core.nodeVersion(nodeType)
             for nodeType in nodeTypes
-            if (version := meshroom.core.nodeVersion(nodeType)) is not None
+            if meshroom.core.nodeVersion(nodeType) is not None
         }
         # Sort them by name (to avoid random order changing from one save to another).
         return dict(sorted(nodeTypesVersions.items()))
@@ -172,12 +172,12 @@ class TemplateGraphSerializer(GraphSerializer):
 class PartialGraphSerializer(GraphSerializer):
     """Serializer to serialize a partial graph (a subset of nodes)."""
 
-    def __init__(self, graph: "Graph", nodes: list[Node]):
+    def __init__(self, graph: "Graph", nodes: List[Node]):
         super().__init__(graph)
         self._nodes = nodes
 
     @property
-    def nodes(self) -> list[Node]:
+    def nodes(self) -> List[Node]:
         """Override to consider only the subset of nodes."""
         return self._nodes
 
@@ -225,9 +225,9 @@ class PartialGraphSerializer(GraphSerializer):
             # Recusively serialize each child of the ListAttribute, skipping those for which the attribute
             # serialization logic above returns None.
             return [
-                exportValue
+                self._serializeAttribute(child)
                 for child in attribute
-                if (exportValue := self._serializeAttribute(child)) is not None
+                if self._serializeAttribute(child) is not None
             ]
 
         if isinstance(attribute, AnySet):

--- a/meshroom/core/node.py
+++ b/meshroom/core/node.py
@@ -14,7 +14,7 @@ import time
 import uuid
 from collections import namedtuple, OrderedDict
 from enum import Enum, IntEnum, auto
-from typing import Callable, Optional, List, Union
+from typing import Callable, Dict, Optional, List, Union
 
 import meshroom
 from meshroom.common import Signal, Variant, Property, BaseObject, Slot, ListModel, DictModel
@@ -483,7 +483,7 @@ class LogManager:
             return logging.NOTSET
 
 
-runningProcesses: dict[str, "NodeChunk"] = {}
+runningProcesses: Dict[str, "NodeChunk"] = {}
 
 
 @atexit.register
@@ -2069,10 +2069,10 @@ class BaseNode(BaseObject):
         else:
             return "NONE"
 
-    def getChunks(self) -> list[NodeChunk]:
+    def getChunks(self) -> List[NodeChunk]:
         return self._chunks
 
-    def getAllChunks(self) -> list[NodeChunk]:
+    def getAllChunks(self) -> List[NodeChunk]:
         chunks = []
         if self.hasPreprocessChunk:
             chunks.append(self._preprocessChunk)

--- a/meshroom/core/nodeFactory.py
+++ b/meshroom/core/nodeFactory.py
@@ -1,6 +1,6 @@
 import logging
-from typing import Any, Optional, Union
-from collections.abc import Iterable
+from typing import Any, Dict, Iterable, List, Optional, Union
+# from collections.abc import Iterable
 
 import meshroom.core
 from meshroom.core import Version, desc
@@ -204,7 +204,7 @@ class _NodeCreator:
         return all(k in allowedNames for k in self.internalInputs.keys())
 
     def _checkAttributesNamesStrictlyMatch(
-        self, descAttributes: Iterable[desc.Attribute], attributesDict: dict[str, Any]
+        self, descAttributes: Iterable[desc.Attribute], attributesDict: Dict[str, Any]
     ) -> bool:
         refNames = sorted([attr.name for attr in descAttributes])
         attrNames = sorted(attributesDict.keys())
@@ -212,7 +212,7 @@ class _NodeCreator:
 
     def _checkAttributesNamesMatchWithOptional(self,
                                                requiredDescAttributes: Iterable[desc.Attribute],
-                                               attributesDict: dict[str, Any],
+                                               attributesDict: Dict[str, Any],
                                                optionalDescAttributes: Iterable[desc.Attribute]) -> bool:
         """
         Check that attribute names in 'attributesDict' match the expected description,
@@ -242,7 +242,7 @@ class _NodeCreator:
         return True
 
     def _checkAttributesCompatibility(
-        self, descAttributes: list[desc.Attribute], attributesDict: dict[str, Any]
+        self, descAttributes: List[desc.Attribute], attributesDict: Dict[str, Any]
     ) -> bool:
         return all(
             CompatibilityNode.attributeDescFromName(descAttributes, attrName, value) is not None

--- a/meshroom/core/plugins/base.py
+++ b/meshroom/core/plugins/base.py
@@ -213,7 +213,8 @@ class Plugin(BaseObject):
             logging.error(f"Error while accessing the configuration file for {self.name}: {err}")
 
         # If both dictionaries have identical keys, os.environ overwrites existing values from _configEnv
-        self._configFullEnv = self._configEnv | os.environ
+        # Python 3.9+ version: self._configFullEnv = self._configEnv | os.environ
+        self._configFullEnv = {**self._configEnv, **os.environ}
 
 
 class NodeDescProviderStatus(Enum):

--- a/meshroom/core/submitter.py
+++ b/meshroom/core/submitter.py
@@ -318,7 +318,8 @@ class OrderedTasks:
         """
         logger.debug(f"* (addNodeTasks) node {orderedNode.node._name}, parent {parentTask.node}")
         # Check if task has already been created
-        visited = (nodeUid := orderedNode.node._uid) in self._nodeUidToBoundaryTasks
+        nodeUid = orderedNode.node._uid
+        visited = nodeUid in self._nodeUidToBoundaryTasks
         if visited:
             logger.debug("  -> is visited")
             # If task is already created simply create the connection

--- a/meshroom/env.py
+++ b/meshroom/env.py
@@ -13,7 +13,7 @@ from dataclasses import dataclass
 from enum import Enum
 import sys
 import tempfile
-from typing import Any, Type
+from typing import Any, List, Type
 
 meshroomFolder = os.path.dirname(__file__)
 
@@ -61,7 +61,7 @@ class EnvVar(Enum):
         return EnvVar._cast(value, envVar.value.valueType)
 
     @staticmethod
-    def getList(envVar: "EnvVar") -> list[Any]:
+    def getList(envVar: "EnvVar") -> List[Any]:
         """Get the value of `envVar` as a list of non-empty strings."""
         paths = EnvVar.get(envVar).split(os.pathsep)
         # filter empty values

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,9 @@
 # runtime
 psutil>=5.6.7
-PySide6==6.8.3
-markdown==3.8.2
-requests==2.32.4
+PySide6==6.8.3; python_version >= "3.9"
+PySide6==6.5.3; python_version < "3.9"
+markdown==3.8.2; python_version >= "3.9"
+markdown==3.4.4; python_version < "3.9"
+requests==2.32.4; python_version >= "3.9"
+requests==2.18.0; python_version < "3.9"
 pyseq==0.9.0

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -313,34 +313,35 @@ class TestPluginsConfiguration:
         }
 
         folder = os.path.join(os.path.dirname(__file__), "plugins")
-        with (overrideOsEnvironmentVariables(environment), registeredPlugins(folder)):
-            plugin = pluginManager.getPlugin("pluginA", uname=False)
-            assert plugin
+        with overrideOsEnvironmentVariables(environment):
+            with registeredPlugins(folder):
+                plugin = pluginManager.getPlugin("pluginA", uname=False)
+                assert plugin
 
-            # Check that the config file has been properly loaded and read
-            # Environment variables that are already set should not have any effect on that
-            # reading of values
-            config = plugin.configEnv
-            assert len(config) == 3
-            assert list(config.keys()) == self.CONFIG_KEYS
-            assert config[self.CONFIG_PATH[0]] == Path(
-                os.path.join(plugin.path, self.CONFIG_PATH[1])).resolve().as_posix()
-            assert config[self.ERRONEOUS_CONFIG_PATH[0]] == self.ERRONEOUS_CONFIG_PATH[1]
-            assert config[self.CONFIG_STRING[0]] == self.CONFIG_STRING[1]
+                # Check that the config file has been properly loaded and read
+                # Environment variables that are already set should not have any effect on that
+                # reading of values
+                config = plugin.configEnv
+                assert len(config) == 3
+                assert list(config.keys()) == self.CONFIG_KEYS
+                assert config[self.CONFIG_PATH[0]] == Path(
+                    os.path.join(plugin.path, self.CONFIG_PATH[1])).resolve().as_posix()
+                assert config[self.ERRONEOUS_CONFIG_PATH[0]] == self.ERRONEOUS_CONFIG_PATH[1]
+                assert config[self.CONFIG_STRING[0]] == self.CONFIG_STRING[1]
 
-            # Check that the values of the configuration file are not taking precedence over
-            # those in the environment
-            configFullEnv = plugin.configFullEnv
-            assert all(key in configFullEnv for key in config.keys())
+                # Check that the values of the configuration file are not taking precedence over
+                # those in the environment
+                configFullEnv = plugin.configFullEnv
+                assert all(key in configFullEnv for key in config.keys())
 
-            assert config[self.CONFIG_PATH[0]] != self.CONFIG_PATH[2]
-            assert configFullEnv[self.CONFIG_PATH[0]] == self.CONFIG_PATH[2]
+                assert config[self.CONFIG_PATH[0]] != self.CONFIG_PATH[2]
+                assert configFullEnv[self.CONFIG_PATH[0]] == self.CONFIG_PATH[2]
 
-            assert config[self.ERRONEOUS_CONFIG_PATH[0]] != self.ERRONEOUS_CONFIG_PATH[2]
-            assert configFullEnv[self.ERRONEOUS_CONFIG_PATH[0]] == self.ERRONEOUS_CONFIG_PATH[2]
+                assert config[self.ERRONEOUS_CONFIG_PATH[0]] != self.ERRONEOUS_CONFIG_PATH[2]
+                assert configFullEnv[self.ERRONEOUS_CONFIG_PATH[0]] == self.ERRONEOUS_CONFIG_PATH[2]
 
-            assert config[self.CONFIG_STRING[0]] != self.CONFIG_STRING[2]
-            assert configFullEnv[self.CONFIG_STRING[0]] == self.CONFIG_STRING[2]
+                assert config[self.CONFIG_STRING[0]] != self.CONFIG_STRING[2]
+                assert configFullEnv[self.CONFIG_STRING[0]] == self.CONFIG_STRING[2]
 
     def test_loadedConfigWithSomeExistingKeys(self):
         # Set some keys from the config file in the current environment
@@ -350,36 +351,37 @@ class TestPluginsConfiguration:
         }
 
         folder = os.path.join(os.path.dirname(__file__), "plugins")
-        with (overrideOsEnvironmentVariables(environment), registeredPlugins(folder)):
-            plugin = pluginManager.getPlugin("pluginA", uname=False)
-            assert plugin
+        with overrideOsEnvironmentVariables(environment):
+            with registeredPlugins(folder):
+                plugin = pluginManager.getPlugin("pluginA", uname=False)
+                assert plugin
 
-            # Check that the config file has been properly loaded and read
-            # Environment variables that are already set should not have any effect on that
-            # reading of values
-            config = plugin.configEnv
-            assert len(config) == 3
-            assert list(config.keys()) == self.CONFIG_KEYS
-            assert config[self.CONFIG_PATH[0]] == Path(
-                os.path.join(plugin.path, self.CONFIG_PATH[1])).resolve().as_posix()
-            assert config[self.ERRONEOUS_CONFIG_PATH[0]] == self.ERRONEOUS_CONFIG_PATH[1]
-            assert config[self.CONFIG_STRING[0]] == self.CONFIG_STRING[1]
+                # Check that the config file has been properly loaded and read
+                # Environment variables that are already set should not have any effect on that
+                # reading of values
+                config = plugin.configEnv
+                assert len(config) == 3
+                assert list(config.keys()) == self.CONFIG_KEYS
+                assert config[self.CONFIG_PATH[0]] == Path(
+                    os.path.join(plugin.path, self.CONFIG_PATH[1])).resolve().as_posix()
+                assert config[self.ERRONEOUS_CONFIG_PATH[0]] == self.ERRONEOUS_CONFIG_PATH[1]
+                assert config[self.CONFIG_STRING[0]] == self.CONFIG_STRING[1]
 
-            # Check that the values of the configuration file are not taking precedence over
-            # those in the environment
-            configFullEnv = plugin.configFullEnv
-            assert all(key in configFullEnv for key in config.keys())
+                # Check that the values of the configuration file are not taking precedence over
+                # those in the environment
+                configFullEnv = plugin.configFullEnv
+                assert all(key in configFullEnv for key in config.keys())
 
-            assert config[self.CONFIG_PATH[0]] == Path(os.path.join(
-                plugin.path, self.CONFIG_PATH[1])).resolve().as_posix()
-            assert configFullEnv[self.CONFIG_PATH[0]] == Path(os.path.join(
-                plugin.path, self.CONFIG_PATH[1])).resolve().as_posix()
+                assert config[self.CONFIG_PATH[0]] == Path(os.path.join(
+                    plugin.path, self.CONFIG_PATH[1])).resolve().as_posix()
+                assert configFullEnv[self.CONFIG_PATH[0]] == Path(os.path.join(
+                    plugin.path, self.CONFIG_PATH[1])).resolve().as_posix()
 
-            assert config[self.ERRONEOUS_CONFIG_PATH[0]] != self.ERRONEOUS_CONFIG_PATH[2]
-            assert configFullEnv[self.ERRONEOUS_CONFIG_PATH[0]] == self.ERRONEOUS_CONFIG_PATH[2]
+                assert config[self.ERRONEOUS_CONFIG_PATH[0]] != self.ERRONEOUS_CONFIG_PATH[2]
+                assert configFullEnv[self.ERRONEOUS_CONFIG_PATH[0]] == self.ERRONEOUS_CONFIG_PATH[2]
 
-            assert config[self.CONFIG_STRING[0]] != self.CONFIG_STRING[2]
-            assert configFullEnv[self.CONFIG_STRING[0]] == self.CONFIG_STRING[2]
+                assert config[self.CONFIG_STRING[0]] != self.CONFIG_STRING[2]
+                assert configFullEnv[self.CONFIG_STRING[0]] == self.CONFIG_STRING[2]
 
 
 class TestVersionPlugins:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,4 +1,5 @@
 from contextlib import contextmanager
+from typing import List, Dict
 from unittest.mock import patch
 
 import meshroom
@@ -9,7 +10,7 @@ import os
 
 
 @contextmanager
-def registeredNodeTypes(nodeTypes: list[desc.Node]):
+def registeredNodeTypes(nodeTypes: List[desc.Node]):
     nodeDescProvidersList = {}
     for nodeType in nodeTypes:
         nodeDescProvider = NodeDescProvider(nodeType)
@@ -66,6 +67,6 @@ def registeredUserPlugins(folder: str):
 
 
 @contextmanager
-def overrideOsEnvironmentVariables(envVariables: dict):
+def overrideOsEnvironmentVariables(envVariables: Dict):
     with patch.dict(os.environ, envVariables, clear=False):
         yield


### PR DESCRIPTION
## Description

This PR adds Python 3.7 support for all the core features that are used by `meshroom_compute`. This ensures that a wider range of executables are supported for the processing of nodes. 

In addition to ensuring Meshroom's core is 3.7-compatible, the continuous integration is also updated with another smoke test for `meshroom_compute`. Following the restructuring of the `plugins` modules, the test suite for the plugins are also executed, both for Python 3.9 and 3.7. This ensures that any breaking change for Python 3.7 or 3.9 will be immediately detected. 

Finally, requirements (in both `requirements.txt` and `dev_requirements.txt`) are updated with some version-based variants to be correctly installed with Python 3.7. In particular, `cx_Freeze` in `dev_requirements.txt` was only compatible with Python 3.10+; there now is a variant that works for both Python 3.9 and Python 3.7.


## Implementation remarks

The smoke test and plugins unit tests for Python 3.7 are only added for the Windows variant of the continuous integration, as Ubuntu 24 (which corresponds to the `ubuntu-latest` image we are using) does not support Python 3.7 anymore.