### PR TITLE
[desc] Add Python 3.7+ compatibility for validators

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -121,3 +121,4 @@ jobs:
         if: runner.os == 'Windows'
         run: |
           pytest tests/test_plugins.py
+          pytest tests/test_attributes.py

--- a/meshroom/core/desc/attribute.py
+++ b/meshroom/core/desc/attribute.py
@@ -94,7 +94,8 @@ class Attribute(BaseObject):
 
         if validators is None:
             self._validators = []
-        elif isinstance(validators, Sequence) and all(isinstance(x, AttributeValidator) for x in validators):
+        elif isinstance(validators, Sequence) and all(callable(x) for x in validators):
+            # Use "callable(x)" instead of "isinstance(x, AttributeEditor)" for Python 3.7+ compatibility
             self._validators = validators
         else:
             raise RuntimeError(f"Validators should be of type 'Sequence[AttributeValidator]', the type '{type(validators)}' is not supported.")

--- a/meshroom/nodes/general/CopyFiles.py
+++ b/meshroom/nodes/general/CopyFiles.py
@@ -6,12 +6,12 @@ from meshroom.core.utils import VERBOSE_LEVEL
 import shutil
 import glob
 import os
-from typing import ClassVar
+from typing import ClassVar, List
 
 
 class CopyFiles(desc.Node, desc.OutputNode):
     size = desc.DynamicNodeSize("inputFiles")
-    outputAttributes: ClassVar[list[str]] = ["output"]
+    outputAttributes: ClassVar[List[str]] = ["output"]
 
     category = "Export"
     documentation = """

--- a/meshroom/nodes/general/GenerateMeshroomScene.py
+++ b/meshroom/nodes/general/GenerateMeshroomScene.py
@@ -137,10 +137,10 @@ class GenerateMeshroomScene(desc.Node):
         if paramOverrides:
             command += ["--paramOverrides"] + paramOverrides
         command += ["--compute", "no"]
-        if invalidationString := node.setInvalidationString.value:
-            command += ["--setInvalidationString", invalidationString]
-        if cacheDir := node.setCacheDir.value:
-            command += ["--overrideCacheDir", cacheDir]
+        if node.setInvalidationString.value:
+            command += ["--setInvalidationString", node.setInvalidationString.value]
+        if node.setCacheDir.value:
+            command += ["--overrideCacheDir", node.setCacheDir.value]
 
         # Launch subprocess
         logging.info(f"{'='*10} Command {'='*10}")


### PR DESCRIPTION
## Description

This PR is a complement to https://github.com/alicevision/Meshroom/pull/3175. 

It ensures that attributes, and specifically validators, can be used fully with Python 3.7. The change here specifically concerns validators, as they were using a specific check (`isinstance(x, AttributeValidator)`) that fails when used with a lambda or any object that does not explicitly subclasses `AttributeValidator` with Python 3.7. Since validators are meant to be wildly used with lambdas, the failing of this check defeats the purpose. Instead, we can check that the validators are callable. 

The unit test suite on attributes is also run on Python 3.7 (on Windows exclusively) to make sure attributes are always Python-3.7 compatible (otherwise, node descriptions might be rejected upon loading).