### PR TITLE
[ui] Viewer3D: orthographic projection and axis-aligned views

### DIFF
--- a/meshroom/ui/qml/Viewer3D/Viewer3D.qml
+++ b/meshroom/ui/qml/Viewer3D/Viewer3D.qml
@@ -33,6 +33,18 @@ FocusScope {
         mainCamera.viewCenter = defaultCamViewCenter
     }
 
+    /// Look along 'direction', keeping the current distance to the view center.
+    function setCameraDirection(direction, upVector) {
+        var distance = mainCamera.viewCenter.minus(mainCamera.position).length()
+        mainCamera.upVector = upVector
+        mainCamera.position = mainCamera.viewCenter.minus(direction.times(distance))
+    }
+
+    /// Look at the scene from the opposite side, along the same axis.
+    function flipCameraDirection() {
+        mainCamera.position = mainCamera.viewCenter.times(2).minus(mainCamera.position)
+    }
+
     function load(filepath, label = undefined) {
         mediaLibrary.load(filepath, label)
     }
@@ -98,7 +110,8 @@ FocusScope {
 
             Camera {
                 id: mainCamera
-                projectionType: CameraLens.PerspectiveProjection
+                projectionType: Viewer3DSettings.orthographic ? CameraLens.OrthographicProjection
+                                                              : CameraLens.PerspectiveProjection
                 enabled: cameraSelector.camera == mainCamera
                 fieldOfView: 45
                 nearPlane : 0.01
@@ -107,6 +120,17 @@ FocusScope {
                 upVector: defaultCamUpVector
                 viewCenter: defaultCamViewCenter
                 aspectRatio: width/height
+
+                // An orthographic projection has no field of view, so its view volume is
+                // derived from the distance to the view center: what lies at that distance
+                // keeps its apparent size when toggling projection, and the existing
+                // distance-based zoom keeps working with no change to the controller.
+                readonly property real orthoHalfHeight: viewCenter.minus(position).length()
+                                                        * Math.tan(fieldOfView * Math.PI / 360)
+                top: orthoHalfHeight
+                bottom: -orthoHalfHeight
+                left: -orthoHalfHeight * aspectRatio
+                right: orthoHalfHeight * aspectRatio
             }
 
             ViewpointCamera {
@@ -294,6 +318,47 @@ FocusScope {
                 onCheckedChanged: Viewer3DSettings.displayNormals = checked
             }
 
+        }
+    }
+
+    // Projection and axis-aligned viewpoints
+    FloatingPane {
+        anchors.bottom: parent.bottom
+        anchors.left: renderModesPanel.right
+        padding: 4
+        Row {
+            MaterialToolButton {
+                text: Viewer3DSettings.orthographic ? MaterialIcons.crop_free : MaterialIcons.view_in_ar
+                ToolTip.text: Viewer3DSettings.orthographic ? "Orthographic Projection" : "Perspective Projection"
+                font.pointSize: 11
+                checkable: true
+                checked: Viewer3DSettings.orthographic
+                onClicked: Viewer3DSettings.orthographic = checked
+            }
+            MaterialToolButton {
+                text: MaterialIcons.vertical_align_top
+                ToolTip.text: "Top View"
+                font.pointSize: 11
+                onClicked: setCameraDirection(Qt.vector3d(0, -1, 0), Qt.vector3d(0, 0, -1))
+            }
+            MaterialToolButton {
+                text: MaterialIcons.north
+                ToolTip.text: "Front View"
+                font.pointSize: 11
+                onClicked: setCameraDirection(Qt.vector3d(0, 0, -1), Qt.vector3d(0, 1, 0))
+            }
+            MaterialToolButton {
+                text: MaterialIcons.east
+                ToolTip.text: "Side View"
+                font.pointSize: 11
+                onClicked: setCameraDirection(Qt.vector3d(-1, 0, 0), Qt.vector3d(0, 1, 0))
+            }
+            MaterialToolButton {
+                text: MaterialIcons.flip
+                ToolTip.text: "Flip View"
+                font.pointSize: 11
+                onClicked: flipCameraDirection()
+            }
         }
     }
 

--- a/meshroom/ui/qml/Viewer3D/Viewer3DSettings.qml
+++ b/meshroom/ui/qml/Viewer3D/Viewer3DSettings.qml
@@ -55,6 +55,9 @@ Item {
     property bool displayOrigin: false
     property bool displayLightController: false
     // Camera
+    // Use a parallel projection instead of a perspective one, to compare
+    // directions and proportions without perspective foreshortening
+    property bool orthographic: false
     property bool syncViewpointCamera: false
     property bool syncWithPickedViewId: false  // Sync active camera with picked view ID from sequence player if the setting is enabled
     property bool viewpointImageOverlay: true


### PR DESCRIPTION
## Description

The 3D Viewer only offers a perspective camera, so directions and proportions cannot be compared without foreshortening, and there is no way to look along a principal axis.

This adds a projection toggle and Top / Front / Side / Flip buttons, in a pane next to the existing render modes.

Fix #3183. Connect to #616.

## Features list

- [x] Toggle between perspective and orthographic projection
- [x] Top / Front / Side view presets
- [x] Flip view (look from the opposite side, same axis)

## Implementation remarks

- Qt3D's orthographic projection has no field of view, so the view volume is derived from the camera's distance to `viewCenter` together with the existing `fieldOfView`. Two consequences: toggling preserves the apparent size of whatever sits at that distance, and the existing distance-based zoom (wheel and alt+RMB, which translate the camera) keeps working with no change to `DefaultCameraController` — otherwise zoom would appear dead in orthographic mode.
- The presets keep the current distance to `viewCenter` and set an explicit `upVector`, which avoids a degenerate one when looking straight down. The world is Y-up, per `Grid3D`.
- Tested on Windows against the 2025.1.0 build, whose `Viewer3D.qml` differs from `develop` by a single unrelated line.

Implemented with the assistance of an AI coding agent (Claude), reviewed and tested by me.