### PR TITLE
[plugins] env: Forward `PYTHONPATH` and plugins definitions in rez subrequires' environment

### DIFF
--- a/meshroom/core/plugins/env.py
+++ b/meshroom/core/plugins/env.py
@@ -193,6 +193,15 @@ class RezProcessEnv(ProcessEnv):
         # This will allow loading properly descriptions for nodes from other plugins that may have imports that
         # cannot be resolved from the subrequires' PYTHONPATH alone.
         currentPythonPaths = os.environ.get("PYTHONPATH", "")
+        splitPythonPaths = currentPythonPaths.split(os.pathsep)
+        filteredPaths = []
+        for path in splitPythonPaths:
+            if "pyside" in path.lower():
+                continue
+            if "shiboken" in path.lower():
+                continue
+            filteredPaths.append(path)
+        currentPythonPaths = os.pathsep.join(filteredPaths)
         pythonPaths = f"{os.pathsep.join(['$PYTHONPATH', f'{_MESHROOM_ROOT}', f'{self._folder}', f'{currentPythonPaths}'])}"
 
         # Retrieve the loaded plugins and nodes to re-inject them in the subrequires' environment.

--- a/meshroom/core/plugins/env.py
+++ b/meshroom/core/plugins/env.py
@@ -188,12 +188,27 @@ class RezProcessEnv(ProcessEnv):
     def getCommandPrefix(self):
         # TODO: make Windows-compatible
 
-        # Use the PYTHONPATH from the subrequires' environment (which will only be resolved once
-        # inside the execution environment) and add MESHROOM_ROOT and the plugin's folder itself
-        # to it
-        pythonPaths = f"{os.pathsep.join(['$PYTHONPATH', f'{_MESHROOM_ROOT}', f'{self._folder}'])}"
+        # Retrieve the global PYTHONPATH and append to the subrequires' environment (which will only be resolved inside
+        # the execution environment).
+        # This will allow loading properly descriptions for nodes from other plugins that may have imports that
+        # cannot be resolved from the subrequires' PYTHONPATH alone.
+        currentPythonPaths = os.environ.get("PYTHONPATH", "")
+        pythonPaths = f"{os.pathsep.join(['$PYTHONPATH', f'{_MESHROOM_ROOT}', f'{self._folder}', f'{currentPythonPaths}'])}"
 
-        return f"rez env {' '.join(self.resolveRezSubrequires())} -c 'PYTHONPATH={pythonPaths} "
+        # Retrieve the loaded plugins and nodes to re-inject them in the subrequires' environment.
+        # In most cases, this is overkill as these variables are inherited by rez, but there might be some
+        # cases where a package in the subrequires' environment edits one of these variables, which will
+        # reset it.
+        rezPlugins = os.environ.get("MESHROOM_REZ_PLUGINS", "")
+        regPlugins = os.environ.get("MESHROOM_PLUGINS_PATH", "")
+        rezUserPlugins = os.environ.get("MESHROOM_USER_REZ_PLUGINS", "")
+        regUserPlugins = os.environ.get("MESHROOM_USER_PLUGINS_PATH", "")
+        meshroomNodesPath = os.environ.get("MESHROOM_NODES_PATH", "")
+
+        return f"rez env {' '.join(self.resolveRezSubrequires())} " \
+               f"-c 'PYTHONPATH={pythonPaths} MESHROOM_REZ_PLUGINS={rezPlugins} " \
+               f"MESHROOM_PLUGINS_PATH={regPlugins} MESHROOM_USER_PLUGINS_PATH={regUserPlugins} " \
+               f"MESHROOM_USER_REZ_PLUGINS={rezUserPlugins} MESHROOM_NODES_PATH={meshroomNodesPath} "
 
     def getCommandSuffix(self):
         return "'"


### PR DESCRIPTION
## Description

This PR addresses two specific issues related to the resolution of Rez environments during node computations.
Up until now, when resolving a processing environment with Rez (using the plugin's declared "subrequires"), the only thing that was done besides resolving the listed packages was reinjecting Meshroom's folder (to have access to `meshroom_compute`) and the plugin's folder (to have access to local imports made in the node descriptions) to the `PYTHONPATH`. Environment variables that describe which plugins and nodes to load were assumed to be correctly inherited in the subrequires' environment.

Although it was minimalist and easy to read (and consequently, easier to debug), the problems that came with that were:
1. If any local import is made at the global level in a node description that came from another plugin, this import cannot be resolved (as the corresponding plugin's folder is not part of the `PYTHONPATH`), and the node description is rejected. In return, when `meshroom_compute` is loading the graph to evaluate the executed node's dependencies, if such a node is part of it, it is marked as "Unknown node type", which causes the executed node's UID to evaluate differently. As a consequence, the executed node cannot be processed.
2. If any of the "subrequires" packages appends or edits a (or several) variable related to the loading of plugins/nodes (`MESHROOM_PLUGINS_PATH`, `MESHROOM_USER_PLUGINS_PATH`, `MESHROOM_REZ_PLUGINS`, `MESHROOM_USER_REZ_PLUGINS`, `MESHROOM_NODES_PATH`), it automatically resets it in the subrequires' environment, meaning the other plugins/nodes that were contained in it will be lost, causing the node descriptions not to be found, leading to the same erroneous UID evaluation.

This PR solves those by reinjecting all the content of the `PYTHONPATH` into the subrequires' environment, as well as all the plugins/nodes-related variables. It ensures all imports are always accessible, and no node description is lost because the plugin was not correctly loaded (or because its description was rejected due to the global imports of local modules).

The trade-off is that it makes the subprocess' command line extremely verbose and harder to understand, and it might additionally overload the `PYTHONPATH` with unnecessary modules. 